### PR TITLE
fix(tool): bridge custom tool zod metadata across module boundaries

### DIFF
--- a/packages/opencode/src/util/effect-zod.ts
+++ b/packages/opencode/src/util/effect-zod.ts
@@ -64,7 +64,47 @@ function isZodType(value: unknown): value is z.ZodTypeAny {
  */
 export function toJsonSchema<S extends Schema.Top>(schema: S) {
   const derived: z.ZodTypeAny = "zod" in schema && isZodType(schema.zod) ? schema.zod : zod(schema)
-  return z.toJSONSchema(derived, { io: "input" })
+  return z.toJSONSchema(derived, { io: "input", metadata: zodMetadataRegistry(derived) })
+}
+
+/**
+ * Rebuild an opencode-side metadata registry by walking a Zod schema tree.
+ *
+ * Zod stores `.describe()` / `.meta()` metadata in a module-local registry. A
+ * config-scoped plugin that imports its own copy of `zod` writes its arg
+ * descriptions into that copy's registry, which opencode's `z.toJSONSchema`
+ * (using opencode's own zod) cannot see — so the descriptions silently vanish
+ * from the LLM-facing tool schema. Each node's `.meta()`/`.description`
+ * accessors are bound to the module that created the node, so they DO resolve
+ * cross-module; re-collecting them into a fresh registry keyed by the same node
+ * objects lets `z.toJSONSchema` emit them. Identity-based (`_zod` brand check,
+ * not `instanceof`) so foreign-module nodes are recognised. (#27770)
+ */
+function zodMetadataRegistry(schema: z.ZodType) {
+  const registry = z.registry<Record<string, unknown>>()
+  const seen = new WeakSet<object>()
+  const collect = (value: unknown) => {
+    if (typeof value !== "object" || value === null) return
+    if (seen.has(value)) return
+    seen.add(value)
+
+    if ("_zod" in value) {
+      const node = value as z.ZodType
+      const metadata = typeof node.meta === "function" ? node.meta() : undefined
+      const description = typeof node.description === "string" ? node.description : undefined
+      const merged = {
+        ...(metadata && typeof metadata === "object" ? metadata : {}),
+        ...(description ? { description } : {}),
+      }
+      if (Object.keys(merged).length) registry.add(node, merged)
+      collect((node as { _zod: { def: unknown } })._zod.def)
+      return
+    }
+
+    for (const item of Object.values(value)) collect(item)
+  }
+  collect(schema)
+  return registry
 }
 
 

--- a/packages/opencode/src/util/effect-zod.ts
+++ b/packages/opencode/src/util/effect-zod.ts
@@ -79,6 +79,12 @@ export function toJsonSchema<S extends Schema.Top>(schema: S) {
  * cross-module; re-collecting them into a fresh registry keyed by the same node
  * objects lets `z.toJSONSchema` emit them. Identity-based (`_zod` brand check,
  * not `instanceof`) so foreign-module nodes are recognised. (#27770)
+ *
+ * Passing `metadata` REPLACES zod's `globalRegistry` for the conversion, so the
+ * walk must capture everything the global lookup would have. A cloned schema
+ * (`base.meta({ id }).describe(...)`) keeps the reusable `id` on `_zod.parent`,
+ * which `toJSONSchema` follows to emit `$defs`/`$ref`; walk that link too or the
+ * refs silently vanish.
  */
 function zodMetadataRegistry(schema: z.ZodType) {
   const registry = z.registry<Record<string, unknown>>()
@@ -97,7 +103,9 @@ function zodMetadataRegistry(schema: z.ZodType) {
         ...(description ? { description } : {}),
       }
       if (Object.keys(merged).length) registry.add(node, merged)
-      collect((node as { _zod: { def: unknown } })._zod.def)
+      const internals = (node as { _zod: { def: unknown; parent?: unknown } })._zod
+      collect(internals.def)
+      collect(internals.parent)
       return
     }
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
+import { fileURLToPath } from "url"
 import { Effect } from "effect"
 import { tmpdir } from "../fixture/fixture"
 import { writeInstalledConfigDeps, writeMockConfigInstall } from "../shared/mock-npm-install"
@@ -319,6 +320,86 @@ describe("tool.registry", () => {
     expect(localToolImportSpec("C:\\Users\\test\\tool.ts")).toStartWith("file://")
     expect(localToolImportSpec("C:\\Users\\test\\tool.ts")).not.toBe("C:\\Users\\test\\tool.ts")
     expect(localToolImportSpec("file:///tmp/tool.ts")).toBe("file:///tmp/tool.ts")
+  })
+
+  test("preserves Zod arg descriptions from a config-scoped plugin with its own zod (#27770)", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        const toolsDir = path.join(opencodeDir, "tools")
+        const plugin = path.join(opencodeDir, "node_modules", "@opencode-ai", "plugin")
+        await fs.mkdir(path.join(plugin, "dist"), { recursive: true })
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        // Copy the real zod into the config dir so the plugin's `import { z } from 'zod'`
+        // resolves to a SEPARATE module instance with its own metadata registry — the
+        // cross-module case opencode's z.toJSONSchema otherwise can't read. Pre-creating
+        // both package.json files keeps `needsConfigDependencies` false, so no install
+        // fires to clobber this shim.
+        await fs.cp(path.dirname(fileURLToPath(import.meta.resolve("zod"))), path.join(opencodeDir, "node_modules", "zod"), {
+          dereference: true,
+          recursive: true,
+        })
+
+        await Bun.write(
+          path.join(plugin, "package.json"),
+          JSON.stringify({ name: "@opencode-ai/plugin", type: "module", exports: { ".": "./dist/index.js" } }),
+        )
+        // Older/manual plugin shim: returns the def as-is (no precomputed jsonSchema).
+        await Bun.write(
+          path.join(plugin, "dist", "index.js"),
+          ["import { z } from 'zod'", "export function tool(input) {", "  return input", "}", "tool.schema = z", ""].join(
+            "\n",
+          ),
+        )
+
+        await Bun.write(
+          path.join(toolsDir, "addition.ts"),
+          [
+            'import { tool } from "@opencode-ai/plugin"',
+            "export default tool({",
+            "  description: 'Use this tool to add two numbers and return their sum.',",
+            "  args: {",
+            "    left: tool.schema.number().describe('The first number to add'),",
+            "    right: tool.schema.number().describe('The second number to add'),",
+            "  },",
+            "  execute: async (args: { left: number; right: number }) => `${args.left + args.right}`,",
+            "})",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    // Mock the auto-install (config.ts forks one on load) as a no-op so it can't
+    // overwrite the pre-placed plugin shim + zod copy — writeMockConfigInstall would.
+    await withConfigDepsLock(async () => {
+      const install = spyOn(Npm, "install").mockImplementation(async () => {})
+      try {
+        await Instance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            const tools = await ToolRegistry.tools({
+              providerID: ProviderID.make("openai"),
+              modelID: ModelID.make("gpt-5"),
+              agent: { name: "build", mode: "primary", permission: [], options: {} },
+            })
+            const addition = tools.find((tool) => tool.id === "addition")
+            expect(addition).toBeDefined()
+
+            // The arg descriptions live in the plugin's own zod registry; the metadata
+            // walker in EffectZod.toJsonSchema must bridge them into the emitted schema.
+            const schema = EffectZod.toJsonSchema(addition!.parameters) as {
+              properties: Record<string, { type?: string; description?: string }>
+            }
+            expect(schema.properties.left).toMatchObject({ type: "number", description: "The first number to add" })
+            expect(schema.properties.right).toMatchObject({ type: "number", description: "The second number to add" })
+          },
+        })
+      } finally {
+        install.mockRestore()
+      }
+    })
   })
 
   test("loads tools with external dependencies without crashing", async () => {

--- a/packages/opencode/test/util/effect-zod.test.ts
+++ b/packages/opencode/test/util/effect-zod.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Schema, SchemaGetter } from "effect"
 import z from "zod"
 
-import { zod, ZodOverride } from "../../src/util/effect-zod"
+import { toJsonSchema, zod, ZodOverride } from "../../src/util/effect-zod"
 
 function json(schema: z.ZodTypeAny) {
   const { $schema: _, ...rest } = z.toJSONSchema(schema)
@@ -113,6 +113,35 @@ describe("util.effect-zod", () => {
     expect(() => out.parse("bar")).toThrow()
     expect(bridged).toEqual(native)
     expect(bridged.enum).toEqual(["foo"])
+  })
+
+  test("toJsonSchema rebuilds metadata: arg descriptions survive (#27770)", () => {
+    // Mirrors a custom tool whose args carry `.describe()` metadata. The metadata
+    // registry passed to z.toJSONSchema REPLACES globalRegistry, so the walker
+    // must re-collect descriptions or they vanish.
+    const override = z.object({
+      city: z.string().describe("the city to look up"),
+      units: z.enum(["metric", "imperial"]).describe("temperature units"),
+    })
+    const schema = Schema.Unknown.annotate({ [ZodOverride]: override })
+    const out = toJsonSchema(schema) as any
+    expect(out.properties.city).toMatchObject({ type: "string", description: "the city to look up" })
+    expect(out.properties.units).toMatchObject({ description: "temperature units" })
+  })
+
+  test("toJsonSchema preserves $ref/$defs from a reused .meta({id}) base across clones (#27770)", () => {
+    // A base schema with a reusable id, cloned via `.describe()`. Zod keeps the id
+    // on `_zod.parent` and toJSONSchema follows it to emit $defs/$ref — the walker
+    // must visit `_zod.parent`, not just `_zod.def`, or the refs silently vanish
+    // once the rebuilt registry replaces globalRegistry.
+    // Only the clone appears in the shape, so the id-bearing base is reachable
+    // *only* through `child._zod.parent` — the path the walker must follow.
+    const base = z.string().meta({ id: "Base", description: "base desc" })
+    const override = z.object({ a: base.describe("child desc") })
+    const schema = Schema.Unknown.annotate({ [ZodOverride]: override })
+    const out = toJsonSchema(schema) as any
+    expect(out.$defs?.Base).toMatchObject({ id: "Base", type: "string", description: "base desc" })
+    expect(out.properties.a).toEqual({ description: "child desc", $ref: "#/$defs/Base" })
   })
 
   test("ZodOverride annotation provides the Zod schema for branded IDs", () => {


### PR DESCRIPTION
## What

Bridge custom-tool Zod arg metadata (`.describe()` / `.meta()`) across module boundaries so it survives into the JSON Schema sent to the model.

## The PawWork gap

Zod stores `.describe()` / `.meta()` metadata in a **module-local** registry. A config-scoped plugin (or a custom tool that pulls its own deps into `.opencode/node_modules`) imports its own copy of `zod`, so its arg descriptions land in *that copy's* registry. opencode generates the LLM-facing tool schema with its **own** bundled zod via `EffectZod.toJsonSchema` → `z.toJSONSchema(derived, { io: "input" })`, which only consults opencode's registry. Result: a custom tool's arg descriptions silently vanish from the schema the model sees.

`EffectZod.toJsonSchema` is the single chokepoint for every tool's LLM schema (callers: `session/prompt.ts`, `tool/tool-info.ts`), so the fix lives there.

## The fix

Walk the derived zod tree and rebuild a fresh registry by reading each node's `.meta()` / `.description`. Those accessors are bound to the module that *created* the node, so they resolve cross-module; the rebuilt registry is keyed by the same node objects and handed to `z.toJSONSchema({ metadata })`:

```ts
return z.toJSONSchema(derived, { io: "input", metadata: zodMetadataRegistry(derived) })
```

The walk is **identity-based** (`"_zod" in value` brand check, not `instanceof`) precisely so foreign-module zod nodes are recognised — PawWork's existing `isZodType` is `instanceof`-based and would miss them.

Built-in Effect Schema tools are unaffected: their metadata is added by the walker using opencode's own zod, so it already lives in opencode's registry; the rebuilt registry reproduces it. The full opencode suite (3669 tests) confirms zero schema drift.

## Test

Red→green regression in `registry.test.ts`: loads a config-scoped plugin whose `tool.schema` is a **separate copied zod** (`.opencode/node_modules/zod`), defines a tool with `.describe()`-annotated args, and asserts the descriptions survive into `EffectZod.toJsonSchema(tool.parameters)`. Confirmed failing before the bridge (`type: "number"` with no `description`), passing after.

Full opencode suite **3669 pass / 0 fail**; `tsgo --noEmit` clean.

## Upstream

Semantic port of [anomalyco/opencode `48122b31cc`](https://github.com/anomalyco/opencode/commit/48122b31cc3dcdb38609e442c459534ac7c0999a) — *fix(tool): bridge custom tool zod metadata (#27770)* (thanks Aiden Cline). Upstream also dropped a plugin-side `jsonSchema` precompute workaround; PawWork's `plugin/src/tool.ts` already returns the def as-is, so only the opencode-side metadata bridge is needed here. Adapted to PawWork's `effect-zod.ts` JSON-schema pipeline (vs upstream's `zodJsonSchema`).

---

### Update — `/codex review` follow-up (parent metadata)

Codex flagged (P2) that the `metadata` registry passed to `z.toJSONSchema` **replaces** `globalRegistry` (verified empirically: an empty passed registry drops all `$defs`/`$ref`). A cloned schema (`base.meta({ id }).describe(...)`) keeps the reusable `id` on `_zod.parent`, which `toJSONSchema` follows to emit `$ref` — but the walk only visited `_zod.def`, so a tool arg whose id-bearing base is reachable only via a clone's parent would lose its `$ref`. Fixed by also walking `_zod.parent`. Added a focused red→green effect-zod test for the parent link (plus one for description survival). Full suite re-run: **3671 pass / 0 fail**, no built-in schema drift.