### PR TITLE
fix(shell): show the configured default timeout in the bash tool prompt

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -658,6 +658,7 @@ export const ShellTool = Tool.define(
           directory,
           tmp: Global.Path.tmp,
           limits,
+          defaultTimeout: DEFAULT_TIMEOUT,
         })
 
         const deps: ArtifactDeps = {

--- a/packages/opencode/src/tool/shell.txt
+++ b/packages/opencode/src/tool/shell.txt
@@ -26,7 +26,7 @@ Before executing the command, please follow these steps:
 
 Usage notes:
   - The command argument is required.
-  - You can specify an optional timeout in milliseconds. If not specified, commands will time out after 120000ms (2 minutes).
+  - You can specify an optional timeout in milliseconds. If not specified, commands will time out after ${defaultTimeout}ms.
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
   - If the output exceeds ${maxLines} lines or ${maxBytes} bytes, it will be truncated and the full output will be written to a file. You can use Read with offset/limit to read specific sections or Grep to search the full content. Do NOT use `head`, `tail`, or other truncation commands to limit output; the full output will already be captured to a file for more precise searching.
 

--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -64,6 +64,7 @@ export function render(input: {
   directory: string
   tmp: string
   limits: Limits
+  defaultTimeout: number
 }) {
   return DESCRIPTION.replaceAll("${directory}", input.directory)
     .replaceAll("${tmp}", input.tmp)
@@ -72,4 +73,5 @@ export function render(input: {
     .replaceAll("${chaining}", chainingFor(input.name))
     .replaceAll("${maxLines}", String(input.limits.maxLines))
     .replaceAll("${maxBytes}", String(input.limits.maxBytes))
+    .replaceAll("${defaultTimeout}", String(input.defaultTimeout))
 }

--- a/packages/opencode/test/tool/shell-prompt.test.ts
+++ b/packages/opencode/test/tool/shell-prompt.test.ts
@@ -7,6 +7,7 @@ const DEFAULTS = {
   directory: "/tmp/pawwork-test",
   tmp: "/tmp/global",
   limits: LIMITS,
+  defaultTimeout: 120_000,
 }
 
 describe("bash prompt", () => {
@@ -54,6 +55,18 @@ describe("bash prompt", () => {
       expect(out).toContain("OS: darwin")
       expect(out).toContain("2000 lines")
       expect(out).toContain("51200 bytes")
+    })
+
+    test("interpolates the configured default timeout, not the old hardcoded 120000ms / '2 minutes'", () => {
+      // Regression for the shell.txt usage note that hardcoded "120000ms (2
+      // minutes)" even though the default is configurable via
+      // OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS (shell.ts:48). The rendered
+      // prompt must reflect the real DEFAULT_TIMEOUT threaded in by the caller.
+      // Adapted from upstream opencode #28998.
+      const out = render({ ...DEFAULTS, name: "bash", defaultTimeout: 30_000 })
+      expect(out).toContain("time out after 30000ms")
+      expect(out).not.toContain("120000ms")
+      expect(out).not.toContain("2 minutes")
     })
 
     test("no unreplaced template placeholders", () => {


### PR DESCRIPTION
## Summary

The shell (bash) tool description hardcoded `commands will time out after 120000ms (2 minutes)`, but the default timeout is configurable via `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` (`shell.ts` `DEFAULT_TIMEOUT`). When that flag is set, the prompt advertised a stale, wrong number to the model.

Thread `DEFAULT_TIMEOUT` into `ShellPrompt.render` via a `${defaultTimeout}` placeholder (the same `replaceAll` template style already used for `${maxLines}` / `${maxBytes}`), so the rendered description always reflects the real default.

## Why

The tool description is what the model reads to decide whether to pass an explicit `timeout`. Advertising `120000ms` when the configured default is different is misinformation. This makes the one dynamic value honest without changing any runtime behavior.

## Related Issue

None — upstream port (#28998).

## Human Review Status

Pending

## Review Focus

- `DEFAULT_TIMEOUT` is `number` (`Flag.number(...) || 2*60*1000`, and `flag.number` returns `number | undefined`), so it satisfies the new `defaultTimeout: number` field — no `string | number` leak.
- The parenthetical `(2 minutes)` was intentionally dropped: the value is now dynamic and can't be re-derived into prose, matching upstream #28998.

## Risk Notes

Very low. Prompt-text-only change plus one threaded argument; no execution path, no platform/packaging/UI surface, no deps/permissions/generated files. The actual timeout enforcement (`shell.ts` `DEFAULT_TIMEOUT`) is untouched — this only fixes what the description *says*.

## How To Verify

```text
Extended test/tool/shell-prompt.test.ts:
  render({ ...DEFAULTS, name: "bash", defaultTimeout: 30_000 }) must contain
  "time out after 30000ms" and must NOT contain "120000ms" or "2 minutes".
    - red (pre-change): shell.txt still says "120000ms (2 minutes)" and render
      ignores defaultTimeout -> assertions fail.
    - green (with change): ${defaultTimeout} interpolates 30000 -> passes.
  DEFAULTS gains defaultTimeout: 120_000 so the existing render() cases (and the
  "no unreplaced template placeholders" guard) keep compiling and passing.
Full bun test (unit-opencode) + typecheck left to CI per workflow.
```

## Screenshots or Recordings

N/A — no visible UI change (model-facing tool description only).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — at least one of `app`, `ui`, `platform`, `harness`, `ci` (labeler bot assigns on open; confirm then tick).
- [ ] **Priority label** — exactly one of `P0`, `P1`, `P2`, `P3` (triage bot suggests on open; confirm then tick).
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** Visible UI / copy changes checked. N/A — no visible UI changed.
- [ ] **(conditional)** macOS / Windows impact considered. N/A — no platform/packaging surface touched.
- [ ] **(conditional)** Docs / release notes / deps / permissions called out. N/A — none touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
