### PR TITLE
fix(server): hide unexpected 500 error details from response body

### DIFF
--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -49,8 +49,9 @@ export const ErrorMiddleware: ErrorHandler = (err, c) => {
     return c.json(new NamedError.Unknown({ message: err.message }).toObject(), { status: 409 })
   }
   if (err instanceof HTTPException) return err.getResponse()
-  const message = err instanceof Error && err.stack ? err.stack : err.toString()
-  return c.json(new NamedError.Unknown({ message }).toObject(), {
+  // Never serialize err.stack/message into the response: it leaks internal paths and
+  // implementation detail to any client. The full error is already in the server log above.
+  return c.json(new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(), {
     status: 500,
   })
 }

--- a/packages/opencode/test/server/middleware.test.ts
+++ b/packages/opencode/test/server/middleware.test.ts
@@ -200,6 +200,28 @@ describe("server error middleware", () => {
     expect(calls).toEqual([{ message: "failed", extra: { error } }])
   })
 
+  test("hides unexpected server error details from the 500 response body", async () => {
+    const error = new Error("secret stack marker: /Users/alice/project sk-secret")
+    const app = new Hono().get("/boom", () => {
+      throw error
+    })
+    app.onError(ErrorMiddleware)
+
+    let response!: Response
+    let body!: { name: string; data: { message: string } }
+    const calls = await captureServerErrorLogs(async () => {
+      response = await app.request("/boom")
+      body = await response.json()
+    })
+
+    expect(response.status).toBe(500)
+    expect(body.name).toBe("UnknownError")
+    expect(body.data.message).toBe("Unexpected server error. Check server logs for details.")
+    // The stack trace must never leak to clients, but it must still reach the server log.
+    expect(JSON.stringify(body)).not.toContain("secret stack marker")
+    expect(calls).toEqual([{ message: "failed", extra: { error } }])
+  })
+
   test("maps provider oauth callback failures to 400 instead of 500", async () => {
     const providerID = "anthropic" as ProviderID
     const cases = [

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -396,7 +396,9 @@ describe("workspace router", () => {
       expect(response.status).toBe(500)
       const body = await response.json()
       expect(body.name).toBe("UnknownError")
-      expect(body.data.message).toContain("No context found for instance")
+      // The unexpected 500 body is intentionally redacted to a constant (the internal
+      // routing error stays in the server log only); see ErrorMiddleware.
+      expect(body.data.message).toBe("Unexpected server error. Check server logs for details.")
       expect(remoteHits).toBe(0)
     } finally {
       ensureSync.mockRestore()
@@ -565,7 +567,9 @@ describe("workspace router", () => {
 
       expect(response.status).toBe(500)
       expect(body.name).toBe("UnknownError")
-      expect(body.data.message).toContain(message)
+      // The Effect failure channel above still carries the real message; the HTTP body is
+      // redacted to a constant so the internal failure never leaks to clients (ErrorMiddleware).
+      expect(body.data.message).toBe("Unexpected server error. Check server logs for details.")
     } finally {
       ensureSync.mockRestore()
     }


### PR DESCRIPTION
## Summary

The 500 fallback in `ErrorMiddleware` (`packages/opencode/src/server/middleware.ts`) serialized `err.stack` (or `err.toString()`) straight into the JSON response body. Any client that triggered an unexpected server error received the internal stack trace, absolute filesystem paths, and implementation detail. This replaces that with a constant message and keeps the original error in the server log.

```diff
-  const message = err instanceof Error && err.stack ? err.stack : err.toString()
-  return c.json(new NamedError.Unknown({ message }).toObject(), {
+  return c.json(new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(), {
     status: 500,
   })
```

## Why

Returning a stack trace to the client is an information-disclosure issue: it exposes server-side paths (e.g. user home directories) and code structure to anyone who can reach the API. The full error is already written via `log.error("failed", { error: err })` one line above, so the response body never needed it. Server operators keep full diagnostics in the log; clients get a safe, generic message.

This re-implements the fix from upstream opencode #27251 (thanks @nexxeln). Upstream patched its Effect `HttpApi` error layer; this fork's server uses a Hono `ErrorMiddleware`, so the same fix is adapted to that surface. No cherry-pick — the gap was re-proven on current `dev` and the smallest equivalent change applied.

## Related Issue

No tracking issue; this is a security hardening port from upstream opencode #27251.

## Human Review Status

Pending

## Review Focus

- Confirm the constant body is correct and that no other 500 path still leaks `err.stack`/`err.message`.
- Confirm the server-side `log.error` still receives the original error object (diagnostics preserved).

## Risk Notes

Behavior change is limited to the body of unexpected 500 responses: clients that previously parsed the stack string now receive `{ name: "UnknownError", data: { message: "Unexpected server error. Check server logs for details." } }`. NamedError responses (400/404/409) and the `HTTPException` path are unchanged.

Skipped conditional checklist items:
- Manual UI/copy check — no visible UI or user-facing copy changed (the constant is an API error body, not surfaced literally in the product UI).
- Platform/packaging — no runtime, packaging, updater, signing, paths, shell, or permissions surface touched.
- Docs/release-notes/deps/etc. — none of those surfaces changed; pure server-side hardening.

## How To Verify

```text
bun run typecheck (worktree root): 8 successful, 0 errors
Targeted: bun test test/server/middleware.test.ts -> 11 pass, 0 fail
  - new test "hides unexpected server error details from the 500 response body":
    red before the fix (body leaked the full stack + secret marker),
    green after (body == constant message; server log still gets the original error)
Full bun test suite: deferred to PR CI
```

## Screenshots or Recordings

N/A — no visible UI or copy change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved security by preventing internal system details from being exposed in error responses. Unexpected server errors now return a generic message, while detailed error information remains available in server logs for troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->