### PR TITLE
fix(provider): type default model failures

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -312,7 +312,7 @@ export namespace Agent {
           model?: { providerID: ProviderID; modelID: ModelID }
         }) {
           const cfg = yield* config.get()
-          const model = input.model ?? (yield* provider.defaultModel())
+          const model = input.model ?? (yield* provider.defaultModel().pipe(Effect.orDie))
           const resolved = yield* provider.getModel(model.providerID, model.modelID)
           const language = yield* provider.getLanguage(resolved)
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -991,7 +991,7 @@ export interface Interface {
     query: string[],
   ) => Effect.Effect<{ providerID: ProviderID; modelID: string } | undefined>
   readonly getSmallModel: (providerID: ProviderID) => Effect.Effect<Model | undefined>
-  readonly defaultModel: () => Effect.Effect<{ providerID: ProviderID; modelID: ModelID }>
+  readonly defaultModel: () => Effect.Effect<{ providerID: ProviderID; modelID: ModelID }, DefaultModelError>
 }
 
 interface State {
@@ -1805,10 +1805,10 @@ const layer: Layer.Layer<
       }
 
       const provider = Object.values(s.providers).find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
-      if (!provider) throw new Error("no providers found")
+      if (!provider) return yield* Effect.fail(new NoProvidersError({}))
       const modelID = defaultModelID(provider)
       const model = provider.models[modelID]
-      if (!model) throw new Error("no models found")
+      if (!model) return yield* Effect.fail(new NoModelsError({ providerID: provider.id }))
       return {
         providerID: provider.id,
         modelID: model.id,
@@ -1893,6 +1893,17 @@ export const InitError = NamedError.create(
   }),
 )
 
+export const NoProvidersError = NamedError.create("ProviderNoProvidersError", z.object({}))
+
+export const NoModelsError = NamedError.create(
+  "ProviderNoModelsError",
+  z.object({
+    providerID: ProviderID.zod,
+  }),
+)
+
+export type DefaultModelError = InstanceType<typeof NoProvidersError> | InstanceType<typeof NoModelsError>
+
 const ProviderServiceValue = Service
 const ProviderDefaultLayerValue = defaultLayer
 const ProviderModelValue = Model
@@ -1913,6 +1924,8 @@ const ProviderSortValue = sort
 const ProviderParseModelValue = parseModel
 const ProviderModelNotFoundErrorValue = ModelNotFoundError
 const ProviderInitErrorValue = InitError
+const ProviderNoProvidersErrorValue = NoProvidersError
+const ProviderNoModelsErrorValue = NoModelsError
 
 export namespace Provider {
   export type Interface = import("./provider").Interface
@@ -1941,4 +1954,7 @@ export namespace Provider {
   export const parseModel = ProviderParseModelValue
   export const ModelNotFoundError = ProviderModelNotFoundErrorValue
   export const InitError = ProviderInitErrorValue
+  export const NoProvidersError = ProviderNoProvidersErrorValue
+  export const NoModelsError = ProviderNoModelsErrorValue
+  export type DefaultModelError = import("./provider").DefaultModelError
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1463,7 +1463,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const lastModel = Effect.fnUntraced(function* (sessionID: SessionID) {
       const match = yield* sessions.findMessage(sessionID, (m) => m.info.role === "user" && !!m.info.model)
       if (Option.isSome(match) && match.value.info.role === "user") return match.value.info.model
-      return yield* provider.defaultModel()
+      return yield* provider.defaultModel().pipe(Effect.orDie)
     })
 
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -102,7 +102,7 @@ export function createAutomateDefinition(
           variant = params.variant
         } else {
           const fromSession = sessionModel(ctx.sessionID)
-          const inherited = fromSession ?? (yield* provider.defaultModel())
+          const inherited = fromSession ?? (yield* provider.defaultModel().pipe(Effect.orDie))
           model = { providerID: inherited.providerID, modelID: inherited.modelID }
           variant = params.variant ?? fromSession?.variant
         }

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -103,7 +103,7 @@ export const PlanExitTool = Tool.define(
             }
           }
 
-          const model = getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel())
+          const model = getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel().pipe(Effect.orDie))
 
           const msg: MessageV2.User = {
             id: MessageID.ascending(),

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -228,6 +228,34 @@ test("enabled_providers restricts to only listed providers", async () => {
   })
 })
 
