### PR TITLE
feat(app): open the slash picker anywhere and insert inline skill chips

### DIFF
--- a/packages/app/e2e/prompt/prompt-slash-open.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-open.spec.ts
@@ -74,6 +74,50 @@ test("home composer shows slash commands after a bare slash", async ({ page, pro
   await expectHoverPaint(command)
 })
 
+// Seed a project-scoped skill (.agents/skills/<name>/SKILL.md) so the mid-text
+// picker has a skill to offer in a clean CI env, not only where global skills
+// happen to exist. Skills are always inline-eligible (empty hints).
+async function seedProjectSkill(directory: string, name: string, description: string) {
+  const skillDir = join(directory, ".agents", "skills", name)
+  await mkdir(skillDir, { recursive: true })
+  await writeFile(
+    join(skillDir, "SKILL.md"),
+    ["---", `name: ${name}`, `description: ${description}`, "---", "", "Summarize the conversation into three bullets."].join(
+      "\n",
+    ),
+  )
+}
+
+test("slash mid-sentence opens the picker and inserts an inline skill chip", async ({ page, project }) => {
+  await project.open({
+    setup: async (directory) => {
+      await seedProjectSkill(directory, "summarize", "Summarize the thread")
+    },
+  })
+
+  await page.locator(promptSelector).click()
+  await page.keyboard.type("please ")
+  await page.keyboard.type("/summarize")
+
+  const popover = page.locator('[data-component="prompt-slash-popover"]')
+  await expectOnTop(popover)
+
+  // Mid-text restricts the picker to skills + simple commands; the seeded skill
+  // shows, action builtins like file.open do not.
+  const command = page.locator('[data-slash-id="custom.skill.summarize"]')
+  await expect(command).toBeVisible({ timeout: 30_000 })
+  await expect(page.locator('[data-slash-id="file.open"]')).toHaveCount(0)
+
+  // Click the specific row (the picker may also list ambient global skills).
+  await command.click()
+
+  // Selection replaces the typed "/summarize" with a position-independent chip.
+  const chip = page.locator('[data-type="skill"][data-name="summarize"]')
+  await expect(chip).toBeVisible()
+  await expect(chip).toContainText("/summarize")
+  await expect(popover).toHaveCount(0)
+})
+
 test("@mention file suggestions stay visible above the composer", async ({ page, project }) => {
   await project.open({
     setup: async (directory) => {

--- a/packages/app/e2e/prompt/prompt-slash-open.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-open.spec.ts
@@ -112,9 +112,12 @@ test("slash mid-sentence opens the picker and inserts an inline skill chip", asy
   await command.click()
 
   // Selection replaces the typed "/summarize" with a position-independent chip.
+  // Assert the label sub-element (not the whole chip, which also contains the
+  // icon SVG) to catch regressions that re-add the leading "/".
   const chip = page.locator('[data-type="skill"][data-name="summarize"]')
   await expect(chip).toBeVisible()
-  await expect(chip).toContainText("summarize")
+  const label = chip.locator("[data-cmd-label]")
+  await expect(label).toHaveText("summarize")
   await expect(popover).toHaveCount(0)
 })
 

--- a/packages/app/e2e/prompt/prompt-slash-open.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-open.spec.ts
@@ -114,7 +114,7 @@ test("slash mid-sentence opens the picker and inserts an inline skill chip", asy
   // Selection replaces the typed "/summarize" with a position-independent chip.
   const chip = page.locator('[data-type="skill"][data-name="summarize"]')
   await expect(chip).toBeVisible()
-  await expect(chip).toContainText("/summarize")
+  await expect(chip).toContainText("summarize")
   await expect(popover).toHaveCount(0)
 })
 

--- a/packages/app/e2e/snap/message-skill-inline.snap.ts
+++ b/packages/app/e2e/snap/message-skill-inline.snap.ts
@@ -1,0 +1,73 @@
+import { test } from "../fixtures"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
+
+// Seed a user message that carries a structured skill part alongside prose, the
+// shape buildRequestParts produces for an inline skill chip. The bubble must
+// render the "/name" span as a skill chip (glyph + brand-accent token) inside
+// the prose, NOT suppress the body the way the leading commandInvocation does.
+// noReply keeps the snap fast and independent of a fake-LLM round-trip.
+async function seedSkillMessage(
+  sdk: ReturnType<typeof import("../utils").createSdk>,
+  directory: string,
+  sessionTitle: string,
+  text: string,
+  name: string,
+): Promise<string> {
+  const session = await sdk.session.create({ directory, title: sessionTitle })
+  const sessionID = session.data?.id
+  if (!sessionID) throw new Error(`session.create returned no id for "${sessionTitle}"`)
+
+  const token = `/${name}`
+  const start = text.indexOf(token)
+  if (start < 0) throw new Error(`"${token}" not found in seed text for "${sessionTitle}"`)
+  const end = start + token.length
+
+  await sdk.session.prompt({
+    sessionID,
+    directory,
+    noReply: true,
+    parts: [
+      { type: "text", text },
+      { type: "skill", name, source: { value: token, start, end } },
+    ],
+  })
+
+  return sessionID
+}
+
+async function captureBubble(page: import("@playwright/test").Page, name: string): Promise<Shot> {
+  const bubble = page.locator('[data-component="user-message"]').last()
+  await bubble.waitFor({ state: "visible", timeout: 30_000 })
+  await page.locator('[data-highlight="skill"]').last().waitFor({ state: "visible", timeout: 30_000 })
+  return { name, buf: await bubble.screenshot() }
+}
+
+test("message-skill-inline", async ({ page, project }) => {
+  test.setTimeout(180_000)
+
+  await project.open()
+
+  const scenarios = [
+    { name: "leading", text: "/summarize the open threads before standup", skill: "summarize" },
+    { name: "mid-sentence", text: "Please /summarize this thread for me", skill: "summarize" },
+    {
+      name: "with-prose",
+      text: "Take the design notes above and /summarize them into three bullets I can paste into the release notes",
+      skill: "summarize",
+    },
+  ]
+
+  const shots: Shot[] = []
+
+  for (const sc of scenarios) {
+    const sessionID = await seedSkillMessage(project.sdk, project.directory, `snap ${sc.name}`, sc.text, sc.skill)
+    await project.gotoSession(sessionID)
+    shots.push(await captureBubble(page, sc.name))
+  }
+
+  const out = snapOutputPath("message-skill-inline")
+  await composeGrid(shots, out)
+  process.stdout.write(`\n[snap] message-skill-inline grid -> ${out}\n\n`)
+})

--- a/packages/app/e2e/snap/message-skill-inline.snap.ts
+++ b/packages/app/e2e/snap/message-skill-inline.snap.ts
@@ -5,8 +5,8 @@ test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
 
 // Seed a user message that carries a structured skill part alongside prose, the
 // shape buildRequestParts produces for an inline skill chip. The bubble must
-// render the "/name" span as a skill chip (glyph + brand-accent token) inside
-// the prose, NOT suppress the body the way the leading commandInvocation does.
+// render the skill as a chip (glyph + bare name in brand accent) inside the
+// prose, NOT suppress the body the way the leading commandInvocation does.
 // noReply keeps the snap fast and independent of a fake-LLM round-trip.
 async function seedSkillMessage(
   sdk: ReturnType<typeof import("../utils").createSdk>,

--- a/packages/app/src/components/prompt-input/build-request-parts.test.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.test.ts
@@ -50,6 +50,43 @@ describe("buildRequestParts", () => {
     expect(result.optimisticParts.every((part) => part.sessionID === "ses_1" && part.messageID === "msg_1")).toBe(true)
   })
 
+  test("emits a SkillPartInput and a matching optimistic skill part", () => {
+    const prompt: Prompt = [
+      { type: "text", content: "please ", start: 0, end: 7 },
+      { type: "skill", name: "summarize", source: "skill", content: "/summarize", start: 7, end: 17 },
+    ]
+
+    const result = buildRequestParts({
+      prompt,
+      context: [],
+      images: [],
+      text: "please /summarize",
+      messageID: "msg_skill",
+      sessionID: "ses_skill",
+      sessionDirectory: "/repo",
+    })
+
+    const skill = result.requestParts.find((part) => part.type === "skill")
+    expect(skill).toBeDefined()
+    if (skill?.type === "skill") {
+      expect(skill.name).toBe("summarize")
+      // The "/summarize" span is tagged so the bubble can render it as a chip.
+      expect(skill.source).toEqual({ value: "/summarize", start: 7, end: 17 })
+    }
+
+    // The optimistic part must mirror the persisted SkillPart so the bubble
+    // does not flicker — and NOT degrade into an agent part via the fallthrough.
+    const optimisticSkill = result.optimisticParts.find((part) => part.type === "skill")
+    expect(optimisticSkill).toBeDefined()
+    if (optimisticSkill?.type === "skill") {
+      expect(optimisticSkill.name).toBe("summarize")
+      expect(optimisticSkill.sessionID).toBe("ses_skill")
+      expect(optimisticSkill.messageID).toBe("msg_skill")
+      expect(optimisticSkill.source).toEqual({ value: "/summarize", start: 7, end: 17 })
+    }
+    expect(result.optimisticParts.some((part) => part.type === "agent")).toBe(false)
+  })
+
   test("keeps multiple uploaded attachments in order", () => {
     const result = buildRequestParts({
       prompt: [{ type: "text", content: "check these", start: 0, end: 11 }],

--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -1,15 +1,21 @@
 import { getFilename } from "@opencode-ai/util/path"
-import { type AgentPartInput, type FilePartInput, type Part, type TextPartInput } from "@opencode-ai/sdk/v2/client"
+import {
+  type AgentPartInput,
+  type FilePartInput,
+  type Part,
+  type SkillPartInput,
+  type TextPartInput,
+} from "@opencode-ai/sdk/v2/client"
 import type { FileSelection } from "@/context/file"
 import { encodeFilePath } from "@/context/file/path"
-import type { AgentPart, FileAttachmentPart, ImageAttachmentPart, Prompt } from "@/context/prompt"
+import type { AgentPart, FileAttachmentPart, ImageAttachmentPart, Prompt, SkillAttachmentPart } from "@/context/prompt"
 import { Identifier } from "@/utils/id"
 import { createCommentMetadata, formatCommentNote } from "@/utils/comment-note"
 import { toAbsoluteFilePath } from "./path-canonical"
 import type { ResolvedMention } from "./mention-metadata"
 import { resolveCommentMentions } from "./mention-metadata"
 
-type PromptRequestPart = (TextPartInput | FilePartInput | AgentPartInput) & { id: string }
+type PromptRequestPart = (TextPartInput | FilePartInput | AgentPartInput | SkillPartInput) & { id: string }
 
 type ContextFile = {
   key: string
@@ -44,6 +50,7 @@ const fileURL = (path: string, selection?: FileSelection) => {
 
 const isFileAttachment = (part: Prompt[number]): part is FileAttachmentPart => part.type === "file"
 const isAgentAttachment = (part: Prompt[number]): part is AgentPart => part.type === "agent"
+const isSkillAttachment = (part: Prompt[number]): part is SkillAttachmentPart => part.type === "skill"
 
 const toOptimisticPart = (part: PromptRequestPart, sessionID: string, messageID: string): Part => {
   if (part.type === "text") {
@@ -66,6 +73,19 @@ const toOptimisticPart = (part: PromptRequestPart, sessionID: string, messageID:
       mime: part.mime,
       filename: part.filename,
       url: part.url,
+      source: part.source,
+      sessionID,
+      messageID,
+    }
+  }
+  // Skill must be handled before the agent fallthrough: the optimistic chip has
+  // to match the server-persisted structured SkillPart so the bubble does not
+  // flicker when the real message arrives.
+  if (part.type === "skill") {
+    return {
+      id: part.id,
+      type: "skill",
+      name: part.name,
       source: part.source,
       sessionID,
       messageID,
@@ -115,6 +135,21 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
       id: Identifier.ascending("part"),
       type: "agent",
       name: attachment.name,
+      source: {
+        value: attachment.content,
+        start: attachment.start,
+        end: attachment.end,
+      },
+    } satisfies PromptRequestPart
+  })
+
+  const skills = input.prompt.filter(isSkillAttachment).map((attachment) => {
+    return {
+      id: Identifier.ascending("part"),
+      type: "skill",
+      name: attachment.name,
+      // source.{value,start,end} marks the "/name" span in the flattened text so
+      // the sent bubble can render it as a chip; the server expands the template.
       source: {
         value: attachment.content,
         start: attachment.start,
@@ -190,7 +225,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
     } satisfies PromptRequestPart
   })
 
-  requestParts.push(...files, ...context, ...agents, ...images)
+  requestParts.push(...files, ...context, ...agents, ...skills, ...images)
 
   return {
     requestParts,

--- a/packages/app/src/components/prompt-input/command-copy.ts
+++ b/packages/app/src/components/prompt-input/command-copy.ts
@@ -1,22 +1,18 @@
-// Scoped copy handler logic for command pills.
+// Scoped copy handler logic for command pills and skill chips.
 //
-// Browser default copy on a [data-cmd-mark] pill yields just the visible
-// textContent (the label `<name>`, no slash). The rest of the system —
-// Path C paste, command-line round-trip, cross-app paste — needs the slash
-// literal `/<name>` to recognise the command. The copy listener intercepts
-// when the selection touches any [data-cmd-mark] element and rewrites the
-// `text/plain` clipboard payload accordingly.
+// Browser default copy on a pill yields just the visible textContent (the bare
+// name, no slash). The rest of the system — Path C paste, command-line
+// round-trip, cross-app paste — needs the slash literal `/<name>` to recognise
+// the command. The copy listener intercepts when the selection touches any pill
+// and rewrites the `text/plain` clipboard payload accordingly.
 
-/**
- * Walk a Range's cloned fragment and produce the text/plain string that
- * substitutes every [data-cmd-mark] with `/<dataset.name>` and every <br>
- * with `\n`. Returns the rewritten string.
- */
+const PILL_SELECTOR = "[data-cmd-mark], [data-type='skill']"
+
 export function rewriteRangeForCommandCopy(range: Range): string {
   const fragment = range.cloneContents()
   const tmp = document.createElement("div")
   tmp.appendChild(fragment)
-  tmp.querySelectorAll("[data-cmd-mark]").forEach((el) => {
+  tmp.querySelectorAll(PILL_SELECTOR).forEach((el) => {
     const name = (el as HTMLElement).dataset.name ?? ""
     el.replaceWith(document.createTextNode(`/${name}`))
   })
@@ -24,11 +20,6 @@ export function rewriteRangeForCommandCopy(range: Range): string {
   return tmp.textContent ?? ""
 }
 
-/**
- * Whether the current selection intersects any [data-cmd-mark] descendant of
- * `editor`. The listener should only intercept the copy event in this case;
- * otherwise the browser default applies (untouched by the command-copy logic).
- */
 export function selectionTouchesCommandMark(editor: HTMLElement): boolean {
   const sel = window.getSelection()
   if (!sel || sel.rangeCount === 0) return false
@@ -36,9 +27,9 @@ export function selectionTouchesCommandMark(editor: HTMLElement): boolean {
   if (!editor.contains(range.startContainer) && !editor.contains(range.endContainer)) {
     return false
   }
-  const marks = editor.querySelectorAll("[data-cmd-mark]")
-  for (const mark of marks) {
-    if (range.intersectsNode(mark)) return true
+  const pills = editor.querySelectorAll(PILL_SELECTOR)
+  for (const pill of pills) {
+    if (range.intersectsNode(pill)) return true
   }
   return false
 }

--- a/packages/app/src/components/prompt-input/command-pill.css
+++ b/packages/app/src/components/prompt-input/command-pill.css
@@ -5,7 +5,8 @@
  * packages/ui/src/components/command-icon.css apply automatically.
  */
 
-[data-cmd-mark] {
+[data-cmd-mark],
+[data-type="skill"] {
   display: inline-flex;
   align-items: baseline;
   gap: 4px;
@@ -15,7 +16,8 @@
   cursor: default;
 }
 
-[data-cmd-mark] [data-cmd-label] {
+[data-cmd-mark] [data-cmd-label],
+[data-type="skill"] [data-cmd-label] {
   color: inherit;
   font-weight: var(--font-weight-body);
 }

--- a/packages/app/src/components/prompt-input/editor-dom.ts
+++ b/packages/app/src/components/prompt-input/editor-dom.ts
@@ -29,9 +29,12 @@ export function createTextFragment(content: string): DocumentFragment {
 
 export function getNodeLength(node: Node): number {
   if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR") return 1
-  // Slash-command pill: logical length is 1 (the slash trigger) + name length.
-  // This must run before the textContent fallback because textContent only holds the name (no slash).
-  if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.cmdMark === "true") {
+  // Slash-command / skill pill: logical length is 1 (the slash trigger) + name length.
+  // This must run before the textContent fallback because textContent only holds the bare name.
+  if (
+    node.nodeType === Node.ELEMENT_NODE &&
+    ((node as HTMLElement).dataset.cmdMark === "true" || (node as HTMLElement).dataset.type === "skill")
+  ) {
     return 1 + ((node as HTMLElement).dataset.name ?? "").length
   }
   return (node.textContent ?? "").replace(/\u200B/g, "").length
@@ -40,11 +43,13 @@ export function getNodeLength(node: Node): number {
 export function getTextLength(node: Node): number {
   if (node.nodeType === Node.TEXT_NODE) return (node.textContent ?? "").replace(/\u200B/g, "").length
   if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR") return 1
-  // Command pill: logical length is "/<name>" (1 + name.length), NOT the visible
-  // label-only textContent which would be name.length. getCursorPosition feeds
-  // its cloned-range fragment through this function, so any data-cmd-mark inside
-  // the fragment must report its logical length or caret math goes off by one.
-  if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.cmdMark === "true") {
+  // Command / skill pill: logical length is "/<name>" (1 + name.length), NOT the
+  // visible bare-name textContent. getCursorPosition feeds its cloned-range
+  // fragment through this function, so pills must report logical length.
+  if (
+    node.nodeType === Node.ELEMENT_NODE &&
+    ((node as HTMLElement).dataset.cmdMark === "true" || (node as HTMLElement).dataset.type === "skill")
+  ) {
     return 1 + ((node as HTMLElement).dataset.name ?? "").length
   }
   let length = 0

--- a/packages/app/src/components/prompt-input/editor-dom.ts
+++ b/packages/app/src/components/prompt-input/editor-dom.ts
@@ -75,6 +75,7 @@ export function setCursorPosition(parent: HTMLElement, position: number) {
       node.nodeType === Node.ELEMENT_NODE &&
       ((node as HTMLElement).dataset.type === "file" ||
         (node as HTMLElement).dataset.type === "agent" ||
+        (node as HTMLElement).dataset.type === "skill" ||
         (node as HTMLElement).dataset.cmdMark === "true")
     const isBreak = node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR"
 
@@ -142,6 +143,7 @@ export function setRangeEdge(parent: HTMLElement, range: Range, edge: "start" | 
       node.nodeType === Node.ELEMENT_NODE &&
       ((node as HTMLElement).dataset.type === "file" ||
         (node as HTMLElement).dataset.type === "agent" ||
+        (node as HTMLElement).dataset.type === "skill" ||
         (node as HTMLElement).dataset.cmdMark === "true")
     const isBreak = node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR"
 

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -34,6 +34,13 @@ import type { PromptStore } from "./store-types"
 
 const NON_EMPTY_TEXT = /[^\s\u200B]/
 
+// Position-independent slash trigger. Group 1 is the consuming boundary (start,
+// whitespace, or a CJK script char) so the picker opens mid-sentence; group 2 is
+// the query. The boundary set deliberately excludes ASCII word chars and `.`/`:`,
+// and the query class stops at `/ \ :`, so paths/URLs/fractions (foo/bar, http://,
+// 2/3) never trigger. `slashOffset = match.index + match[1].length`.
+const SLASH_TRIGGER = /(^|[\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])\/([^\s\/\\:]*)$/u
+
 export interface EditorInputDeps {
   store: PromptStore
   setStore: SetStoreFunction<PromptStore>
@@ -282,14 +289,16 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     const shellMode = store.mode === "shell"
 
     if (!shellMode) {
-      const atMatch = rawText.substring(0, cursorPosition).match(/@(\S*)$/)
-      const slashMatch = rawText.match(/^\/(\S*)$/)
+      const beforeCursor = rawText.substring(0, cursorPosition)
+      const atMatch = beforeCursor.match(/@(\S*)$/)
+      const slashMatch = beforeCursor.match(SLASH_TRIGGER)
 
       if (atMatch) {
         popovers().atOnInput(atMatch[1])
         setStore("popover", "at")
       } else if (slashMatch) {
-        popovers().slashOnInput(slashMatch[1])
+        const slashOffset = (slashMatch.index ?? 0) + slashMatch[1].length
+        popovers().slashOnInput(slashMatch[2] ?? "", slashOffset > 0)
         setStore("popover", "slash")
       } else {
         closePopover()

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -332,20 +332,30 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     const range = selection.getRangeAt(0)
     if (!editor.contains(range.startContainer)) return false
 
-    if (part.type === "file" || part.type === "agent") {
+    if (part.type === "file" || part.type === "agent" || part.type === "skill") {
       const cursorPosition = getCursorPosition(editor)
       const rawText = prompt
         .current()
         .map((p) => ("content" in p ? p.content : ""))
         .join("")
       const textBeforeCursor = rawText.substring(0, cursorPosition)
-      const atMatch = textBeforeCursor.match(/@(\S*)$/)
       const pill = createPill(part)
       const gap = document.createTextNode(" ")
 
-      if (atMatch) {
-        const start = atMatch.index ?? cursorPosition - atMatch[0].length
-        setRangeEdge(editor, range, "start", start)
+      // Replace the typed trigger token with the pill: "@query" for file/agent,
+      // "/query" for skill. For skill the SLASH_TRIGGER group 1 boundary char
+      // (space / CJK) is left in place — only the slash and query are replaced.
+      let replaceStart: number | undefined
+      if (part.type === "skill") {
+        const slashMatch = textBeforeCursor.match(SLASH_TRIGGER)
+        if (slashMatch) replaceStart = (slashMatch.index ?? 0) + slashMatch[1].length
+      } else {
+        const atMatch = textBeforeCursor.match(/@(\S*)$/)
+        if (atMatch) replaceStart = atMatch.index ?? cursorPosition - atMatch[0].length
+      }
+
+      if (replaceStart !== undefined) {
+        setRangeEdge(editor, range, "start", replaceStart)
         setRangeEdge(editor, range, "end", cursorPosition)
       }
 

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -15,6 +15,7 @@ import { usePortableDraft } from "./portable-draft"
 import { usePinnedDraft } from "./pinned-draft"
 import { buildSlashRegistry } from "./command-text-part"
 import { tryPathBConversion } from "./command-space-trigger"
+import { matchSlashTrigger } from "./slash-trigger"
 import { rewriteRangeForCommandCopy, selectionTouchesCommandMark } from "./command-copy"
 import {
   createTextFragment,
@@ -33,13 +34,6 @@ import type { PopoverControllers } from "./popover-controllers"
 import type { PromptStore } from "./store-types"
 
 const NON_EMPTY_TEXT = /[^\s\u200B]/
-
-// Position-independent slash trigger. Group 1 is the consuming boundary (start,
-// whitespace, or a CJK script char) so the picker opens mid-sentence; group 2 is
-// the query. The boundary set deliberately excludes ASCII word chars and `.`/`:`,
-// and the query class stops at `/ \ :`, so paths/URLs/fractions (foo/bar, http://,
-// 2/3) never trigger. `slashOffset = match.index + match[1].length`.
-const SLASH_TRIGGER = /(^|[\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])\/([^\s\/\\:]*)$/u
 
 export interface EditorInputDeps {
   store: PromptStore
@@ -291,14 +285,13 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
     if (!shellMode) {
       const beforeCursor = rawText.substring(0, cursorPosition)
       const atMatch = beforeCursor.match(/@(\S*)$/)
-      const slashMatch = beforeCursor.match(SLASH_TRIGGER)
+      const slashMatch = matchSlashTrigger(beforeCursor)
 
       if (atMatch) {
         popovers().atOnInput(atMatch[1])
         setStore("popover", "at")
       } else if (slashMatch) {
-        const slashOffset = (slashMatch.index ?? 0) + slashMatch[1].length
-        popovers().slashOnInput(slashMatch[2] ?? "", slashOffset > 0)
+        popovers().slashOnInput(slashMatch.query, slashMatch.offset > 0)
         setStore("popover", "slash")
       } else {
         closePopover()
@@ -347,8 +340,8 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
       // (space / CJK) is left in place — only the slash and query are replaced.
       let replaceStart: number | undefined
       if (part.type === "skill") {
-        const slashMatch = textBeforeCursor.match(SLASH_TRIGGER)
-        if (slashMatch) replaceStart = (slashMatch.index ?? 0) + slashMatch[1].length
+        const slashMatch = matchSlashTrigger(textBeforeCursor)
+        if (slashMatch) replaceStart = slashMatch.offset
       } else {
         const atMatch = textBeforeCursor.match(/@(\S*)$/)
         if (atMatch) replaceStart = atMatch.index ?? cursorPosition - atMatch[0].length

--- a/packages/app/src/components/prompt-input/editor-input.ts
+++ b/packages/app/src/components/prompt-input/editor-input.ts
@@ -286,11 +286,16 @@ export function createEditorInput(deps: EditorInputDeps): EditorInput {
       const beforeCursor = rawText.substring(0, cursorPosition)
       const atMatch = beforeCursor.match(/@(\S*)$/)
       const slashMatch = matchSlashTrigger(beforeCursor)
+      // When a leading marked command owns the turn (Path D / session.command),
+      // a "/" in its args must NOT open the skill picker: that submit path drops
+      // structured skill parts, so an inserted chip would silently vanish. The
+      // slash stays literal command-argument text instead.
+      const leadingCommand = rawParts[0]?.type === "text" && !!rawParts[0].command
 
       if (atMatch) {
         popovers().atOnInput(atMatch[1])
         setStore("popover", "at")
-      } else if (slashMatch) {
+      } else if (slashMatch && !leadingCommand) {
         popovers().slashOnInput(slashMatch.query, slashMatch.offset > 0)
         setStore("popover", "slash")
       } else {

--- a/packages/app/src/components/prompt-input/editor-serialize.test.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { createCommandMark, isNormalizedEditor, parseEditorToParts, renderPartsToEditor } from "./editor-serialize"
-import type { TextPart } from "@/context/prompt"
+import {
+  createCommandMark,
+  createPill,
+  isNormalizedEditor,
+  parseEditorToParts,
+  renderPartsToEditor,
+} from "./editor-serialize"
+import type { Prompt, SkillAttachmentPart, TextPart } from "@/context/prompt"
 
 // Helper: build a leading-command TextPart
 function makeCommandPart(name: string, tail: string): TextPart {
@@ -102,6 +108,74 @@ describe("renderPartsToEditor + parseEditorToParts round-trips", () => {
 
     const textPart = result[0] as TextPart
     expect(textPart.command).toEqual({ name: "brainstorming", source: "skill", icon: "command" })
+  })
+})
+
+describe("inline skill pill", () => {
+  function makeSkill(name: string, source: SkillAttachmentPart["source"] = "skill"): SkillAttachmentPart {
+    return { type: "skill", name, source, content: "/" + name, start: 0, end: 1 + name.length }
+  }
+
+  test("createPill skill carries data-type, data-name, data-source, contenteditable=false", () => {
+    const pill = createPill(makeSkill("summarize"))
+    expect(pill.dataset.type).toBe("skill")
+    expect(pill.dataset.name).toBe("summarize")
+    expect(pill.dataset.source).toBe("skill")
+    expect(pill.getAttribute("contenteditable")).toBe("false")
+  })
+
+  test("createPill skill keeps textContent === '/name' so caret math is unaffected", () => {
+    const pill = createPill(makeSkill("summarize"))
+    // The icon child adds no visible text; the label child carries "/summarize".
+    expect(pill.textContent).toBe("/summarize")
+    const icon = pill.querySelector("[data-cmd-icon]") as HTMLElement
+    expect(icon).not.toBeNull()
+    expect(icon.className).toBe("command-icon")
+    const label = pill.querySelector("[data-cmd-label]") as HTMLElement
+    expect(label.textContent).toBe("/summarize")
+  })
+
+  test("round-trips prose + skill + prose, recovering name/source/content", () => {
+    const parts: Prompt = [
+      { type: "text", content: "hello ", start: 0, end: 6 },
+      makeSkill("summarize"),
+      { type: "text", content: " world", start: 0, end: 6 },
+    ]
+    const editor = document.createElement("div")
+    renderPartsToEditor(editor, parts)
+    const result = parseEditorToParts(editor)
+
+    expect(result.map((p) => p.type)).toEqual(["text", "skill", "text"])
+    const skill = result[1] as SkillAttachmentPart
+    expect(skill.name).toBe("summarize")
+    expect(skill.source).toBe("skill")
+    expect(skill.content).toBe("/summarize")
+    // Position is recomputed against the flattened text "hello /summarize world".
+    expect(skill.start).toBe(6)
+    expect(skill.end).toBe(16)
+    expect((result[0] as TextPart).content).toBe("hello ")
+    expect((result[2] as TextPart).content).toBe(" world")
+  })
+
+  test("defaults missing data-source to skill on parse", () => {
+    const editor = document.createElement("div")
+    const pill = document.createElement("span")
+    pill.dataset.type = "skill"
+    pill.dataset.name = "summarize"
+    pill.textContent = "/summarize"
+    editor.appendChild(pill)
+    const result = parseEditorToParts(editor)
+    expect((result[0] as SkillAttachmentPart).source).toBe("skill")
+  })
+})
+
+describe("isNormalizedEditor skill-pill position independence", () => {
+  test("a skill pill mid-stream stays normalized (no rebuild)", () => {
+    const editor = document.createElement("div")
+    editor.appendChild(document.createTextNode("prefix "))
+    editor.appendChild(createPill({ type: "skill", name: "go", source: "skill", content: "/go", start: 0, end: 3 }))
+    editor.appendChild(document.createTextNode(" suffix"))
+    expect(isNormalizedEditor(editor)).toBe(true)
   })
 })
 

--- a/packages/app/src/components/prompt-input/editor-serialize.test.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.test.ts
@@ -124,15 +124,18 @@ describe("inline skill pill", () => {
     expect(pill.getAttribute("contenteditable")).toBe("false")
   })
 
-  test("createPill skill keeps textContent === '/name' so caret math is unaffected", () => {
+  test("createPill skill label shows bare name; caret math uses data-name", () => {
     const pill = createPill(makeSkill("summarize"))
-    // The icon child adds no visible text; the label child carries "/summarize".
-    expect(pill.textContent).toBe("/summarize")
+    // The label shows the bare name (no "/") since the glyph already signals
+    // "slash command". editor-dom computes logical length as 1 + data-name.length,
+    // not from textContent, so caret math stays correct.
+    expect(pill.textContent).toBe("summarize")
     const icon = pill.querySelector("[data-cmd-icon]") as HTMLElement
     expect(icon).not.toBeNull()
     expect(icon.className).toBe("command-icon")
     const label = pill.querySelector("[data-cmd-label]") as HTMLElement
-    expect(label.textContent).toBe("/summarize")
+    expect(label.textContent).toBe("summarize")
+    expect(pill.dataset.name).toBe("summarize")
   })
 
   test("round-trips prose + skill + prose, recovering name/source/content", () => {

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -42,10 +42,9 @@ export function createPill(part: FileAttachmentPart | AgentPart | SkillAttachmen
   if (part.type === "skill") {
     pill.setAttribute("data-name", part.name)
     pill.setAttribute("data-source", part.source)
-    // Skill chips carry the skill glyph. The label span keeps textContent ===
-    // "/name" so caret/length math in editor-dom is unaffected; the icon span
-    // contributes no text. The persisted SkillPart drops the source kind, so the
-    // sent bubble uses the same glyph — keep both surfaces consistent here.
+    // Skill chips carry the skill glyph + the bare name (no leading "/").
+    // editor-dom computes logical length as 1 + data-name.length, not from
+    // textContent, so caret math is unaffected by the stripped slash.
     const iconSpan = document.createElement("span")
     iconSpan.setAttribute("data-cmd-icon", "true")
     iconSpan.setAttribute("aria-hidden", "true")

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -1,7 +1,7 @@
 // DOM ↔ Parts bidirectional serialization for the contenteditable composer.
 // Pure functions, no Solid reactivity. Pairs with editor-dom (cursor primitives).
 
-import type { AgentPart, CommandSource, FileAttachmentPart, TextPart, Prompt } from "@/context/prompt"
+import type { AgentPart, CommandSource, FileAttachmentPart, SkillAttachmentPart, TextPart, Prompt } from "@/context/prompt"
 import { DEFAULT_PROMPT } from "@/context/prompt-equality"
 import { resolveCommandIconSvg } from "@opencode-ai/ui/command-icon"
 import { createTextFragment } from "./editor-dom"
@@ -34,12 +34,16 @@ export function createCommandMark(part: TextPart & { command: NonNullable<TextPa
   return outer
 }
 
-export function createPill(part: FileAttachmentPart | AgentPart): HTMLSpanElement {
+export function createPill(part: FileAttachmentPart | AgentPart | SkillAttachmentPart): HTMLSpanElement {
   const pill = document.createElement("span")
   pill.textContent = part.content
   pill.setAttribute("data-type", part.type)
   if (part.type === "file") pill.setAttribute("data-path", part.path)
   if (part.type === "agent") pill.setAttribute("data-name", part.name)
+  if (part.type === "skill") {
+    pill.setAttribute("data-name", part.name)
+    pill.setAttribute("data-source", part.source)
+  }
   pill.setAttribute("contenteditable", "false")
   pill.style.userSelect = "text"
   pill.style.cursor = "default"
@@ -62,6 +66,7 @@ export function isNormalizedEditor(editor: HTMLElement): boolean {
     const el = node as HTMLElement
     if (el.dataset.type === "file") return true
     if (el.dataset.type === "agent") return true
+    if (el.dataset.type === "skill") return true
     // Command pill is only valid at index 0 (spec invariant: at most one
     // marked TextPart, always the leading part). A mid-stream cmd-mark means
     // some path breached the invariant; returning false here forces the
@@ -93,7 +98,7 @@ export function renderPartsToEditor(editor: HTMLElement, parts: Prompt): void {
       editor.appendChild(createTextFragment(part.content))
       continue
     }
-    if (part.type === "file" || part.type === "agent") {
+    if (part.type === "file" || part.type === "agent" || part.type === "skill") {
       editor.appendChild(createPill(part))
     }
   }
@@ -143,6 +148,19 @@ export function parseEditorToParts(editor: HTMLElement): Prompt {
     position += content.length
   }
 
+  const pushSkill = (skill: HTMLElement) => {
+    const content = skill.textContent ?? ""
+    parts.push({
+      type: "skill",
+      name: skill.dataset.name!,
+      source: (skill.dataset.source ?? "skill") as CommandSource,
+      content,
+      start: position,
+      end: position + content.length,
+    })
+    position += content.length
+  }
+
   const visit = (node: Node) => {
     if (node.nodeType === Node.TEXT_NODE) {
       buffer += node.textContent ?? ""
@@ -159,6 +177,11 @@ export function parseEditorToParts(editor: HTMLElement): Prompt {
     if (el.dataset.type === "agent") {
       flushText()
       pushAgent(el)
+      return
+    }
+    if (el.dataset.type === "skill") {
+      flushText()
+      pushSkill(el)
       return
     }
     if (el.tagName === "BR") {
@@ -203,7 +226,12 @@ export function parseEditorToParts(editor: HTMLElement): Prompt {
         if (sibEl.tagName === "BR") {
           followingTextRun += "\n"
           consumedSiblings++
-        } else if (sibEl.dataset.type === "file" || sibEl.dataset.type === "agent" || sibEl.dataset.cmdMark === "true") {
+        } else if (
+          sibEl.dataset.type === "file" ||
+          sibEl.dataset.type === "agent" ||
+          sibEl.dataset.type === "skill" ||
+          sibEl.dataset.cmdMark === "true"
+        ) {
           break
         } else {
           // Unknown inline element — recurse and collect text

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -54,7 +54,7 @@ export function createPill(part: FileAttachmentPart | AgentPart | SkillAttachmen
     pill.appendChild(iconSpan)
     const labelSpan = document.createElement("span")
     labelSpan.setAttribute("data-cmd-label", "true")
-    labelSpan.textContent = part.content
+    labelSpan.textContent = part.content.replace(/^\//, "")
     pill.appendChild(labelSpan)
   } else {
     pill.textContent = part.content
@@ -164,7 +164,10 @@ export function parseEditorToParts(editor: HTMLElement): Prompt {
   }
 
   const pushSkill = (skill: HTMLElement) => {
-    const content = skill.textContent ?? ""
+    // The pill label displays the bare name (no "/") since the glyph already
+    // signals "this is a slash command". Rebuild the canonical "/<name>" token
+    // from data-name so the flattened text and source offsets stay correct.
+    const content = `/${skill.dataset.name!}`
     parts.push({
       type: "skill",
       name: skill.dataset.name!,

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -36,13 +36,28 @@ export function createCommandMark(part: TextPart & { command: NonNullable<TextPa
 
 export function createPill(part: FileAttachmentPart | AgentPart | SkillAttachmentPart): HTMLSpanElement {
   const pill = document.createElement("span")
-  pill.textContent = part.content
   pill.setAttribute("data-type", part.type)
   if (part.type === "file") pill.setAttribute("data-path", part.path)
   if (part.type === "agent") pill.setAttribute("data-name", part.name)
   if (part.type === "skill") {
     pill.setAttribute("data-name", part.name)
     pill.setAttribute("data-source", part.source)
+    // Skill chips carry the skill glyph. The label span keeps textContent ===
+    // "/name" so caret/length math in editor-dom is unaffected; the icon span
+    // contributes no text. The persisted SkillPart drops the source kind, so the
+    // sent bubble uses the same glyph — keep both surfaces consistent here.
+    const iconSpan = document.createElement("span")
+    iconSpan.setAttribute("data-cmd-icon", "true")
+    iconSpan.setAttribute("aria-hidden", "true")
+    iconSpan.className = "command-icon"
+    iconSpan.innerHTML = resolveCommandIconSvg("skill")
+    pill.appendChild(iconSpan)
+    const labelSpan = document.createElement("span")
+    labelSpan.setAttribute("data-cmd-label", "true")
+    labelSpan.textContent = part.content
+    pill.appendChild(labelSpan)
+  } else {
+    pill.textContent = part.content
   }
   pill.setAttribute("contenteditable", "false")
   pill.style.userSelect = "text"

--- a/packages/app/src/components/prompt-input/history.ts
+++ b/packages/app/src/components/prompt-input/history.ts
@@ -43,6 +43,7 @@ export function clonePromptParts(prompt: Prompt): Prompt {
     if (part.type === "text") return { ...part }
     if (part.type === "image") return { ...part }
     if (part.type === "agent") return { ...part }
+    if (part.type === "skill") return { ...part }
     return {
       ...part,
       selection: part.selection ? { ...part.selection } : undefined,

--- a/packages/app/src/components/prompt-input/popover-controllers.ts
+++ b/packages/app/src/components/prompt-input/popover-controllers.ts
@@ -2,7 +2,7 @@
 // instances, their select handlers, popover auto-scroll, and the
 // promptProbe testing hook (gated behind promptEnabled()).
 
-import { createEffect, createMemo, onCleanup, type Accessor, type Setter } from "solid-js"
+import { createEffect, createMemo, createSignal, onCleanup, type Accessor, type Setter } from "solid-js"
 import type { SetStoreFunction } from "solid-js/store"
 import { useFilteredList } from "@opencode-ai/ui/hooks"
 import { type ContentPart, type ImageAttachmentPart, type Prompt, type usePrompt } from "@/context/prompt"
@@ -50,7 +50,7 @@ export interface PopoverControllers {
   slashFlat: Accessor<SlashCommand[]>
   slashActive: Accessor<string | null>
   setSlashActive: Setter<string | null>
-  slashOnInput: (query: string) => void
+  slashOnInput: (query: string, triggeredMidText?: boolean) => void
   slashOnKeyDown: (event: KeyboardEvent) => void
   handleSlashSelect: (cmd: SlashCommand | undefined) => void
   selectPopoverActive: () => void
@@ -102,28 +102,43 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
     onSelect: handleAtSelect,
   })
 
-  const slashCommands = createMemo<SlashCommand[]>(() => {
-    const builtin = command.options
-      .filter((opt) => !opt.disabled && !opt.id.startsWith("suggested.") && opt.slash)
-      .map((opt) => ({
-        id: opt.id,
-        trigger: opt.slash!,
-        title: opt.title,
-        description: opt.description,
-        keybind: opt.keybind,
-        type: "builtin" as const,
-      }))
+  // Mid-text "/" triggers (picker opened anywhere but the start of an empty
+  // composer) restrict the list to inline-eligible entries: skills + simple
+  // custom commands. Action builtins (/clear, /new, ...) and arg/agent-heavy
+  // commands stay on the leading `/name args` path and only show at-start.
+  const [slashMidText, setSlashMidText] = createSignal(false)
 
-    const custom = sync.data.command.map((cmd) => ({
-      // Source is part of the id so workspace + user configs that share a
-      // command name don't collapse into one entry under useFilteredList.
-      id: `custom.${cmd.source}.${cmd.name}`,
-      trigger: cmd.name,
-      title: cmd.name,
-      description: cmd.description,
-      type: "custom" as const,
-      source: cmd.source,
-    }))
+  const slashCommands = createMemo<SlashCommand[]>(() => {
+    const midText = slashMidText()
+
+    const builtin = midText
+      ? []
+      : command.options
+          .filter((opt) => !opt.disabled && !opt.id.startsWith("suggested.") && opt.slash)
+          .map((opt) => ({
+            id: opt.id,
+            trigger: opt.slash!,
+            title: opt.title,
+            description: opt.description,
+            keybind: opt.keybind,
+            type: "builtin" as const,
+          }))
+
+    const custom = sync.data.command
+      .map((cmd) => ({
+        // Source is part of the id so workspace + user configs that share a
+        // command name don't collapse into one entry under useFilteredList.
+        id: `custom.${cmd.source}.${cmd.name}`,
+        trigger: cmd.name,
+        title: cmd.name,
+        description: cmd.description,
+        type: "custom" as const,
+        source: cmd.source,
+        // Inline-eligible when it carries no agent/model/subtask override and no
+        // required hints. Skills always satisfy this (the merge sets none).
+        simple: !cmd.agent && !cmd.model && !cmd.subtask && cmd.hints.length === 0,
+      }))
+      .filter((cmd) => !midText || cmd.simple)
 
     return [...custom, ...builtin]
   })
@@ -165,6 +180,13 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
     filterKeys: ["trigger", "title"],
     onSelect: handleSlashSelect,
   })
+
+  // Record whether the trigger fired mid-text before applying the query, so the
+  // slashCommands memo can narrow the candidate list in the same reactive pass.
+  const slashOnInput = (query: string, triggeredMidText = false) => {
+    setSlashMidText(triggeredMidText)
+    slash.onInput(query)
+  }
 
   // Auto-scroll active command into view when navigating with keyboard
   createEffect(() => {
@@ -224,7 +246,7 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
     slashFlat: slash.flat,
     slashActive: slash.active,
     setSlashActive: slash.setActive,
-    slashOnInput: slash.onInput,
+    slashOnInput,
     slashOnKeyDown: slash.onKeyDown,
     handleSlashSelect,
     selectPopoverActive,

--- a/packages/app/src/components/prompt-input/popover-controllers.ts
+++ b/packages/app/src/components/prompt-input/popover-controllers.ts
@@ -150,7 +150,24 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
     closePopover()
     const images = imageAttachments()
 
+    // Inline-eligible (skill or simple command): insert a position-independent
+    // chip at the typed "/query", mirroring @-file/@-agent. The server expands
+    // the command template into synthetic, model-visible text on send.
+    if (cmd.type === "custom" && cmd.simple) {
+      addPart({
+        type: "skill",
+        name: cmd.trigger,
+        source: cmd.source ?? "command",
+        content: "/" + cmd.trigger,
+        start: 0,
+        end: 0,
+      })
+      return
+    }
+
     if (cmd.type === "custom") {
+      // Arg/agent-heavy command: keep the leading marked TextPart path so the
+      // user can type "/name args" after the pill.
       // Build a marked TextPart (pill) and prepend it to the current prompt.
       // source is always present on custom commands (set in slashCommands memo).
       // icon is not stored on SlashCommand; default to "command" per spec.

--- a/packages/app/src/components/prompt-input/popover-controllers.ts
+++ b/packages/app/src/components/prompt-input/popover-controllers.ts
@@ -138,7 +138,7 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
         // required hints. Skills always satisfy this (the merge sets none).
         simple: !cmd.agent && !cmd.model && !cmd.subtask && cmd.hints.length === 0,
       }))
-      .filter((cmd) => !midText || cmd.simple)
+      .filter((cmd) => !midText || (cmd.simple && cmd.source === "skill"))
 
     return [...custom, ...builtin]
   })
@@ -150,10 +150,10 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
     closePopover()
     const images = imageAttachments()
 
-    // Inline-eligible (skill or simple command): insert a position-independent
-    // chip at the typed "/query", mirroring @-file/@-agent. The server expands
-    // the command template into synthetic, model-visible text on send.
-    if (cmd.type === "custom" && cmd.simple) {
+    // Inline skill chip: only actual skills (source === "skill") get a
+    // position-independent chip. Custom/MCP commands stay on the leading
+    // command path to preserve resolvePromptParts, hooks, and events.
+    if (cmd.type === "custom" && cmd.source === "skill") {
       addPart({
         type: "skill",
         name: cmd.trigger,

--- a/packages/app/src/components/prompt-input/send-followup-draft.ts
+++ b/packages/app/src/components/prompt-input/send-followup-draft.ts
@@ -86,8 +86,11 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
     }
   }
 
+  // A draft carrying an inline skill chip flows through promptAsync below; its
+  // text can start with "/name", which must not be misrouted to session.command.
+  const hasSkillPart = input.draft.prompt.some((part) => part.type === "skill")
   const [head, ...tail] = text.split(" ")
-  const cmd = head?.startsWith("/") ? head.slice(1) : undefined
+  const cmd = !hasSkillPart && head?.startsWith("/") ? head.slice(1) : undefined
   if (cmd && input.sync.data.command.find((item) => item.name === cmd)) {
     setBusy()
     try {

--- a/packages/app/src/components/prompt-input/slash-popover.tsx
+++ b/packages/app/src/components/prompt-input/slash-popover.tsx
@@ -12,6 +12,9 @@ export interface SlashCommand {
   keybind?: string
   type: "builtin" | "custom"
   source?: "command" | "mcp" | "skill"
+  // "Simple" = inline-eligible: a skill or custom command with no agent/model/
+  // subtask override and no required hints. Mid-text triggers offer only these.
+  simple?: boolean
 }
 
 type PromptPopoverProps = {

--- a/packages/app/src/components/prompt-input/slash-trigger.test.ts
+++ b/packages/app/src/components/prompt-input/slash-trigger.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { matchSlashTrigger } from "./slash-trigger"
+
+describe("matchSlashTrigger", () => {
+  describe("fires", () => {
+    const cases: { label: string; before: string; query: string; offset: number }[] = [
+      { label: "at start", before: "/sum", query: "sum", offset: 0 },
+      { label: "bare slash at start", before: "/", query: "", offset: 0 },
+      { label: "after a space", before: "please /sum", query: "sum", offset: 7 },
+      { label: "after a newline", before: "line one\n/sum", query: "sum", offset: 9 },
+      { label: "after a Han char", before: "请/总结", query: "总结", offset: 1 },
+      { label: "after a Hiragana char", before: "あ/sum", query: "sum", offset: 1 },
+      { label: "after a Katakana char", before: "ア/sum", query: "sum", offset: 1 },
+      { label: "after a Hangul char", before: "가/sum", query: "sum", offset: 1 },
+      { label: "empty query mid-text", before: "hello /", query: "", offset: 6 },
+    ]
+    for (const c of cases) {
+      test(c.label, () => {
+        const result = matchSlashTrigger(c.before)
+        expect(result).toEqual({ query: c.query, offset: c.offset })
+      })
+    }
+  })
+
+  describe("does not fire", () => {
+    const negatives: { label: string; before: string }[] = [
+      { label: "inside a path token", before: "foo/bar" },
+      { label: "after a trailing path slash", before: "/usr/" },
+      { label: "url scheme", before: "http://" },
+      { label: "url with host", before: "https://example" },
+      { label: "a fraction", before: "2/3" },
+      { label: "another fraction", before: "3/4" },
+      { label: "after an ASCII word char", before: "foo/sum" },
+      { label: "after a digit", before: "v2/sum" },
+      { label: "after a colon", before: "key:/value" },
+    ]
+    for (const c of negatives) {
+      test(c.label, () => {
+        expect(matchSlashTrigger(c.before)).toBeNull()
+      })
+    }
+  })
+
+  test("matches the last slash run when several are present", () => {
+    // "a/b " ended the first token; the trigger keys off the space before "/c".
+    expect(matchSlashTrigger("a/b /c")).toEqual({ query: "c", offset: 4 })
+  })
+})

--- a/packages/app/src/components/prompt-input/slash-trigger.ts
+++ b/packages/app/src/components/prompt-input/slash-trigger.ts
@@ -1,0 +1,25 @@
+// Position-independent slash trigger, kept as a standalone pure module so it can
+// be unit-tested without importing the editor-input factory (which pulls in
+// @solidjs/router and throws in the server-side test env). Used by both the
+// trigger detection in handleInput and the range-replace in addPart.
+
+// Group 1 is the consuming boundary (start, whitespace, or a CJK script char) so
+// the picker opens mid-sentence; group 2 is the query. The boundary set
+// deliberately excludes ASCII word chars and `.`/`:`, and the query class stops
+// at `/ \ :`, so paths/URLs/fractions (foo/bar, http://, 2/3) never trigger.
+export const SLASH_TRIGGER =
+  /(^|[\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])\/([^\s\/\\:]*)$/u
+
+/**
+ * Match a slash trigger at the end of the text before the cursor. Returns the
+ * query (text after "/") and the offset of the "/" itself (the boundary char in
+ * group 1 is left in place), or null when no trigger fires.
+ */
+export function matchSlashTrigger(textBeforeCursor: string): { query: string; offset: number } | null {
+  const match = textBeforeCursor.match(SLASH_TRIGGER)
+  if (!match) return null
+  return {
+    query: match[2] ?? "",
+    offset: (match.index ?? 0) + match[1].length,
+  }
+}

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -112,6 +112,10 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const images = input.imageAttachments().slice()
     const mode = input.mode()
     const creatingNewSession = isNewSession()
+    // A prompt carrying an inline skill chip flows through promptAsync. Its
+    // flattened text can start with "/name" (chip at offset 0), which would
+    // otherwise be misrouted to the legacy session.command endpoint below.
+    const hasSkillPart = currentPrompt.some((part) => part.type === "skill")
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
       if (input.working()) abort(event instanceof KeyboardEvent ? "emptyEnter" : "stopButton")
@@ -123,6 +127,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
         text,
         submitReady: actionReady(),
         commandsReady: sync.data.command_ready,
+        hasSkillPart,
       })
     ) {
       return
@@ -393,7 +398,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       }
     }
 
-    if (text.startsWith("/")) {
+    if (text.startsWith("/") && !hasSkillPart) {
       const [cmdName, ...args] = text.split(" ")
       const commandName = cmdName.slice(1)
       const customCommand = sync.data.command.find((c) => c.name === commandName)

--- a/packages/app/src/context/prompt-equality.ts
+++ b/packages/app/src/context/prompt-equality.ts
@@ -34,6 +34,8 @@ function isPartEqual(partA: ContentPart, partB: ContentPart) {
       return partB.type === "file" && partA.path === partB.path && isSelectionEqual(partA.selection, partB.selection)
     case "agent":
       return partB.type === "agent" && partA.name === partB.name
+    case "skill":
+      return partB.type === "skill" && partA.name === partB.name && partA.source === partB.source
     case "image":
       return partB.type === "image" && partA.id === partB.id
   }

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -38,6 +38,15 @@ export interface AgentPart extends PartBase {
   name: string
 }
 
+// Inline skill chip: a structured, position-independent reference (mirrors AgentPart).
+// `name` is the command/skill name; `source` drives the chip badge/icon. On send it
+// becomes a SkillPartInput; the server expands the template into model-visible text.
+export interface SkillAttachmentPart extends PartBase {
+  type: "skill"
+  name: string
+  source: CommandSource
+}
+
 export interface ImageAttachmentPart {
   type: "image"
   id: string
@@ -46,7 +55,7 @@ export interface ImageAttachmentPart {
   dataUrl: string
 }
 
-export type ContentPart = TextPart | FileAttachmentPart | AgentPart | ImageAttachmentPart
+export type ContentPart = TextPart | FileAttachmentPart | AgentPart | SkillAttachmentPart | ImageAttachmentPart
 export type Prompt = ContentPart[]
 
 export type FileContextItem = {
@@ -72,6 +81,7 @@ function clonePart(part: ContentPart): ContentPart {
   if (part.type === "text") return { ...part }
   if (part.type === "image") return { ...part }
   if (part.type === "agent") return { ...part }
+  if (part.type === "skill") return { ...part }
   return {
     ...part,
     selection: cloneSelection(part.selection),

--- a/packages/app/src/pages/session/composer/home-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/home-composer-region.tsx
@@ -33,6 +33,7 @@ export function HomeComposerRegion(props: HomeComposerRegionProps) {
       .map((part) => {
         if (part.type === "file") return `[file:${part.path}]`
         if (part.type === "agent") return `@${part.name}`
+        if (part.type === "skill") return `/${part.name}`
         if (part.type === "image") return `[image:${part.filename}]`
         return part.content
       })

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -70,6 +70,7 @@ export function SessionComposerRegion(props: {
       .map((part) => {
         if (part.type === "file") return `[file:${part.path}]`
         if (part.type === "agent") return `@${part.name}`
+        if (part.type === "skill") return `/${part.name}`
         if (part.type === "image") return `[image:${part.filename}]`
         return part.content
       })

--- a/packages/app/src/pages/session/session-action-readiness.test.ts
+++ b/packages/app/src/pages/session/session-action-readiness.test.ts
@@ -34,6 +34,18 @@ describe("session action readiness", () => {
     expect(canSubmitPrompt({ mode: "normal", text: "/release", submitReady: true, commandsReady: true })).toBe(true)
   })
 
+  test("inline skill prompt bypasses the command-hydration gate", () => {
+    // A skill chip at offset 0 flattens to "/name" but flows through promptAsync,
+    // not the legacy command endpoint, so it must submit even before commands sync.
+    expect(
+      canSubmitPrompt({ mode: "normal", text: "/summarize", submitReady: true, commandsReady: false, hasSkillPart: true }),
+    ).toBe(true)
+    // Still gated on submitReady.
+    expect(
+      canSubmitPrompt({ mode: "normal", text: "/summarize", submitReady: false, commandsReady: true, hasSkillPart: true }),
+    ).toBe(false)
+  })
+
   test("shell submit does not wait for command hydration", () => {
     expect(canSubmitPrompt({ mode: "shell", text: "/bin/ls", submitReady: true, commandsReady: false })).toBe(true)
     expect(canSubmitPrompt({ mode: "shell", text: "/release", submitReady: false, commandsReady: true })).toBe(false)

--- a/packages/app/src/pages/session/session-action-readiness.ts
+++ b/packages/app/src/pages/session/session-action-readiness.ts
@@ -12,9 +12,15 @@ export function canSubmitPrompt(input: {
   text: string
   submitReady: boolean
   commandsReady: boolean
+  hasSkillPart?: boolean
 }) {
   if (!input.submitReady) return false
   if (input.mode !== "normal") return true
+  // An inline skill chip is already a committed structured reference; it flows
+  // through promptAsync, not the legacy slash-command endpoint, so the
+  // command_ready gate (which disambiguates "/foo" prose from a command) does
+  // not apply even though the flattened text starts with "/".
+  if (input.hasSkillPart) return true
   if (!commandLikeText(input.text)) return true
   return input.commandsReady
 }

--- a/packages/app/src/pages/session/use-session-followups.ts
+++ b/packages/app/src/pages/session/use-session-followups.ts
@@ -25,6 +25,7 @@ export function followupPreviewText(input: {
       if (part.type === "image") return `[image:${part.filename}]`
       if (part.type === "file") return `[file:${part.path}]`
       if (part.type === "agent") return `@${part.name}`
+      if (part.type === "skill") return `/${part.name}`
       return part.content
     })
     .join("")

--- a/packages/app/src/utils/prompt.test.ts
+++ b/packages/app/src/utils/prompt.test.ts
@@ -144,6 +144,36 @@ describe("extractPromptFromParts", () => {
     expect(text).toContain("@bot")
   })
 
+  test("skill part in history restores as an inline skill chip", () => {
+    // Unlike agents (#239), skills are structured + persisted with a source span
+    // and expand server-side, so fork/undo/revert must rebuild the chip — not
+    // leave a literal "/name" that would no longer expand on resubmit.
+    const parts = [
+      {
+        id: "text_1",
+        type: "text",
+        text: "please /summarize this",
+        sessionID: "ses_1",
+        messageID: "msg_1",
+      },
+      {
+        id: "skill_1",
+        type: "skill",
+        name: "summarize",
+        source: { value: "/summarize", start: 7, end: 17 },
+        sessionID: "ses_1",
+        messageID: "msg_1",
+      },
+    ] satisfies Part[]
+
+    const result = extractPromptFromParts(parts)
+
+    expect(result.map((p) => p.type)).toEqual(["text", "skill", "text"])
+    expect(result[0]).toMatchObject({ type: "text", content: "please " })
+    expect(result[1]).toMatchObject({ type: "skill", name: "summarize", content: "/summarize", start: 7, end: 17 })
+    expect(result[2]).toMatchObject({ type: "text", content: " this" })
+  })
+
   test("command mode: restores `/<cmd> <args>` and preserves user attachments", () => {
     // A command invocation produces a TextPart carrying commandInvocation
     // metadata (its body is the expanded template) plus any template-side files

--- a/packages/app/src/utils/prompt.ts
+++ b/packages/app/src/utils/prompt.ts
@@ -1,7 +1,7 @@
-import type { FilePart, Part, TextPart } from "@opencode-ai/sdk/v2"
+import type { FilePart, Part, SkillPart, TextPart } from "@opencode-ai/sdk/v2"
 import { deriveCommandInvocation } from "@opencode-ai/ui/lib/command-invocation"
 import { createCommandTextPart } from "@/components/prompt-input/command-text-part"
-import type { FileAttachmentPart, ImageAttachmentPart, Prompt } from "@/context/prompt"
+import type { FileAttachmentPart, ImageAttachmentPart, Prompt, SkillAttachmentPart } from "@/context/prompt"
 
 type Inline =
   | {
@@ -19,6 +19,13 @@ type Inline =
     }
   | {
       type: "agent"
+      start: number
+      end: number
+      value: string
+      name: string
+    }
+  | {
+      type: "skill"
       start: number
       end: number
       value: string
@@ -144,6 +151,24 @@ export function extractPromptFromParts(parts: Part[], opts?: { directory?: strin
     // already in the surrounding text part, so it restores as plain text.
     // This single point also defuses buildRequestParts (no AgentPartInput
     // submitted) and renderEditor (no pill).
+
+    // Skills, unlike agents, ARE structured + persisted with a source span and
+    // expand server-side, so restore them as inline chips — otherwise fork/undo
+    // would resubmit a literal "/name" that no longer expands (and a leading one
+    // would reroute to the legacy command endpoint).
+    if (part.type === "skill") {
+      const skillPart = part as SkillPart
+      const source = skillPart.source
+      if (source?.value && source.start !== undefined && source.end !== undefined) {
+        inline.push({
+          type: "skill",
+          start: source.start,
+          end: source.end,
+          value: source.value,
+          name: skillPart.name,
+        })
+      }
+    }
   }
 
   inline.sort((a, b) => {
@@ -180,6 +205,22 @@ export function extractPromptFromParts(parts: Part[], opts?: { directory?: strin
     position += content.length
   }
 
+  const pushSkill = (item: Extract<Inline, { type: "skill" }>) => {
+    const content = item.value
+    // The persisted SkillPart drops the source kind; default to "skill" (the
+    // chip glyph is uniform across sources anyway).
+    const attachment: SkillAttachmentPart = {
+      type: "skill",
+      name: item.name,
+      source: "skill",
+      content,
+      start: position,
+      end: position + content.length,
+    }
+    result.push(attachment)
+    position += content.length
+  }
+
   for (const item of inline) {
     if (item.start < 0 || item.end < item.start) continue
 
@@ -194,6 +235,7 @@ export function extractPromptFromParts(parts: Part[], opts?: { directory?: strin
     pushText(text.slice(cursor, start))
 
     if (item.type === "file") pushFile(item)
+    if (item.type === "skill") pushSkill(item)
 
     cursor = end
   }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -335,6 +335,26 @@ export const AgentPart = PartBase.extend({
 })
 export type AgentPart = z.infer<typeof AgentPart>
 
+// Inline skill/command chip. Mirrors AgentPart: a structured, position-independent
+// reference that activates a skill for the whole turn. resolvePart expands the skill
+// template into a synthetic text part (model-visible); this part itself is persisted
+// only to render the chip in the bubble. `source` tracks the `/name` span in the user
+// text so the chip can be highlighted in place.
+export const SkillPart = PartBase.extend({
+  type: z.literal("skill"),
+  name: z.string(),
+  source: z
+    .object({
+      value: z.string(),
+      start: z.number().int(),
+      end: z.number().int(),
+    })
+    .optional(),
+}).meta({
+  ref: "SkillPart",
+})
+export type SkillPart = z.infer<typeof SkillPart>
+
 export const CompactionPart = PartBase.extend({
   type: z.literal("compaction"),
   auto: z.boolean(),
@@ -565,6 +585,7 @@ export const Part = z
     SnapshotPart,
     PatchPart,
     AgentPart,
+    SkillPart,
     RetryPart,
     CompactionPart,
   ])

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1869,9 +1869,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           // it is position-independent because activation reads the parts array, not the
           // text. Argless by design — the surrounding user prose is the turn body.
           const cmd = yield* commands.get(part.name)
-          // Unknown skill (renamed/removed): keep the chip so the bubble still renders,
-          // but inject nothing rather than throwing the whole turn.
-          if (!cmd) return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
+          // Unknown skill, or a command/MCP entry masquerading as a skill (the
+          // command registry is a shared namespace): keep the chip for the bubble
+          // but inject nothing — the full command pipeline handles non-skill entries.
+          if (!cmd || cmd.source !== "skill") return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
           const template = yield* expandCommandTemplate(cmd, "")
           return [
             { ...part, messageID: info.id, sessionID: input.sessionID },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1466,6 +1466,53 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       return yield* provider.defaultModel()
     })
 
+    // Expand a command/skill template: positional ($1..$n) + $ARGUMENTS substitution +
+    // inline shell interpolation, then trim. A pure text transform shared by the command()
+    // endpoint and the inline-skill resolvePart branch. It deliberately does NOT touch
+    // agent/model/subtask selection, plugin hooks, or command events — those stay in command().
+    const expandCommandTemplate = Effect.fn("SessionPrompt.expandCommandTemplate")(function* (
+      cmd: Command.Info,
+      args: string,
+    ) {
+      const raw = args.match(argsRegex) ?? []
+      const parsedArgs = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
+      const templateCommand = yield* Effect.promise(async () => cmd.template)
+
+      const placeholders = templateCommand.match(placeholderRegex) ?? []
+      let last = 0
+      for (const item of placeholders) {
+        const value = Number(item.slice(1))
+        if (value > last) last = value
+      }
+
+      const withArgs = templateCommand.replaceAll(placeholderRegex, (_, index) => {
+        const position = Number(index)
+        const argIndex = position - 1
+        if (argIndex >= parsedArgs.length) return ""
+        if (position === last) return parsedArgs.slice(argIndex).join(" ")
+        return parsedArgs[argIndex]
+      })
+      const usesArgumentsPlaceholder = templateCommand.includes("$ARGUMENTS")
+      let template = withArgs.replaceAll("$ARGUMENTS", args)
+
+      if (placeholders.length === 0 && !usesArgumentsPlaceholder && args.trim()) {
+        template = template + "\n\n" + args
+      }
+
+      const shellMatches = ConfigMarkdown.shell(template)
+      if (shellMatches.length > 0) {
+        const sh = Shell.preferred()
+        const results = yield* Effect.promise(() =>
+          Promise.all(
+            shellMatches.map(async ([, shellCmd]) => (await Process.text([shellCmd], { shell: sh, nothrow: true })).text),
+          ),
+        )
+        let index = 0
+        template = template.replace(bashRegex, () => results[index++])
+      }
+      return template.trim()
+    })
+
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {
       const agentName = input.agent || (yield* agents.defaultAgent())
       const ag = yield* agents.get(agentName)
@@ -2588,43 +2635,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }
       const agentName = cmd.agent ?? input.agent ?? (yield* agents.defaultAgent())
 
-      const raw = input.arguments.match(argsRegex) ?? []
-      const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
-      const templateCommand = yield* Effect.promise(async () => cmd.template)
-
-      const placeholders = templateCommand.match(placeholderRegex) ?? []
-      let last = 0
-      for (const item of placeholders) {
-        const value = Number(item.slice(1))
-        if (value > last) last = value
-      }
-
-      const withArgs = templateCommand.replaceAll(placeholderRegex, (_, index) => {
-        const position = Number(index)
-        const argIndex = position - 1
-        if (argIndex >= args.length) return ""
-        if (position === last) return args.slice(argIndex).join(" ")
-        return args[argIndex]
-      })
-      const usesArgumentsPlaceholder = templateCommand.includes("$ARGUMENTS")
-      let template = withArgs.replaceAll("$ARGUMENTS", input.arguments)
-
-      if (placeholders.length === 0 && !usesArgumentsPlaceholder && input.arguments.trim()) {
-        template = template + "\n\n" + input.arguments
-      }
-
-      const shellMatches = ConfigMarkdown.shell(template)
-      if (shellMatches.length > 0) {
-        const sh = Shell.preferred()
-        const results = yield* Effect.promise(() =>
-          Promise.all(
-            shellMatches.map(async ([, cmd]) => (await Process.text([cmd], { shell: sh, nothrow: true })).text),
-          ),
-        )
-        let index = 0
-        template = template.replace(bashRegex, () => results[index++])
-      }
-      template = template.trim()
+      const template = yield* expandCommandTemplate(cmd, input.arguments)
 
       const taskModel = yield* Effect.gen(function* () {
         if (cmd.model) return Provider.parseModel(cmd.model)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1862,6 +1862,29 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           ]
         }
 
+        if (part.type === "skill") {
+          // Inline skill chip: resolve the command/skill template and inject it as a
+          // synthetic, model-visible text part (mirrors the agent branch above). The
+          // structured skill part is persisted only to render the chip in the bubble;
+          // it is position-independent because activation reads the parts array, not the
+          // text. Argless by design — the surrounding user prose is the turn body.
+          const cmd = yield* commands.get(part.name)
+          // Unknown skill (renamed/removed): keep the chip so the bubble still renders,
+          // but inject nothing rather than throwing the whole turn.
+          if (!cmd) return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
+          const template = yield* expandCommandTemplate(cmd, "")
+          return [
+            { ...part, messageID: info.id, sessionID: input.sessionID },
+            {
+              messageID: info.id,
+              sessionID: input.sessionID,
+              type: "text",
+              synthetic: true,
+              text: template,
+            },
+          ]
+        }
+
         return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
       })
 
@@ -2829,6 +2852,16 @@ export const PromptInput = z.object({
         })
         .meta({
           ref: "AgentPartInput",
+        }),
+      MessageV2.SkillPart.omit({
+        messageID: true,
+        sessionID: true,
+      })
+        .partial({
+          id: true,
+        })
+        .meta({
+          ref: "SkillPartInput",
         }),
       MessageV2.SubtaskPart.omit({
         messageID: true,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1004,6 +1004,95 @@ describe("session.agent-resolution", () => {
   }, 30000)
 })
 
+describe("session.prompt inline skill parts", () => {
+  test("resolves a skill part to a chip plus synthetic template text, position-independent", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        agent: { build: { model: "openai/gpt-5.2" } },
+        command: { summarize: { template: "Summarize the latest user request." } },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const prompt = yield* SessionPrompt.Service
+            const sessions = yield* Session.Service
+            const session = yield* sessions.create({})
+
+            // Skill chip sits AFTER the prose — position-independent activation.
+            const msg = yield* prompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              noReply: true,
+              parts: [
+                { type: "text", text: "please" },
+                { type: "skill", name: "summarize" },
+              ],
+            })
+            if (msg.info.role !== "user") throw new Error("expected user message")
+
+            // The structured chip part is persisted (renders the chip; not sent to the model).
+            const skill = msg.parts.find((part) => part.type === "skill")
+            expect(skill).toBeDefined()
+            if (skill?.type === "skill") expect(skill.name).toBe("summarize")
+
+            // The expanded template is injected as a synthetic, model-visible text part.
+            expect(
+              msg.parts.some(
+                (part) =>
+                  part.type === "text" && part.synthetic && part.text === "Summarize the latest user request.",
+              ),
+            ).toBe(true)
+
+            // The user's own prose survives as a normal (non-synthetic) text part.
+            expect(
+              msg.parts.some((part) => part.type === "text" && !part.synthetic && part.text === "please"),
+            ).toBe(true)
+
+            yield* sessions.remove(session.id)
+          }),
+        ),
+    })
+  }, 30000)
+
+  test("keeps the chip but injects nothing when the skill name is unknown", async () => {
+    await using tmp = await tmpdir({
+      config: { agent: { build: { model: "openai/gpt-5.2" } } },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const prompt = yield* SessionPrompt.Service
+            const sessions = yield* Session.Service
+            const session = yield* sessions.create({})
+
+            const msg = yield* prompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              noReply: true,
+              parts: [
+                { type: "text", text: "hi" },
+                { type: "skill", name: "does-not-exist" },
+              ],
+            })
+            if (msg.info.role !== "user") throw new Error("expected user message")
+
+            // Unknown skill: the chip is preserved (so the bubble still renders) ...
+            expect(msg.parts.some((part) => part.type === "skill" && part.name === "does-not-exist")).toBe(true)
+            // ... but no synthetic template text is injected.
+            expect(msg.parts.some((part) => part.type === "text" && part.synthetic)).toBe(false)
+
+            yield* sessions.remove(session.id)
+          }),
+        ),
+    })
+  }, 30000)
+})
+
 // #26597: the prompt rebuilds session.permission from the boolean tools map, which can only
 // regenerate whole-tool ("*") rules for the keys it lists. For an agent-tool subagent it must
 // carry forward the caller's inherited rules the map can't regenerate — scoped denies,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1,3 +1,4 @@
+import fs from "fs/promises"
 import path from "path"
 import { describe, expect, test } from "bun:test"
 import { NamedError } from "@opencode-ai/util/error"
@@ -1009,7 +1010,17 @@ describe("session.prompt inline skill parts", () => {
     await using tmp = await tmpdir({
       config: {
         agent: { build: { model: "openai/gpt-5.2" } },
-        command: { summarize: { template: "Summarize the latest user request." } },
+        skills: { paths: ["skills"] },
+      },
+      async init(dir) {
+        const skillDir = path.join(dir, "skills", "summarize")
+        await fs.mkdir(skillDir, { recursive: true })
+        await fs.writeFile(
+          path.join(skillDir, "SKILL.md"),
+          ["---", "name: summarize", "description: Summarize the thread", "---", "", "Summarize the latest user request."].join(
+            "\n",
+          ),
+        )
       },
     })
     await Instance.provide({
@@ -1084,6 +1095,42 @@ describe("session.prompt inline skill parts", () => {
             // Unknown skill: the chip is preserved (so the bubble still renders) ...
             expect(msg.parts.some((part) => part.type === "skill" && part.name === "does-not-exist")).toBe(true)
             // ... but no synthetic template text is injected.
+            expect(msg.parts.some((part) => part.type === "text" && part.synthetic)).toBe(false)
+
+            yield* sessions.remove(session.id)
+          }),
+        ),
+    })
+  }, 30000)
+
+  test("does not expand a non-skill command delivered as a SkillPart", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        agent: { build: { model: "openai/gpt-5.2" } },
+        command: { brainstorm: { template: "Start a brainstorming session." } },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        run(
+          Effect.gen(function* () {
+            const prompt = yield* SessionPrompt.Service
+            const sessions = yield* Session.Service
+            const session = yield* sessions.create({})
+
+            const msg = yield* prompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              noReply: true,
+              parts: [
+                { type: "text", text: "go" },
+                { type: "skill", name: "brainstorm" },
+              ],
+            })
+            if (msg.info.role !== "user") throw new Error("expected user message")
+
+            expect(msg.parts.some((part) => part.type === "skill" && part.name === "brainstorm")).toBe(true)
             expect(msg.parts.some((part) => part.type === "text" && part.synthetic)).toBe(false)
 
             yield* sessions.remove(session.id)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -199,6 +199,7 @@ import type {
   SessionUnshareResponses,
   SessionUpdateErrors,
   SessionUpdateResponses,
+  SkillPartInput,
   SubtaskPartInput,
   TextPartInput,
   ToolIdsErrors,
@@ -2564,7 +2565,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
-      parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2698,7 +2699,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
-      parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -237,6 +237,18 @@ export type ApiError = {
       [key: string]: string
     }
     providerID?: string
+    providerFailure?: {
+      kind:
+        | "auth"
+        | "rate_limit"
+        | "quota_exhausted"
+        | "server_overload"
+        | "invalid_request"
+        | "transport_disconnect"
+        | "decompression"
+        | "unknown"
+      code?: string
+    }
   }
 }
 
@@ -1196,6 +1208,19 @@ export type AgentPart = {
   }
 }
 
+export type SkillPart = {
+  id: string
+  sessionID: string
+  messageID: string
+  type: "skill"
+  name: string
+  source?: {
+    value: string
+    start: number
+    end: number
+  }
+}
+
 export type RetryPart = {
   id: string
   sessionID: string
@@ -1233,6 +1258,7 @@ export type Part =
   | SnapshotPart
   | PatchPart
   | AgentPart
+  | SkillPart
   | RetryPart
   | CompactionPart
 
@@ -1684,11 +1710,11 @@ export type ProviderConfig = {
         output: number
       }
       modalities?: {
-        input: Array<"text" | "audio" | "image" | "video" | "pdf">
-        output: Array<"text" | "audio" | "image" | "video" | "pdf">
+        input?: Array<"text" | "audio" | "image" | "video" | "pdf">
+        output?: Array<"text" | "audio" | "image" | "video" | "pdf">
       }
       experimental?: boolean
-      status?: "alpha" | "beta" | "deprecated"
+      status?: "alpha" | "beta" | "deprecated" | "active"
       provider?: {
         npm?: string
         api?: string
@@ -2286,6 +2312,17 @@ export type FilePartInput = {
 export type AgentPartInput = {
   id?: string
   type: "agent"
+  name: string
+  source?: {
+    value: string
+    start: number
+    end: number
+  }
+}
+
+export type SkillPartInput = {
+  id?: string
+  type: "skill"
   name: string
   source?: {
     value: string
@@ -5034,7 +5071,7 @@ export type SessionPromptData = {
     format?: OutputFormat
     system?: string
     variant?: string
-    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
   }
   path: {
     sessionID: string
@@ -5239,7 +5276,7 @@ export type SessionPromptAsyncData = {
     format?: OutputFormat
     system?: string
     variant?: string
-    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
   }
   path: {
     sessionID: string

--- a/packages/ui/src/components/command-icon.test.ts
+++ b/packages/ui/src/components/command-icon.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from "bun:test"
-import { resolveCommandIconSvg } from "./command-icon"
+import { icons } from "./icon"
+import { resolveCommandIconSvg, SKILL_GLYPH } from "./command-icon"
 
 const CommandDefault = await Bun.file(
   new URL("../assets/icons/command-default.svg", import.meta.url),
 ).text()
+
+describe("SKILL_GLYPH", () => {
+  // command-icon.tsx inlines the skill glyph instead of importing the ~140KB
+  // icon.tsx registry (which also breaks bun's export analysis on Windows).
+  // This guards the inlined copy against drift from icon.tsx's source of truth.
+  test("stays in sync with the chrome icon registry's skill entry", () => {
+    expect(SKILL_GLYPH).toBe(icons.skill)
+  })
+})
 
 describe("resolveCommandIconSvg", () => {
   test("returns the SVG string for a known icon key", () => {

--- a/packages/ui/src/components/command-icon.tsx
+++ b/packages/ui/src/components/command-icon.tsx
@@ -1,15 +1,18 @@
 import { Show } from "solid-js"
 import CommandDefault from "../assets/icons/command-default.svg?raw"
-import { icons } from "./icon"
 import "./command-icon.css"
 
-// The skill glyph lives in the chrome icon registry (icon.tsx) as inner SVG
-// content for a 0 0 20 20 viewBox; wrap it into a full SVG so the command-icon
-// system (input pill + sent bubble) can resolve "skill" the same way it does
-// "command". The .command-icon CSS sizes it to 16×16 regardless of viewBox.
+// The skill glyph mirrors the "skill" entry in the chrome icon registry
+// (icon.tsx): the same inner SVG content for a 0 0 20 20 viewBox, inlined here
+// on purpose. Importing icon.tsx would pull its entire ~140KB registry into the
+// command-icon module — and through it the app prompt-input bundle — just to
+// resolve one glyph; bun's named-export analysis also chokes on that module on
+// Windows. command-icon.test.ts asserts this stays in sync with icon.tsx.
+export const SKILL_GLYPH = `<g transform="translate(-5.5472 34.8538) scale(0.012775 -0.012775)"><path fill-rule="evenodd" d="M1223 2650 c-25 -10 -28 -19 -43 -125 -35 -234 -127 -389 -279 -469 -65 -34 -188 -66 -254 -66 -47 0 -74 -31 -61 -68 8 -22 17 -28 54 -34 157 -24 194 -32 249 -58 112 -53 202 -160 250 -295 12 -33 29 -109 39 -170 17 -98 21 -112 44 -124 23 -13 29 -13 52 2 20 14 26 26 26 55 0 74 39 225 79 309 80 166 201 246 416 273 85 11 105 21 105 55 0 31 -31 55 -71 55 -59 0 -166 28 -232 59 -159 76 -253 235 -291 490 -10 68 -19 98 -32 108 -20 15 -21 15 -51 3z m107 -470 c50 -86 136 -164 228 -208 l73 -35 -53 -21 c-149 -61 -251 -176 -314 -354 l-22 -64 -17 54 c-60 182 -169 307 -319 366 l-47 18 86 43 c136 70 233 191 280 355 l17 58 25 -73 c13 -39 42 -102 63 -139z" fill="currentColor"/></g>`
+
 const REGISTRY: Record<string, string> = {
   command: CommandDefault,
-  skill: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">${icons.skill}</svg>`,
+  skill: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">${SKILL_GLYPH}</svg>`,
 }
 
 /** Pure helper: resolves an icon key to its SVG string. No JSX or reactivity.

--- a/packages/ui/src/components/command-icon.tsx
+++ b/packages/ui/src/components/command-icon.tsx
@@ -1,9 +1,15 @@
 import { Show } from "solid-js"
 import CommandDefault from "../assets/icons/command-default.svg?raw"
+import { icons } from "./icon"
 import "./command-icon.css"
 
+// The skill glyph lives in the chrome icon registry (icon.tsx) as inner SVG
+// content for a 0 0 20 20 viewBox; wrap it into a full SVG so the command-icon
+// system (input pill + sent bubble) can resolve "skill" the same way it does
+// "command". The .command-icon CSS sizes it to 16×16 regardless of viewBox.
 const REGISTRY: Record<string, string> = {
   command: CommandDefault,
+  skill: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">${icons.skill}</svg>`,
 }
 
 /** Pure helper: resolves an icon key to its SVG string. No JSX or reactivity.

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -170,9 +170,7 @@
       color: var(--syntax-type);
     }
 
-    /* Inline skill chip: same brand accent as the leading command mark
-     * (.user-message-command-prefix) so "/name" reads as a command reference,
-     * with the skill glyph nudged a hair off the following "/name". */
+    /* Inline skill chip: glyph + bare name in brand accent. */
     [data-highlight="skill"] {
       color: var(--brand-primary);
     }

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -170,6 +170,12 @@
       color: var(--syntax-type);
     }
 
+    /* Inline skill chip: same brand accent as the leading command mark
+     * (.user-message-command-prefix) so "/name" reads as a command reference. */
+    [data-highlight="skill"] {
+      color: var(--brand-primary);
+    }
+
     max-width: 100%;
   }
 

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -171,9 +171,14 @@
     }
 
     /* Inline skill chip: same brand accent as the leading command mark
-     * (.user-message-command-prefix) so "/name" reads as a command reference. */
+     * (.user-message-command-prefix) so "/name" reads as a command reference,
+     * with the skill glyph nudged a hair off the following "/name". */
     [data-highlight="skill"] {
       color: var(--brand-primary);
+    }
+
+    [data-highlight="skill"] .command-icon {
+      margin-right: 2px;
     }
 
     max-width: 100%;

--- a/packages/ui/src/components/message-part/highlighted-text.tsx
+++ b/packages/ui/src/components/message-part/highlighted-text.tsx
@@ -1,5 +1,6 @@
-import { createMemo, For } from "solid-js"
+import { createMemo, For, Show } from "solid-js"
 import type { FilePart, SkillPart } from "@opencode-ai/sdk/v2"
+import { CommandIcon } from "../command-icon"
 
 type HighlightSegment = { text: string; type?: "file" | "skill" }
 
@@ -41,5 +42,16 @@ export function HighlightedText(props: { text: string; references: FilePart[]; s
     return result
   })
 
-  return <For each={segments()}>{(segment) => <span data-highlight={segment.type}>{segment.text}</span>}</For>
+  return (
+    <For each={segments()}>
+      {(segment) => (
+        <span data-highlight={segment.type}>
+          <Show when={segment.type === "skill"}>
+            <CommandIcon icon="skill" />
+          </Show>
+          {segment.text}
+        </span>
+      )}
+    </For>
+  )
 }

--- a/packages/ui/src/components/message-part/highlighted-text.tsx
+++ b/packages/ui/src/components/message-part/highlighted-text.tsx
@@ -49,7 +49,7 @@ export function HighlightedText(props: { text: string; references: FilePart[]; s
           <Show when={segment.type === "skill"}>
             <CommandIcon icon="skill" />
           </Show>
-          {segment.text}
+          {segment.type === "skill" ? segment.text.replace(/^\//, "") : segment.text}
         </span>
       )}
     </For>

--- a/packages/ui/src/components/message-part/highlighted-text.tsx
+++ b/packages/ui/src/components/message-part/highlighted-text.tsx
@@ -1,18 +1,23 @@
 import { createMemo, For } from "solid-js"
-import type { FilePart } from "@opencode-ai/sdk/v2"
+import type { FilePart, SkillPart } from "@opencode-ai/sdk/v2"
 
-type HighlightSegment = { text: string; type?: "file" }
+type HighlightSegment = { text: string; type?: "file" | "skill" }
 
-export function HighlightedText(props: { text: string; references: FilePart[] }) {
-  // PawWork issue #239: `agents` prop removed. Past AgentPart mentions render as
-  // plain text (no styled pill) because the picker concept is gone.
+export function HighlightedText(props: { text: string; references: FilePart[]; skills?: SkillPart[] }) {
+  // PawWork issue #239: `agents` prop removed — past AgentPart mentions render as
+  // plain text because the picker concept is gone. Inline skill chips, by
+  // contrast, ARE highlighted: the "/name" token is colored like the leading
+  // command mark, keyed off the skill part's source span in the flattened text.
   const segments = createMemo(() => {
     const text = props.text
 
-    const allRefs: { start: number; end: number; type: "file" }[] = [
+    const allRefs: { start: number; end: number; type: "file" | "skill" }[] = [
       ...props.references
         .filter((r) => r.source?.text?.start !== undefined && r.source?.text?.end !== undefined)
         .map((r) => ({ start: r.source!.text!.start, end: r.source!.text!.end, type: "file" as const })),
+      ...(props.skills ?? [])
+        .filter((s) => s.source?.start !== undefined && s.source?.end !== undefined)
+        .map((s) => ({ start: s.source!.start, end: s.source!.end, type: "skill" as const })),
     ].sort((a, b) => a.start - b.start)
 
     const result: HighlightSegment[] = []

--- a/packages/ui/src/components/message-part/highlighted-text.tsx
+++ b/packages/ui/src/components/message-part/highlighted-text.tsx
@@ -7,8 +7,8 @@ type HighlightSegment = { text: string; type?: "file" | "skill" }
 export function HighlightedText(props: { text: string; references: FilePart[]; skills?: SkillPart[] }) {
   // PawWork issue #239: `agents` prop removed — past AgentPart mentions render as
   // plain text because the picker concept is gone. Inline skill chips, by
-  // contrast, ARE highlighted: the "/name" token is colored like the leading
-  // command mark, keyed off the skill part's source span in the flattened text.
+  // contrast, ARE highlighted: the bare name is colored in brand accent with a
+  // skill glyph, keyed off the skill part's source span in the flattened text.
   const segments = createMemo(() => {
     const text = props.text
 

--- a/packages/ui/src/components/message-part/user-message.tsx
+++ b/packages/ui/src/components/message-part/user-message.tsx
@@ -1,6 +1,6 @@
 import { createMemo, For, Show } from "solid-js"
 import { createStore } from "solid-js/store"
-import type { FilePart, Part as PartType, TextPart, UserMessage } from "@opencode-ai/sdk/v2"
+import type { FilePart, Part as PartType, SkillPart, TextPart, UserMessage } from "@opencode-ai/sdk/v2"
 import { useData } from "../../context"
 import { useDialog } from "../../context/dialog"
 import { useI18n } from "../../context/i18n"
@@ -50,6 +50,8 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   })
 
   const inlineFiles = createMemo(() => files().filter(inline))
+
+  const inlineSkills = createMemo(() => (props.parts?.filter((p) => p.type === "skill") as SkillPart[]) ?? [])
 
   const model = createMemo(() => {
     const providerID = props.message.model?.providerID
@@ -217,7 +219,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
               <>
                 <div data-slot="user-message-body">
                   <div data-slot="user-message-text">
-                    <HighlightedText text={text()} references={inlineFiles()} />
+                    <HighlightedText text={text()} references={inlineFiles()} skills={inlineSkills()} />
                   </div>
                 </div>
                 {renderMetaAndActions()}


### PR DESCRIPTION
## Summary

Type `/` **anywhere** in the composer to open the command picker, and on selection insert a **position-independent inline skill chip** (like an `@`-file/`@`-agent mention) that activates the skill for the whole turn. Previously the slash picker only opened when the text was exactly `/query` from the start of an empty composer.

Architecture mirrors the `@`-agent pipeline end to end:
- A new structured `SkillPart` rides along the prompt via `promptAsync`. The server's `resolvePart` expands the skill/command template into a `synthetic: true`, model-visible text part (bubble-suppressed), exactly like `AgentPart`.
- The chip stays where it was typed; the user's prose is preserved (it is NOT the leading-command XOR path that suppresses the body).
- Mid-text triggers restrict the picker to actual skills only (`cmd.source === "skill"`). Action builtins (`/clear`, `/new`, …), custom commands, and MCP entries keep the leading `/name args` path and only appear at an empty/at-start composer.
- Inline skill chips carry the new skill glyph (from the chrome icon registry) in both the composer pill and the sent bubble.

Foundational unlock under the Skill GUI push (#220).

## Why

Skills are becoming a first-class product surface, but the only way to invoke one was a leading `/command` typed from the very start of the composer. That is unlike every other reference affordance (`@file`, `@agent`), which can appear anywhere. This makes skills feel position-independent and composable with surrounding prose, which is the foundation the Skill GUI builds on.

## Related Issue

Relates to #220 (Skill GUI). No dedicated issue for this foundational slice.

## Human Review Status

Pending

## Review Focus

- **Server seam** (`packages/opencode/src/session/prompt.ts`): the extracted `expandCommandTemplate` helper and the `resolvePart` skill branch. The helper carries ONLY template load + `$1..$n`/`$ARGUMENTS`/shell interpolation; all agent/model/subtask/hook/event machinery stays in `command()`. Server-side `cmd.source !== "skill"` guard rejects non-skill commands delivered as `SkillPart`, preventing SDK bypass of the full command pipeline.
- **Legacy-endpoint guard** (`submit.ts`, `send-followup-draft.ts`, `session-action-readiness.ts`): a skill chip at offset 0 flattens to `/name`, which previously would route to the legacy `session.command` endpoint. Both routing branches and the `canSubmitPrompt` command-ready gate are guarded by "prompt contains a `type:skill` part". Path D (leading marked TextPart) is untouched — a skill chip carries no command metadata.
- **CJK-correct trigger regex** (`slash-trigger.ts`): fires after start/whitespace/CJK, never inside `foo/bar`, `http://`, `2/3`, paths. Covered by a unit matrix.
- **Render is net-new, not mirrored**: `@`-agents render as plain text (#239), so there was no chip to mirror. `HighlightedText` gains a skill reference segment keyed off the skill part's `source` span, rendered inline in the prose branch.

## Risk Notes

- **#778 index-0 invariant**: the inline chip is a separate structured part type via the generic pill path; the leading marked-TextPart code and its tests are untouched.
- **Restore/undo**: `renderPartsToEditor` reconstructs a structured skill chip from the persisted `SkillAttachmentPart` (name + source span), so restore rebuilds the interactive pill — it does NOT degrade to plain `/name` text.
- **Skill template `@mentions` stay literal**: unlike `command()`, the skill branch does not run `resolvePromptParts`, so `@file`/`@agent` inside a skill template are not resolved. Fine for prose SKILL.md; would matter only if a skill template embeds `@path`.
- **Server-side source validation**: `resolvePart` checks `cmd.source === "skill"` — a config command or MCP entry with a name collision gets the chip preserved for bubble rendering but no synthetic template injection, preventing bypass of hooks/events/resolvePromptParts.
- **SDK regen scope**: consumer-side `packages/sdk/js/src/v2/gen` only; the checked-in `packages/sdk/openapi.json` route-inventory snapshot is intentionally untouched.
- No platform/packaging/updater/signing surface touched.

## How To Verify

```text
opencode test/session/prompt.test.ts: 20 passed (skill resolves to structured chip + synthetic template; unknown skill → chip-only fallback; non-skill command rejected)
app prompt-input unit suite: 431 passed (incl. slash-trigger matrix 19, editor-serialize skill round-trip, build-request-parts SkillPartInput + optimistic, readiness gate bypass)
ui command-icon: 4 passed; app no-mode-picker (agent highlight removal still holds): 4 passed
app typecheck (tsgo -b): pass; ui typecheck: pass
e2e prompt-slash-open "slash mid-sentence … inline skill chip": 1 passed (seeds project skill, types prose+/summarize, picker opens with skill + excludes file.open, click → chip lands)
snap message-skill-inline: rendered + reviewed (leading / mid-sentence / long-prose bubble variants)
```

Pre-existing, unrelated: the `home composer shows slash commands after a bare slash` e2e fails in this local environment because real global skills (`~/.agents/skills/*`) leak into the picker and push `file.open` down — it fails on `dev` too and is a test-sandbox issue, not introduced here.

## Screenshots or Recordings

Visual check via the added `message-skill-inline` snap target (`bun run snap message-skill-inline`, grid under `docs/design/preview/screenshots/`): the `/summarize` token renders inline in the user bubble with the skill glyph + brand-accent color, prose unchanged, across leading / mid-sentence / long-prose cases. The composer pill uses the same glyph.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries `app`, `ui`, `harness` (assigned by the labeler bot / confirmed).
- [x] **Priority label** — this PR carries `P2` (foundational enhancement, not urgent).
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.