### PR TITLE
fix(run): drain SSE event loop and set exit code on non-interactive failure

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -73,29 +73,40 @@ function formatRunError(error: unknown) {
   return FormatError(error) ?? FormatUnknownError(error)
 }
 
-// Idle arrives right after the turn completes, so this only trips on a broken
-// stream (e.g. a dropped/reconnected --attach SSE that missed the idle event),
-// where any lost events are unrecoverable regardless of how long we wait.
-const DRAIN_FALLBACK_MS = 10_000
+// The non-interactive exit code reflects the TERMINAL outcome of the run, not
+// intermediate `session.error` events — those can be recoverable (e.g. a
+// ContextOverflowError that auto-compacts and then continues to success). A
+// shaped SDK error (`result.error`, e.g. an unknown command/model rejected
+// before a turn ran) or a terminal error on the final assistant message both
+// fail (#27371); a recovered run reports success.
+export function runExitCode(result: { error?: unknown; data?: { info?: { error?: unknown } } }): 1 | undefined {
+  return result.error || result.data?.info?.error ? 1 : undefined
+}
 
-// Decide the exit code for a non-interactive `run` after the prompt/command
-// request resolves. A shaped SDK error (`result.error`) means the request was
-// rejected before a turn ran, so no `session.status: idle` event will arrive
-// and awaiting `drained` would hang forever (see #27371) — fail fast instead.
-// Otherwise a turn ran: wait for the event stream to finish draining trailing
-// JSON/text and the idle event (so output is not lost when the instance is torn
-// down, see #26955), then fail if it accumulated a session error. The drain is
-// bounded so a missed idle event on a live stream can't hang an otherwise
-// finished run; a fallback timeout resolves as a clean (exit-zero) run, same as
-// a drain that yielded no error.
-export async function finalizeRun(
-  drained: Promise<string | undefined>,
-  result: { error?: unknown },
-  drainFallbackMs = DRAIN_FALLBACK_MS,
-): Promise<1 | undefined> {
-  if (result.error) return 1
-  const sessionError = await Promise.race([drained, delay(drainFallbackMs, undefined, { ref: false })])
-  return sessionError ? 1 : undefined
+// Once the request resolves the turn is done and all output has been produced;
+// the drain just flushes the remaining stream events before the in-process
+// instance is torn down (otherwise trailing JSON/text is lost, see #26955).
+// Wait for the stream to reach idle, but abort it once it stops making progress
+// for this long, so a dropped/missed-idle --attach stream can't hang the run. A
+// stream still delivering events (a slow but healthy drain) is never cut short;
+// only a stalled one is abandoned.
+const DRAIN_INACTIVITY_MS = 10_000
+
+export async function drainTrailingOutput(
+  drained: Promise<unknown>,
+  lastEventAt: () => number,
+  abort: Pick<AbortController, "abort">,
+  inactivityMs = DRAIN_INACTIVITY_MS,
+): Promise<void> {
+  const DONE = Symbol()
+  while (true) {
+    const outcome = await Promise.race([drained.then(() => DONE), delay(inactivityMs, undefined, { ref: false })])
+    if (outcome === DONE) return
+    if (performance.now() - lastEventAt() >= inactivityMs) {
+      abort.abort()
+      return
+    }
+  }
 }
 
 function fallback(part: ToolPart) {
@@ -472,11 +483,13 @@ export const RunCommand = cmd({
       const drainAbort = new AbortController()
       const events = await sdk.event.subscribe(undefined, { signal: drainAbort.signal })
       let error: string | undefined
+      let lastEventAt = performance.now()
 
       async function loop() {
         const toggles = new Map<string, boolean>()
 
         for await (const event of events.stream) {
+          lastEventAt = performance.now()
           if (
             event.type === "message.updated" &&
             event.properties.info.role === "assistant" &&
@@ -566,9 +579,6 @@ export const RunCommand = cmd({
               err = String(props.error.data.message)
             }
             error = error ? error + EOL + err : err
-            // Fail the exit code the moment an error is seen, so a later missed
-            // idle event (which leaves loop()/drained pending) can't exit 0.
-            process.exitCode = 1
             if (emit("error", { error: props.error })) continue
             UI.error(err)
           }
@@ -603,7 +613,6 @@ export const RunCommand = cmd({
             }
           }
         }
-        return error
       }
 
       // Validate agent if specified
@@ -710,7 +719,10 @@ export const RunCommand = cmd({
       // only shows up here.
       if (result.error && !emit("error", { error: result.error })) UI.error(formatRunError(result.error))
 
-      const exitCode = await finalizeRun(drained, result)
+      const exitCode = runExitCode(result)
+      // A pre-turn request error ran no turn, so there is nothing to drain and no
+      // idle event will arrive; otherwise flush trailing output before teardown.
+      if (!result.error) await drainTrailingOutput(drained, () => lastEventAt, drainAbort)
       // Close the (auto-retrying) SSE subscription so the process can exit even
       // when the turn errored before idle or the live stream missed idle.
       drainAbort.abort()

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -469,7 +469,8 @@ export const RunCommand = cmd({
         return false
       }
 
-      const events = await sdk.event.subscribe()
+      const drainAbort = new AbortController()
+      const events = await sdk.event.subscribe(undefined, { signal: drainAbort.signal })
       let error: string | undefined
 
       async function loop() {
@@ -565,6 +566,9 @@ export const RunCommand = cmd({
               err = String(props.error.data.message)
             }
             error = error ? error + EOL + err : err
+            // Fail the exit code the moment an error is seen, so a later missed
+            // idle event (which leaves loop()/drained pending) can't exit 0.
+            process.exitCode = 1
             if (emit("error", { error: props.error })) continue
             UI.error(err)
           }
@@ -676,6 +680,9 @@ export const RunCommand = cmd({
       // can await it after the request resolves instead of letting the instance
       // be disposed mid-drain (which drops trailing JSON/text output).
       const drained = loop().catch((e) => {
+        // We aborted the subscription ourselves (fail-fast / post-drain cleanup);
+        // that surfaces as a stream error but is a clean stop, not a failure.
+        if (drainAbort.signal.aborted) return undefined
         console.error(e)
         process.exitCode = 1
         return undefined
@@ -704,6 +711,9 @@ export const RunCommand = cmd({
       if (result.error && !emit("error", { error: result.error })) UI.error(formatRunError(result.error))
 
       const exitCode = await finalizeRun(drained, result)
+      // Close the (auto-retrying) SSE subscription so the process can exit even
+      // when the turn errored before idle or the live stream missed idle.
+      drainAbort.abort()
       if (exitCode) process.exitCode = exitCode
     }
 

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -481,6 +481,9 @@ export const RunCommand = cmd({
       }
 
       const drainAbort = new AbortController()
+      // event.subscribe(parameters, options): the signal goes in the second
+      // (options) arg, which is spread into the underlying fetch; the first arg
+      // is the (unused) directory/workspace query params.
       const events = await sdk.event.subscribe(undefined, { signal: drainAbort.signal })
       let error: string | undefined
       let lastEventAt = performance.now()

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -489,7 +489,6 @@ export const RunCommand = cmd({
         const toggles = new Map<string, boolean>()
 
         for await (const event of events.stream) {
-          lastEventAt = performance.now()
           if (
             event.type === "message.updated" &&
             event.properties.info.role === "assistant" &&
@@ -505,6 +504,9 @@ export const RunCommand = cmd({
           if (event.type === "message.part.updated") {
             const part = event.properties.part
             if (part.sessionID !== sessionID) continue
+            // Count only this session's part output as drain progress — heartbeats
+            // and other-session events must not keep the watchdog alive (#1154).
+            lastEventAt = performance.now()
 
             if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
               if (emit("tool_use", { part })) continue

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
 import { AppRuntime } from "@/effect/app-runtime"
 import { ServerAuth } from "../../server/auth"
+import { FormatError, FormatUnknownError } from "../error"
 
 type ToolProps<T> = {
   input: Tool.InferParameters<T>
@@ -66,6 +67,26 @@ function block(info: Inline, output?: string) {
 // render after the tool id flip. Keep in sync with agent-rename:legacy-render sweep (Task 18).
 export const isAgentToolPart = (tool: string): boolean =>
   tool === "task" || tool === "agent" // agent-rename:legacy-render
+
+function formatRunError(error: unknown) {
+  return FormatError(error) ?? FormatUnknownError(error)
+}
+
+// Decide the exit code for a non-interactive `run` after the prompt/command
+// request resolves. A shaped SDK error (`result.error`) means the request was
+// rejected before a turn ran, so no `session.status: idle` event will arrive
+// and awaiting `drained` would hang forever (see #27371) — fail fast instead.
+// Otherwise a turn ran: wait for the event stream to finish draining trailing
+// JSON/text and the idle event (so output is not lost when the instance is torn
+// down, see #26955), then fail if it accumulated a session error.
+export async function finalizeRun(
+  drained: Promise<string | undefined>,
+  result: { error?: unknown },
+): Promise<1 | undefined> {
+  if (result.error) return 1
+  const sessionError = await drained
+  return sessionError ? 1 : undefined
+}
 
 function fallback(part: ToolPart) {
   const state = part.state
@@ -568,6 +589,7 @@ export const RunCommand = cmd({
             }
           }
         }
+        return error
       }
 
       // Validate agent if specified
@@ -640,30 +662,39 @@ export const RunCommand = cmd({
       }
       await share(sdk, sessionID)
 
-      loop().catch((e) => {
+      // Drain the SSE event stream in the background; capture the promise so we
+      // can await it after the request resolves instead of letting the instance
+      // be disposed mid-drain (which drops trailing JSON/text output).
+      const drained = loop().catch((e) => {
         console.error(e)
-        process.exit(1)
+        process.exitCode = 1
+        return undefined
       })
 
-      if (args.command) {
-        await sdk.session.command({
-          sessionID,
-          agent: agentName,
-          model: args.model,
-          command: args.command,
-          arguments: message,
-          variant: args.variant,
-        })
-      } else {
-        const model = args.model ? Provider.parseModel(args.model) : undefined
-        await sdk.session.prompt({
-          sessionID,
-          agent: agentName,
-          model,
-          variant: args.variant,
-          parts: [...files, { type: "text", text: message }],
-        })
-      }
+      const result = args.command
+        ? await sdk.session.command({
+            sessionID,
+            agent: agentName,
+            model: args.model,
+            command: args.command,
+            arguments: message,
+            variant: args.variant,
+          })
+        : await sdk.session.prompt({
+            sessionID,
+            agent: agentName,
+            model: args.model ? Provider.parseModel(args.model) : undefined,
+            variant: args.variant,
+            parts: [...files, { type: "text", text: message }],
+          })
+
+      // Surface a shaped request error: in-turn errors arrive on the SSE bus,
+      // but a request rejected before the turn ran (e.g. unknown command/model)
+      // only shows up here.
+      if (result.error && !emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+
+      const exitCode = await finalizeRun(drained, result)
+      if (exitCode) process.exitCode = exitCode
     }
 
     if (args.attach) {

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -6,6 +6,7 @@ import { cmd } from "./cmd"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { bootstrap } from "../bootstrap"
 import { EOL } from "os"
+import { setTimeout as delay } from "node:timers/promises"
 import { Filesystem } from "../../util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { Server } from "../../server/server"
@@ -72,19 +73,28 @@ function formatRunError(error: unknown) {
   return FormatError(error) ?? FormatUnknownError(error)
 }
 
+// Idle arrives right after the turn completes, so this only trips on a broken
+// stream (e.g. a dropped/reconnected --attach SSE that missed the idle event),
+// where any lost events are unrecoverable regardless of how long we wait.
+const DRAIN_FALLBACK_MS = 10_000
+
 // Decide the exit code for a non-interactive `run` after the prompt/command
 // request resolves. A shaped SDK error (`result.error`) means the request was
 // rejected before a turn ran, so no `session.status: idle` event will arrive
 // and awaiting `drained` would hang forever (see #27371) — fail fast instead.
 // Otherwise a turn ran: wait for the event stream to finish draining trailing
 // JSON/text and the idle event (so output is not lost when the instance is torn
-// down, see #26955), then fail if it accumulated a session error.
+// down, see #26955), then fail if it accumulated a session error. The drain is
+// bounded so a missed idle event on a live stream can't hang an otherwise
+// finished run; a fallback timeout resolves as a clean (exit-zero) run, same as
+// a drain that yielded no error.
 export async function finalizeRun(
   drained: Promise<string | undefined>,
   result: { error?: unknown },
+  drainFallbackMs = DRAIN_FALLBACK_MS,
 ): Promise<1 | undefined> {
   if (result.error) return 1
-  const sessionError = await drained
+  const sessionError = await Promise.race([drained, delay(drainFallbackMs, undefined, { ref: false })])
   return sessionError ? 1 : undefined
 }
 

--- a/packages/opencode/test/cli/run-finalize.test.ts
+++ b/packages/opencode/test/cli/run-finalize.test.ts
@@ -26,4 +26,12 @@ describe("CLI run finalizeRun (#26955/#27371: drain + exit code)", () => {
     const neverDrains = new Promise<string | undefined>(() => {})
     expect(await finalizeRun(neverDrains, { error: { name: "NotFoundError" } })).toBe(1)
   })
+
+  test("a successful request whose drain misses the idle event is bounded (no hang)", async () => {
+    // A live stream (e.g. a dropped/reconnected --attach SSE) can miss the idle
+    // event so the drain never resolves even though the turn finished. The
+    // bounded fallback must resolve as a clean run instead of awaiting forever.
+    const neverDrains = new Promise<string | undefined>(() => {})
+    expect(await finalizeRun(neverDrains, {}, 30)).toBeUndefined()
+  })
 })

--- a/packages/opencode/test/cli/run-finalize.test.ts
+++ b/packages/opencode/test/cli/run-finalize.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { finalizeRun } from "@/cli/cmd/run"
+
+// R3.6 (#26955 + #27371): a non-interactive `run` must wait for the SSE event
+// stream to finish draining (so trailing JSON/text is not dropped when the
+// instance is disposed) and report a non-zero exit code on failure — without
+// hanging when the request was rejected before a turn ever ran.
+describe("CLI run finalizeRun (#26955/#27371: drain + exit code)", () => {
+  test("a clean run drains the loop and exits zero", async () => {
+    expect(await finalizeRun(Promise.resolve(undefined), {})).toBeUndefined()
+  })
+
+  test("a session error accumulated by the drained loop exits non-zero", async () => {
+    expect(await finalizeRun(Promise.resolve("provider request failed"), {})).toBe(1)
+  })
+
+  test("a shaped SDK request error exits non-zero", async () => {
+    expect(await finalizeRun(Promise.resolve(undefined), { error: { name: "BadRequest" } })).toBe(1)
+  })
+
+  test("a request error fails fast without awaiting the drain loop (no hang)", async () => {
+    // A request rejected before a turn ran never produces a `session.status:
+    // idle` event, so the drain loop never resolves. finalizeRun must short
+    // circuit on `result.error` instead of awaiting it — otherwise this test
+    // would hang and time out.
+    const neverDrains = new Promise<string | undefined>(() => {})
+    expect(await finalizeRun(neverDrains, { error: { name: "NotFoundError" } })).toBe(1)
+  })
+})

--- a/packages/opencode/test/cli/run-finalize.test.ts
+++ b/packages/opencode/test/cli/run-finalize.test.ts
@@ -1,37 +1,57 @@
 import { describe, expect, test } from "bun:test"
-import { finalizeRun } from "@/cli/cmd/run"
+import { runExitCode, drainTrailingOutput } from "@/cli/cmd/run"
 
-// R3.6 (#26955 + #27371): a non-interactive `run` must wait for the SSE event
-// stream to finish draining (so trailing JSON/text is not dropped when the
-// instance is disposed) and report a non-zero exit code on failure — without
-// hanging when the request was rejected before a turn ever ran.
-describe("CLI run finalizeRun (#26955/#27371: drain + exit code)", () => {
-  test("a clean run drains the loop and exits zero", async () => {
-    expect(await finalizeRun(Promise.resolve(undefined), {})).toBeUndefined()
+// R3.6 (#26955 + #27371): a non-interactive `run` must flush trailing output
+// before teardown and report a non-zero exit code on a TERMINAL failure, without
+// hanging when the drain stream stalls.
+describe("CLI run exit code (#26955/#27371)", () => {
+  test("a clean run exits zero", () => {
+    expect(runExitCode({})).toBeUndefined()
+    expect(runExitCode({ data: { info: {} } })).toBeUndefined()
   })
 
-  test("a session error accumulated by the drained loop exits non-zero", async () => {
-    expect(await finalizeRun(Promise.resolve("provider request failed"), {})).toBe(1)
+  test("a shaped SDK request error (rejected before a turn ran) exits non-zero", () => {
+    expect(runExitCode({ error: { name: "BadRequest" } })).toBe(1)
   })
 
-  test("a shaped SDK request error exits non-zero", async () => {
-    expect(await finalizeRun(Promise.resolve(undefined), { error: { name: "BadRequest" } })).toBe(1)
+  test("a terminal error on the final assistant message exits non-zero", () => {
+    expect(runExitCode({ data: { info: { error: { name: "ProviderError" } } } })).toBe(1)
   })
 
-  test("a request error fails fast without awaiting the drain loop (no hang)", async () => {
-    // A request rejected before a turn ran never produces a `session.status:
-    // idle` event, so the drain loop never resolves. finalizeRun must short
-    // circuit on `result.error` instead of awaiting it — otherwise this test
-    // would hang and time out.
-    const neverDrains = new Promise<string | undefined>(() => {})
-    expect(await finalizeRun(neverDrains, { error: { name: "NotFoundError" } })).toBe(1)
+  test("a recovered intermediate error (final message has no error) exits zero", () => {
+    // A ContextOverflowError that auto-compacts and then continues leaves the
+    // final assistant message without an error — the run succeeded, so the
+    // intermediate session.error must not fail the exit code.
+    expect(runExitCode({ data: { info: {} } })).toBeUndefined()
+  })
+})
+
+describe("CLI run drain (#26955)", () => {
+  test("returns as soon as the stream reaches idle", async () => {
+    let aborted = false
+    await drainTrailingOutput(Promise.resolve(), () => performance.now(), {
+      abort: () => {
+        aborted = true
+      },
+    })
+    expect(aborted).toBe(false)
   })
 
-  test("a successful request whose drain misses the idle event is bounded (no hang)", async () => {
-    // A live stream (e.g. a dropped/reconnected --attach SSE) can miss the idle
-    // event so the drain never resolves even though the turn finished. The
-    // bounded fallback must resolve as a clean run instead of awaiting forever.
-    const neverDrains = new Promise<string | undefined>(() => {})
-    expect(await finalizeRun(neverDrains, {}, 30)).toBeUndefined()
+  test("aborts a stalled stream instead of hanging", async () => {
+    // The drain never resolves and no events arrive (the last event is ancient),
+    // so the watchdog must abort the subscription rather than wait forever.
+    let aborted = false
+    const neverDrains = new Promise<void>(() => {})
+    await drainTrailingOutput(
+      neverDrains,
+      () => 0,
+      {
+        abort: () => {
+          aborted = true
+        },
+      },
+      20,
+    )
+    expect(aborted).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Non-interactive `opencode run` fired the SSE-draining `loop()` fire-and-forget and returned as soon as the prompt/command HTTP call resolved (`run.ts`). `bootstrap()` then disposes the instance in its `finally`, so trailing JSON/text events could be dropped before they were written, and a failed run always exited `0`.

Final design in `packages/opencode/src/cli/cmd/run.ts`:
- **Exit code from the terminal result.** `runExitCode(result)` fails (exit 1) only on a shaped request error (`result.error`, e.g. unknown command/model rejected before a turn ran) or a terminal error on the final assistant message (`result.data.info.error`). Intermediate `session.error` events are ignored, so a run that recovers (e.g. `ContextOverflowError` → auto-compact → continue) exits `0`.
- **Drain trailing output before teardown.** `loop()` is captured (not fire-and-forget) and awaited via `drainTrailingOutput()`, so trailing JSON/text flushes before the in-process instance is disposed.
- **Inactivity watchdog, not a fixed timeout.** The drain waits for the idle event but aborts only once *this session's* part output stops arriving for `DRAIN_INACTIVITY_MS`. A slow-but-healthy stream drains fully; a dropped/missed-idle stream can't hang. Heartbeats and other-session events do not count as progress.
- **Cancellable subscription.** An `AbortController` signal is passed to `event.subscribe`; after the request resolves the subscription is aborted so the process can exit (the abort surfaces in `loop()`'s catch as a clean stop). A pre-turn request error skips the drain entirely (no turn ran → no idle).

## Why

Two real bugs on the non-interactive `run` path: (1) data loss — trailing JSON/text output dropped when the in-process instance is disposed before the fire-and-forget loop drains; (2) scripting/CI correctness — a failed run reported exit code `0`.

## Related Issue

No PawWork issue. Ports two upstream fixes for the same seam:
- anomalyco/opencode#26955 — *Fix run JSON output draining*. Thanks @kitlangton.
- anomalyco/opencode#27371 — *fix(run): restore non-interactive exit behavior* (exit code on failure + avoid waiting indefinitely for idle). Thanks @rekram1-node.

`dev` shares no ancestor with `upstream/dev`, so this is a re-implementation adapted to PawWork's shape (parameterless closure `loop()`, `{ info, parts }` prompt response, `bootstrap` `finally`-dispose), not a cherry-pick. Upstream landed #27371 by reverting #26955's `await` to avoid hanging on the never-idle path; PawWork keeps the drain (needed because of the immediate `Instance.dispose()`) and makes it non-hanging via the terminal-result exit code + inactivity watchdog + abort.

## Human Review Status

Pending

## Review Focus

- `runExitCode`: exit status is the *terminal* outcome (`result.error` or `result.data.info.error`), never an intermediate `session.error` — recovered runs must exit `0`.
- The drain watchdog: only `message.part.updated` for the run's own session bumps `lastEventAt`, so heartbeats/other-session events can't keep a stalled stream alive; a healthy slow stream is never cut short.
- `event.subscribe(undefined, { signal })` — the 2-arg signature passes the abort signal through the options (2nd) arg (the 1-arg form is the unrelated global sync-event subscribe).

## Risk Notes

Scope limited to the non-interactive `run`/`command` SSE branch in `run.ts`. No UI, no platform/packaging surface, no generated files, no dependency changes. The default in-process `run` path (in-memory event stream) is unaffected by all the `--attach` edge handling: idle is delivered promptly, so the drain returns immediately and the watchdog never fires.

Known residual (out of scope here): on `run --attach`, if the SSE client is inside its retry backoff sleep when the drain aborts, the process can stay alive until that sleep resolves (up to the SDK's max retry delay) — a delayed exit, not a hang, and the exit code is still correct. A clean fix needs an abort-aware/unref'd SSE sleep at the SDK (`@opencode-ai/sdk/v2`) layer, which is generated/third-party code outside this change's scope.

This change was reviewed with `codex review` across several rounds; all in-scope findings (missed-idle hang, pre-turn-error hang, recovered-error misclassification, fixed-timeout truncation, heartbeat watchdog reset) were addressed, and the residual above is recorded.

## How To Verify

Per local policy, tests/typecheck run in PR CI rather than locally.

```text
Added packages/opencode/test/cli/run-finalize.test.ts:
  runExitCode:
    - clean run ({} and {data:{info:{}}}) -> undefined (exit 0)
    - shaped request error -> 1
    - terminal final-message error -> 1
    - recovered intermediate error (final message no error) -> exit 0
  drainTrailingOutput:
    - resolves immediately when the stream reaches idle (no abort)
    - aborts a stalled stream (never-resolving drain, ancient lastEventAt) instead of hanging
Red->green: runExitCode/drainTrailingOutput are newly exported.
CI: bun test (packages/opencode) + bun run typecheck.
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. (`harness`, applied by the labeler bot.)
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. (`P2`, applied by the priority-triage bot.)
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.