### PR TITLE
fix(server): parse boolean session query params with an enum transform

### DIFF
--- a/packages/opencode/src/server/instance/experimental.ts
+++ b/packages/opencode/src/server/instance/experimental.ts
@@ -44,6 +44,9 @@ function encodeCreatedSessionCursor(session: Session.GlobalInfo) {
 
 const CreatedSessionCursor = z.object({ created: z.number(), id: SessionID.zod })
 const ActivitySessionCursor = z.object({ activityAt: z.number(), id: SessionID.zod })
+// z.coerce.boolean() runs Boolean(value), so the string "false" coerces to true and clients
+// can never disable a boolean query flag. Parse the literal strings instead.
+const QueryBoolean = z.enum(["true", "false"]).transform((value) => value === "true")
 
 function decodeCreatedSessionCursor(value: string | number | undefined) {
   if (value === undefined) return undefined
@@ -416,7 +419,7 @@ export const ExperimentalRoutes = lazy(() =>
         "query",
         z.object({
           directory: z.string().optional().meta({ description: "Filter sessions by project directory" }),
-          roots: z.coerce.boolean().optional().meta({ description: "Only return root sessions (no parentID)" }),
+          roots: QueryBoolean.optional().meta({ description: "Only return root sessions (no parentID)" }),
           start: z.coerce
             .number()
             .optional()
@@ -430,7 +433,7 @@ export const ExperimentalRoutes = lazy(() =>
             .meta({ description: "Cursor for loading the next page" }),
           search: z.string().optional().meta({ description: "Filter sessions by title (case-insensitive)" }),
           limit: z.coerce.number().optional().meta({ description: "Maximum number of sessions to return" }),
-          archived: z.coerce.boolean().optional().meta({ description: "Include archived sessions (default false)" }),
+          archived: QueryBoolean.optional().meta({ description: "Include archived sessions (default false)" }),
           sort: z
             .enum(["updated", "created", "activity"])
             .optional()

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -35,6 +35,9 @@ import { Env } from "@/env"
 
 const log = Log.create({ service: "server" })
 const AbortSource = z.string().regex(/^[A-Za-z0-9._-]{1,80}$/)
+// z.coerce.boolean() runs Boolean(value), so the string "false" coerces to true and clients
+// can never disable a boolean query flag. Parse the literal strings instead.
+const QueryBoolean = z.enum(["true", "false"]).transform((value) => value === "true")
 
 // tool/respond returns route-local failure bodies ({ error } for not-found /
 // already-resolved, plus optional decoder { details } on 422) rather than the
@@ -98,7 +101,7 @@ export const SessionRoutes = lazy(() =>
         "query",
         z.object({
           directory: z.string().optional().meta({ description: "Filter sessions by project directory" }),
-          roots: z.coerce.boolean().optional().meta({ description: "Only return root sessions (no parentID)" }),
+          roots: QueryBoolean.optional().meta({ description: "Only return root sessions (no parentID)" }),
           start: z.coerce
             .number()
             .optional()

--- a/packages/opencode/test/server/experimental-routes.test.ts
+++ b/packages/opencode/test/server/experimental-routes.test.ts
@@ -90,4 +90,37 @@ describe("experimental routes", () => {
       },
     })
   })
+
+  test("parses ?roots=false and ?archived=false as false instead of coercing them to true", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const root = await Session.create({ title: "roots-false-root" })
+        const child = await Session.create({ title: "roots-false-child", parentID: root.id })
+        const archived = await Session.create({ title: "archived-false" })
+        await Session.setArchived({ sessionID: archived.id, time: Date.now() })
+
+        // Scope listGlobal to this tmpdir so the default 100-row window can't push the
+        // seeded sessions out when the in-memory DB holds other tests' sessions.
+        const dir = encodeURIComponent(tmp.path)
+
+        // z.coerce.boolean() coerced "false" to true, hiding child sessions; QueryBoolean
+        // must parse ?roots=false as false so the roots filter stays disabled.
+        const rootsRes = await app().request(`/experimental/session?roots=false&directory=${dir}`)
+        expect(rootsRes.status).toBe(200)
+        const rootsIds = (await rootsRes.json()).map((session: { id: string }) => session.id)
+        expect(rootsIds).toContain(root.id)
+        expect(rootsIds).toContain(child.id)
+
+        // ?archived=false coerced to true would wrongly include archived sessions; it must
+        // parse as false so the archived filter is applied.
+        const archivedRes = await app().request(`/experimental/session?archived=false&directory=${dir}`)
+        expect(archivedRes.status).toBe(200)
+        const archivedIds = (await archivedRes.json()).map((session: { id: string }) => session.id)
+        expect(archivedIds).toContain(root.id)
+        expect(archivedIds).not.toContain(archived.id)
+      },
+    })
+  })
 })

