### PR TITLE
fix(session): ignore instruction findUp lookup errors

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -160,7 +160,9 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
           for (const file of FILES()) {
-            const matches = yield* fs.findUp(file, Instance.directory, Instance.worktree)
+            const matches = yield* fs
+              .findUp(file, Instance.directory, Instance.worktree)
+              .pipe(Effect.catch(() => Effect.succeed([] as string[])))
             const stats = yield* Effect.forEach(matches, (item) =>
               fs.isFile(item).pipe(Effect.map((isFile) => ({ item, isFile }))),
             )
@@ -245,7 +247,9 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.S
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
           let projectLoaded = false
           for (const file of FILES()) {
-            const matches = yield* fs.findUp(file, Instance.directory, Instance.worktree)
+            const matches = yield* fs
+              .findUp(file, Instance.directory, Instance.worktree)
+              .pipe(Effect.catch(() => Effect.succeed([] as string[])))
             const stats = yield* Effect.forEach(matches, (item) =>
               fs.isFile(item).pipe(Effect.map((isFile) => ({ item, isFile }))),
             )

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Instruction, projectFiles } from "../../src/session/instruction"
 import { Config } from "../../src/config"
@@ -1400,6 +1402,84 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
               expect(rules).toContain(
                 `Instructions from: ${path.join(pawworkConfig.path, "rules", "fallback.md")}\n# Fallback Config`,
               )
+            }),
+          ),
+        ),
+    })
+  })
+})
+
+describe("Instruction findUp lookup errors", () => {
+  // findUp walks the directory tree calling fs.exists, which propagates I/O errors
+  // such as EACCES on an unreadable ancestor. Every other I/O in instruction.ts
+  // degrades to an empty result on failure; the project-level findUp walk must do
+  // the same so a single unreadable ancestor cannot crash prompt construction.
+  const failingFindUpFs = Layer.effect(
+    AppFileSystem.Service,
+    Effect.gen(function* () {
+      const real = yield* AppFileSystem.Service
+      return AppFileSystem.Service.of({
+        ...real,
+        findUp: () => Effect.fail(new AppFileSystem.FileSystemError({ method: "findUp" })),
+      })
+    }),
+  ).pipe(Layer.provide(AppFileSystem.defaultLayer))
+
+  const failingLayer = Instruction.layer.pipe(
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(failingFindUpFs),
+    Layer.provide(FetchHttpClient.layer),
+  )
+
+  const runFailing = <A>(effect: Effect.Effect<A, any, Instruction.Service>) =>
+    Effect.runPromise(effect.pipe(Effect.provide(failingLayer)))
+
+  let originalDisableProjectConfig: string | undefined
+  beforeEach(() => {
+    originalDisableProjectConfig = process.env.OPENCODE_DISABLE_PROJECT_CONFIG
+    delete process.env.OPENCODE_DISABLE_PROJECT_CONFIG
+  })
+  afterEach(() => {
+    if (originalDisableProjectConfig === undefined) delete process.env.OPENCODE_DISABLE_PROJECT_CONFIG
+    else process.env.OPENCODE_DISABLE_PROJECT_CONFIG = originalDisableProjectConfig
+  })
+
+  test("systemPaths() degrades to no project match when findUp fails instead of crashing", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Root Instructions")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        runFailing(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const paths = yield* svc.systemPaths()
+              // The project AGENTS.md would have been discovered by findUp; with findUp
+              // failing the walk yields nothing rather than propagating the error.
+              expect(paths.has(path.join(tmp.path, "AGENTS.md"))).toBe(false)
+            }),
+          ),
+        ),
+    })
+  })
+
+  test("sources() does not crash when findUp fails", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Root Instructions")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        runFailing(
+          Instruction.Service.use((svc) =>
+            Effect.gen(function* () {
+              const sources = yield* svc.sources()
+              expect(Array.isArray(sources)).toBe(true)
             }),
           ),
         ),


### PR DESCRIPTION
## Summary

`session/instruction.ts` walks ancestor directories via `fs.findUp` in both `systemPaths()` and `sources()` to locate project-level `AGENTS.md` / `CLAUDE.md`. `fs.findUp` calls `fs.exists`, which propagates I/O errors (e.g. `EACCES` on an unreadable ancestor directory) instead of treating them as "not found". These two `findUp` calls were the only unwrapped I/O in the file — every other filesystem/network call already degrades to an empty result via `Effect.catch(() => Effect.succeed(...))`.

This change wraps both `findUp` calls in `.pipe(Effect.catch(() => Effect.succeed([] as string[])))`, matching the file's existing convention, so a single unreadable ancestor degrades to "no project match" rather than failing the whole prompt build.

## Why

If any ancestor directory between the project root and the instance worktree is unreadable (`EACCES`) — or any other I/O error surfaces during the upward walk — the unhandled failure propagates out of `systemPaths()` / `sources()` and crashes prompt construction. The rest of the file is already written to degrade gracefully on I/O failure; these two call sites were inconsistent.

## Related Issue

No PawWork issue. Ports the fix from upstream opencode #27656 (`af06e52708`, "fix(session): ignore instruction lookup errors") — thanks to the upstream author. Adapted to PawWork's diverged `instruction.ts`, which has two `findUp` call sites (`systemPaths()` and the diagnostics-oriented `sources()`) versus one upstream.

## Human Review Status

Pending

## Review Focus

- The two-line wrapping matches the surrounding convention (see the already-wrapped `globUp`/`glob`/`readFileString` calls in the same file).
- The regression test forces `findUp` to fail via a decorator layer over `AppFileSystem.Service` (overriding only `findUp`, delegating the rest to the real implementation), which is deterministic and OS/permission independent — no `chmod`/root games that could false-green.

## Risk Notes

Low risk. Behavior change is strictly additive error tolerance: on success the result is unchanged; on I/O failure the walk now yields an empty match list (consistent with the rest of the file) instead of throwing. No platform/packaging surface touched. No UI/copy changes.

## How To Verify

```text
bun run typecheck (turbo, all packages): 8 successful, 0 failed
Targeted: bun test test/session/instruction.test.ts: 40 pass, 1 todo, 0 fail
  - new "Instruction findUp lookup errors" block is red on base (FileSystemError
    propagates from instruction.ts:163 and :248) and green after the fix
Full suite: bun test (packages/opencode): 3670 pass, 9 skip, 1 todo, 0 fail
```

## Screenshots or Recordings

N/A — no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.