### PR TITLE
fix(mcp): surface unknown MCP server as not-found on connect

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -11,6 +11,7 @@ import {
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import { Config } from "../config/config"
+import { NotFoundError } from "../storage/db"
 import { Log } from "@opencode-ai/core/util/log"
 import { NamedError } from "@opencode-ai/util/error"
 import z from "zod/v4"
@@ -655,11 +656,7 @@ export namespace MCP {
       })
 
       const connect = Effect.fn("MCP.connect")(function* (name: string) {
-        const mcp = yield* getMcpConfig(name)
-        if (!mcp) {
-          log.error("MCP config not found or invalid", { name })
-          return
-        }
+        const mcp = yield* requireMcpConfig(name)
         yield* createAndStore(name, { ...mcp, enabled: true })
       })
 
@@ -769,6 +766,12 @@ export namespace MCP {
         const cfg = yield* cfgSvc.get()
         const mcpConfig = cfg.mcp?.[mcpName]
         if (!mcpConfig || !isMcpConfigured(mcpConfig)) return undefined
+        return mcpConfig
+      })
+
+      const requireMcpConfig = Effect.fnUntraced(function* (mcpName: string) {
+        const mcpConfig = yield* getMcpConfig(mcpName)
+        if (!mcpConfig) throw new NotFoundError({ message: `MCP server not found: ${mcpName}` })
         return mcpConfig
       })
 

--- a/packages/opencode/src/server/instance/mcp.ts
+++ b/packages/opencode/src/server/instance/mcp.ts
@@ -198,6 +198,7 @@ export const McpRoutes = lazy(() =>
               },
             },
           },
+          ...errors(404),
         },
       }),
       validator("param", z.object({ name: z.string() })),

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -175,6 +175,7 @@ beforeEach(() => {
 const { MCP } = await import("../../src/mcp/index")
 const { Bus } = await import("../../src/bus/index")
 const { Instance } = await import("../../src/project/instance")
+const { NotFoundError } = await import("../../src/storage/db")
 const { tmpdir } = await import("../fixture/fixture")
 
 // --- Helper ---
@@ -656,14 +657,23 @@ test(
 )
 
 // ========================================================================
-// Test: connect() on nonexistent server
+// Test: connect() on an unknown server name surfaces NotFoundError (#28817)
+// connect() used to log + bare-return for an unknown name, so the route
+// reported 200 for a server that was never connected. It now throws the
+// shared NotFoundError (storage/db), which ErrorMiddleware maps to 404.
+// instanceof NotFoundError is exactly the check the middleware relies on.
 // ========================================================================
 
 test(
-  "connect() on nonexistent server does not throw",
+  "connect() on an unknown server name rejects with NotFoundError",
   withInstance({}, async () => {
-    // Should not throw
-    await MCP.connect("nonexistent")
+    let caught: unknown
+    await MCP.connect("nonexistent").catch((err) => {
+      caught = err
+    })
+    expect(caught).toBeInstanceOf(NotFoundError)
+
+    // The unknown server is never registered.
     const status = await MCP.status()
     expect(status["nonexistent"]).toBeUndefined()
   }),


### PR DESCRIPTION
## Summary

`MCP.connect(name)` looked up the server config and, for an unknown or invalid
name, only logged and bare-returned. The `POST /mcp/:name/connect` route then
replied `200` for a server that was never connected — a silent no-op the caller
could not distinguish from success.

Add a `requireMcpConfig` helper that throws the shared `NotFoundError`
(`storage/db`) for an unknown name, and route `connect()` through it.

## Why

A client asking to connect a server that isn't in config got `200 OK` and no
connection — no way to tell the request was a no-op. Returning a real not-found
error makes the failure observable.

`ErrorMiddleware` already maps `NotFoundError` → 404, so no middleware change and
no new error class are needed — `connect()` just has to throw the shared error.
`throw new NotFoundError({ message })` is the established in-repo idiom (pty,
session, project, automation all do this) and matches the in-file `startAuth`
not-found path. `connect()` is the only caller of this service method (the route),
so no other flow regresses.

## Related Issue

No PawWork issue. Adapts upstream **anomalyco/opencode#28817** — *fix(httpapi):
return mcp server not found errors* (thanks @thdxr). Re-proven and reimplemented
minimally against current `dev`, not cherry-picked. Deviation from the upstream
shape: upstream added a typed `MCP.NotFoundError`; PawWork reuses the existing
shared `storage/db` `NotFoundError` that `middleware.ts` already maps, so no new
error class is introduced.

## Human Review Status

Pending

## Review Focus

- `requireMcpConfig` throws (a defect) rather than `Effect.fail`, so `connect()`'s
  interface type is unchanged. The shared runtime restores the `NotFoundError`
  instance on `runPromise`, so `instanceof NotFoundError` holds at the route
  boundary (same path the middleware checks) — the test asserts exactly that.
- The error is now the connect signal; the previous `log.error` is dropped on
  purpose (the 404 is the observable result).

## Risk Notes

Low risk, confined to `packages/opencode/src/mcp/index.ts`. Behavior change:
connecting an unknown/invalid MCP server name now returns 404 instead of a silent
200. The route already accepted this contract (`connect()` is its only caller).
No platform/packaging/UI/docs surface touched.

## How To Verify

```text
bun test test/mcp/lifecycle.test.ts -t "unknown server name rejects"
  - before fix: FAIL (caught: undefined — connect() did not throw)
  - after fix:  PASS (instanceof NotFoundError)
bun test test/mcp/ test/server/mcp-routes.test.ts  -> 42 pass, 0 fail
bun run typecheck  -> clean (tsgo --noEmit)
```

Full `bun test` suite runs in CI.

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

