### PR TITLE
fix(session): clamp negative token counts in getUsage

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -430,7 +430,10 @@ export function plan(input: { slug: string; time: { created: number } }) {
 export const getUsage = (input: { model: Provider.Model; usage: LanguageModelUsage; metadata?: ProviderMetadata }) => {
   const safe = (value: number) => {
     if (!Number.isFinite(value)) return 0
-    return value
+    // Clamp negatives: provider accounting can make a subtraction underflow (reasoning
+    // tokens exceeding output, or cache tokens exceeding input). Negative usage understates
+    // context and can delay auto-compaction.
+    return Math.max(0, value)
   }
   const inputTokens = safe(input.usage.inputTokens ?? 0)
   const outputTokens = safe(input.usage.outputTokens ?? 0)

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -2020,6 +2020,31 @@ describe("SessionNs.getUsage", () => {
     expect(result.tokens.total).toBe(1500)
   })
 
+  test("clamps negative output to zero when reasoning exceeds output tokens", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    const result = SessionNs.getUsage({
+      model,
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 100,
+        totalTokens: 1100,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: 150,
+        },
+      },
+    })
+
+    // output = outputTokens - reasoningTokens = 100 - 150 underflows; clamp to 0, not -50
+    expect(result.tokens.output).toBe(0)
+    expect(result.tokens.reasoning).toBe(150)
+  })
+
   test("does not double count reasoning tokens in cost", () => {
     const model = createModel({
       context: 100_000,


### PR DESCRIPTION
## Problem

`Session.getUsage` derives token buckets with subtractions that can underflow on real provider usage:

- `output: safe(outputTokens - reasoningTokens)` — some providers report `reasoningTokens` **not** included in `outputTokens`, so `output` goes negative.
- `adjustedInputTokens = safe(inputTokens - cacheReadInputTokens - cacheWriteInputTokens)` — cache tokens can exceed the normalized input count.

`safe()` only guarded `NaN`/`Infinity` and returned the raw value, so these underflows produced **negative token counts**. They flow into `context-usage` totals, understate how full the context is, and can delay auto-compaction.

## Fix

Clamp `safe()` to non-negative: `return Math.max(0, value)`. One line; it already canonicalizes every token bucket and the cost.

## Test

`test/session/compaction.test.ts` (`describe("SessionNs.getUsage")`): a usage with `outputTokens: 100` and `reasoningTokens: 150` now yields `tokens.output === 0` instead of `-50`. Verified red→green (reverting the clamp makes it `-50`). Full file green (50 pass); `bun run typecheck` clean.

## Credit

Mirrors anomalyco/opencode#26620 ([`c6e6bdf59f`](https://github.com/anomalyco/opencode/commit/c6e6bdf59f)). The upstream commit's accompanying schema loosening (`NonNegativeInt` → `Schema.Finite` on stored token fields) is non-applicable here — PawWork's message token schema already uses permissive `z.number()`, so negative values never failed to parse; the write-side clamp in `getUsage` is the applicable part. Thanks @kitlangton.