### PR TITLE
chore(release): bump desktop version to v2026.6.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.5.29",
+      "version": "2026.6.2",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.6.1",
+  "version": "2026.6.2",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the PawWork desktop release version to `2026.6.2`.

No related issue; this is the release preparation PR for the next stable desktop build.

## Why

The latest stable release is `v2026.6.1`. `dev` now contains the next release train, so the desktop package metadata needs to move to `2026.6.2` before the production release workflow runs.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Confirm the diff is limited to release metadata:

- `packages/desktop-electron/package.json` version `2026.6.1 -> 2026.6.2`
- `bun.lock` workspace package version `2026.5.29 -> 2026.6.2`

## Risk Notes

Release metadata only. No runtime behavior, dependency, UI, copy, permission, signing, updater, or packaging workflow logic changed.

Skipped conditional checklist items:

- Visible UI/copy manual check: not applicable; no visible UI or copy changed.
- macOS/Windows platform impact: considered; the change only selects the version used by the existing release workflow and artifact names.
- Release notes/dependencies/etc.: release notes will be prepared in the GitHub Release draft before publishing; no dependency graph changed.

## How To Verify

```text
bun install --frozen-lockfile: passed in the release worktree.
bun test scripts/release-metadata-contract.test.ts scripts/verify-release.test.ts scripts/publish-when-complete.test.ts scripts/mirror-release-to-r2.test.ts: 67 pass, 0 fail.
node -p "require('./packages/desktop-electron/package.json').version": 2026.6.2.
rg -n '2026\\.6\\.1|2026\\.6\\.2|2026\\.5\\.29' packages/desktop-electron/package.json bun.lock: only 2026.6.2 remains in the release metadata files.
git diff --check -- packages/desktop-electron/package.json bun.lock: passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
