### PR TITLE
fix(compaction): size the retained tail at full fidelity to prevent post-compaction overflow

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -246,15 +246,13 @@ export const layer: Layer.Layer<
       messages: MessageV2.WithParts[]
       model: Provider.Model
     }) {
-      // Match the serialization options that processCompaction() actually
-      // applies (see line 405-408). Estimating with full media + un-truncated
-      // tool output overstates the post-compaction size, which makes select()
-      // drop recent turns that would have fit through compaction anyway.
-      const msgs = yield* MessageV2.toModelMessagesEffect(input.messages, input.model, {
-        stripMedia: true,
-        toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
-        toolInputMaxChars: TOOL_INPUT_MAX_CHARS,
-      })
+      // Size the retained tail the way it actually re-enters the live prompt:
+      // prompt.ts serializes messages with no options, i.e. full media and
+      // un-truncated tool output. Only the head is summarized cheaply (stripMedia
+      // + truncation in processCompaction()); the tail is kept verbatim. Using
+      // those head options here undercounts the tail, so select()/splitTurn()
+      // keep recent turns that overflow the very next live prompt.
+      const msgs = yield* MessageV2.toModelMessagesEffect(input.messages, input.model)
       return Token.estimate(JSON.stringify(msgs))
     })
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -981,6 +981,86 @@ describe("session.compaction.process", () => {
       },
     })
   })
+  test("sizes the retained tail at full fidelity so a large tool output cannot sneak past the budget", async () => {
+    // Regression: estimate() must size the retained tail the way it re-enters the
+    // live prompt (full media + un-truncated tool output), not with the cheaper
+    // stripMedia + toolOutputMaxChars options that only the summarized head uses.
+    // A recent turn carrying a huge tool output looks small under the truncated
+    // estimate, so the old code retained it and overflowed the next live prompt.
+    await using tmp = await tmpdir()
+    const model = createModel({ context: 30_000, input: 30_000, output: 4_000 })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create()
+        const first = await user(session.id, "first request")
+        await assistant(session.id, first.id, tmp.path)
+        const heavy = await user(session.id, "tool heavy request")
+        const heavyAssistant = await assistant(session.id, heavy.id, tmp.path)
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: heavyAssistant.id,
+          sessionID: session.id,
+          type: "tool",
+          callID: "call-heavy",
+          tool: "bash",
+          state: {
+            status: "completed",
+            input: {},
+            // ~50k tokens at full fidelity, but truncates to ~0.5k under the
+            // head's toolOutputMaxChars cap — the exact gap this test guards.
+            output: "x".repeat(200_000),
+            title: "done",
+            metadata: {},
+            time: { start: 0, end: 1 },
+          },
+        })
+        const latest = await user(session.id, "latest request")
+        await assistant(session.id, latest.id, tmp.path)
+        const compact = await user(session.id, "compact now")
+        await svc.updatePart({
+          id: PartID.ascending(),
+          messageID: compact.id,
+          sessionID: session.id,
+          type: "compaction",
+          auto: true,
+        })
+
+        const fakeLLM = llm()
+        fakeLLM.push(reply("older summary"))
+        const live = liveRuntime(
+          fakeLLM.layer,
+          ProviderTest.fake({ model }),
+          // Budget clears the truncated tool output (~0.5k) but not the full one (~50k).
+          cfg({ tail_turns: 2, preserve_recent_tokens: 6_000 }),
+        )
+        try {
+          const beforeCompaction = await svc.messages({ sessionID: session.id })
+          await live.runPromise(
+            SessionCompaction.Service.use((compaction) =>
+              compaction.process({
+                parentID: compact.id,
+                messages: beforeCompaction,
+                sessionID: session.id,
+                auto: true,
+              }),
+            ),
+          )
+        } finally {
+          await live.dispose()
+        }
+
+        const messages = await svc.messages({ sessionID: session.id })
+        const compactPart = messages
+          .flatMap((message) => message.parts)
+          .find((part): part is MessageV2.CompactionPart => part.type === "compaction")
+
+        // With the fix the tail boundary stops at the small latest turn; the
+        // tool-heavy turn is summarized into the head instead of retained verbatim.
+        expect(compactPart?.tail_start_id).toBe(latest.id)
+      },
+    })
+  })
   test("throws when parent is not a user message", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({


### PR DESCRIPTION
## Summary

`SessionCompaction.estimate()` sizes the **verbatim retained tail** using the same `stripMedia` + tool output/input truncation options that only the summarized head needs. The tail re-enters the live prompt at full fidelity (`prompt.ts` serializes with no options), so this estimate undercounts it. Dropping the options in `estimate()` makes the tail sizing match how the tail is actually replayed.

No linked issue — found via an upstream-port audit (see Related Issue).

## Why

`estimate()` is only used by `select()` / `splitTurn()` to size the recent turns kept verbatim past `tail_start_id`, against the preserve-recent budget (capped at `MAX_PRESERVE_RECENT_TOKENS = 8000`). With `stripMedia: true` + `toolOutputMaxChars`/`toolInputMaxChars`, a large image collapses to a tiny stub and a large tool output truncates to ~2k chars, so a recent turn carrying them estimates near-zero. But that same tail re-enters the **live prompt** at `prompt.ts:2255` via `toModelMessagesEffect(msgs, model)` with **no options** — full media, full tool output. So an image/tool-heavy tail passes the budget on its cheap estimate yet blows past it once kept verbatim, defeating the tail bound and risking immediate post-compaction re-overflow.

The summarized **head** is a different message set — it is replaced by a summary and is correctly serialized with truncation in `processCompaction()` (unchanged here). The old in-code comment justified `stripMedia` by pointing at that head path, but it does not cover tail sizing.

## Related Issue

No GitHub issue. Adapts upstream opencode `42771c1db3` (`fix(compaction): budget retained tail with media`). Thanks to the upstream author. Upstream only removed `{ stripMedia: true }`; PawWork's `estimate()` additionally truncates tool output/input (a local divergence), so the correct local fix drops **all three** options to match the live prompt serialization.

## Human Review Status

Pending

## Review Focus

- Correctness of removing the serialization options in `estimate()` — that the tail estimate now matches the live prompt path (`prompt.ts:2255`, no options), and that the head path in `processCompaction()` keeps its own truncated serialization.
- The regression test genuinely discriminates: under the old truncated estimate the tool-heavy turn fits the budget (`tail_start_id` lands on it); with the fix the full-fidelity estimate pushes it into the summarized head, so `tail_start_id` stops at the latest small turn.

## Risk Notes

More conservative tail sizing: a media/tool-heavy recent turn that previously slipped under the budget on its stripped estimate will now be summarized into the head instead of retained verbatim. That is the intended correctness fix — retaining it verbatim is exactly what would overflow the next live prompt.

Skipped conditional checklist items:
- Visible UI / copy: none changed.
- macOS/Windows platform surface: none touched (pure token-estimation logic).
- Docs / release notes / deps / permissions: none touched.

## How To Verify

```text
bun run typecheck (tsgo --noEmit): passed, no errors
New regression test "sizes the retained tail at full fidelity so a large tool
output cannot sneak past the budget" added to test/session/compaction.test.ts;
runs in the unit-opencode CI job (repo policy: unit tests run in CI).
Red -> green: a 200k-char tool output truncates to ~0.5k tokens under the old
head options (fits the 6k budget -> tail_start_id = tool-heavy turn) but is ~50k
tokens at full fidelity (exceeds budget -> tail_start_id = latest small turn).
```

## Screenshots or Recordings

N/A — no UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
