### PR TITLE
ci(labeler): route packages/core changes to the harness label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,3 +29,4 @@ harness:
       - any-glob-to-any-file:
           - "packages/opencode/**"
           - "packages/sdk/**"
+          - "packages/core/**"


### PR DESCRIPTION
## Summary

`packages/core/**` had no rule in `.github/labeler.yml`, so any PR touching only `packages/core` could not satisfy the label policy: `pr-triage` runs `actions/labeler` with `sync-labels: true` (which strips any routing label not backed by a path glob), and `.github/scripts/label-policy-check.js` then requires at least one routing label (`app`/`ui`/`platform`/`harness`/`ci`). The result was a structural deadlock — the labeler removed any manually added routing label, and `pr-triage` failed every time.

Map `packages/core/**` to `harness`, alongside the existing `packages/opencode/**` and `packages/sdk/**` rules (core is the engine the opencode harness builds on).

## Why

Without this, every `packages/core`-only PR is un-mergeable under the label policy. This surfaced on #1167 (a `core/util/log.ts` fix). The fix is one glob and unblocks all future core-only PRs.

## Related Issue

None — discovered while landing #1167.

## Human Review Status

Pending

## Review Focus

That `harness` is the right routing bucket for `packages/core` (it backs the opencode CLI/runtime, not the desktop app/ui/electron/ci surfaces).

## Risk Notes

Minimal. CI label-routing config only; no product code, no build/test behavior. Worst case is a mis-routed label, fixable by editing one line.

## How To Verify

```text
After merge, re-trigger pr-triage on a packages/core-only PR (e.g. #1167):
the labeler assigns `harness` from the new packages/core/** glob, and the label
policy (one type + one priority + one routing) passes.
```

## Screenshots or Recordings

N/A — CI config only.

## Checklist

- [x] **Type label** — exactly one of `bug`, `enhancement`, `task`, `documentation` (`task`).
- [ ] **Routing labels** — `ci` is auto-assigned by the labeler (this PR touches `.github/**`).
- [ ] **Priority label** — auto-suggested by the triage bot.
- [x] Human Review Status: Pending.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps.
- [x] I did not introduce unrelated changes beyond the stated scope.
- [x] I reviewed the final diff.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow configuration to optimize labeling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->