### PR TITLE
fix(opencode): export AI SDK telemetry spans

### DIFF
--- a/packages/core/src/effect/observability.ts
+++ b/packages/core/src/effect/observability.ts
@@ -1,4 +1,5 @@
-import { Effect, Layer, Logger } from "effect"
+import { Effect, Layer, Logger, Option } from "effect"
+import { OtelTracer } from "@effect/opentelemetry/Tracer"
 import { FetchHttpClient } from "effect/unstable/http"
 import { OtlpLogger, OtlpSerialization } from "effect/unstable/observability"
 import * as EffectLogger from "./logger"
@@ -104,5 +105,21 @@ export const layer = !base
         return Layer.mergeAll(trace, logs())
       }),
     )
+
+// Re-exported so consumers (and tests) can resolve or provide the tracer without
+// taking a direct dependency on @effect/opentelemetry. The Tracer module only
+// pulls @opentelemetry/api, not the heavy NodeSdk/exporter chain (kept lazy in
+// traces() above), so importing it eagerly here is cheap.
+export { OtelTracer }
+
+/**
+ * Resolve the AI-SDK-compatible OpenTelemetry tracer registered by the trace
+ * layer above, or undefined when OTel tracing is not active. NodeSdk.layer wires
+ * this tracer into the Effect context but never registers a global
+ * TracerProvider, so the AI SDK — which falls back to the no-op global tracer
+ * when handed none — must be given this tracer explicitly or its spans never
+ * export.
+ */
+export const aiSdkTracer = Effect.serviceOption(OtelTracer).pipe(Effect.map(Option.getOrUndefined))
 
 export const Observability = { enabled, layer }

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -20,6 +20,7 @@ import { Effect, Context, Layer } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { Global } from "@opencode-ai/core/global"
+import { aiSdkTracer } from "@opencode-ai/core/effect/observability"
 import path from "path"
 
 export namespace Agent {
@@ -326,9 +327,14 @@ export namespace Agent {
           const authInfo = yield* auth.get(model.providerID).pipe(Effect.orDie)
           const isOpenaiOauth = model.providerID === "openai" && authInfo?.type === "oauth"
 
+          // Resolve the registered OTel tracer so AI-SDK spans export; without it
+          // the SDK falls back to the no-op global tracer. Only on the opt-in path.
+          const tracer = cfg.experimental?.openTelemetry ? yield* aiSdkTracer : undefined
+
           const params = {
             experimental_telemetry: {
               isEnabled: cfg.experimental?.openTelemetry,
+              tracer,
               metadata: {
                 userId: cfg.username ?? "unknown",
               },

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -22,6 +22,7 @@ import { SessionID } from "@/session/schema"
 import { Auth } from "@/auth"
 import { Installation } from "@/installation"
 import { EffectBridge } from "@/effect"
+import { aiSdkTracer } from "@opencode-ai/core/effect/observability"
 import * as Option from "effect/Option"
 import { LLMTrace } from "./llm-trace"
 import { ExternalResult } from "@/tool/external-result"
@@ -331,7 +332,10 @@ const live: Layer.Layer<
         })
       }
 
-      const tracer = undefined
+      // Resolve the registered OTel tracer so AI-SDK spans export; without it the
+      // SDK falls back to the no-op global tracer (NodeSdk never registers a
+      // global TracerProvider). Only on the opt-in openTelemetry path.
+      const tracer = cfg.experimental?.openTelemetry ? yield* aiSdkTracer : undefined
       const activeToolNames = Object.keys(tools).filter((x) => x !== "invalid")
 
       input.trace?.request(

--- a/packages/opencode/test/effect/observability-tracer.test.ts
+++ b/packages/opencode/test/effect/observability-tracer.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { OtelTracer, aiSdkTracer } from "@opencode-ai/core/effect/observability"
+
+// Regression for the AI-SDK telemetry export gap: session.llm / agent.generate
+// used to hardcode tracer=undefined, so AI-SDK spans fell back to the no-op
+// global tracer (NodeSdk never registers a global TracerProvider) and never
+// exported. They now resolve aiSdkTracer, which must return the OTel tracer when
+// one is registered in the Effect context and undefined otherwise.
+describe("aiSdkTracer", () => {
+  test("returns undefined when no OTel tracer is registered in context", async () => {
+    const result = await Effect.runPromise(aiSdkTracer)
+    expect(result).toBeUndefined()
+  })
+
+  test("returns the registered OTel tracer so AI-SDK spans can export", async () => {
+    const fakeTracer = { startSpan() {}, startActiveSpan() {} }
+    const result = await Effect.runPromise(
+      aiSdkTracer.pipe(Effect.provideService(OtelTracer, fakeTracer as never)),
+    )
+    expect(result).toBe(fakeTracer as never)
+  })
+})


### PR DESCRIPTION
## Summary

`session.llm` and `agent.generate` enable the AI SDK's `experimental_telemetry` when `config.experimental.openTelemetry` is set, but never passed a tracer: `llm.ts` hardcoded `const tracer = undefined` and `agent.ts` omitted the `tracer` field entirely. With no tracer the AI SDK falls back to the global `@opentelemetry/api` tracer, which stays the no-op `ProxyTracer` because PawWork's Effect `NodeSdk` layer wires a `NodeTracerProvider` into the `OtelTracer` service but never registers it as the global provider. Net result: AI-SDK spans are never exported even with OpenTelemetry enabled and an OTLP endpoint configured.

This adds an `aiSdkTracer` accessor to `core/effect/observability.ts` that resolves the registered `OtelTracer` service via `Effect.serviceOption` (so it stays **optional** and adds no requirement to the LLM/Agent layer signatures), and threads it into both telemetry blocks behind the existing `openTelemetry` flag.

## Why

Observability is opt-in (`experimental.openTelemetry` + `OTEL_EXPORTER_OTLP_ENDPOINT`), but when enabled it silently exports nothing from the AI SDK — the most interesting spans (model calls) are exactly the ones lost. PawWork's existing `AsyncLocalStorageContextManager` workaround only fixes parent-span context propagation for an already-real tracer; it does not register a global `TracerProvider`, so the no-tracer fallback still hits the no-op global tracer.

## Related Issue

No PawWork issue. Ports upstream opencode #22526 (`f73ff781e7`, "fix(opencode): export AI SDK telemetry spans") — thanks to the upstream author. Adapted to PawWork: upstream imports `OtelTracer` directly in `opencode`, but `packages/opencode` does not depend on `@effect/opentelemetry` (it does not resolve from there), so the tracer is resolved through `@opencode-ai/core` (which does depend on it) instead of adding a new dependency + lockfile churn.

## Human Review Status

Pending

## Review Focus

- **Dependency routing:** `packages/opencode` cannot import `@effect/opentelemetry` (not a dependency — `require.resolve` fails), so the accessor and the `OtelTracer` tag live in `core/effect/observability.ts` (which already depends on it) and are imported from `@opencode-ai/core/effect/observability`. No new dependency, no `bun.lock` change.
- **`Effect.serviceOption`** keeps the tracer optional: it returns `undefined` when no `OtelTracer` is in context, so the LLM/Agent layer requirement signatures are unchanged and normal (non-OTel) sessions are unaffected.
- **Eager load:** the static `import { OtelTracer } from "@effect/opentelemetry/Tracer"` pulls only `@opentelemetry/api` (the tag/resource module), not the heavy `NodeSdk`/exporter chain, which stays lazily imported in `traces()`.
- **Test coverage:** the regression test exercises the substantive new logic (the accessor resolving the optional service). The threading in `llm.ts`/`agent.ts` is a one-line wiring behind the existing flag, covered by typecheck; intercepting the AI-SDK `streamText`/`generateObject` call directly would require mocking the `ai` module, which the project avoids.

## Risk Notes

Low risk, opt-in path only. When `openTelemetry` is off the behavior is byte-for-byte unchanged (`tracer` stays `undefined`). When on but no `OtelTracer` is registered (e.g. no OTLP endpoint), the accessor returns `undefined` — same as before. No platform/packaging surface. No UI/copy changes.

## How To Verify

```text
bun run typecheck (turbo, all 9 packages): 8 successful, 0 failed
  - validates the cross-package tracer type flows from the core accessor into
    both AI-SDK experimental_telemetry.tracer sites
New regression test: packages/opencode/test/effect/observability-tracer.test.ts
  - aiSdkTracer returns undefined with no OtelTracer in context; returns the
    provided tracer when one is registered
  - per this lane's policy the bun test suite runs in PR CI (unit-opencode), not
    locally; red→green is structural: aiSdkTracer/OtelTracer do not exist on base
    so the test cannot compile against it, and passes after the change
```

## Screenshots or Recordings

N/A — no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.