### PR TITLE
fix(lsp): guard zls/luals asset lookup against a malformed GitHub release

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -703,8 +703,8 @@ export namespace LSPServer {
           return
         }
 
-        const asset = release.assets.find((a: any) => a.name === assetName)
-        if (!asset) {
+        const asset = (release.assets ?? []).find((a: any) => a.name === assetName)
+        if (!asset?.browser_download_url) {
           log.error(`Could not find asset ${assetName} in latest zls release`)
           return
         }
@@ -1431,8 +1431,8 @@ export namespace LSPServer {
           return
         }
 
-        const asset = release.assets.find((a: any) => a.name === assetName)
-        if (!asset) {
+        const asset = (release.assets ?? []).find((a: any) => a.name === assetName)
+        if (!asset?.browser_download_url) {
           log.error(`Could not find asset ${assetName} in latest lua-language-server release`)
           return
         }

--- a/packages/opencode/test/lsp/server-download-asset-guard.test.ts
+++ b/packages/opencode/test/lsp/server-download-asset-guard.test.ts
@@ -5,9 +5,12 @@ import { LSPServer } from "../../src/lsp/server"
 void Log.init({ print: false })
 
 const originalFetch = globalThis.fetch
+const originalPath = process.env.PATH
 
 afterEach(() => {
   globalThis.fetch = originalFetch
+  if (originalPath === undefined) delete process.env.PATH
+  else process.env.PATH = originalPath
 })
 
 // Regression for the unguarded `release.assets.find` in the LSP download paths
@@ -19,6 +22,11 @@ afterEach(() => {
 // prerequisite binary, just an absent `lua-language-server` (true in CI) and a
 // fetch that returns an asset-less release. Zls.spawn carries the identical guard.
 test("LuaLS.spawn tolerates a GitHub release without an assets array", async () => {
+  // Hermetic: an empty PATH means `which("lua-language-server")` only looks in
+  // Global.Path.bin (never the runner image), so it reliably finds nothing and
+  // spawn always takes the download path instead of launching a preinstalled LSP.
+  process.env.PATH = ""
+
   let fetched = false
   globalThis.fetch = (async () => {
     fetched = true
@@ -26,6 +34,9 @@ test("LuaLS.spawn tolerates a GitHub release without an assets array", async () 
     return new Response(JSON.stringify({ tag_name: "3.0.0" }), { status: 200 })
   }) as unknown as typeof fetch
 
+  // On every platform combo CI runs (linux-x64 / win32-x64 / darwin-arm64) spawn
+  // reaches the asset lookup; an unsupported combo would bail one step earlier at
+  // the supported-combos check, so the assertion targets "resolves, no TypeError".
   await expect(LSPServer.LuaLS.spawn(process.cwd())).resolves.toBeUndefined()
   // Guard against a false green: prove spawn actually entered the download/parse
   // path (and thus the asset lookup) rather than short-circuiting before it.

--- a/packages/opencode/test/lsp/server-download-asset-guard.test.ts
+++ b/packages/opencode/test/lsp/server-download-asset-guard.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, expect, test } from "bun:test"
+import { Log } from "@opencode-ai/core/util/log"
+import { LSPServer } from "../../src/lsp/server"
+
+void Log.init({ print: false })
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+// Regression for the unguarded `release.assets.find` in the LSP download paths
+// (mirrors upstream opencode #22882, thanks @kitlangton). A malformed GitHub
+// release body with no `assets` array must not crash spawn with a TypeError — it
+// should log and bail, the way the clangd / texlab / tinymist guards already do.
+//
+// LuaLS.spawn is the cleanest way to exercise the shared guard: it needs no
+// prerequisite binary, just an absent `lua-language-server` (true in CI) and a
+// fetch that returns an asset-less release. Zls.spawn carries the identical guard.
+test("LuaLS.spawn tolerates a GitHub release without an assets array", async () => {
+  let fetched = false
+  globalThis.fetch = (async () => {
+    fetched = true
+    // No `assets` field — the pre-fix `release.assets.find(...)` threw a TypeError here.
+    return new Response(JSON.stringify({ tag_name: "3.0.0" }), { status: 200 })
+  }) as unknown as typeof fetch
+
+  await expect(LSPServer.LuaLS.spawn(process.cwd())).resolves.toBeUndefined()
+  // Guard against a false green: prove spawn actually entered the download/parse
+  // path (and thus the asset lookup) rather than short-circuiting before it.
+  expect(fetched).toBe(true)
+})


### PR DESCRIPTION
## Summary

Guard the Zls and LuaLS LSP download paths against a malformed GitHub releases body. Both did `release.assets.find(...)` and then read `asset.browser_download_url` unguarded; a response with no `assets` array threw a `TypeError` (`Cannot read properties of undefined (reading 'find')`). This mirrors the `release.assets ?? []` + optional-chained `browser_download_url` guard that clangd / texlab / tinymist in the same file already use, so a bad release body logs and bails instead of throwing.

## Why

Defensive consistency: the GitHub `releases/latest` response is external input. Three other LSP download paths already guard it; Zls and LuaLS were the two stragglers. The throw was already caught upstream (`lsp/index.ts`), so this is a robustness/consistency fix, not a crash escape.

## Related Issue

None — upstream port (#22882).

## Human Review Status

Pending

## Review Focus

That the guard matches the existing in-file idiom (`release.assets ?? []` + `if (!asset?.browser_download_url)`), and that the `(a: any)` cast / surrounding `as any` were intentionally left untouched (upstream #22882 also removed those casts — out of scope for this minimal guard port).

## Risk Notes

Low. Behavior changes only for a malformed release body (previously threw, now logs + returns — same as the other LSP guards). No platform/packaging/UI surface touched. No deps/permissions/generated-file changes.

## How To Verify

```text
Added test/lsp/server-download-asset-guard.test.ts: stubs fetch to return an
asset-less LuaLS release and asserts LuaLS.spawn resolves (no TypeError); a
`fetched` flag asserts the download path was actually entered (no false green).
  - red (pre-guard): release.assets.find on an undefined assets -> TypeError -> spawn rejects -> fails
  - green (with guard): resolves to undefined -> passes
LuaLS.spawn exercises the shared guard with no prerequisite binary; Zls carries the identical change.
bun run typecheck (turbo, all packages incl. opencode): 8 successful
Full bun test left to CI (unit-opencode) per request.
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