--- a/packages/opencode/test/server/session-core-routes.test.ts
+++ b/packages/opencode/test/server/session-core-routes.test.ts
@@ -140,4 +140,30 @@ describe("session core routes", () => {
 
     expect(seen).toEqual(busyOps)
   })
+
+  test("parses ?roots=false as false instead of coercing it to true", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const root = await svc.create({ title: "roots-false-root" })
+        const child = await svc.create({ title: "roots-false-child", parentID: root.id })
+        try {
+          const app = Server.Default().app
+          // z.coerce.boolean() turned "false" into true, hiding every child session;
+          // QueryBoolean must parse ?roots=false as false so the filter stays disabled.
+          const res = await app.request("/session?roots=false", {
+            headers: { "x-opencode-directory": tmp.path },
+          })
+          expect(res.status).toBe(200)
+          const ids = (await res.json()).map((session: { id: string }) => session.id)
+          expect(ids).toContain(root.id)
+          expect(ids).toContain(child.id)
+        } finally {
+          await svc.remove(child.id).catch(() => undefined)
+          await svc.remove(root.id).catch(() => undefined)
+        }
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary

The session-list query validators parsed `roots` / `archived` with `z.coerce.boolean()`, which runs `Boolean(value)` — so the literal query string `"false"` coerces to `true`. Clients could therefore never disable those filters: `?roots=false` returned only root sessions, and `?archived=false` wrongly included archived sessions.

Replace `z.coerce.boolean()` with a shared `QueryBoolean = z.enum(["true", "false"]).transform((v) => v === "true")` at the three live sites.

```diff
-          roots: z.coerce.boolean().optional().meta({ description: "Only return root sessions (no parentID)" }),
+          roots: QueryBoolean.optional().meta({ description: "Only return root sessions (no parentID)" }),
```

## Why

`z.coerce.boolean()` is `Boolean(str)`, and every non-empty string (including `"false"`) is truthy. So the API contract said `?roots=false` / `?archived=false` should turn the filter off, but in practice it turned it on. The enum-transform parses the literal strings, so `"false"` correctly yields `false`. The same `z.enum(["true", "false"])` pattern is already used for `file.ts` `dirs`, confirming this was an inconsistency rather than a deliberate choice. Consumers (`Session.list` / `Session.listGlobal`) already expect a boolean, so there is no downstream change.

This re-implements upstream opencode #24693 (thanks @kitlangton), adapted to this fork's Hono route schemas (upstream patched its Effect HttpApi + zod routes; the bug and fix are identical). No cherry-pick — the gap was re-proven on current `dev` (empirically: `z.coerce.boolean().parse("false") === true` on this repo's zod 4.1.8) and the smallest equivalent change applied.

## Related Issue

No tracking issue; this is a correctness port from upstream opencode #24693.

## Human Review Status

Pending

## Review Focus

- Confirm `QueryBoolean` rejects nothing it should accept (only `"true"`/`"false"` are valid; omitted stays `undefined` via `.optional()`), and that no caller passed values other than those two strings.
- Confirm the three swapped sites are the only `z.coerce.boolean()` usages in the server query schemas.

## Risk Notes

Behavior change is intentional and limited to the two session-list endpoints: `?roots=false` and `?archived=false` now actually disable their filters (previously a no-op). `?roots=true` / `?archived=true` and the omitted case are unchanged. A client that sent a non-`"true"`/`"false"` value to these flags previously got silent coercion; it now gets a 400 validation error — but the OpenAPI/meta always documented these as booleans, and the only documented values are the two literals.

Skipped conditional checklist items:
- Manual UI/copy check — no visible UI or user-facing copy changed (server query-schema only).
- Platform/packaging — no runtime, packaging, updater, signing, paths, shell, or permissions surface touched.
- Docs/release-notes/deps/etc. — none of those surfaces changed.

## How To Verify

```text
bun run typecheck (worktree root): 8 successful, 0 errors
Targeted: bun test test/server/session-core-routes.test.ts test/server/experimental-routes.test.ts -> 10 pass, 0 fail
  New tests (route-level, red->green):
   - session "?roots=false" keeps child sessions in the list (red: only root returned)
   - experimental "?roots=false & ?archived=false": child included, archived excluded
     (red: child dropped / archived wrongly included)
  Proven red by reverting the 3 sites to z.coerce.boolean() (both tests fail), then restored.
Full bun test suite: deferred to PR CI
```

## Screenshots or Recordings

N/A — no visible UI or copy change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
