### PR TITLE
fix(mcp): deliver tool-list-changed notifications to the instance bus

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -25,7 +25,7 @@ import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import open from "open"
 import { Effect, Exit, Layer, Option, Context, Stream } from "effect"
-import * as EffectLogger from "@opencode-ai/core/effect/logger"
+import { EffectBridge, type Shape as EffectBridgeShape } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
@@ -512,25 +512,24 @@ export namespace MCP {
         Effect.catch(() => Effect.succeed([] as number[])),
       )
 
-      function watch(s: State, name: string, client: MCPClient, timeout?: number) {
+      function watch(s: State, name: string, client: MCPClient, bridge: EffectBridgeShape, timeout?: number) {
         client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
           log.info("tools list changed notification received", { server: name })
           if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
 
-          const listed = await Effect.runPromise(defs(name, client, timeout).pipe(Effect.provide(EffectLogger.layer)))
+          const listed = await bridge.promise(defs(name, client, timeout))
           if (!listed) return
           if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
 
           s.defs[name] = listed
-          await Effect.runPromise(
-            bus.publish(ToolsChanged, { server: name }).pipe(Effect.ignore, Effect.provide(EffectLogger.layer)),
-          )
+          await bridge.promise(bus.publish(ToolsChanged, { server: name }).pipe(Effect.ignore))
         })
       }
 
       const state = yield* InstanceState.make<State>(
         Effect.fn("MCP.state")(function* () {
           const cfg = yield* cfgSvc.get()
+          const bridge = yield* EffectBridge.make()
           const config = cfg.mcp ?? {}
           const s: State = {
             status: {},
@@ -559,7 +558,7 @@ export namespace MCP {
                 if (result.mcpClient) {
                   s.clients[key] = result.mcpClient
                   s.defs[key] = result.defs!
-                  watch(s, key, result.mcpClient, mcp.timeout)
+                  watch(s, key, result.mcpClient, bridge, mcp.timeout)
                 }
               }),
             { concurrency: "unbounded" },
@@ -606,11 +605,12 @@ export namespace MCP {
         listed: MCPToolDef[],
         timeout?: number,
       ) {
+        const bridge = yield* EffectBridge.make()
         yield* closeClient(s, name)
         s.status[name] = { status: "connected" }
         s.clients[name] = client
         s.defs[name] = listed
-        watch(s, name, client, timeout)
+        watch(s, name, client, bridge, timeout)
         return s.status[name]
       })
 

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -173,6 +173,7 @@ beforeEach(() => {
 
 // Import after mocks
 const { MCP } = await import("../../src/mcp/index")
+const { Bus } = await import("../../src/bus/index")
 const { Instance } = await import("../../src/project/instance")
 const { tmpdir } = await import("../fixture/fixture")
 
@@ -264,6 +265,66 @@ test(
     expect(serverState.listToolsCalls).toBe(2)
   }),
 )
+
+// ========================================================================
+// Test: tool change notifications publish ToolsChanged on the instance bus (#22504)
+// The MCP SDK fires the notification handler from a detached transport callback,
+// outside the instance async context. The buggy handler ran bus.publish via a bare
+// Effect.runPromise, so InstanceState.get found no instance and the event silently
+// never reached subscribers (the cache still refreshed, but the UI was never told).
+// Firing the captured handler OUTSIDE Instance.provide reproduces that detached
+// context; a real subscriber must still receive the event.
+// ========================================================================
+
+test("tool change notification reaches the instance bus from a detached callback", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({ $schema: "https://opencode.ai/config.json", mcp: {} }),
+      )
+    },
+  })
+
+  const received: string[] = []
+  let detachedHandler: (() => Promise<void>) | undefined
+  let unsubscribe: (() => void) | undefined
+
+  // Set up the server + subscriber inside the instance context, then leave the
+  // instance alive (no dispose) so the bus can still deliver after we exit.
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      lastCreatedClientName = "notify-server"
+      const serverState = getOrCreateClientState("notify-server")
+
+      await MCP.add("notify-server", { type: "local", command: ["echo", "test"] })
+
+      unsubscribe = Bus.subscribe(MCP.ToolsChanged, (event) => {
+        received.push(event.properties.server)
+      })
+
+      serverState.tools = [{ name: "next_tool", description: "next", inputSchema: { type: "object", properties: {} } }]
+      detachedHandler = Array.from(serverState.notificationHandlers.values())[0]
+    },
+  })
+
+  try {
+    // Fire OUTSIDE the instance ALS — mirrors the MCP SDK transport callback.
+    // The SDK treats the handler as fire-and-forget, so a rejection is swallowed
+    // there too; tolerate it and let the received-event assertion be the pivot.
+    expect(detachedHandler).toBeDefined()
+    await detachedHandler?.().catch(() => {})
+
+    // Bus delivery happens on a forked fiber consuming the PubSub; give it a tick.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(received).toContain("notify-server")
+  } finally {
+    unsubscribe?.()
+    await Instance.disposeDirectory(tmp.path)
+  }
+})
 
 // ========================================================================
 // Test: connect() / disconnect() lifecycle


### PR DESCRIPTION
## Summary

Thread the existing `EffectBridge` through MCP's `watch()` so `tools/list_changed`
notifications actually reach the instance bus (and therefore the UI).

`watch()` registered the SDK notification handler and ran its work via a bare
`Effect.runPromise(...).pipe(Effect.provide(EffectLogger.layer))`. The MCP SDK
fires that handler from a detached transport callback with **no** instance async
context bound, so `bus.publish(ToolsChanged)` reached `InstanceState.get` with no
instance, threw `LocalContext.NotFound`, and was swallowed by `Effect.ignore`. The
local tool cache still refreshed (`defs()` only needs the captured client), but no
subscriber ever heard about the change.

The fix creates an `EffectBridge` where the instance context **is** bound — inside
`MCP.state` and `storeClient` — and passes it into `watch()`. Both `defs()` and
`bus.publish` now run through `bridge.promise(...)`, which restores the captured
instance when the detached callback fires.

## Why

Dynamic MCP tool-list changes were silently invisible to the UI: a server that
added/removed tools at runtime emitted `tools/list_changed`, but the `mcp.tools.changed`
bus event never propagated, so any consumer driven off the bus stayed stale.

## Related Issue

No PawWork issue. Adapts upstream **anomalyco/opencode#22504** — *fix(effect): add
effect bridge for callback contexts* (thanks @kitlangton). The fork has diverged, so
this is a re-proven, minimal reimplementation against current `dev` rather than a
cherry-pick: the upstream commit introduces a general `EffectBridge`; PawWork already
has that bridge (`effect/bridge.ts`, used in provider/session/tool), so only the MCP
call sites needed adapting.

## Human Review Status

Pending

## Review Focus

- The bridge must be created where the instance is bound. It is created in `MCP.state`
  (the `InstanceState.make` setup) and in `storeClient` — both run inside the instance
  context — and then closed over by `watch()`. Creating it once at layer-build time
  would capture no instance.
- `EffectLogger` is no longer imported in `mcp/index.ts`; its only two uses were the
  replaced call sites.

## Risk Notes

Low risk, confined to `packages/opencode/src/mcp/index.ts`. No public API, schema, or
config change. None on platform/packaging/UI/docs surfaces.

## How To Verify

```text
bun test test/mcp/lifecycle.test.ts -t "detached callback"
  - before fix: FAIL (received: [], event never delivered)
  - after fix:  PASS
bun test test/mcp/   -> 41 pass, 0 fail
bun run typecheck    -> clean (tsgo --noEmit)
```

Full `bun test` suite runs in CI.

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

