### PR TITLE
chore(release): bump desktop version to v2026.6.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.6.2",
+      "version": "2026.6.3",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.6.2",
+  "version": "2026.6.3",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the PawWork desktop release metadata from `2026.6.2` to `2026.6.3` so the production release workflow can build the next stable desktop version. The release tag will be `v2026.6.3`.

Scope:
- `packages/desktop-electron/package.json` version `2026.6.2` -> `2026.6.3`
- `bun.lock` workspace package version `2026.6.2` -> `2026.6.3`

## Why

Version bumps are a manual prerequisite to the `build.yml` release dispatch. This PR only moves the pinned version; no product code, workflow, or dependency changes. An unrelated `luxon`/`@types/luxon` lockfile drift surfaced by a full `bun install` was deliberately excluded to keep this PR surgical (frozen install stays green without it).

## Verification

- `bun install --frozen-lockfile`: lockfile consistent, no changes.
- `bun test` (release-metadata-contract, release-workflow-contract, verify-release, publish-when-complete, mirror-release-to-r2): 77 pass, 0 fail.
- `git grep`: only `2026.6.3` remains in `package.json` and `bun.lock`.

## Risk Notes

- No product code or release workflow behavior changed.
- Production artifacts, R2 mirror, and packaged startup smoke are verified after the release workflow publishes `v2026.6.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version release (2026.6.3) of the desktop application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->