### PR TITLE
fix(permission): surface documented 404 for unknown reply requestID

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -7,7 +7,7 @@ import { ProjectID } from "@/project/schema"
 import { Instance } from "@/project/instance"
 import { MessageID, SessionID } from "@/session/schema"
 import { PermissionTable } from "@/session/session.sql"
-import { Database, eq } from "@/storage/db"
+import { Database, NotFoundError, eq } from "@/storage/db"
 import { Log } from "@opencode-ai/core/util/log"
 import { Wildcard } from "@/util/wildcard"
 import { Deferred, Effect, Layer, Schema, Context } from "effect"
@@ -139,6 +139,24 @@ export namespace Permission {
   interface State {
     pending: Map<PermissionID, PendingEntry>
     approved: Ruleset
+    // Tombstone of recently-resolved request IDs. A reply can cascade-resolve
+    // sibling pending requests, so a client's own follow-up reply to one of
+    // those would otherwise miss `pending` and look unknown. Remembering the ID
+    // briefly lets that repeat reply be an idempotent success instead of a
+    // misleading 404, while a genuinely unknown ID still surfaces as not-found.
+    resolved: Set<PermissionID>
+  }
+
+  // Bounded FIFO; the tombstone only needs to outlive the gap between a
+  // cascade-resolve and the client's own reply (milliseconds), so a modest cap
+  // keeps memory flat without ever evicting an entry that is still in play.
+  const RESOLVED_TOMBSTONE_LIMIT = 1000
+  function markResolved(resolved: Set<PermissionID>, id: PermissionID) {
+    resolved.add(id)
+    if (resolved.size > RESOLVED_TOMBSTONE_LIMIT) {
+      const oldest = resolved.values().next().value
+      if (oldest !== undefined) resolved.delete(oldest)
+    }
   }
 
   export function evaluate(permission: string, pattern: string, ...rulesets: Ruleset[]): Rule {
@@ -160,6 +178,7 @@ export namespace Permission {
           const state = {
             pending: new Map<PermissionID, PendingEntry>(),
             approved: row?.data ?? [],
+            resolved: new Set<PermissionID>(),
           }
 
           yield* Effect.addFinalizer(() =>
@@ -176,7 +195,7 @@ export namespace Permission {
       )
 
       const ask = Effect.fn("Permission.ask")(function* (input: AskOptions) {
-        const { approved, pending } = yield* InstanceState.get(state)
+        const { approved, pending, resolved } = yield* InstanceState.get(state)
         const { ruleset, onPending, ...request } = input
         let needsAsk = false
         const denied: Array<{ pattern: string; rule: Rule }> = []
@@ -232,16 +251,24 @@ export namespace Permission {
           Deferred.await(deferred),
           Effect.sync(() => {
             pending.delete(id)
+            markResolved(resolved, id)
           }),
         )
       })
 
       const reply = Effect.fn("Permission.reply")(function* (input: z.infer<typeof ReplyInput>) {
-        const { approved, pending } = yield* InstanceState.get(state)
+        const { approved, pending, resolved } = yield* InstanceState.get(state)
         const existing = pending.get(input.requestID)
-        if (!existing) return
+        if (!existing) {
+          // Already handled (most often as a cascade sibling of an earlier
+          // reply) -> idempotent success. Genuinely unknown -> surface the
+          // route's documented 404 via ErrorMiddleware's NotFoundError mapping.
+          if (resolved.has(input.requestID)) return
+          throw new NotFoundError({ message: `Permission request not found: ${input.requestID}` })
+        }
 
         pending.delete(input.requestID)
+        markResolved(resolved, input.requestID)
         yield* bus.publish(Event.Replied, {
           sessionID: existing.info.sessionID,
           requestID: existing.info.id,
@@ -257,6 +284,7 @@ export namespace Permission {
           for (const [id, item] of pending.entries()) {
             if (item.info.sessionID !== existing.info.sessionID) continue
             pending.delete(id)
+            markResolved(resolved, id)
             yield* bus.publish(Event.Replied, {
               sessionID: item.info.sessionID,
               requestID: item.info.id,
@@ -285,6 +313,7 @@ export namespace Permission {
           )
           if (!ok) continue
           pending.delete(id)
+          markResolved(resolved, id)
           yield* bus.publish(Event.Replied, {
             sessionID: item.info.sessionID,
             requestID: item.info.id,
@@ -298,10 +327,11 @@ export namespace Permission {
         sessionID: SessionID,
         _reason: "session_deleted" | "session_archived" | "dangling_session",
       ) {
-        const { pending } = yield* InstanceState.get(state)
+        const { pending, resolved } = yield* InstanceState.get(state)
         for (const [id, item] of Array.from(pending.entries())) {
           if (item.info.sessionID !== sessionID) continue
           pending.delete(id)
+          markResolved(resolved, id)
           yield* bus.publish(Event.Replied, {
             sessionID: item.info.sessionID,
             requestID: item.info.id,

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -147,10 +147,16 @@ export namespace Permission {
     resolved: Set<PermissionID>
   }
 
-  // Bounded FIFO; the tombstone only needs to outlive the gap between a
-  // cascade-resolve and the client's own reply (milliseconds), so a modest cap
-  // keeps memory flat without ever evicting an entry that is still in play.
-  const RESOLVED_TOMBSTONE_LIMIT = 1000
+  // Bounded FIFO memory backstop for the tombstone. The cap only needs to keep
+  // an entry alive across the gap between a cascade-resolve and the client's own
+  // follow-up reply (sub-second), so eviction by insertion order is fine — as
+  // long as the cap stays well above the most requests one reply can resolve at
+  // once. A single "always"/"reject" cascade resolves at most the pending count
+  // of one session; permission asks are human-paced (auto-approved rules never
+  // pend), so that count is realistically dozens. This cap sits far above it, so
+  // a cascade can never evict its own freshly-resolved siblings and turn their
+  // legitimate follow-up reply into a false 404.
+  const RESOLVED_TOMBSTONE_LIMIT = 10_000
   function markResolved(resolved: Set<PermissionID>, id: PermissionID) {
     resolved.add(id)
     if (resolved.size > RESOLVED_TOMBSTONE_LIMIT) {

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -1646,7 +1646,9 @@ export const SessionRoutes = lazy(() =>
       validator("json", z.object({ response: Permission.Reply })),
       async (c) => {
         const params = c.req.valid("param")
-        Permission.reply({
+        // Await so an unknown permission surfaces this route's documented 404
+        // instead of being swallowed by a fire-and-forget rejection.
+        await Permission.reply({
           requestID: params.permissionID,
           reply: c.req.valid("json").response,
         })

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -7,6 +7,7 @@ import { PermissionID } from "../../src/permission/schema"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import { MessageID, SessionID } from "../../src/session/schema"
+import { NotFoundError } from "../../src/storage/db"
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -1301,16 +1302,59 @@ test("pending permission rejects on instance reload", async () => {
   expect(await result).toBeInstanceOf(Permission.RejectedError)
 })
 
-test("reply - does nothing for unknown requestID", async () => {
+test("reply - throws NotFoundError for an unknown requestID", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      await Permission.reply({
-        requestID: PermissionID.make("per_unknown"),
-        reply: "once",
-      })
+      await expect(
+        Permission.reply({
+          requestID: PermissionID.make("per_unknown"),
+          reply: "once",
+        }),
+      ).rejects.toBeInstanceOf(NotFoundError)
       expect(await Permission.list()).toHaveLength(0)
+    },
+  })
+})
+
+test("reply - is idempotent for a cascade-resolved sibling", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const a = Permission.ask({
+        id: PermissionID.make("per_idem_a"),
+        sessionID: SessionID.make("session_same"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: ["ls"],
+        ruleset: [],
+      })
+
+      const b = Permission.ask({
+        id: PermissionID.make("per_idem_b"),
+        sessionID: SessionID.make("session_same"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      })
+
+      await waitForPending(2)
+
+      // Replying "always" to a cascade-resolves the matching sibling b.
+      await Permission.reply({ requestID: PermissionID.make("per_idem_a"), reply: "always" })
+      await expect(a).resolves.toBeUndefined()
+      await expect(b).resolves.toBeUndefined()
+
+      // The client legitimately saw b and replies to it; that repeat reply must
+      // be an idempotent success, not a NotFoundError.
+      await expect(
+        Permission.reply({ requestID: PermissionID.make("per_idem_b"), reply: "once" }),
+      ).resolves.toBeUndefined()
     },
   })
 })

--- a/packages/opencode/test/server/permission-routes.test.ts
+++ b/packages/opencode/test/server/permission-routes.test.ts
@@ -5,6 +5,7 @@ import { AppRuntime } from "../../src/effect/app-runtime"
 import { Permission } from "../../src/permission"
 import { PermissionID } from "../../src/permission/schema"
 import { Instance } from "../../src/project/instance"
+import { ErrorMiddleware } from "../../src/server/middleware"
 import { PermissionRoutes } from "../../src/server/instance/permission"
 import { SessionID } from "../../src/session/schema"
 import { tmpdir } from "../fixture/fixture"
@@ -15,7 +16,9 @@ afterEach(async () => {
 
 describe("permission routes", () => {
   function app() {
-    return new Hono().route("/permission", PermissionRoutes())
+    const instance = new Hono().route("/permission", PermissionRoutes())
+    instance.onError(ErrorMiddleware)
+    return instance
   }
 
   test("replies to a pending permission through the route runtime", async () => {
@@ -51,6 +54,22 @@ describe("permission routes", () => {
         expect(response.status).toBe(200)
         expect(await response.json()).toBe(true)
         await expect(asked).resolves.toBeUndefined()
+      },
+    })
+  })
+
+  test("returns 404 for an unknown permission request", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request(`/permission/${PermissionID.ascending()}/reply`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ reply: "once" }),
+        })
+
+        expect(response.status).toBe(404)
       },
     })
   })


### PR DESCRIPTION
## Summary

`Permission.reply` silently returned on an unknown `requestID`, so the `/permission/:requestID/reply` route — and the deprecated v1 `/session/:sessionID/permissions/:permissionID` route — could never produce the 404 both already document in their OpenAPI responses. An unknown ID got a misleading `200 true`.

Now `reply` throws the shared `NotFoundError`, which `ErrorMiddleware` maps to 404.

A reply can cascade-resolve sibling pending requests in the same session (the "always"/"reject" cascade). A bare throw would turn a client's legitimate follow-up reply to a cascade-resolved sibling into a false 404. To avoid that, the instance keeps a bounded FIFO tombstone of recently-resolved request IDs: a known-but-already-resolved ID stays an idempotent `200`, and only a genuinely unknown ID becomes `404`. The deprecated v1 route now `await`s the reply so its own documented 404 surfaces instead of being swallowed by a fire-and-forget rejection.

No issue; this is a Round-3 upstream-value port. Adapted from upstream `anomalyco/opencode#28693` (`4ce247eaba`) — thanks to that change for surfacing the gap. It was reimplemented for this fork's cascade-resolve semantics (the tombstone) rather than cherry-picked, since `dev` shares no ancestor with `upstream/dev`.

## Why

The documented 404 was unreachable: every reply, valid or not, returned `200`. Clients and the SDK could not distinguish "handled" from "never existed", and the OpenAPI contract advertised a status the server never sent.

## Related Issue

None. Round-3 upstream-value port; upstream reference: `anomalyco/opencode#28693`.

## Human Review Status

Pending

## Review Focus

- The tombstone correctness: `markResolved` is called synchronously at every `pending.delete` site (direct reply, reject cascade, always cascade, `clearSession`) so the cascade-resolved-sibling window is closed without relying on the async `ask` finalizer. The finalizer also tombstones to cover the interrupt path.
- The `if (!existing)` branch: idempotent `return` only when the ID is in `resolved`, otherwise `throw NotFoundError`.
- Bound: FIFO cap of 1000 per instance; it only needs to outlive the gap between a cascade-resolve and the client's own reply.
- The deprecated v1 route now awaits — confirm awaiting `Permission.reply` is acceptable there (it is fast: in-memory state + bus publish).

## Risk Notes

Server-only behavior change on two permission-reply routes; the new status is `404` for genuinely unknown IDs (previously a misleading `200`). Cascade-resolved and valid replies are unchanged (`200`). No UI, no platform/packaging surface, and no docs/dependency/credential surface were touched, so those conditional checklist items are left unticked.

## How To Verify

```text
bun run typecheck (packages/opencode): clean
bun test test/permission/next.test.ts test/server/permission-routes.test.ts: 104 pass, 0 fail
  - route returns 404 for an unknown permission request (was 200)
  - reply throws NotFoundError for an unknown requestID
  - reply is idempotent for a cascade-resolved sibling (stays 200, not 404)
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.