### PR TITLE
test(import): assert reseeded directory identity for Windows portability

### DIFF
--- a/packages/opencode/test/cli/import.test.ts
+++ b/packages/opencode/test/cli/import.test.ts
@@ -7,6 +7,7 @@ import {
   transformShareData,
   type ShareData,
 } from "../../src/cli/cmd/import"
+import { sameDirectory } from "../../src/session/execution-context"
 
 // parseShareUrl tests
 test("parses valid share URLs", () => {
@@ -85,9 +86,12 @@ test("re-homes an imported session onto the local instance, dropping every forei
   // foreign workspace binding is dropped (a foreign id would break workspace routing)
   expect(localized.workspaceID).toBeUndefined()
   // executionContext (the real shell/tool cwd source) is reseeded at the local owner;
-  // the exporter's absolute paths and worktree are gone
-  expect(localized.executionContext.ownerDirectory).toBe("/exporter-test/importer/local-project")
-  expect(localized.executionContext.activeDirectory).toBe("/exporter-test/importer/local-project")
+  // the exporter's absolute paths and worktree are gone. rootContext canonicalizes the
+  // owner dir (path.resolve + normalize), so assert directory identity, not a literal
+  // string — a hardcoded POSIX path drive-prefixes to D:\... on Windows.
+  expect(sameDirectory(localized.executionContext.ownerDirectory, "/exporter-test/importer/local-project")).toBe(true)
+  expect(sameDirectory(localized.executionContext.activeDirectory, "/exporter-test/importer/local-project")).toBe(true)
+  expect(sameDirectory(localized.executionContext.ownerDirectory, exported.executionContext.ownerDirectory)).toBe(false)
   expect(localized.executionContext.activeWorktree).toBeUndefined()
   // unrelated fields preserved; input not mutated
   expect(localized.id).toBe("sess-1")


### PR DESCRIPTION
## Summary

Fixes the Windows CI failure introduced by #1145.

`import.test.ts` asserted `localized.executionContext.ownerDirectory` (and `activeDirectory`) equalled the hardcoded POSIX literal `/exporter-test/importer/local-project`. But `localizeImportedSession` reseeds the context via `rootContext` → `canonicalDirectory`, which runs the owner dir through `path.resolve` + `path.normalize`. On Windows a rootless POSIX path drive-prefixes to `D:\exporter-test\…`, so the literal assertion failed **deterministically** in the `unit-windows-opencode-server-tools` job (0.78ms `toBe` mismatch) while passing on macOS/Linux.

The production code is correct — canonicalizing the owner dir is the intended behavior. Only the test asserted a non-portable string representation.

## Change

Switch the assertions to the project's own cross-platform `sameDirectory` helper (canonicalizes both sides, Windows case-insensitive), testing the contract — *reseeded at the local owner, not the exporter's path* — instead of a literal string. Adds a negative assertion that the reseeded owner is not the exporter's owner directory. Mirrors the established pattern in `session.test.ts` (already uses `canonicalDirectory`); portable by construction.

Test-only change; no production code touched.

## Verification

- macOS `bun test test/cli/import.test.ts` → 7 pass, 0 fail (33 expect calls).
- Local probe confirmed `canonicalDirectory` idempotency (platform-agnostic) and that `sameDirectory`'s compare returns `true` for the real Windows-normalized value (`D:\exporter-test\…`) and `false` for the exporter path.
- Windows-green confirmation: the `windows advisory` job on this PR.

## Note (not in this PR)

The same `windows advisory` run also fails `unit-windows-opencode-session` on `export.test.ts` with an `EBUSY` on `fs.rm` after `Instance.disposeDirectory` — a **pre-existing flaky Windows teardown race** (the helper + tests predate #1145), unrelated to this fix. Tracked separately.