### PR TITLE
perf(vcs): make init non-blocking by forking branch resolution

### DIFF
--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Context, Stream } from "effect"
+import { Effect, Layer, Context, Stream, Scope } from "effect"
 import { formatPatch, structuredPatch } from "diff"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
@@ -251,6 +251,7 @@ export namespace Vcs {
     Effect.gen(function* () {
       const git = yield* Git.Service
       const bus = yield* Bus.Service
+      const scope = yield* Scope.Scope
 
       const state = yield* InstanceState.make<State>(
         Effect.fn("Vcs.state")(function* (ctx) {
@@ -288,7 +289,9 @@ export namespace Vcs {
 
       return Service.of({
         init: Effect.fn("Vcs.init")(function* () {
-          yield* InstanceState.get(state)
+          // Fork the branch/default-branch materialization into the layer scope so init()
+          // returns immediately instead of blocking the caller on git subprocesses (#22771).
+          yield* InstanceState.get(state).pipe(Effect.forkIn(scope))
         }),
         branch: Effect.fn("Vcs.branch")(function* () {
           return yield* InstanceState.use(state, (x) => x.current)

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -540,15 +540,24 @@ describe("Vcs init", () => {
   // Regression for #22771 (thanks upstream, Dax). init() must fork the branch
   // resolution into the layer scope and return immediately rather than block the
   // caller on git subprocesses. With the git latch held closed a blocking init()
-  // never resolves; a forked init() returns right away.
+  // never resolves; a forked init() returns right away yet still drives the
+  // materialization in the background.
   test("init() returns without waiting for git branch resolution", async () => {
     await using tmp = await tmpdir({ git: true })
     const latch = await Effect.runPromise(Deferred.make<void>())
+    // Resolved by the mock git.branch once the forked materialization actually
+    // reaches it — proves init() forked the work rather than becoming a no-op.
+    const entered = await Effect.runPromise(Deferred.make<void>())
 
     const notCalled = () => Effect.die("git method not exercised by init()")
     const git: Git.Interface = {
       run: notCalled,
-      branch: () => Deferred.await(latch).pipe(Effect.as("main")),
+      branch: () =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(entered, void 0)
+          yield* Deferred.await(latch)
+          return "main"
+        }),
       prefix: notCalled,
       defaultBranch: () => Deferred.await(latch).pipe(Effect.as(undefined)),
       hasHead: notCalled,
@@ -575,11 +584,19 @@ describe("Vcs init", () => {
         directory: tmp.path,
         fn: () => runtime.runPromise(Vcs.Service.use((svc) => svc.init())),
       })
-      const outcome = await Promise.race([
+      const returned = await Promise.race([
         init.then(() => "returned" as const),
         Bun.sleep(2_000).then(() => "blocked" as const),
       ])
-      expect(outcome).toBe("returned")
+      expect(returned).toBe("returned")
+
+      // The forked fiber must still drive the materialization to the (latched)
+      // git calls, so init() returning is not a silent no-op.
+      const started = await Promise.race([
+        Effect.runPromise(Deferred.await(entered)).then(() => "started" as const),
+        Bun.sleep(2_000).then(() => "idle" as const),
+      ])
+      expect(started).toBe("started")
     } finally {
       await Effect.runPromise(Deferred.succeed(latch, void 0))
       await runtime.dispose()

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -1,11 +1,13 @@
 import { $ } from "bun"
 import { afterEach, describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Deferred, Effect, Layer, ManagedRuntime } from "effect"
 import fs from "fs/promises"
 import path from "path"
 import { provideInstance, tmpdir } from "../fixture/fixture"
 import { AppRuntime } from "../../src/effect/app-runtime"
+import { Bus } from "../../src/bus"
 import { FileWatcher } from "../../src/file/watcher"
+import { Git } from "../../src/git"
 import { Instance } from "../../src/project/instance"
 import { GlobalBus } from "../../src/bus/global"
 import { Vcs } from "../../src/project/vcs"
@@ -528,4 +530,59 @@ describe("Vcs diff", () => {
       })
     }),
   )
+})
+
+describe("Vcs init", () => {
+  afterEach(async () => {
+    await Instance.disposeAll()
+  })
+
+  // Regression for #22771 (thanks upstream, Dax). init() must fork the branch
+  // resolution into the layer scope and return immediately rather than block the
+  // caller on git subprocesses. With the git latch held closed a blocking init()
+  // never resolves; a forked init() returns right away.
+  test("init() returns without waiting for git branch resolution", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const latch = await Effect.runPromise(Deferred.make<void>())
+
+    const notCalled = () => Effect.die("git method not exercised by init()")
+    const git: Git.Interface = {
+      run: notCalled,
+      branch: () => Deferred.await(latch).pipe(Effect.as("main")),
+      prefix: notCalled,
+      defaultBranch: () => Deferred.await(latch).pipe(Effect.as(undefined)),
+      hasHead: notCalled,
+      mergeBase: notCalled,
+      show: notCalled,
+      showIndex: notCalled,
+      status: notCalled,
+      diff: notCalled,
+      stats: notCalled,
+      patch: notCalled,
+      patchAll: notCalled,
+      patchAllUnstaged: notCalled,
+      patchUntracked: notCalled,
+      statUntracked: notCalled,
+      applyPatch: notCalled,
+    }
+
+    const runtime = ManagedRuntime.make(
+      Vcs.layer.pipe(Layer.provide(Layer.succeed(Git.Service, git)), Layer.provide(Bus.layer)),
+    )
+
+    try {
+      const init = Instance.provide({
+        directory: tmp.path,
+        fn: () => runtime.runPromise(Vcs.Service.use((svc) => svc.init())),
+      })
+      const outcome = await Promise.race([
+        init.then(() => "returned" as const),
+        Bun.sleep(2_000).then(() => "blocked" as const),
+      ])
+      expect(outcome).toBe("returned")
+    } finally {
+      await Effect.runPromise(Deferred.succeed(latch, void 0))
+      await runtime.dispose()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

`Vcs.init()` forks the per-instance branch materialization into the layer scope instead of blocking the caller on it.

`init()` awaited `InstanceState.get(state)`, and that lookup shells out to git (`git.branch` + `git.defaultBranch`) to build the branch state. So `init()` blocked on those subprocesses before it could return. This forks the materialization with `Effect.forkIn(scope)` so `init()` returns immediately; later `branch()` / `diff()` reads still await the cached state, so results are unchanged. The `forkIn(scope)` idiom is already used across `project/project.ts`, `instance-store.ts`, and `share/session.ts`.

## Why

Removes an avoidable startup stall: the caller of `init()` no longer waits on git subprocesses just to kick off branch resolution.

Adapted from upstream opencode #22771 (thanks @thdxr). PawWork's fork has diverged from `anomalyco/opencode`, so this was re-proven against current `dev` and reimplemented as the smallest local change rather than cherry-picked.

## Related Issue

None — upstream port (#22771).

## Human Review Status

Pending

## Review Focus

That `Scope.Scope` resolves to the layer scope inside `Layer.effect` (it does — same pattern as `project/project.ts`, no change to the `layer` requirements signature), and that forking does not change observable results (`branch()` / `diff()` still await the cached state).

## Risk Notes

Low. Behavior is unchanged for all reads; only the timing of `init()` changes (returns before branch resolution completes). No platform/packaging/UI surface touched. No docs/deps/permissions changes.

## How To Verify

```text
Added test (test/project/vcs.test.ts "Vcs init"): mock Git layer whose
branch/defaultBranch block on a latch; init() must return while the latch
is held.
  - red (before fork): outcome "blocked" — init() never returns (2s race)
  - green (after fork): 1 pass, returns in ~1s
bun test test/project/vcs.test.ts: 22 pass, 0 fail
bun run typecheck (packages/opencode): clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