+test("defaultModel fails with a typed NoProvidersError when config excludes every provider", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          enabled_providers: [],
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      expect(Object.keys(await list())).toHaveLength(0)
+      // Effect.flip moves the typed failure into the success channel; a bare-Error
+      // defect (the old behavior) would reject instead, so this is red->green.
+      const error = await run((provider) => provider.defaultModel().pipe(Effect.flip))
+      expect(Provider.NoProvidersError.isInstance(error)).toBe(true)
+      expect((error as { name: string }).name).toBe("ProviderNoProvidersError")
+    },
+  })
+})
+
 test("model whitelist filters models for provider", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
## Summary

`Provider.Interface.defaultModel()` threw bare `new Error("no providers found")` / `new Error("no models found")` inside an `Effect.fn`. Inside an Effect, a `throw` becomes an untyped **defect** (Die), and the interface declared `E = never`, so a zero-provider / no-models state surfaced as an opaque, uncatchable defect with no machine-readable identity.

This adds two typed errors — `NoProvidersError` and `NoModelsError` — and a `DefaultModelError` channel, and fails `defaultModel()` with them instead of throwing. The new errors use the existing `NamedError.create` pattern (same as `ModelNotFoundError` / `InitError`) and are exported on the `Provider` namespace.

## Why

Ports upstream anomalyco/opencode#28881 ("type default model failures", thanks @nexxeln), adapted to PawWork's error idiom. Re-proven on current `dev`: `provider/provider.ts` still threw bare `Error` at the two `defaultModel` guards with `E = never`.

The adaptation differs from upstream in one deliberate way: upstream uses `Schema.TaggedErrorClass`; PawWork uses `NamedError` (a plain `Error` subclass), so the errors enter the failure channel via `Effect.fail(...)` rather than `yield* new X()`, and the typed `DefaultModelError` is `InstanceType<typeof ...>`.

## Related Issue

None. Upstream port (anomalyco/opencode#28881).

## Human Review Status

Pending

## Review Focus

- **Boundary / call-site adaptations.** Typing `defaultModel`'s error channel is type-infectious. The internal callers that treat default-model resolution as an invariant — `agent.generate` (`agent.ts`), `session prompt lastModel` (`prompt.ts`), and the `automate`/`plan` tools — pipe `Effect.orDie` to **preserve their current defect behavior** (zero behavior change; same as the old bare-`Error` defect, now typed). The cli `debug agent` command consumes `defaultModel` through the module-level `runPromise` wrapper (`export async function defaultModel()`), so its rejection is now a typed error with no code change. Confirm these per-site choices match how each context should treat an unresolved default model.
- **No failure leaks into a constrained channel.** Full `bun run typecheck` is green across all 9 packages, so no caller's declared `E` was silently widened.

## Risk Notes

Behavior is preserved at every current caller (all internal callers `orDie`, matching today's defect; the cli rejection is unchanged except the error is now typed). The only observable change is that `defaultModel()`'s failures are typed and catchable for future callers and in tests. Skipped conditional checklist items:

- UI/copy item — no visible UI or copy changed (engine-internal error typing).
- Platform item — no platform, packaging, updater, signing, paths, shell, or permissions surface touched.
- Docs/release/deps item — no docs, dependencies, generated files, or local file surfaces touched.

## How To Verify

```text
Red->green test (test/provider/provider.test.ts): with enabled_providers: [] (config excludes every provider), defaultModel().pipe(Effect.flip) yields a NoProvidersError. Before the fix defaultModel died with a bare Error (flip does not catch defects -> the run rejects), so the test is red without the change and green with it. Verified in CI (unit-opencode).
bun run typecheck (turbo, all 9 packages): 8 successful, 0 errors — confirms no call-site E channel was broken.
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

