### PR TITLE
fix(log): truncate dev.log once per run id, not on every init

### DIFF
--- a/packages/core/src/util/log.ts
+++ b/packages/core/src/util/log.ts
@@ -49,6 +49,7 @@ export namespace Log {
     level?: Level
   }
 
+  const initializedRunID = "OPENCODE_LOG_INITIALIZED_RUN_ID"
   let logpath = ""
   export function file() {
     return logpath
@@ -66,7 +67,14 @@ export namespace Log {
       Global.Path.log,
       options.dev ? "dev.log" : new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
     )
-    await fs.truncate(logpath).catch(() => {})
+    // Truncate dev.log only once per run: a single OPENCODE_RUN_ID may init the
+    // logger multiple times (re-entry, subprocesses), and wiping it on every
+    // init drops earlier lines from the same run. Non-dev (timestamped) files
+    // and runs without a run id keep the original truncate-on-init behavior.
+    const runID = process.env.OPENCODE_RUN_ID
+    const shouldTruncate = !options.dev || !runID || process.env[initializedRunID] !== runID
+    if (shouldTruncate) await fs.truncate(logpath).catch(() => {})
+    if (options.dev && runID) process.env[initializedRunID] = runID
     const stream = createWriteStream(logpath, { flags: "a" })
     write = async (msg: any) => {
       return new Promise((resolve, reject) => {

--- a/packages/core/test/util/log-dev-truncate.test.ts
+++ b/packages/core/test/util/log-dev-truncate.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import os from "node:os"
+import path from "node:path"
+
+// Regression for the unconditional `fs.truncate(logpath)` in Log.init (adapted
+// from the log-truncation portion of upstream opencode #27384). A single
+// OPENCODE_RUN_ID may init the logger more than once (re-entry, subprocesses);
+// wiping dev.log on every init dropped earlier lines from the same run. The guard
+// truncates dev.log only the first time a given run id is seen.
+//
+// Hermetic, mirroring test/global.test.ts: run in a subprocess with XDG_* pointed
+// at a throwaway dir so Global.Path.log (computed at module load) resolves under
+// tmp, never the real ~/.local/share, and the parent process env stays untouched.
+function probeTruncationAcrossInits() {
+  const root = path.join(os.tmpdir(), "pawwork-log-truncate-test")
+  const MARKER = "MARKER_R316"
+  const script = `
+    process.env.XDG_DATA_HOME = ${JSON.stringify(path.join(root, "share"))}
+    process.env.XDG_CACHE_HOME = ${JSON.stringify(path.join(root, "cache"))}
+    process.env.XDG_CONFIG_HOME = ${JSON.stringify(path.join(root, "config"))}
+    process.env.XDG_STATE_HOME = ${JSON.stringify(path.join(root, "state"))}
+    process.env.OPENCODE_RUN_ID = "run-A"
+    delete process.env.OPENCODE_LOG_INITIALIZED_RUN_ID
+    const fsp = await import("node:fs/promises")
+    const { Log } = await import("./src/util/log.ts")
+
+    // run-A, first init: records the run (truncates the empty/fresh file).
+    await Log.init({ print: false, dev: true })
+    await fsp.writeFile(Log.file(), ${JSON.stringify(MARKER + "\n")})
+    // run-A, second init: same run, must NOT truncate.
+    await Log.init({ print: false, dev: true })
+    const sameRunSurvived = (await fsp.readFile(Log.file(), "utf8")).includes(${JSON.stringify(MARKER)})
+
+    // A different run id must still truncate (the guard is not "never truncate").
+    await fsp.writeFile(Log.file(), ${JSON.stringify(MARKER + "\n")})
+    process.env.OPENCODE_RUN_ID = "run-B"
+    await Log.init({ print: false, dev: true })
+    const newRunSurvived = (await fsp.readFile(Log.file(), "utf8")).includes(${JSON.stringify(MARKER)})
+
+    console.log(JSON.stringify({ sameRunSurvived, newRunSurvived }))
+  `
+  const result = spawnSync(process.execPath, ["--eval", script], {
+    cwd: path.join(import.meta.dir, "..", ".."),
+    env: { ...process.env },
+  })
+  if (result.status !== 0) throw new Error(result.stderr.toString())
+  return JSON.parse(result.stdout.toString()) as { sameRunSurvived: boolean; newRunSurvived: boolean }
+}
+
+test("dev.log is truncated once per OPENCODE_RUN_ID: re-init within a run preserves earlier lines", () => {
+  const { sameRunSurvived, newRunSurvived } = probeTruncationAcrossInits()
+  // The fix: second init under the same run id leaves earlier lines intact.
+  expect(sameRunSurvived).toBe(true)
+  // Guard against an over-broad fix: a new run id still truncates as before.
+  expect(newRunSurvived).toBe(false)
+})


### PR DESCRIPTION
## Summary

`Log.init` ran `fs.truncate(logpath)` unconditionally, so `dev.log` was wiped on every init. A single `OPENCODE_RUN_ID` can init the logger more than once (re-entry, subprocesses), which dropped earlier lines belonging to the same run.

Guard truncation behind an `OPENCODE_LOG_INITIALIZED_RUN_ID` env marker: truncate `dev.log` only the first time a given dev run id is seen. Non-dev (timestamped) log files and runs without a run id keep the original truncate-on-init behavior.

## Why

Losing earlier lines from the same run makes `dev.log` unreliable for debugging anything that re-initializes logging mid-run. The marker makes truncation once-per-run instead of once-per-init, with no change for the non-dev / no-run-id paths.

## Related Issue

None — upstream port (the log-truncation portion of #27384).

## Review Focus

- The `shouldTruncate` boolean: `!options.dev || !runID || process.env[initializedRunID] !== runID`. It must still truncate for (a) non-dev timestamped files, (b) dev with no run id, and (c) the first dev init of a new run id; and skip only for (d) a repeat dev init under the same run id.
- The marker is written only on the dev+runID path (`if (options.dev && runID)`), so non-dev inits never pollute the env.

## Risk Notes

Low. Touches only the dev-logging init path in `core/util/log.ts`. No public API, no platform/packaging/UI surface, no deps/generated files. Worst case of a wrong guard is a stale-or-wiped `dev.log`, never a runtime failure (the `fs.truncate` is still `.catch(() => {})`).

## How To Verify

```text
Added test/util/log-dev-truncate.test.ts (hermetic, mirrors test/global.test.ts):
spawns a subprocess with XDG_* pointed at a tmp dir so Global.Path.log resolves
under tmp (never the real ~/.local/share), then:
  - run-A init #1 -> write MARKER -> run-A init #2 -> MARKER must survive
    (same run id => no truncate). [the fix]
  - re-write MARKER -> switch to run-B -> init -> MARKER must be gone
    (new run id => still truncates). [guards against an over-broad fix]
    - red (pre-change): init always truncates -> same-run MARKER wiped -> fails.
    - green (with change): same-run preserved, new-run truncated -> passes.
Full bun test (unit-opencode covers @opencode-ai/core) + typecheck left to CI.
```

## Screenshots or Recordings

N/A — no visible UI change (dev logging behavior only).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — at least one of `app`, `ui`, `platform`, `harness`, `ci` (labeler bot assigns on open; confirm then tick).
- [ ] **Priority label** — exactly one of `P0`, `P1`, `P2`, `P3` (triage bot suggests on open; confirm then tick).
- [x] Human Review Status: Pending.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** Visible UI / copy changes checked. N/A — no visible UI changed.
- [ ] **(conditional)** macOS / Windows impact considered. N/A — no platform/packaging surface; the env-marker logic is platform-agnostic.
- [ ] **(conditional)** Docs / release notes / deps / permissions called out. N/A — none touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dev.log handling to ensure log file truncation occurs only once per run, preserving log entries throughout execution.

* **Tests**
  * Added comprehensive test coverage for log truncation behavior across multiple runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->