### PR TITLE
fix(app): stabilize session opening composer

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
@@ -295,9 +295,12 @@ test("opening a delayed sidebar session never shows the previous session as load
           `${sessionComposerDockSelector}[data-state="opening-placeholder"]`,
         )
         await expect(openingDock).toHaveCount(1)
-        const openingDockBox = await openingDock.boundingBox()
-        if (!openingDockBox) throw new Error("Opening composer placeholder did not expose a bounding box")
-        expect(Math.abs(openingDockBox.height - sourceDockBox.height)).toBeLessThanOrEqual(2)
+        await expect
+          .poll(async () => {
+            const openingDockBox = await openingDock.boundingBox()
+            return openingDockBox ? Math.abs(openingDockBox.height - sourceDockBox.height) : Infinity
+          })
+          .toBeLessThanOrEqual(2)
 
         releaseMessages?.()
         releaseMessages = undefined

--- a/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
@@ -1,7 +1,7 @@
 import type { Page, Route } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { cleanupSession, cleanupTestProject, createTestProject, openSidebar, waitSession, withSession } from "../actions"
-import { promptSelector, sessionTurnListSelector } from "../selectors"
+import { promptSelector, sessionComposerDockSelector, sessionTurnListSelector } from "../selectors"
 import type { createSdk } from "../utils"
 
 async function sessionRowPaint(page: Page, sessionID: string) {
@@ -279,6 +279,8 @@ test("opening a delayed sidebar session never shows the previous session as load
       try {
         await gotoSession(source.id)
         await expect(page.locator(sessionTurnListSelector).getByText(sourceText)).toBeVisible()
+        const sourceDockBox = await page.locator(sessionComposerDockSelector).boundingBox()
+        if (!sourceDockBox) throw new Error("Source composer dock did not expose a bounding box")
         await openSidebar(page)
         await expect.poll(() => targetMessageRequests, { timeout: 10_000 }).toBeGreaterThan(0)
 
@@ -289,10 +291,19 @@ test("opening a delayed sidebar session never shows the previous session as load
         await expect(page.locator(sessionTurnListSelector).getByText(sourceText)).toHaveCount(0)
         await expect(page.locator(sessionTurnListSelector).getByText(targetText)).toHaveCount(0)
         await expect(page.locator(promptSelector)).toHaveCount(0)
+        const openingDock = page.locator(
+          `${sessionComposerDockSelector}[data-state="opening-placeholder"]`,
+        )
+        await expect(openingDock).toHaveCount(1)
+        const openingDockBox = await openingDock.boundingBox()
+        if (!openingDockBox) throw new Error("Opening composer placeholder did not expose a bounding box")
+        expect(Math.abs(openingDockBox.height - sourceDockBox.height)).toBeLessThanOrEqual(2)
 
-        await page.locator('[data-component="session-opening-state"]').getByRole("button", { name: "New session" }).click()
-        await expect(page).toHaveURL(new RegExp(`/${slug}/session(?:\\?|#|$)`))
-        await expect(page.locator('[data-component="session-new-home"]')).toBeVisible()
+        releaseMessages?.()
+        releaseMessages = undefined
+        await expect(page.locator(sessionTurnListSelector).getByText(targetText)).toBeVisible()
+        await expect(page.locator(promptSelector)).toHaveCount(1)
+        await expect(openingDock).toHaveCount(0)
       } finally {
         releaseMessages?.()
         await page.unroute(`**/session/${target.id}/message*`, delayTargetMessages)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -20,6 +20,7 @@ import { createSessionComposerState, HomeComposerRegion } from "@/pages/session/
 import { createSizing } from "@/pages/session/helpers"
 import { createSessionExecutionState } from "@/pages/session/session-execution-directory"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { shouldShowSessionOpeningState } from "@/pages/session/session-main-view-state"
 import { SessionPageComposerRegion } from "@/pages/session/session-composer-region"
 import { SessionMainView } from "@/pages/session/session-main-view"
 import { createSessionRunning, isSessionRunning } from "@/pages/session/session-running-state"
@@ -123,6 +124,14 @@ export default function Page() {
   const timelineHistoryMore = timeline.historyMore
   const timelineHistoryLoading = timeline.historyLoading
   const lastUserMessage = timeline.lastUserMessage
+  const sessionOpening = createMemo(() =>
+    shouldShowSessionOpeningState({
+      activeSessionID: params.id,
+      routeSessionID: params.id,
+      routeReady: timelineMessagesReady(),
+      timelineSessionID: timelineSessionID(),
+    }),
+  )
   const turnChangeController = createSessionTurnChanges({ sessionID: timelineSessionID, sessionMessages: timelineMessages })
   const diagnostics = createSessionPageDiagnostics({
     routeSessionID: () => params.id,
@@ -379,6 +388,7 @@ export default function Page() {
   const renderComposerRegion = (ctx?: { onModeChange: (mode: "normal" | "shell") => void }) => (
     <SessionPageComposerRegion
       state={composer}
+      opening={sessionOpening()}
       ready={!deferRender() && sessionActionReady()}
       actionReady={submitReady()}
       abortReady={sessionActionReady()}
@@ -453,8 +463,7 @@ export default function Page() {
       mobileTab={mobileTab()}
       setMobileTab={setMobileTab}
       language={language}
-      routeSessionID={params.id}
-      routeReady={timelineMessagesReady()}
+      sessionOpening={sessionOpening()}
       transitioning={timeline.transitioning()}
       timelineSessionID={timelineSessionID()}
       timelineSessionKey={timelineSessionKey()}

--- a/packages/app/src/pages/session/session-composer-region.tsx
+++ b/packages/app/src/pages/session/session-composer-region.tsx
@@ -1,10 +1,11 @@
-import type { ComponentProps } from "solid-js"
+import { createMemo, type ComponentProps } from "solid-js"
 import { SessionComposerRegion, type createSessionComposerState } from "@/pages/session/composer"
 
 type ComposerRegionProps = ComponentProps<typeof SessionComposerRegion>
 
 export function SessionPageComposerRegion(props: {
   state: ReturnType<typeof createSessionComposerState>
+  opening?: boolean
   ready: boolean
   actionReady?: boolean
   abortReady?: boolean
@@ -21,5 +22,40 @@ export function SessionPageComposerRegion(props: {
   revert?: ComposerRegionProps["revert"]
   setPromptDockRef: (el: HTMLDivElement) => void
 }) {
-  return <SessionComposerRegion {...props} />
+  const content = createMemo(() =>
+    props.opening ? (
+      <SessionOpeningComposerPlaceholder centered={props.centered} setPromptDockRef={props.setPromptDockRef} />
+    ) : (
+      <SessionComposerRegion {...props} />
+    ),
+  )
+
+  return <>{content()}</>
+}
+
+function SessionOpeningComposerPlaceholder(props: {
+  centered: boolean
+  setPromptDockRef: (el: HTMLDivElement) => void
+}) {
+  return (
+    <div
+      ref={props.setPromptDockRef}
+      data-component="session-prompt-dock"
+      data-variant="session"
+      data-dock-kind="composer"
+      data-state="opening-placeholder"
+      aria-hidden="true"
+      class="w-full pointer-events-none absolute inset-x-0 bottom-0 box-border"
+      style={{ height: "var(--composer-dock-height, 112px)" }}
+    >
+      <div
+        data-component="session-composer-column"
+        data-state="opening-placeholder"
+        classList={{
+          "h-full w-full px-4 md:px-3": true,
+          "md:max-w-[720px] md:mx-auto 2xl:max-w-[920px]": props.centered,
+        }}
+      />
+    </div>
+  )
 }

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -6,7 +6,6 @@ import type { createSizing } from "@/pages/session/helpers"
 import { MessageTimeline } from "@/pages/session/message-timeline"
 import { SessionOpeningSkeleton } from "@/pages/session/session-opening-skeleton"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
-import { shouldShowSessionOpeningState } from "@/pages/session/session-main-view-state"
 import type { createSessionHistoryWindow } from "@/pages/session/use-session-history-window"
 import type { createSessionReviewState } from "@/pages/session/use-session-review-state"
 import type { createSessionScrollDock } from "@/pages/session/use-session-scroll-dock"
@@ -23,8 +22,7 @@ export function SessionMainView(props: {
   mobileTab: "session" | "changes"
   setMobileTab: (tab: "session" | "changes") => void
   language: ReturnType<typeof useLanguage>
-  routeSessionID?: string
-  routeReady: boolean
+  sessionOpening: boolean
   transitioning: boolean
   timelineSessionID?: string
   timelineSessionKey: string
@@ -64,14 +62,8 @@ export function SessionMainView(props: {
   files: ReturnType<typeof createSessionReviewState>["artifactFiles"]
   size: ReturnType<typeof createSizing>
 }) {
-  const showSessionOpeningState = () =>
-    shouldShowSessionOpeningState({
-      activeSessionID: props.activeSessionID,
-      routeSessionID: props.routeSessionID,
-      routeReady: props.routeReady,
-      timelineSessionID: props.timelineSessionID,
-    })
-  const [openingSkeletonMounted, setOpeningSkeletonMounted] = createSignal(showSessionOpeningState())
+  const showSessionOpeningState = () => props.sessionOpening
+  const [openingSkeletonMounted, setOpeningSkeletonMounted] = createSignal(props.sessionOpening)
   const [openingSkeletonVisible, setOpeningSkeletonVisible] = createSignal(false)
   let openingShowTimer: ReturnType<typeof setTimeout> | undefined
   let openingHideTimer: ReturnType<typeof setTimeout> | undefined


### PR DESCRIPTION
## Summary

Fixes a session-opening flicker where the previous session composer stayed visible while a sidebar-selected target session was still waiting for its messages to hydrate.

No linked issue; this came from a user-reported local recording where the stale composer was visible during the 2s-3s opening window.

## Why

The previous session-opening guard only hid the timeline area. The real session composer still rendered whenever an `activeSessionID` existed, so route selection, opening UI, and stale input chrome could appear together during a delayed session switch.

This change lifts the opening-state calculation to the page layer and reuses it for both the main view and composer region. While opening, the composer region renders a non-interactive placeholder dock that preserves the measured bottom space without exposing the real prompt.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please focus on the session-opening state boundary: the placeholder should only render while the target route is not ready, should not expose `[data-component="prompt-input"]`, and should give way to the real composer once the target timeline loads.

## Risk Notes

Low to medium UI risk. This touches the session page composer mount boundary, but the focused E2E covers delayed sidebar navigation, stale timeline content, prompt absence during opening, placeholder height stability, and restoration of the real prompt after load.

Skipped conditional checklist items:
- Platform impact: not applicable; no platform, packaging, updater, signing, path, shell, or permission code changed.
- Docs/release/dependency/local-file surfaces: not applicable; no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file surfaces changed.

## How To Verify

```text
Focused E2E: PASS - PAWWORK_PERF_TRACE=1 bun run test:e2e:local -- e2e/sidebar/sidebar-session-links.spec.ts -g "opening a delayed sidebar session never shows the previous session as loading UI"
Typecheck: PASS - bun run typecheck
Session unit tests: PASS - bun test src/pages/session/session-main-view.test.ts src/pages/session/session-opening-skeleton.test.ts src/pages/session/use-session-timeline-data.test.ts src/pages/session/session-view-controller.test.ts (40 passed)
Shell frame contract: PASS - bun test src/shell-frame-contract.test.ts (10 passed)
Diff check: PASS - git diff --check
```

## Screenshots or Recordings

Visible UI check completed from the Playwright trace produced by the focused delayed-sidebar E2E. In the opening frames, the target sidebar row is selected, previous-session text is absent, target text is still hidden until hydrated, and the real prompt is absent while the bottom space remains reserved by the opening placeholder.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session opening state UI with a placeholder composer dock that appears while a session loads and disappears once content is ready.

* **Tests**
  * Enhanced e2e test coverage for session loading scenarios, including placeholder dock rendering and loading UI behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->