### PR TITLE
fix(github-copilot): mark auto-continued compaction turns as agent initiated

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -363,7 +363,18 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         })
         .catch(() => undefined)
 
-      if (parts?.data.parts?.some((part) => part.type === "compaction")) {
+      // Auto-compaction resumes the turn via a synthetic user text part marked
+      // metadata.compaction_continue (written in session/compaction.ts); that
+      // follow-up request carries no `compaction`-type part, so match it explicitly
+      // to keep x-initiator: agent on the resumed turn. Manual post-compaction
+      // prompts are not synthetic and stay user-initiated.
+      if (
+        parts?.data.parts?.some(
+          (part) =>
+            part.type === "compaction" ||
+            (part.type === "text" && part.synthetic && part.metadata?.compaction_continue === true),
+        )
+      ) {
         output.headers["x-initiator"] = "agent"
         return
       }

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -452,6 +452,93 @@ test("sets anthropic beta header only for github copilot anthropic chat headers"
   expect(anthropic.headers).not.toHaveProperty("anthropic-beta")
 })
 
+test("marks an auto-continued compaction turn (synthetic text part) as agent initiated", async () => {
+  // Auto-compaction resumes the turn with a synthetic user text part marked
+  // metadata.compaction_continue (session/compaction.ts). That follow-up request
+  // carries no `compaction`-type part, so x-initiator must still be set to agent.
+  const hooks = await CopilotAuthPlugin({
+    client: {
+      session: {
+        message: async () => ({
+          data: {
+            parts: [
+              {
+                type: "text",
+                text: "Continue if you have next steps, or stop and ask for clarification.",
+                synthetic: true,
+                metadata: { compaction_continue: true },
+              },
+            ],
+          },
+        }),
+        get: async () => ({ data: { parentID: undefined } }),
+      },
+    } as never,
+    project: {} as never,
+    directory: "",
+    worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
+    serverUrl: new URL("https://example.com"),
+    $: {} as never,
+  })
+
+  const output = { headers: {} as Record<string, string> }
+  await hooks["chat.headers"]?.(
+    {
+      model: {
+        providerID: "github-copilot",
+        id: "gpt",
+        api: { id: "gpt-5", npm: "@ai-sdk/openai" },
+      },
+      message: { sessionID: "s", id: "m" },
+    } as never,
+    output as never,
+  )
+
+  expect(output.headers["x-initiator"]).toBe("agent")
+})
+
+test("keeps a manual post-compaction user prompt user initiated", async () => {
+  // A real user prompt after compaction is not synthetic and carries no
+  // compaction_continue marker, so x-initiator must not be forced to agent on a
+  // top-level session — only the parentID (subagent) fallback may set it.
+  const hooks = await CopilotAuthPlugin({
+    client: {
+      session: {
+        message: async () => ({
+          data: { parts: [{ type: "text", text: "now refactor the parser" }] },
+        }),
+        get: async () => ({ data: { parentID: undefined } }),
+      },
+    } as never,
+    project: {} as never,
+    directory: "",
+    worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
+    serverUrl: new URL("https://example.com"),
+    $: {} as never,
+  })
+
+  const output = { headers: {} as Record<string, string> }
+  await hooks["chat.headers"]?.(
+    {
+      model: {
+        providerID: "github-copilot",
+        id: "gpt",
+        api: { id: "gpt-5", npm: "@ai-sdk/openai" },
+      },
+      message: { sessionID: "s", id: "m" },
+    } as never,
+    output as never,
+  )
+
+  expect(output.headers).not.toHaveProperty("x-initiator")
+})
+
 test("excludes models disabled by org/enterprise policy", async () => {
   const model = (id: string, extra: Record<string, unknown>) => ({
     model_picker_enabled: true,


### PR DESCRIPTION
## Summary

Widen the `chat.headers` predicate in the GitHub Copilot plugin so an auto-continued compaction turn keeps `x-initiator: agent`. The hook previously set the header only when the message carried a `compaction`-type part; it now also matches the synthetic user text part that auto-compaction injects to resume the turn (`part.type === "text" && part.synthetic && part.metadata?.compaction_continue === true`).

No PawWork issue — this ports the missing **read half** of upstream `sst/opencode#22567`. The **write half** (compaction stamping `metadata.compaction_continue` on the synthetic continue part) already shipped in `session/compaction.ts`.

## Why

Auto-compaction resumes a turn by appending a synthetic `user` text part marked `metadata.compaction_continue` — there is no `compaction`-type part on that follow-up message (the `compaction` part is created on a separate message). So when `chat.headers` fired for the resumed request, the old predicate did not match and `x-initiator: agent` was not set. The only fallback (`session.parentID`) covers subagent sessions, so a **top-level** Copilot session's auto-continued request was mis-classified as **user-initiated**, skewing Copilot's agent-vs-user request accounting. Thanks to the upstream authors of `sst/opencode#22567`.

## Related Issue

None — upstream port of `sst/opencode#22567` (read half). Tracked in the Round-3 upstream value ledger as R3.9.

## Human Review Status

Pending

## Review Focus

- The predicate matches the write-half contract in `session/compaction.ts` (`synthetic: true` + `metadata: { compaction_continue: true }` on a `type: "text"` part) and nothing broader.
- The negative path: a real (non-synthetic) post-compaction user prompt must stay user-initiated on a top-level session.

## Risk Notes

Blast radius limited to the GitHub Copilot `x-initiator` header classification. No behavior change for non-Copilot providers, subagent sessions (still covered by the `parentID` fallback), or manual prompts. Conditional checklist items left unticked: **UI** (no visible UI/copy changed), **platform** (no platform/packaging/path/permission surface touched), **docs/deps** (none touched).

## How To Verify

<!-- Local test run skipped by project workflow for this task — CI is the gate. Verification below is by construction + type-checking; CI runs the full opencode unit suite. -->

```text
Red→green (test/plugin/github-copilot-models.test.ts):
  - "marks an auto-continued compaction turn (synthetic text part) as agent initiated":
    old predicate matches only `compaction` parts → the synthetic text part is not
    matched, session.get returns no parentID → x-initiator never set → FAILS (red).
    Widened predicate matches text+synthetic+compaction_continue → x-initiator:agent → PASS (green).
  - "keeps a manual post-compaction user prompt user initiated":
    plain (non-synthetic) text part stays user-initiated under both predicates → guards over-matching.
Type check: predicate narrows cleanly on `part.type === "text"` against SDK TextPart
  (synthetic?: boolean; metadata?: { [k]: unknown }) — `metadata?.compaction_continue === true` on unknown is valid.
CI gates: typecheck + unit-opencode (runs the file above) + lint.
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [ ] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
