### PR TITLE
fix(app): use active directory for review VCS scope

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -17,9 +17,8 @@ import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
 import { buildDesktopContext } from "@/utils/desktop-context"
 import { createSessionComposerState, HomeComposerRegion } from "@/pages/session/composer"
-import { createExecutionScopeTracker, type ExecutionScope } from "@/pages/session/execution-scope"
 import { createSizing } from "@/pages/session/helpers"
-import { sessionExecutionDirectory } from "@/pages/session/session-execution-directory"
+import { createSessionExecutionState } from "@/pages/session/session-execution-directory"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { SessionPageComposerRegion } from "@/pages/session/session-composer-region"
 import { SessionMainView } from "@/pages/session/session-main-view"
@@ -179,15 +178,12 @@ export default function Page() {
   const wantsReview = createMemo(() =>
     isDesktop() ? desktopSidePanelOpen() && view().sidePanel.tab() === "review" : mobileChanges(),
   )
-  const executionScopeTracker = createExecutionScopeTracker()
-  const currentExecutionDirectory = createMemo(() =>
-    sessionExecutionDirectory({ routeDirectory: sdk.directory, session: timeline.sessionInfo() }),
-  )
-  const currentExecutionScope = (): ExecutionScope =>
-    executionScopeTracker({
-      serverKey: server.key,
-      directory: currentExecutionDirectory(),
-    })
+  const executionState = createSessionExecutionState({
+    serverKey: () => server.key,
+    routeDirectory: () => sdk.directory,
+    session: timeline.sessionInfo,
+  })
+  const currentExecutionScope = executionState.scope
   const reviewState = createSessionReviewState({
     directory: () => sdk.directory,
     executionScope: currentExecutionScope,
@@ -230,7 +226,7 @@ export default function Page() {
   })
 
   useSessionVcsRefresh({
-    directory: currentExecutionDirectory,
+    directory: executionState.directory,
     event: sdk.event,
     branch: () => sync.data.vcs?.branch,
     defaultBranch: () => sync.data.vcs?.default_branch,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -19,6 +19,7 @@ import { buildDesktopContext } from "@/utils/desktop-context"
 import { createSessionComposerState, HomeComposerRegion } from "@/pages/session/composer"
 import { createExecutionScopeTracker, type ExecutionScope } from "@/pages/session/execution-scope"
 import { createSizing } from "@/pages/session/helpers"
+import { sessionExecutionDirectory } from "@/pages/session/session-execution-directory"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { SessionPageComposerRegion } from "@/pages/session/session-composer-region"
 import { SessionMainView } from "@/pages/session/session-main-view"
@@ -179,10 +180,13 @@ export default function Page() {
     isDesktop() ? desktopSidePanelOpen() && view().sidePanel.tab() === "review" : mobileChanges(),
   )
   const executionScopeTracker = createExecutionScopeTracker()
+  const currentExecutionDirectory = createMemo(() =>
+    sessionExecutionDirectory({ routeDirectory: sdk.directory, session: timeline.sessionInfo() }),
+  )
   const currentExecutionScope = (): ExecutionScope =>
     executionScopeTracker({
       serverKey: server.key,
-      directory: sdk.directory,
+      directory: currentExecutionDirectory(),
     })
   const reviewState = createSessionReviewState({
     directory: () => sdk.directory,
@@ -226,7 +230,7 @@ export default function Page() {
   })
 
   useSessionVcsRefresh({
-    directory: () => sdk.directory,
+    directory: currentExecutionDirectory,
     event: sdk.event,
     branch: () => sync.data.vcs?.branch,
     defaultBranch: () => sync.data.vcs?.default_branch,

--- a/packages/app/src/pages/session/session-execution-directory.test.ts
+++ b/packages/app/src/pages/session/session-execution-directory.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { sessionExecutionDirectory } from "./session-execution-directory"
+
+describe("session execution directory", () => {
+  test("uses the active execution directory when a session is inside a worktree", () => {
+    expect(
+      sessionExecutionDirectory({
+        routeDirectory: "/repo",
+        session: {
+          executionContext: {
+            activeDirectory: "/repo/.worktrees/feature",
+          },
+        },
+      }),
+    ).toBe("/repo/.worktrees/feature")
+  })
+
+  test("falls back to the route directory before session context is available", () => {
+    expect(sessionExecutionDirectory({ routeDirectory: "/repo", session: undefined })).toBe("/repo")
+    expect(sessionExecutionDirectory({ routeDirectory: "/repo", session: { executionContext: null } })).toBe("/repo")
+  })
+
+  test("wires review VCS state to the shared execution directory", async () => {
+    const source = await Bun.file(new URL("../session.tsx", import.meta.url)).text()
+    const currentScopeBlock = source.match(/const currentExecutionScope[\s\S]*?const reviewState =/)?.[0]
+    const vcsRefreshBlock = source.match(/useSessionVcsRefresh\(\{[\s\S]*?\n  \}\)/)?.[0]
+
+    expect(source).toContain("sessionExecutionDirectory")
+    expect(currentScopeBlock).toContain("directory: currentExecutionDirectory()")
+    expect(vcsRefreshBlock).toContain("directory: currentExecutionDirectory")
+  })
+})

--- a/packages/app/src/pages/session/session-execution-directory.test.ts
+++ b/packages/app/src/pages/session/session-execution-directory.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { sessionExecutionDirectory } from "./session-execution-directory"
+import { createRoot, createSignal } from "solid-js"
+import {
+  createSessionExecutionState,
+  type SessionExecutionDirectoryInfo,
+  sessionExecutionDirectory,
+} from "./session-execution-directory"
 
 describe("session execution directory", () => {
   test("uses the active execution directory when a session is inside a worktree", () => {
@@ -17,16 +22,43 @@ describe("session execution directory", () => {
 
   test("falls back to the route directory before session context is available", () => {
     expect(sessionExecutionDirectory({ routeDirectory: "/repo", session: undefined })).toBe("/repo")
+    expect(sessionExecutionDirectory({ routeDirectory: "/repo", session: null })).toBe("/repo")
     expect(sessionExecutionDirectory({ routeDirectory: "/repo", session: { executionContext: null } })).toBe("/repo")
+    expect(
+      sessionExecutionDirectory({
+        routeDirectory: "/repo",
+        session: { executionContext: { activeDirectory: null } },
+      }),
+    ).toBe("/repo")
   })
 
-  test("wires review VCS state to the shared execution directory", async () => {
-    const source = await Bun.file(new URL("../session.tsx", import.meta.url)).text()
-    const currentScopeBlock = source.match(/const currentExecutionScope[\s\S]*?const reviewState =/)?.[0]
-    const vcsRefreshBlock = source.match(/useSessionVcsRefresh\(\{[\s\S]*?\n  \}\)/)?.[0]
+  test("shares active-directory selection between review directory and execution scope", () => {
+    createRoot((dispose) => {
+      const [serverKey, setServerKey] = createSignal("sidecar")
+      const [session, setSession] = createSignal<SessionExecutionDirectoryInfo | undefined>()
+      const execution = createSessionExecutionState({
+        serverKey,
+        routeDirectory: () => "/repo",
+        session,
+      })
 
-    expect(source).toContain("sessionExecutionDirectory")
-    expect(currentScopeBlock).toContain("directory: currentExecutionDirectory()")
-    expect(vcsRefreshBlock).toContain("directory: currentExecutionDirectory")
+      const routeScope = execution.scope()
+      expect(execution.directory()).toBe("/repo")
+      expect(routeScope).toEqual({ serverKey: "sidecar", directory: "/repo", epoch: 0 })
+
+      setSession({ executionContext: { activeDirectory: "/repo/.worktrees/feature" } })
+      const worktreeScope = execution.scope()
+      expect(execution.directory()).toBe("/repo/.worktrees/feature")
+      expect(worktreeScope).toEqual({ serverKey: "sidecar", directory: "/repo/.worktrees/feature", epoch: 1 })
+
+      setSession({ executionContext: { activeDirectory: null } })
+      expect(execution.directory()).toBe("/repo")
+      expect(execution.scope()).toEqual({ serverKey: "sidecar", directory: "/repo", epoch: 2 })
+
+      setServerKey("remote")
+      expect(execution.scope()).toEqual({ serverKey: "remote", directory: "/repo", epoch: 3 })
+
+      dispose()
+    })
   })
 })

--- a/packages/app/src/pages/session/session-execution-directory.ts
+++ b/packages/app/src/pages/session/session-execution-directory.ts
@@ -1,4 +1,6 @@
-type SessionExecutionDirectoryInfo = {
+import { createExecutionScopeTracker, type ExecutionScope } from "./execution-scope"
+
+export type SessionExecutionDirectoryInfo = {
   executionContext?: {
     activeDirectory?: string | null
   } | null
@@ -9,4 +11,22 @@ export function sessionExecutionDirectory(input: {
   session: SessionExecutionDirectoryInfo | undefined
 }) {
   return input.session?.executionContext?.activeDirectory || input.routeDirectory
+}
+
+export function createSessionExecutionState(input: {
+  serverKey: () => string
+  routeDirectory: () => string
+  session: () => SessionExecutionDirectoryInfo | undefined
+}): {
+  directory: () => string
+  scope: () => ExecutionScope
+} {
+  const directory = () =>
+    sessionExecutionDirectory({ routeDirectory: input.routeDirectory(), session: input.session() })
+  const tracker = createExecutionScopeTracker()
+
+  return {
+    directory,
+    scope: () => tracker({ serverKey: input.serverKey(), directory: directory() }),
+  }
 }

--- a/packages/app/src/pages/session/session-execution-directory.ts
+++ b/packages/app/src/pages/session/session-execution-directory.ts
@@ -1,0 +1,12 @@
+type SessionExecutionDirectoryInfo = {
+  executionContext?: {
+    activeDirectory?: string | null
+  } | null
+} | null
+
+export function sessionExecutionDirectory(input: {
+  routeDirectory: string
+  session: SessionExecutionDirectoryInfo | undefined
+}) {
+  return input.session?.executionContext?.activeDirectory || input.routeDirectory
+}


### PR DESCRIPTION
## Summary

Fixes a worktree Review panel regression reported from the installed app, without a tracked issue. The session page now derives Review execution state from the session's active execution directory when available, so worktree sessions show their actual file and branch changes.

## Why

A root-owned session can enter a git worktree while still being routed under the owner repository directory. The Review panel was using the route directory for VCS diff requests, so it asked the clean owner checkout for changes and rendered empty "Branch changes" and "File changes" states even when the active worktree had edits.

## Related Issue

None. Reported directly from the installed app during local debugging.

## Human Review Status

Pending

## Review Focus

Please focus on the scope boundary in `packages/app/src/pages/session.tsx`: session sync remains owner-directory scoped, while Review VCS state and its cache reset now follow the active execution directory.

## Risk Notes

The existing event stream still comes from the route SDK context. This PR resets VCS state when the active execution directory changes and sends explicit Review VCS loads to the active directory, but it does not redesign file watcher event subscription for worktree-local live refresh.

## How To Verify

```text
Regression test: bun test src/pages/session/session-execution-directory.test.ts -> 3 passed
Related Review/VCS tests: bun test src/pages/session/session-execution-directory.test.ts src/pages/session/use-session-review-state.test.ts src/pages/session/use-session-vcs-refresh.test.ts src/pages/session/execution-scope.test.ts -> 19 passed
Typecheck: bun run typecheck -> tsgo -b passed
Visual snap: bun run snap turn-change-diff -> Chromium snap passed and generated docs/design/preview/screenshots/turn-change-diff.png
Diff check: git diff --check HEAD~1..HEAD -> no whitespace errors
```

## Screenshots or Recordings

Visual check completed with `bun run snap turn-change-diff`; the generated grid screenshot rendered the Review diff cards normally.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented per-session execution directory context for version control and review operations, enabling session-specific directory handling with fallback support.

* **Tests**
  * Added test coverage for session execution directory functionality and integration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->