### PR TITLE
fix(app): index pending external-result questions

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -261,6 +261,7 @@ function createGlobalSync() {
       const next = trimSessions(store.session, {
         limit: store.limit,
         permission: store.permission,
+        externalResultQuestion: store.external_result_question,
       })
       if (next.length !== store.session.length) {
         cleanupDroppedSessionCaches(store, setStore, next, {
@@ -292,6 +293,7 @@ function createGlobalSync() {
               const sessions = trimSessions([...nonArchived, ...childSessions], {
                 limit,
                 permission: store.permission,
+                externalResultQuestion: store.external_result_question,
               })
               setStore(
                 "sessionTotal",

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -118,6 +118,75 @@ describe("bootstrapDirectory", () => {
     })
   })
 
+  test("tolerates undefined pending question slots while pruning stale questions", async () => {
+    const directory = "/repo"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+    setStore("external_result_question", "ses_undefined", undefined as never)
+    setStore("external_result_question", "ses_stale", [
+      {
+        id: "msg_stale:call_stale",
+        sessionID: "ses_stale",
+        questions: [{ question: "Continue?" }],
+        messageID: "msg_stale",
+        callID: "call_stale",
+        partID: "part_stale",
+      },
+    ])
+    let externalResultCalls = 0
+    const warnings: unknown[] = []
+    const originalWarn = console.warn
+    console.warn = mock((...args: unknown[]) => {
+      warnings.push(args)
+    }) as typeof console.warn
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }) },
+      session: {
+        status: async () => ({ data: {} }),
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: { list: async () => ({ data: [] }) },
+      permission: { list: async () => ({ data: [] }) },
+      externalResult: {
+        list: async () => {
+          externalResultCalls += 1
+          return { data: [] }
+        },
+      },
+      mcp: { status: async () => ({ data: {} }) },
+      automation: { list: async () => ({ data: { items: [] } }) },
+      provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+    } as any
+
+    try {
+      await bootstrapDirectory({
+        directory,
+        sdk,
+        store,
+        setStore,
+        vcsCache: createVcsCache(),
+        loadSessions: () => undefined,
+        translate: (key) => key,
+        global: {
+          config: {} as Config,
+          path: { state: "", config: "", worktree: "", directory: "", home: "" } as Path,
+          project: [] as Project[],
+          provider: { all: [], connected: [], default: {} },
+        },
+        queryClient,
+      })
+      await waitFor(() => externalResultCalls === 1)
+      await waitFor(() => store.external_result_question.ses_stale === undefined)
+      expect(warnings).toEqual([])
+    } finally {
+      console.warn = originalWarn
+    }
+  })
+
   test("refreshes directory providers even when sessions query cache is already populated", async () => {
     const directory = "/tmp/project"
     const queryClient = new QueryClient()

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -32,6 +32,7 @@ function createState(): State {
     turn_change_aggregate: {},
     todo: {},
     permission: {},
+    external_result_question: {},
     mcp_ready: false,
     mcp: {},
     lsp_ready: false,
@@ -709,6 +710,87 @@ describe("hydratePendingExternalResults", () => {
     expect(store.session.map((s) => s.id)).toEqual(["ses_child"])
     expect(store.message.ses_child?.map((m) => m.id)).toEqual(["msg_child"])
     expect(store.part.msg_child?.map((p) => p.id)).toEqual(["part_child"])
+    expect(store.external_result_question.ses_child?.[0]).toMatchObject({
+      id: "msg_child:call_child",
+      sessionID: "ses_child",
+      messageID: "msg_child",
+      callID: "call_child",
+      partID: "part_child",
+    })
+  })
+
+  test("prunes indexed pending questions that are absent from the pending hydrate snapshot", () => {
+    const [store, setStore] = createStore(createState())
+    setStore("external_result_question", "ses_child", [
+      {
+        id: "msg_child:call_child",
+        sessionID: "ses_child",
+        questions: [{ header: "h", question: "q?", options: [] }],
+        messageID: "msg_child",
+        callID: "call_child",
+        partID: "part_child",
+      },
+    ])
+    hydratePendingExternalResults({
+      store,
+      setStore,
+      entries: [],
+      pruneQuestionIDs: new Set(["msg_child:call_child"]),
+    })
+    expect(store.external_result_question.ses_child).toBeUndefined()
+  })
+
+  test("removes pruned ready question parts so fallback traversal cannot reopen the dock", () => {
+    const [store, setStore] = createStore(createState())
+    setStore("message", "ses_child", [childMessage])
+    setStore("part", "msg_child", [childPart])
+    setStore("external_result_question", "ses_child", [
+      {
+        id: "msg_child:call_child",
+        sessionID: "ses_child",
+        questions: [{ header: "h", question: "q?", options: [] }],
+        messageID: "msg_child",
+        callID: "call_child",
+        partID: "part_child",
+      },
+    ])
+    hydratePendingExternalResults({
+      store,
+      setStore,
+      entries: [],
+      pruneQuestionIDs: new Set(["msg_child:call_child"]),
+    })
+    expect(store.external_result_question.ses_child).toBeUndefined()
+    expect(store.part.msg_child).toBeUndefined()
+  })
+
+  test("does not prune questions added after the pending hydrate request snapshot", () => {
+    const [store, setStore] = createStore(createState())
+    setStore("external_result_question", "ses_child", [
+      {
+        id: "msg_old:call_old",
+        sessionID: "ses_child",
+        questions: [{ header: "h", question: "old?", options: [] }],
+        messageID: "msg_old",
+        callID: "call_old",
+        partID: "part_old",
+      },
+      {
+        id: "msg_new:call_new",
+        sessionID: "ses_child",
+        questions: [{ header: "h", question: "new?", options: [] }],
+        messageID: "msg_new",
+        callID: "call_new",
+        partID: "part_new",
+      },
+    ])
+    hydratePendingExternalResults({
+      store,
+      setStore,
+      entries: [],
+      pruneQuestionIDs: new Set(["msg_old:call_old"]),
+    })
+    expect(store.external_result_question.ses_child?.map((question) => question.id)).toEqual(["msg_new:call_new"])
   })
 
   test("merges into existing session list and existing message list without duplicating", () => {
@@ -742,6 +824,26 @@ describe("hydratePendingExternalResults", () => {
     expect(store.part.msg_child?.length).toBe(1)
     const updated = store.part.msg_child?.[0] as any
     expect(updated?.state?.metadata?.externalResultReady).toBe(true)
+  })
+
+  test("does not let a stale pending hydrate response revert a local terminal question part", () => {
+    const [store, setStore] = createStore(createState())
+    const terminalPart = {
+      ...childPart,
+      state: { ...childPart.state, status: "completed" },
+    } as any
+    setStore("part", "msg_child", [terminalPart])
+    hydratePendingExternalResults({
+      store,
+      setStore,
+      entries: [{ session: childSession, message: childMessage, part: childPart }],
+      pruneQuestionIDs: new Set(["msg_child:call_child"]),
+    })
+    expect(store.session.map((s) => s.id)).toEqual(["ses_child"])
+    expect(store.message.ses_child?.map((m) => m.id)).toEqual(["msg_child"])
+    expect(store.external_result_question.ses_child).toBeUndefined()
+    const updated = store.part.msg_child?.[0] as any
+    expect(updated?.state?.status).toBe("completed")
   })
 
   test("skips entries that are missing identifiers", () => {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -313,8 +313,13 @@ export function hydratePendingExternalResults(input: {
         produce((draft) => {
           const prunedQuestions: PendingExternalResultQuestion[] = []
           for (const sessionID of Object.keys(draft.external_result_question)) {
+            const questions = draft.external_result_question[sessionID]
+            if (!questions) {
+              delete draft.external_result_question[sessionID]
+              continue
+            }
             const next: PendingExternalResultQuestion[] = []
-            for (const question of draft.external_result_question[sessionID]) {
+            for (const question of questions) {
               if (input.pruneQuestionIDs!.has(question.id) && !activeQuestionIDs.has(question.id)) {
                 prunedQuestions.push(question)
                 continue
@@ -346,6 +351,7 @@ export function hydratePendingExternalResults(input: {
 function snapshotExternalResultQuestionIDs(store: Store<State>) {
   const ids = new Set<string>()
   for (const list of Object.values(store.external_result_question)) {
+    if (!list) continue
     for (const question of list) ids.add(question.id)
   }
   return ids

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -19,6 +19,11 @@ import { batch } from "solid-js"
 import { produce, reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import type { State, VcsCache } from "./types"
 import { mergeAutomationList } from "./automation-store"
+import {
+  pendingExternalResultQuestionFromPart,
+  type PendingExternalResultQuestion,
+  upsertPendingExternalResultQuestion,
+} from "./external-result-question"
 import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
 import { QueryClient, queryOptions } from "@tanstack/solid-query"
@@ -242,14 +247,29 @@ export function hydratePendingExternalResults(input: {
   store: Store<State>
   setStore: SetStoreFunction<State>
   entries: ReadonlyArray<{ session: Session; message: Message; part: Part }>
+  pruneQuestionIDs?: ReadonlySet<string>
 }) {
   batch(() => {
+    const activeQuestionIDs = new Set<string>()
     for (const entry of input.entries) {
       const session = entry.session
       const message = entry.message
       const part = entry.part
       if (!session?.id || !message?.id || !part?.id || !part.messageID) continue
       mergeSession(input.setStore, session)
+      const pendingQuestion = pendingExternalResultQuestionFromPart(part)
+      const localPart = input.store.part[part.messageID]?.find((item) => item.id === part.id)
+      const localTerminalQuestion =
+        pendingQuestion &&
+        localPart?.type === "tool" &&
+        localPart.tool === "question" &&
+        localPart.state.status !== "running"
+      if (pendingQuestion && !localTerminalQuestion) {
+        activeQuestionIDs.add(pendingQuestion.id)
+        input.setStore("external_result_question", pendingQuestion.sessionID, (list) =>
+          upsertPendingExternalResultQuestion(list, pendingQuestion),
+        )
+      }
 
       const messages = input.store.message[session.id]
       if (!messages) {
@@ -269,6 +289,7 @@ export function hydratePendingExternalResults(input: {
         }
       }
 
+      if (localTerminalQuestion) continue
       const parts = input.store.part[part.messageID]
       if (!parts) {
         input.setStore("part", part.messageID, [part])
@@ -287,7 +308,47 @@ export function hydratePendingExternalResults(input: {
         }
       }
     }
+    if (input.pruneQuestionIDs?.size) {
+      input.setStore(
+        produce((draft) => {
+          const prunedQuestions: PendingExternalResultQuestion[] = []
+          for (const sessionID of Object.keys(draft.external_result_question)) {
+            const next: PendingExternalResultQuestion[] = []
+            for (const question of draft.external_result_question[sessionID]) {
+              if (input.pruneQuestionIDs!.has(question.id) && !activeQuestionIDs.has(question.id)) {
+                prunedQuestions.push(question)
+                continue
+              }
+              next.push(question)
+            }
+            if (next.length > 0) draft.external_result_question[sessionID] = next
+            else delete draft.external_result_question[sessionID]
+          }
+          for (const question of prunedQuestions) {
+            const parts = draft.part[question.messageID]
+            if (!parts) continue
+            const next = parts.filter((part) => {
+              if (part.id !== question.partID) return true
+              if (part.type !== "tool" || part.tool !== "question") return true
+              if (part.callID !== question.callID) return true
+              if (part.state.status !== "running") return true
+              return part.state.metadata?.externalResultReady !== true
+            })
+            if (next.length > 0) draft.part[question.messageID] = next
+            else delete draft.part[question.messageID]
+          }
+        }),
+      )
+    }
   })
+}
+
+function snapshotExternalResultQuestionIDs(store: Store<State>) {
+  const ids = new Set<string>()
+  for (const list of Object.values(store.external_result_question)) {
+    for (const question of list) ids.add(question.id)
+  }
+  return ids
 }
 
 const inactiveQueryFn = async () => null
@@ -472,20 +533,22 @@ export async function bootstrapDirectory(input: {
           }),
         ),
       () =>
-        retry(() =>
-          input.sdk.externalResult.list().then((x) => {
+        retry(() => {
+          const pruneQuestionIDs = snapshotExternalResultQuestionIDs(input.store)
+          return input.sdk.externalResult.list().then((x) => {
             const entries = (x.data ?? []).filter(
               (entry): entry is { session: Session; message: Message; part: Part } =>
                 !!entry?.session?.id && !!entry.message?.id && !!entry.part?.id,
             )
-            if (entries.length === 0) return
+            if (entries.length === 0 && pruneQuestionIDs.size === 0) return
             hydratePendingExternalResults({
               store: input.store,
               setStore: input.setStore,
               entries,
+              pruneQuestionIDs,
             })
-          }),
-        ).catch((err) => {
+          })
+        }).catch((err) => {
           // Hydrate is best-effort: a transient failure should not surface
           // the project-level "reloadFailed" toast. The dock recovers on
           // the next SSE message.part.updated for live questions, or on

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -192,6 +192,7 @@ export function createChildStoreManager(input: {
             turn_change_aggregate: {},
             todo: {},
             permission: {},
+            external_result_question: {},
             mcp_ready: false,
             mcp: {},
             lsp_ready: false,

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -68,6 +68,28 @@ const todoToolPart = (id: string, sessionID: string, messageID: string, metadata
     },
   }) as Part
 
+const questionToolPart = (
+  id: string,
+  sessionID: string,
+  messageID: string,
+  status: "running" | "completed" | "error" = "running",
+) =>
+  ({
+    id,
+    sessionID,
+    messageID,
+    type: "tool",
+    callID: `call_${id}`,
+    tool: "question",
+    state: {
+      status,
+      input: { questions: [{ header: "Question", question: "Continue?", options: [] }] },
+      title: "",
+      metadata: { externalResultReady: true },
+      time: { start: 1 },
+    },
+  }) as Part
+
 const permissionRequest = (id: string, sessionID: string, title = id) =>
   ({
     id,
@@ -122,6 +144,7 @@ const baseState = (input: Partial<State> = {}) =>
     turn_change_aggregate: {},
     todo: {},
     permission: {},
+    external_result_question: {},
     mcp: {},
     lsp: [],
     vcs: undefined,
@@ -340,6 +363,18 @@ describe("applyDirectoryEvent", () => {
         turn_change_aggregate: { ses_1: emptyAggregate("ses_1") },
         todo: { ses_1: [] },
         permission: { ses_1: [] },
+        external_result_question: {
+          ses_1: [
+            {
+              id: `${message.id}:call_1`,
+              sessionID: "ses_1",
+              questions: [{ question: "Continue?" }],
+              messageID: message.id,
+              callID: "call_1",
+              partID: "prt_1",
+            },
+          ],
+        },
         session_status: { ses_1: { type: "busy" } },
       }),
     )
@@ -360,6 +395,7 @@ describe("applyDirectoryEvent", () => {
     expect(store.turn_change_aggregate.ses_1).toBeUndefined()
     expect(store.todo.ses_1).toBeUndefined()
     expect(store.permission.ses_1).toBeUndefined()
+    expect(store.external_result_question.ses_1).toBeUndefined()
     expect(store.session_status.ses_1).toBeUndefined()
   })
 
@@ -384,6 +420,18 @@ describe("applyDirectoryEvent", () => {
           turn_change_aggregate: { [item.info.id]: emptyAggregate(item.info.id) },
           todo: { [item.info.id]: [] },
           permission: { [item.info.id]: [] },
+          external_result_question: {
+            [item.info.id]: [
+              {
+                id: `${message.id}:call_1`,
+                sessionID: item.info.id,
+                questions: [{ question: "Continue?" }],
+                messageID: message.id,
+                callID: "call_1",
+                partID: "prt_1",
+              },
+            ],
+          },
           session_status: { [item.info.id]: { type: "busy" } },
         }),
       )
@@ -404,6 +452,7 @@ describe("applyDirectoryEvent", () => {
       expect(store.turn_change_aggregate[item.info.id]).toBeUndefined()
       expect(store.todo[item.info.id]).toBeUndefined()
       expect(store.permission[item.info.id]).toBeUndefined()
+      expect(store.external_result_question[item.info.id]).toBeUndefined()
       expect(store.session_status[item.info.id]).toBeUndefined()
     }
   })
@@ -610,6 +659,132 @@ describe("applyDirectoryEvent", () => {
     })
 
     expect(store.part[messageID]).toBeUndefined()
+  })
+
+  test("indexes ready question parts even when the owning message row is missing", () => {
+    const sessionID = "ses_1"
+    const messageID = "msg_missing"
+    const [store, setStore] = createStore(baseState())
+
+    applyDirectoryEvent({
+      event: {
+        type: "message.part.updated",
+        properties: { part: questionToolPart("prt_question", sessionID, messageID) },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    expect(store.external_result_question[sessionID]?.[0]).toMatchObject({
+      id: "msg_missing:call_prt_question",
+      sessionID,
+      messageID,
+      callID: "call_prt_question",
+      partID: "prt_question",
+    })
+  })
+
+  test("clears indexed question blockers on terminal update and part removal", () => {
+    const sessionID = "ses_1"
+    const messageID = "msg_missing"
+    const [store, setStore] = createStore(baseState())
+    const running = questionToolPart("prt_question", sessionID, messageID)
+
+    applyDirectoryEvent({
+      event: { type: "message.part.updated", properties: { part: running } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.external_result_question[sessionID]?.length).toBe(1)
+
+    applyDirectoryEvent({
+      event: {
+        type: "message.part.updated",
+        properties: { part: questionToolPart("prt_question", sessionID, messageID, "error") },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.external_result_question[sessionID]).toBeUndefined()
+
+    applyDirectoryEvent({
+      event: { type: "message.part.updated", properties: { part: running } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    applyDirectoryEvent({
+      event: { type: "message.part.removed", properties: { messageID, partID: "prt_question" } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.external_result_question[sessionID]).toBeUndefined()
+  })
+
+  test("keeps sibling question blockers from the same message when one part settles", () => {
+    const sessionID = "ses_1"
+    const messageID = "msg_multi_question"
+    const [store, setStore] = createStore(baseState())
+    const first = questionToolPart("prt_first", sessionID, messageID)
+    const second = questionToolPart("prt_second", sessionID, messageID)
+
+    applyDirectoryEvent({
+      event: { type: "message.part.updated", properties: { part: first } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    applyDirectoryEvent({
+      event: { type: "message.part.updated", properties: { part: second } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.external_result_question[sessionID]?.map((question) => question.partID)).toEqual([
+      "prt_first",
+      "prt_second",
+    ])
+
+    applyDirectoryEvent({
+      event: {
+        type: "message.part.updated",
+        properties: { part: questionToolPart("prt_first", sessionID, messageID, "completed") },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.external_result_question[sessionID]?.map((question) => question.partID)).toEqual(["prt_second"])
+
+    applyDirectoryEvent({
+      event: { type: "message.part.removed", properties: { messageID, partID: "prt_second" } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+    expect(store.external_result_question[sessionID]).toBeUndefined()
   })
 
   test("completed live todowrite metadata writes canonical todo before part storage returns", () => {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -17,6 +17,11 @@ import type { State, VcsCache } from "./types"
 import { applyAutomationDefinition, applyAutomationRun, applyAutomationTombstone } from "./automation-store"
 import { trimSessions } from "./session-trim"
 import { dropSessionCaches } from "./session-cache"
+import {
+  pendingExternalResultQuestionFromPart,
+  removePendingExternalResultQuestion,
+  upsertPendingExternalResultQuestion,
+} from "./external-result-question"
 import { message as clean } from "@/utils/diffs"
 import type { createBlockerTerminalCache } from "./blocker-terminal-cache"
 import type { TodoHydrateCoordinator } from "./todo-hydrate-coordinator"
@@ -119,6 +124,7 @@ export function cleanupDroppedSessionCaches(
   const stale = [
     ...dropped,
     ...Object.keys(store.message),
+    ...Object.keys(store.external_result_question),
     ...Object.keys(store.turn_change_aggregate),
     ...Object.keys(store.todo),
     ...Object.keys(store.permission),
@@ -314,6 +320,13 @@ export function applyDirectoryEvent(input: {
             if (result.found) messages.splice(result.index, 1)
           }
           delete draft.part[props.messageID]
+          for (const sessionID of Object.keys(draft.external_result_question)) {
+            const next = removePendingExternalResultQuestion(draft.external_result_question[sessionID], {
+              messageID: props.messageID,
+            })
+            if (next) draft.external_result_question[sessionID] = next
+            else delete draft.external_result_question[sessionID]
+          }
         }),
       )
       break
@@ -331,6 +344,27 @@ export function applyDirectoryEvent(input: {
           todoHydrate: input.todoHydrate,
         })
         if (accepted) input.setStore("todo", todo.sessionID, reconcile(todo.snapshot.todos, { key: "id" }))
+      }
+      const pendingQuestion = pendingExternalResultQuestionFromPart(part)
+      if (pendingQuestion) {
+        input.setStore("external_result_question", pendingQuestion.sessionID, (list) =>
+          upsertPendingExternalResultQuestion(list, pendingQuestion),
+        )
+      } else if (part.type === "tool" && part.tool === "question") {
+        input.setStore(
+          "external_result_question",
+          produce((draft) => {
+            const sessionIDs = part.sessionID ? [part.sessionID] : Object.keys(draft)
+            for (const sessionID of sessionIDs) {
+              const next = removePendingExternalResultQuestion(draft[sessionID], {
+                messageID: part.messageID,
+                partID: part.id,
+              })
+              if (next) draft[sessionID] = next
+              else delete draft[sessionID]
+            }
+          }),
+        )
       }
       const parts = input.store.part[part.messageID]
       if (!parts) {
@@ -353,6 +387,19 @@ export function applyDirectoryEvent(input: {
     }
     case "message.part.removed": {
       const props = event.properties as { messageID: string; partID: string }
+      input.setStore(
+        "external_result_question",
+        produce((draft) => {
+          for (const sessionID of Object.keys(draft)) {
+            const next = removePendingExternalResultQuestion(draft[sessionID], {
+              messageID: props.messageID,
+              partID: props.partID,
+            })
+            if (next) draft[sessionID] = next
+            else delete draft[sessionID]
+          }
+        }),
+      )
       const parts = input.store.part[props.messageID]
       if (!parts) break
       const result = Binary.search(parts, props.partID, (p) => p.id)

--- a/packages/app/src/context/global-sync/external-result-question.ts
+++ b/packages/app/src/context/global-sync/external-result-question.ts
@@ -1,0 +1,63 @@
+import type { Part } from "@opencode-ai/sdk/v2/client"
+
+export type QuestionInfo = {
+  question: string
+  header?: string
+  options?: ReadonlyArray<{ label: string; description?: string }>
+  multiple?: boolean
+  custom?: boolean
+}
+
+export type PendingExternalResultQuestion = {
+  id: string
+  sessionID: string
+  questions: QuestionInfo[]
+  messageID: string
+  callID: string
+  partID: string
+}
+
+export function pendingExternalResultQuestionFromPart(part: Part): PendingExternalResultQuestion | undefined {
+  if (part.type !== "tool") return undefined
+  if (part.tool !== "question") return undefined
+  if (part.state.status !== "running") return undefined
+  if (part.state.metadata?.externalResultReady !== true) return undefined
+  if (!part.sessionID || !part.messageID || !part.callID || !part.id) return undefined
+  const partInput = part.state.input as { questions?: QuestionInfo[] } | undefined
+  if (!Array.isArray(partInput?.questions) || partInput.questions.length === 0) return undefined
+  return {
+    id: `${part.messageID}:${part.callID}`,
+    sessionID: part.sessionID,
+    questions: partInput.questions,
+    messageID: part.messageID,
+    callID: part.callID,
+    partID: part.id,
+  }
+}
+
+export function upsertPendingExternalResultQuestion(
+  list: PendingExternalResultQuestion[] | undefined,
+  next: PendingExternalResultQuestion,
+) {
+  const current = list ?? []
+  const index = current.findIndex((item) => item.id === next.id)
+  if (index === -1) return [...current, next].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+  const out = current.slice()
+  out[index] = next
+  return out
+}
+
+export function removePendingExternalResultQuestion(
+  list: PendingExternalResultQuestion[] | undefined,
+  match: { id?: string; messageID?: string; partID?: string },
+) {
+  if (!list) return list
+  const next = list.filter((item) => {
+    const matches =
+      (!match.id || item.id === match.id) &&
+      (!match.partID || item.partID === match.partID) &&
+      (!match.messageID || item.messageID === match.messageID)
+    return !matches
+  })
+  return next.length > 0 ? next : undefined
+}

--- a/packages/app/src/context/global-sync/session-cache.test.ts
+++ b/packages/app/src/context/global-sync/session-cache.test.ts
@@ -42,6 +42,26 @@ type CacheShape = {
 const emptyAggregate = (sessionID: string): SessionDiffResponse => ({ kind: "empty", sessionID })
 
 describe("app session cache", () => {
+  test("dropSessionCaches tolerates legacy cache shape without external_result_question", () => {
+    const legacyStore = {
+      session_status: { ses_1: { type: "busy" } as SessionStatus },
+      turn_change_aggregate: { ses_1: emptyAggregate("ses_1") },
+      todo: { ses_1: [] as Todo[] },
+      message: { ses_1: [msg("msg_1", "ses_1")] },
+      part: { msg_1: [part("prt_1", "ses_1", "msg_1")] },
+      permission: { ses_1: [] as PermissionRequest[] },
+    } as Omit<CacheShape, "external_result_question">
+    const store = legacyStore as unknown as CacheShape
+
+    expect(() => dropSessionCaches(store, ["ses_1"])).not.toThrow()
+    expect(store.message.ses_1).toBeUndefined()
+    expect(store.part.msg_1).toBeUndefined()
+    expect(store.todo.ses_1).toBeUndefined()
+    expect(store.turn_change_aggregate.ses_1).toBeUndefined()
+    expect(store.session_status.ses_1).toBeUndefined()
+    expect(store.permission.ses_1).toBeUndefined()
+  })
+
   test("dropSessionCaches clears orphaned parts without message rows", () => {
     const store: CacheShape = {
       session_status: { ses_1: { type: "busy" } as SessionStatus },

--- a/packages/app/src/context/global-sync/session-cache.test.ts
+++ b/packages/app/src/context/global-sync/session-cache.test.ts
@@ -7,6 +7,7 @@ import type {
   SessionStatus,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
+import type { PendingExternalResultQuestion } from "./external-result-question"
 import { dropSessionCaches, pickSessionCacheEvictions } from "./session-cache"
 
 const msg = (id: string, sessionID: string) =>
@@ -35,6 +36,7 @@ type CacheShape = {
   message: Record<string, Message[] | undefined>
   part: Record<string, Part[] | undefined>
   permission: Record<string, PermissionRequest[] | undefined>
+  external_result_question: Record<string, PendingExternalResultQuestion[] | undefined>
 }
 
 const emptyAggregate = (sessionID: string): SessionDiffResponse => ({ kind: "empty", sessionID })
@@ -48,6 +50,18 @@ describe("app session cache", () => {
       message: {},
       part: { msg_1: [part("prt_1", "ses_1", "msg_1")] },
       permission: { ses_1: [] as PermissionRequest[] },
+      external_result_question: {
+        ses_1: [
+          {
+            id: "msg_1:call_1",
+            sessionID: "ses_1",
+            questions: [{ question: "Continue?" }],
+            messageID: "msg_1",
+            callID: "call_1",
+            partID: "prt_1",
+          },
+        ],
+      },
     }
 
     dropSessionCaches(store, ["ses_1"])
@@ -58,6 +72,7 @@ describe("app session cache", () => {
     expect(store.turn_change_aggregate.ses_1).toBeUndefined()
     expect(store.session_status.ses_1).toBeUndefined()
     expect(store.permission.ses_1).toBeUndefined()
+    expect(store.external_result_question.ses_1).toBeUndefined()
   })
 
   test("dropSessionCaches clears message-backed parts", () => {
@@ -69,6 +84,7 @@ describe("app session cache", () => {
       message: { ses_1: [m] },
       part: { [m.id]: [part("prt_1", "ses_1", m.id)] },
       permission: {},
+      external_result_question: {},
     }
 
     dropSessionCaches(store, ["ses_1"])

--- a/packages/app/src/context/global-sync/session-cache.ts
+++ b/packages/app/src/context/global-sync/session-cache.ts
@@ -6,6 +6,7 @@ import type {
   SessionStatus,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
+import type { PendingExternalResultQuestion } from "./external-result-question"
 
 export const SESSION_CACHE_LIMIT = 40
 
@@ -16,6 +17,7 @@ type SessionCache = {
   message: Record<string, Message[] | undefined>
   part: Record<string, Part[] | undefined>
   permission: Record<string, PermissionRequest[] | undefined>
+  external_result_question: Record<string, PendingExternalResultQuestion[] | undefined>
 }
 
 export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<string>) {
@@ -34,6 +36,7 @@ export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<stri
     delete store.turn_change_aggregate[sessionID]
     delete store.session_status[sessionID]
     delete store.permission[sessionID]
+    delete store.external_result_question[sessionID]
   }
 }
 

--- a/packages/app/src/context/global-sync/session-cache.ts
+++ b/packages/app/src/context/global-sync/session-cache.ts
@@ -17,7 +17,7 @@ type SessionCache = {
   message: Record<string, Message[] | undefined>
   part: Record<string, Part[] | undefined>
   permission: Record<string, PermissionRequest[] | undefined>
-  external_result_question: Record<string, PendingExternalResultQuestion[] | undefined>
+  external_result_question?: Record<string, PendingExternalResultQuestion[] | undefined>
 }
 
 export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<string>) {
@@ -36,7 +36,7 @@ export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<stri
     delete store.turn_change_aggregate[sessionID]
     delete store.session_status[sessionID]
     delete store.permission[sessionID]
-    delete store.external_result_question[sessionID]
+    if (store.external_result_question) delete store.external_result_question[sessionID]
   }
 }
 

--- a/packages/app/src/context/global-sync/session-trim.test.ts
+++ b/packages/app/src/context/global-sync/session-trim.test.ts
@@ -50,7 +50,7 @@ describe("trimSessions", () => {
     expect(result.map((x) => x.id)).toEqual(["a", "b", "c", "d"])
   })
 
-  test("keeps children when root is kept, permission exists, or child is recent", () => {
+  test("keeps children when root is kept, blocker exists, or child is recent", () => {
     const now = 1_000_000
     const list = [
       session({ id: "root-1", created: now - 1000 }),
@@ -58,6 +58,7 @@ describe("trimSessions", () => {
       session({ id: "z-root", created: now - 30_000_000 }),
       session({ id: "child-kept-by-root", parentID: "root-1", created: now - 20_000_000 }),
       session({ id: "child-kept-by-permission", parentID: "z-root", created: now - 20_000_000 }),
+      session({ id: "child-kept-by-question", parentID: "z-root", created: now - 20_000_000 }),
       session({ id: "child-kept-by-recency", parentID: "z-root", created: now - 500 }),
       session({ id: "child-trimmed", parentID: "z-root", created: now - 20_000_000 }),
     ]
@@ -67,11 +68,24 @@ describe("trimSessions", () => {
       permission: {
         "child-kept-by-permission": [{ id: "perm-1" } as PermissionRequest],
       },
+      externalResultQuestion: {
+        "child-kept-by-question": [
+          {
+            id: "msg_question:call_question",
+            sessionID: "child-kept-by-question",
+            questions: [{ question: "Continue?" }],
+            messageID: "msg_question",
+            callID: "call_question",
+            partID: "prt_question",
+          },
+        ],
+      },
       now,
     })
 
     expect(result.map((x) => x.id)).toEqual([
       "child-kept-by-permission",
+      "child-kept-by-question",
       "child-kept-by-recency",
       "child-kept-by-root",
       "root-1",

--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -1,4 +1,5 @@
 import type { PermissionRequest, Session } from "@opencode-ai/sdk/v2/client"
+import type { PendingExternalResultQuestion } from "./external-result-question"
 import { cmp, compareSessionsByCreated } from "./utils"
 import { SESSION_RECENT_LIMIT, SESSION_RECENT_WINDOW } from "./types"
 
@@ -32,7 +33,12 @@ export function takeRecentSessions(sessions: Session[], limit: number, cutoff: n
 
 export function trimSessions(
   input: Session[],
-  options: { limit: number; permission: Record<string, PermissionRequest[]>; now?: number },
+  options: {
+    limit: number
+    permission: Record<string, PermissionRequest[] | undefined>
+    externalResultQuestion?: Record<string, PendingExternalResultQuestion[] | undefined>
+    now?: number
+  },
 ) {
   const limit = Math.max(0, options.limit)
   const cutoff = (options.now ?? Date.now()) - SESSION_RECENT_WINDOW
@@ -50,6 +56,8 @@ export function trimSessions(
     if (s.parentID && keepRootIds.has(s.parentID)) return true
     const perms = options.permission[s.id] ?? []
     if (perms.length > 0) return true
+    const questions = options.externalResultQuestion?.[s.id] ?? []
+    if (questions.length > 0) return true
     return sessionUpdatedAt(s) > cutoff
   })
   return [...keepRoots, ...keepChildren].sort((a, b) => cmp(a.id, b.id))

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -19,6 +19,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client"
 import type { Accessor } from "solid-js"
 import type { SetStoreFunction, Store } from "solid-js/store"
+import type { PendingExternalResultQuestion } from "./external-result-question"
 
 export type ProjectMeta = {
   name?: string
@@ -60,6 +61,9 @@ export type State = {
   }
   permission: {
     [sessionID: string]: PermissionRequest[]
+  }
+  external_result_question: {
+    [sessionID: string]: PendingExternalResultQuestion[]
   }
   mcp_ready: boolean
   mcp: {

--- a/packages/app/src/pages/layout/pawwork-session-commands.test.ts
+++ b/packages/app/src/pages/layout/pawwork-session-commands.test.ts
@@ -50,6 +50,7 @@ function setup(opts: SetupOpts = {}) {
     message: Record<string, unknown>
     part: Record<string, unknown>
     permission: Record<string, unknown>
+    external_result_question: Record<string, unknown>
   }>({
     session: opts.sessions ?? [],
     session_status: {},
@@ -58,6 +59,7 @@ function setup(opts: SetupOpts = {}) {
     message: {},
     part: {},
     permission: {},
+    external_result_question: {},
   })
   const defaultExport = ((id: string, dir: string, name: string, label: string) => {
     calls.exportArgs.push([id, dir, name, label])

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -113,6 +113,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       findDescendantExternalResultQuestion({
         sessions: sessionStore.session,
         rootSessionID: props.session.id,
+        pendingQuestions: sessionStore.external_result_question,
         messages: sessionStore.message,
         partsByMessageID: sessionStore.part,
       }) !== undefined

--- a/packages/app/src/pages/session/blockers/running-external-result-question.ts
+++ b/packages/app/src/pages/session/blockers/running-external-result-question.ts
@@ -1,27 +1,29 @@
 import type { Message, Part, Session } from "@opencode-ai/sdk/v2/client"
+import type { PendingExternalResultQuestion, QuestionInfo } from "@/context/global-sync/external-result-question"
 
-// QuestionInfo / QuestionRequest used to live in @opencode-ai/sdk/v2 when the
-// question tool was driven by a dedicated server route. The external-result
-// migration deleted those exports; define the dock-facing shapes locally.
-export type QuestionInfo = {
-  question: string
-  header?: string
-  options?: ReadonlyArray<{ label: string; description?: string }>
-  multiple?: boolean
-  custom?: boolean
-}
+export type { QuestionInfo }
 
 /**
  * Dock request shape: a synthetic representation of a running question tool
  * part. The dock branches its submit handler on the presence of messageID and
  * callID; this matches the route at POST /session/:sessionID/tool/respond.
  */
-export type DockQuestionRequest = {
-  id: string
-  sessionID: string
-  questions: QuestionInfo[]
-  messageID: string
-  callID: string
+export type DockQuestionRequest = PendingExternalResultQuestion
+
+function isKnownStalePendingQuestion(input: {
+  pending: DockQuestionRequest
+  partsByMessageID: { [messageID: string]: Part[] | undefined }
+}) {
+  const part = input.partsByMessageID[input.pending.messageID]?.find((item) => item.id === input.pending.partID)
+  // If the part never reached the local cache, keep the index entry; bootstrap
+  // prune reconciles already-answered questions whose terminal event was missed.
+  if (!part) return false
+  if (part.type !== "tool") return true
+  if (part.tool !== "question") return true
+  if (part.state.status !== "running") return true
+  if (part.state.metadata?.externalResultReady !== true) return true
+  const partInput = part.state.input as { questions?: QuestionInfo[] } | undefined
+  return !Array.isArray(partInput?.questions) || partInput.questions.length === 0
 }
 
 /**
@@ -60,6 +62,7 @@ export function findRunningExternalResultQuestion(input: {
         questions: partInput!.questions,
         messageID: part.messageID,
         callID: part.callID,
+        partID: part.id,
       }
     }
   }
@@ -77,10 +80,11 @@ export function findRunningExternalResultQuestion(input: {
 export function findDescendantExternalResultQuestion(input: {
   sessions: Session[]
   rootSessionID: string
+  pendingQuestions?: { [sessionID: string]: DockQuestionRequest[] | undefined }
   messages: { [sessionID: string]: Message[] | undefined }
   partsByMessageID: { [messageID: string]: Part[] | undefined }
 }): DockQuestionRequest | undefined {
-  const { sessions, rootSessionID, messages, partsByMessageID } = input
+  const { sessions, rootSessionID, pendingQuestions, messages, partsByMessageID } = input
   const childMap = sessions.reduce((acc, item) => {
     if (!item.parentID) return acc
     const list = acc.get(item.parentID)
@@ -93,6 +97,10 @@ export function findDescendantExternalResultQuestion(input: {
   const stack = [rootSessionID]
   while (stack.length > 0) {
     const sid = stack.pop()!
+    const pending = pendingQuestions?.[sid]?.find(
+      (item) => !isKnownStalePendingQuestion({ pending: item, partsByMessageID }),
+    )
+    if (pending) return pending
     const found = findRunningExternalResultQuestion({
       sessionID: sid,
       messages: messages[sid],

--- a/packages/app/src/pages/session/blockers/use-session-blockers.test.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.test.ts
@@ -95,6 +95,7 @@ describe("findRunningExternalResultQuestion", () => {
       questions,
       messageID: "m1",
       callID: "c1",
+      partID: "p1",
     })
   })
 
@@ -144,6 +145,105 @@ describe("findRunningExternalResultQuestion", () => {
 })
 
 describe("findDescendantExternalResultQuestion", () => {
+  test("returns an active session question from the pending blocker index without an owning message row", () => {
+    const result = findDescendantExternalResultQuestion({
+      sessions: [session("parent")],
+      rootSessionID: "parent",
+      pendingQuestions: {
+        parent: [
+          {
+            id: "m-orphan:c-parent",
+            sessionID: "parent",
+            questions,
+            messageID: "m-orphan",
+            callID: "c-parent",
+            partID: "p-orphan",
+          },
+        ],
+      },
+      messages: {},
+      partsByMessageID: {},
+    })
+    expect(result?.sessionID).toBe("parent")
+    expect(result?.callID).toBe("c-parent")
+  })
+
+  test("ignores a pending blocker index entry when the local part is already terminal", () => {
+    const result = findDescendantExternalResultQuestion({
+      sessions: [session("parent")],
+      rootSessionID: "parent",
+      pendingQuestions: {
+        parent: [
+          {
+            id: "m1:c-parent",
+            sessionID: "parent",
+            questions,
+            messageID: "m1",
+            callID: "c-parent",
+            partID: "p1",
+          },
+        ],
+      },
+      messages: { parent: [message("m1")] },
+      partsByMessageID: {
+        m1: [
+          toolPart(
+            "p1",
+            "question",
+            toolState("completed", { externalResultReady: true }, { questions }),
+            { messageID: "m1", callID: "c-parent" },
+          ),
+        ],
+      },
+    })
+    expect(result).toBeUndefined()
+  })
+
+  test("returns a child session question from the pending blocker index without an owning message row", () => {
+    const result = findDescendantExternalResultQuestion({
+      sessions: [session("parent"), session("child", "parent")],
+      rootSessionID: "parent",
+      pendingQuestions: {
+        child: [
+          {
+            id: "m-child-orphan:c-child",
+            sessionID: "child",
+            questions,
+            messageID: "m-child-orphan",
+            callID: "c-child",
+            partID: "p-child-orphan",
+          },
+        ],
+      },
+      messages: {},
+      partsByMessageID: {},
+    })
+    expect(result?.sessionID).toBe("child")
+    expect(result?.callID).toBe("c-child")
+  })
+
+  test("ignores pending blocker index entries outside the active session tree", () => {
+    const result = findDescendantExternalResultQuestion({
+      sessions: [session("parent"), session("other")],
+      rootSessionID: "parent",
+      pendingQuestions: {
+        other: [
+          {
+            id: "m-other:c-other",
+            sessionID: "other",
+            questions,
+            messageID: "m-other",
+            callID: "c-other",
+            partID: "p-other",
+          },
+        ],
+      },
+      messages: {},
+      partsByMessageID: {},
+    })
+    expect(result).toBeUndefined()
+  })
+
   test("returns the request from the active session when present", () => {
     const result = findDescendantExternalResultQuestion({
       sessions: [session("parent"), session("child", "parent")],

--- a/packages/app/src/pages/session/blockers/use-session-blockers.ts
+++ b/packages/app/src/pages/session/blockers/use-session-blockers.ts
@@ -35,6 +35,7 @@ export function createSessionBlockers(input: {
     return findDescendantExternalResultQuestion({
       sessions: sync.data.session,
       rootSessionID: sid,
+      pendingQuestions: sync.data.external_result_question,
       messages: sync.data.message,
       partsByMessageID: sync.data.part,
     })


### PR DESCRIPTION
## Summary

Index pending external-result questions in global sync so the session dock and sidebar can surface a ready `question` tool call even when the owning message row has not reached the app cache yet.

## Why

The stuck-session debug showed a `question` tool part waiting for an external-result response, but the app blocker selector only walked cached messages and parts. When the message row was absent, the UI missed the blocker and left the session looking permanently running.

## Related Issue

No GitHub issue. This came from a local stuck-session debug report and the attached session export.

## Human Review Status

Pending

## Review Focus

Please focus on the pending question lifecycle: event indexing, bootstrap hydrate/prune behavior, stale running-part cleanup, same-message multi-question cleanup, child-session trimming, and parent/child selector scope.

## Risk Notes

No migrations, dependencies, permissions, platform, packaging, or generated files.

Residual risk: `GET /external-result` is treated as the pending-question authority during bootstrap prune. If the server silently skips a truly pending entry because of a transient lookup failure, the dock may disappear until the next bootstrap. Claude classified this as a low-probability P3 because the route normally skips only missing sessions/messages, and the next bootstrap self-heals.

Skipped conditional checklist items:
- Visible UI/copy check: no visual or copy change; the question dock behavior was covered with targeted E2E flows.
- Platform/packaging impact: not applicable; app sync state only.
- Docs/release/dependencies/local-file surfaces: not applicable.

## How To Verify

```text
packages/app typecheck: pass (`bun run typecheck`)
Focused unit tests: 68 passed (`bun test src/context/global-sync/bootstrap.test.ts src/context/global-sync/session-trim.test.ts src/pages/session/blockers/use-session-blockers.test.ts src/context/global-sync/event-reducer.test.ts src/context/global-sync/session-cache.test.ts`)
Focused E2E: 2 passed (`bun run test:e2e -- e2e/session/session-composer-dock.spec.ts --grep "blocked question flow unblocks after submit|child question dock survives parent-page reload via external-result hydrate"`)
Diff whitespace check: pass (`git diff --check origin/dev...HEAD`)
Sub-agent final review: no P1/P2/P3 findings
Claude final review: no P1/P2 findings; one documented low-probability P3 residual risk
```

## Screenshots or Recordings

Not applicable: no visual or copy changes. Targeted E2E exercised the changed question dock behavior.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session retention to preserve active sessions with pending questions during cleanup operations.
  * Enhanced question detection to properly track pending questions even when associated message data is unavailable.
  
* **Improvements**
  * Refined activity status detection in session sidebar to account for pending questions from external sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->