### PR TITLE
fix(app): hold the session opening cover until the timeline settles (#595)

### DIFF
--- a/packages/app/e2e/session/session-reveal-gate.spec.ts
+++ b/packages/app/e2e/session/session-reveal-gate.spec.ts
@@ -1,0 +1,134 @@
+import type { Page } from "@playwright/test"
+import { test, expect } from "../fixtures"
+import { withSession } from "../actions"
+import { sessionMessageItemSelector } from "../selectors"
+
+// Reveal gate (follow-latest open) — opening or switching to a session that is
+// pinned to the latest turn must not expose the mid-render "premature bottom"
+// the virtualizer lands on before it finishes measuring tall content. The
+// timeline mounts and measures behind the opening cover; the cover only lifts
+// once the reconciler has gone quiet, so the first *visible* frame is already
+// the settled bottom. This drives the real navigation path and asserts the
+// invariant on the frames the user could actually see.
+
+type Sdk = Parameters<typeof withSession>[0]
+
+const INITIAL_SESSION_WINDOW_MESSAGES = 10
+// A revealed (visible) frame must already sit at the bottom; small sub-pixel /
+// padding slack only.
+const BOTTOM_TOLERANCE = 24
+// Across all revealed frames scrollTop must be effectively constant — the bug
+// surfaced as a viewport-sized downward jump (hundreds of px), so anything past
+// this gate is the regression, not settle jitter.
+const JUMP_TOLERANCE = 48
+
+type RevealSample = {
+  at: number
+  top: number
+  height: number
+  client: number
+  distanceFromBottom: number
+  covered: boolean
+}
+
+async function seedSessionTurns(input: { sdk: Sdk; sessionID: string; count: number }) {
+  for (let i = 0; i < input.count; i++) {
+    await input.sdk.session.promptAsync({
+      sessionID: input.sessionID,
+      noReply: true,
+      parts: [
+        {
+          type: "text",
+          text: `reveal seed turn ${i}\n${Array.from({ length: 16 }, (_, line) => `line ${line} ${"content ".repeat(8)}`).join("\n")}`,
+        },
+      ],
+    })
+  }
+}
+
+// Install a per-frame probe via addInitScript so it survives the full page
+// navigation `gotoSession` performs and captures from the very first frame of
+// the session route. Each frame records the timeline scroll position plus
+// whether the reveal cover is up (`data-covered`); when the wrapper is absent
+// (pre-fix DOM) every frame counts as visible.
+const REVEAL_PROBE_SCRIPT = `(() => {
+  const TURN_LIST = '[data-slot="session-turn-list"]'
+  const VIEWPORT = '[data-component="scroll-viewport"]'
+  const REVEAL = '[data-slot="session-timeline-reveal"]'
+  const samples = []
+  const read = () => {
+    const list = document.querySelector(TURN_LIST)
+    const viewport = list && list.closest(VIEWPORT)
+    if (!(viewport instanceof HTMLElement)) return null
+    const reveal = document.querySelector(REVEAL)
+    const covered = reveal instanceof HTMLElement ? reveal.getAttribute('data-covered') === 'true' : false
+    return {
+      at: performance.now(),
+      top: viewport.scrollTop,
+      height: viewport.scrollHeight,
+      client: viewport.clientHeight,
+      distanceFromBottom: viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop,
+      covered,
+    }
+  }
+  const push = () => { const s = read(); if (s && samples.length < 4000) samples.push(s) }
+  const tick = () => { push(); requestAnimationFrame(tick) }
+  requestAnimationFrame(tick)
+  window.__revealProbe = { snapshot: () => samples.slice() }
+})()`
+
+function readRevealSamples(page: Page) {
+  return page.evaluate(() => {
+    const probe = (window as unknown as { __revealProbe?: { snapshot: () => RevealSample[] } }).__revealProbe
+    return probe ? probe.snapshot() : []
+  }) as Promise<RevealSample[]>
+}
+
+test("does not expose a premature-bottom jump when opening a follow-latest session", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  const sdk = project.sdk
+
+  await withSession(sdk, `e2e reveal-gate ${Date.now()}`, async (session) => {
+    project.trackSession(session.id)
+    await seedSessionTurns({ sdk, sessionID: session.id, count: 16 })
+
+    // Probe from frame 0 of the upcoming session navigation.
+    await page.addInitScript(REVEAL_PROBE_SCRIPT)
+    await project.gotoSession(session.id)
+
+    await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
+      timeout: 30_000,
+    })
+    // Let the open fully settle so the probe captures the reveal transition and
+    // any trailing re-pin.
+    await page.waitForTimeout(1000)
+
+    const samples = await readRevealSamples(page)
+    expect(samples.length, "reveal probe should have captured frames").toBeGreaterThan(0)
+
+    // Only frames with real overflow matter; an empty/short timeline cannot jump.
+    const overflowing = samples.filter((sample) => sample.height > sample.client + 200)
+    expect(overflowing.length, "expected the seeded timeline to overflow").toBeGreaterThan(0)
+
+    const visible = overflowing.filter((sample) => !sample.covered)
+    expect(visible.length, "the timeline should become visible").toBeGreaterThan(0)
+
+    // Every frame the user could see is already at the settled bottom — the
+    // premature mid-render bottom is never painted.
+    const offBottom = visible.filter((sample) => sample.distanceFromBottom > BOTTOM_TOLERANCE)
+    expect(offBottom, "no visible frame may sit off the settled bottom").toEqual([])
+
+    // And visible scrollTop never jumps — the premature→true bottom correction
+    // happens entirely behind the cover.
+    const tops = visible.map((sample) => sample.top)
+    expect(Math.max(...tops) - Math.min(...tops), "visible scrollTop must not jump").toBeLessThanOrEqual(
+      JUMP_TOLERANCE,
+    )
+
+    // Sanity that the gate actually engaged (rather than the open settling so
+    // fast there was nothing to cover): the cover held for at least one frame.
+    expect(overflowing.some((sample) => sample.covered), "the reveal cover should hold during the open").toBe(true)
+  })
+})

--- a/packages/app/e2e/session/session-reveal-gate.spec.ts
+++ b/packages/app/e2e/session/session-reveal-gate.spec.ts
@@ -101,9 +101,19 @@ test("does not expose a premature-bottom jump when opening a follow-latest sessi
     await expect(page.locator(sessionMessageItemSelector)).toHaveCount(INITIAL_SESSION_WINDOW_MESSAGES, {
       timeout: 30_000,
     })
-    // Let the open fully settle so the probe captures the reveal transition and
-    // any trailing re-pin.
-    await page.waitForTimeout(1000)
+    // Poll the probe instead of a fixed sleep: wait until it has captured a run
+    // of visible (uncovered) overflowing frames, which only exist once the reveal
+    // transition has completed. Several post-reveal frames are enough to expose a
+    // trailing re-pin to the jump assertions below.
+    await expect
+      .poll(
+        async () => {
+          const captured = await readRevealSamples(page)
+          return captured.filter((sample) => sample.height > sample.client + 200 && !sample.covered).length
+        },
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(5)
 
     const samples = await readRevealSamples(page)
     expect(samples.length, "reveal probe should have captured frames").toBeGreaterThan(0)

--- a/packages/app/src/pages/session/session-main-view.tsx
+++ b/packages/app/src/pages/session/session-main-view.tsx
@@ -5,6 +5,7 @@ import type { useLanguage } from "@/context/language"
 import type { createSizing } from "@/pages/session/helpers"
 import { MessageTimeline } from "@/pages/session/message-timeline"
 import { SessionOpeningSkeleton } from "@/pages/session/session-opening-skeleton"
+import { createTimelineRevealGate } from "@/pages/session/timeline-reveal-gate"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import type { createSessionHistoryWindow } from "@/pages/session/use-session-history-window"
 import type { createSessionReviewState } from "@/pages/session/use-session-review-state"
@@ -61,13 +62,24 @@ export function SessionMainView(props: {
   size: ReturnType<typeof createSizing>
 }) {
   const showSessionOpeningState = () => props.sessionOpening
-  const [openingSkeletonMounted, setOpeningSkeletonMounted] = createSignal(props.sessionOpening)
+  // Hold the opening cover past `routeReady` until the freshly mounted timeline
+  // has settled at its anchor, so the first revealed frame is the settled bottom
+  // rather than a mid-render premature bottom that then jumps down. The timeline
+  // mounts and measures behind the cover; the gate lifts it once the reconciler
+  // goes quiet (or a failsafe timeout fires). See timeline-reveal-gate.
+  const revealGate = createTimelineRevealGate({
+    sessionKey: () => props.timelineSessionKey,
+    ready: () => props.timelineMessagesReady,
+    reconcilerActive: () => props.reconcilerActive(),
+  })
+  const timelineCovered = () => !!props.activeSessionID && !!props.timelineSessionID && revealGate.covered()
+  const [openingSkeletonMounted, setOpeningSkeletonMounted] = createSignal(timelineCovered())
   const [openingSkeletonVisible, setOpeningSkeletonVisible] = createSignal(false)
   let openingShowTimer: ReturnType<typeof setTimeout> | undefined
   let openingHideTimer: ReturnType<typeof setTimeout> | undefined
 
   createEffect(() => {
-    const opening = showSessionOpeningState()
+    const opening = timelineCovered()
     if (openingShowTimer) clearTimeout(openingShowTimer)
     if (openingHideTimer) clearTimeout(openingHideTimer)
 
@@ -133,38 +145,48 @@ export function SessionMainView(props: {
                 <div class="flex-1 min-h-0" />
               </Match>
               <Match when={props.activeSessionID && props.timelineSessionID ? props.timelineSessionID : undefined}>
-                <MessageTimeline
-                  sessionID={props.timelineSessionID ?? ""}
-                  sessionKey={props.timelineSessionKey}
-                  sessionMessages={props.timelineMessages}
-                  turnChangeController={props.turnChangeController}
-                  mobileChanges={props.mobileChanges}
-                  mobileFallback={props.mobileFallback}
-                  actions={props.actions}
-                  scroll={props.scroll}
-                  onResumeScroll={props.resumeScroll}
-                  setScrollRef={props.setScrollRef}
-                  onScheduleScrollState={props.scheduleScrollState}
-                  onMarkScrollGesture={props.markScrollGesture}
-                  hasScrollGesture={props.hasScrollGesture}
-                  onUserScroll={props.markUserScroll}
-                  onTimelineScrollIntent={props.onTimelineScrollIntent}
-                  onTimelineScrollObservation={props.onTimelineScrollObservation}
-                  onTurnBackfillScroll={props.historyWindow.onScrollerScroll}
-                  onTimelineInteraction={props.onTimelineInteraction}
-                  centered={props.centered}
-                  setContentRef={props.setContentRef}
-                  turnStart={props.historyWindow.turnStart()}
-                  historyMore={props.historyMore}
-                  historyLoading={props.historyLoading}
-                  onLoadEarlier={() => {
-                    void props.historyWindow.loadAndReveal()
+                <div
+                  class="size-full transition-opacity duration-[var(--duration-base)] ease-out motion-reduce:transition-none"
+                  classList={{
+                    "opacity-0 pointer-events-none": timelineCovered(),
+                    "opacity-100": !timelineCovered(),
                   }}
-                  renderedUserMessages={props.historyWindow.renderedUserMessages()}
-                  anchor={props.anchor}
-                  virtualizerBridge={props.virtualizerBridge}
-                  reconcilerActive={props.reconcilerActive}
-                />
+                  data-slot="session-timeline-reveal"
+                  data-covered={timelineCovered() ? "true" : "false"}
+                >
+                  <MessageTimeline
+                    sessionID={props.timelineSessionID ?? ""}
+                    sessionKey={props.timelineSessionKey}
+                    sessionMessages={props.timelineMessages}
+                    turnChangeController={props.turnChangeController}
+                    mobileChanges={props.mobileChanges}
+                    mobileFallback={props.mobileFallback}
+                    actions={props.actions}
+                    scroll={props.scroll}
+                    onResumeScroll={props.resumeScroll}
+                    setScrollRef={props.setScrollRef}
+                    onScheduleScrollState={props.scheduleScrollState}
+                    onMarkScrollGesture={props.markScrollGesture}
+                    hasScrollGesture={props.hasScrollGesture}
+                    onUserScroll={props.markUserScroll}
+                    onTimelineScrollIntent={props.onTimelineScrollIntent}
+                    onTimelineScrollObservation={props.onTimelineScrollObservation}
+                    onTurnBackfillScroll={props.historyWindow.onScrollerScroll}
+                    onTimelineInteraction={props.onTimelineInteraction}
+                    centered={props.centered}
+                    setContentRef={props.setContentRef}
+                    turnStart={props.historyWindow.turnStart()}
+                    historyMore={props.historyMore}
+                    historyLoading={props.historyLoading}
+                    onLoadEarlier={() => {
+                      void props.historyWindow.loadAndReveal()
+                    }}
+                    renderedUserMessages={props.historyWindow.renderedUserMessages()}
+                    anchor={props.anchor}
+                    virtualizerBridge={props.virtualizerBridge}
+                    reconcilerActive={props.reconcilerActive}
+                  />
+                </div>
               </Match>
               <Match when={!props.activeSessionID}>
                 <NewSessionView composer={props.composerHome} />

--- a/packages/app/src/pages/session/timeline-reveal-gate.test.ts
+++ b/packages/app/src/pages/session/timeline-reveal-gate.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from "bun:test"
+import {
+  createRevealGateMachine,
+  nextRevealGateState,
+  revealGateCovered,
+  type RevealGateEvent,
+  type RevealGateOptions,
+  type RevealGateState,
+} from "./timeline-reveal-gate"
+
+/** A frame scheduler whose callbacks run only when `step` is called. */
+function makeFrameQueue() {
+  const callbacks = new Map<number, () => void>()
+  let nextHandle = 1
+  return {
+    schedule: (callback: () => void) => {
+      const handle = nextHandle++
+      callbacks.set(handle, callback)
+      return handle
+    },
+    cancel: (handle: number) => {
+      callbacks.delete(handle)
+    },
+    /** Run the oldest queued frame (the loop re-queues the next one itself). */
+    step: () => {
+      const entry = callbacks.entries().next().value
+      if (!entry) return false
+      callbacks.delete(entry[0])
+      entry[1]()
+      return true
+    },
+    size: () => callbacks.size,
+  }
+}
+
+/** A timer queue whose callbacks fire only when `fire` is called. */
+function makeTimerQueue() {
+  const callbacks = new Map<number, () => void>()
+  let nextHandle = 1
+  return {
+    set: (callback: () => void) => {
+      const handle = nextHandle++
+      callbacks.set(handle, callback)
+      return handle
+    },
+    clear: (handle: number) => {
+      callbacks.delete(handle)
+    },
+    fire: () => {
+      const entry = callbacks.entries().next().value
+      if (!entry) return false
+      callbacks.delete(entry[0])
+      entry[1]()
+      return true
+    },
+    size: () => callbacks.size,
+  }
+}
+
+describe("nextRevealGateState", () => {
+  const open = (sessionKey: string) => nextRevealGateState(undefined, { type: "session", sessionKey })
+  const reduce = (state: RevealGateState, events: RevealGateEvent[], opts?: RevealGateOptions) =>
+    events.reduce((acc, event) => nextRevealGateState(acc, event, opts), state)
+  const inactive = (n: number): RevealGateEvent[] =>
+    Array.from({ length: n }, () => ({ type: "frame", reconcilerActive: false }))
+
+  test("a freshly opened session starts covered while loading", () => {
+    const state = open("a")
+    expect(state.phase).toBe("loading")
+    expect(revealGateCovered(state)).toBe(true)
+  })
+
+  test("stays covered and loading while messages are not ready, even across frames", () => {
+    const state = reduce(open("a"), [
+      { type: "ready", ready: false },
+      { type: "frame", reconcilerActive: false },
+    ])
+    expect(state.phase).toBe("loading")
+    expect(revealGateCovered(state)).toBe(true)
+  })
+
+  test("enters settling (still covered) once messages are ready", () => {
+    const state = reduce(open("a"), [{ type: "ready", ready: true }])
+    expect(state.phase).toBe("settling")
+    expect(revealGateCovered(state)).toBe(true)
+  })
+
+  test("reveals after the configured number of consecutive inactive frames once ready", () => {
+    const opts: RevealGateOptions = { settleFrames: 2 }
+    const ready = reduce(open("a"), [{ type: "ready", ready: true }], opts)
+    const afterOne = reduce(ready, inactive(1), opts)
+    expect(revealGateCovered(afterOne)).toBe(true)
+    const afterTwo = reduce(ready, inactive(2), opts)
+    expect(afterTwo.phase).toBe("revealed")
+    expect(revealGateCovered(afterTwo)).toBe(false)
+  })
+
+  test("an active reconcile frame resets the stable-frame count", () => {
+    const opts: RevealGateOptions = { settleFrames: 2 }
+    const state = reduce(
+      open("a"),
+      [
+        { type: "ready", ready: true },
+        { type: "frame", reconcilerActive: false },
+        { type: "frame", reconcilerActive: true },
+        { type: "frame", reconcilerActive: false },
+      ],
+      opts,
+    )
+    // Only one inactive frame since the last active one — not yet settled.
+    expect(revealGateCovered(state)).toBe(true)
+  })
+
+  test("timeout reveals once ready even if the reconciler never goes quiet", () => {
+    const settled = reduce(open("a"), [
+      { type: "ready", ready: true },
+      { type: "frame", reconcilerActive: true },
+      { type: "timeout" },
+    ])
+    expect(settled.phase).toBe("revealed")
+  })
+
+  test("timeout while still loading does not reveal a not-yet-ready session", () => {
+    const state = reduce(open("a"), [{ type: "ready", ready: false }, { type: "timeout" }])
+    expect(state.phase).toBe("loading")
+    expect(revealGateCovered(state)).toBe(true)
+  })
+
+  test("release reveals immediately so a user gesture is never hidden behind the cover", () => {
+    const fromLoading = reduce(open("a"), [{ type: "release" }])
+    expect(fromLoading.phase).toBe("revealed")
+    const fromSettling = reduce(open("a"), [{ type: "ready", ready: true }, { type: "release" }])
+    expect(fromSettling.phase).toBe("revealed")
+  })
+
+  test("switching to a new session re-covers and restarts loading", () => {
+    const revealed = reduce(open("a"), [{ type: "ready", ready: true }, { type: "release" }])
+    expect(revealed.phase).toBe("revealed")
+    const next = nextRevealGateState(revealed, { type: "session", sessionKey: "b" })
+    expect(next.sessionKey).toBe("b")
+    expect(next.phase).toBe("loading")
+    expect(revealGateCovered(next)).toBe(true)
+  })
+
+  test("re-emitting the same session key does not re-cover an already revealed timeline", () => {
+    const revealed = reduce(open("a"), [{ type: "ready", ready: true }, { type: "release" }])
+    const same = nextRevealGateState(revealed, { type: "session", sessionKey: "a" })
+    expect(same.phase).toBe("revealed")
+    expect(revealGateCovered(same)).toBe(false)
+  })
+
+  test("once revealed, later ready/frame/timeout events keep it revealed", () => {
+    const revealed = reduce(open("a"), [{ type: "ready", ready: true }, { type: "release" }])
+    const after = reduce(revealed, [
+      { type: "ready", ready: false },
+      { type: "frame", reconcilerActive: true },
+      { type: "timeout" },
+    ])
+    expect(after.phase).toBe("revealed")
+  })
+})
+
+describe("createRevealGateMachine", () => {
+  const makeMachine = (over?: { settleFrames?: number; timeoutMs?: number }) => {
+    const frames = makeFrameQueue()
+    const timers = makeTimerQueue()
+    let active = false
+    let ready = false
+    const machine = createRevealGateMachine({
+      settleFrames: over?.settleFrames ?? 2,
+      timeoutMs: over?.timeoutMs ?? 400,
+      ready: () => ready,
+      reconcilerActive: () => active,
+      scheduleFrame: frames.schedule,
+      cancelFrame: frames.cancel,
+      setTimer: timers.set,
+      clearTimer: timers.clear,
+    })
+    return {
+      machine,
+      frames,
+      timers,
+      setActive: (value: boolean) => {
+        active = value
+      },
+      setReady: (value: boolean) => {
+        ready = value
+      },
+      covered: () => revealGateCovered(machine.state()),
+    }
+  }
+
+  test("lifts the cover after the reconciler stays quiet for settleFrames", () => {
+    const ctx = makeMachine({ settleFrames: 2 })
+    ctx.machine.session("a")
+    expect(ctx.covered()).toBe(true) // loading
+    expect(ctx.frames.size()).toBe(0)
+
+    ctx.setReady(true)
+    ctx.machine.notifyReady() // → settling, arms the loop + failsafe timer
+    expect(ctx.covered()).toBe(true)
+    expect(ctx.frames.size()).toBe(1)
+    expect(ctx.timers.size()).toBe(1)
+
+    ctx.frames.step() // 1 quiet frame
+    expect(ctx.covered()).toBe(true)
+
+    ctx.frames.step() // 2nd quiet frame → reveal; loop stops, timer cleared
+    expect(ctx.covered()).toBe(false)
+    expect(ctx.frames.size()).toBe(0)
+    expect(ctx.timers.size()).toBe(0)
+  })
+
+  test("keeps the cover while the reconciler is active, then lifts once it goes quiet", () => {
+    const ctx = makeMachine({ settleFrames: 2 })
+    ctx.machine.session("a")
+    ctx.setReady(true)
+    ctx.machine.notifyReady()
+
+    ctx.setActive(true)
+    ctx.frames.step()
+    ctx.frames.step()
+    expect(ctx.covered()).toBe(true) // never quiet → never settles
+
+    ctx.setActive(false)
+    ctx.frames.step()
+    ctx.frames.step()
+    expect(ctx.covered()).toBe(false)
+  })
+
+  test("the failsafe timer lifts the cover even if the reconciler never goes quiet", () => {
+    const ctx = makeMachine({ settleFrames: 2 })
+    ctx.machine.session("a")
+    ctx.setReady(true)
+    ctx.machine.notifyReady()
+    ctx.setActive(true)
+    ctx.frames.step() // stays settling
+    expect(ctx.covered()).toBe(true)
+
+    ctx.timers.fire() // failsafe → reveal
+    expect(ctx.covered()).toBe(false)
+    expect(ctx.frames.size()).toBe(0)
+  })
+
+  test("release lifts the cover and stops the loop and timer", () => {
+    const ctx = makeMachine({ settleFrames: 2 })
+    ctx.machine.session("a")
+    ctx.setReady(true)
+    ctx.machine.notifyReady()
+    expect(ctx.frames.size()).toBe(1)
+
+    ctx.machine.release()
+    expect(ctx.covered()).toBe(false)
+    expect(ctx.frames.size()).toBe(0)
+    expect(ctx.timers.size()).toBe(0)
+  })
+
+  test("switching sessions re-covers and re-arms the settle watch when already ready", () => {
+    const ctx = makeMachine({ settleFrames: 2 })
+    ctx.machine.session("a")
+    ctx.setReady(true)
+    ctx.machine.notifyReady()
+    ctx.frames.step()
+    ctx.frames.step()
+    expect(ctx.covered()).toBe(false) // session a revealed
+
+    ctx.machine.session("b") // ready stays true across a same-scope switch
+    expect(ctx.covered()).toBe(true) // re-covered
+    expect(ctx.frames.size()).toBe(1) // settle watch re-armed for b
+  })
+})

--- a/packages/app/src/pages/session/timeline-reveal-gate.test.ts
+++ b/packages/app/src/pages/session/timeline-reveal-gate.test.ts
@@ -171,6 +171,7 @@ describe("createRevealGateMachine", () => {
     const timers = makeTimerQueue()
     let active = false
     let ready = false
+    const coveredChanges: boolean[] = []
     const machine = createRevealGateMachine({
       settleFrames: over?.settleFrames ?? 2,
       timeoutMs: over?.timeoutMs ?? 400,
@@ -180,11 +181,13 @@ describe("createRevealGateMachine", () => {
       cancelFrame: frames.cancel,
       setTimer: timers.set,
       clearTimer: timers.clear,
+      onCoveredChange: (value) => coveredChanges.push(value),
     })
     return {
       machine,
       frames,
       timers,
+      coveredChanges,
       setActive: (value: boolean) => {
         active = value
       },
@@ -214,6 +217,34 @@ describe("createRevealGateMachine", () => {
     expect(ctx.covered()).toBe(false)
     expect(ctx.frames.size()).toBe(0)
     expect(ctx.timers.size()).toBe(0)
+  })
+
+  test("emits covered once on a flip, not on every frame of a busy oscillating settle", () => {
+    // A reconciler that flips active/inactive without ever stringing together
+    // settleFrames quiet frames keeps the gate covered. The covered boolean must
+    // not be re-emitted on those churning frames, or the opening skeleton's
+    // visible-delay timer would reset every frame and never show.
+    const ctx = makeMachine({ settleFrames: 2 })
+    ctx.machine.session("a")
+    ctx.setReady(true)
+    ctx.machine.notifyReady()
+
+    ctx.setActive(true)
+    ctx.frames.step()
+    ctx.setActive(false)
+    ctx.frames.step()
+    ctx.setActive(true)
+    ctx.frames.step()
+    expect(ctx.covered()).toBe(true)
+    expect(ctx.coveredChanges).toEqual([]) // still covered → nothing emitted yet
+
+    // Two consecutive quiet frames finally settle it.
+    ctx.setActive(false)
+    ctx.frames.step()
+    ctx.setActive(false)
+    ctx.frames.step()
+    expect(ctx.covered()).toBe(false)
+    expect(ctx.coveredChanges).toEqual([false]) // exactly one flip
   })
 
   test("keeps the cover while the reconciler is active, then lifts once it goes quiet", () => {

--- a/packages/app/src/pages/session/timeline-reveal-gate.test.ts
+++ b/packages/app/src/pages/session/timeline-reveal-gate.test.ts
@@ -111,6 +111,16 @@ describe("nextRevealGateState", () => {
     expect(revealGateCovered(state)).toBe(true)
   })
 
+  test("an active reconcile frame at zero stable frames keeps the same state object", () => {
+    // While the reconciler stays busy the gate sits in settling with stableFrames
+    // already 0; re-deriving an identical object every frame would churn the
+    // downstream signal for nothing.
+    const settling = reduce(open("a"), [{ type: "ready", ready: true }])
+    expect(settling.stableFrames).toBe(0)
+    const after = nextRevealGateState(settling, { type: "frame", reconcilerActive: true })
+    expect(after).toBe(settling)
+  })
+
   test("timeout reveals once ready even if the reconciler never goes quiet", () => {
     const settled = reduce(open("a"), [
       { type: "ready", ready: true },

--- a/packages/app/src/pages/session/timeline-reveal-gate.test.ts
+++ b/packages/app/src/pages/session/timeline-reveal-gate.test.ts
@@ -63,6 +63,8 @@ describe("nextRevealGateState", () => {
     events.reduce((acc, event) => nextRevealGateState(acc, event, opts), state)
   const inactive = (n: number): RevealGateEvent[] =>
     Array.from({ length: n }, () => ({ type: "frame", reconcilerActive: false }))
+  // Drive session "a" all the way to revealed via the normal settle path.
+  const revealedA = () => reduce(open("a"), [{ type: "ready", ready: true }, ...inactive(2)])
 
   test("a freshly opened session starts covered while loading", () => {
     const state = open("a")
@@ -136,15 +138,8 @@ describe("nextRevealGateState", () => {
     expect(revealGateCovered(state)).toBe(true)
   })
 
-  test("release reveals immediately so a user gesture is never hidden behind the cover", () => {
-    const fromLoading = reduce(open("a"), [{ type: "release" }])
-    expect(fromLoading.phase).toBe("revealed")
-    const fromSettling = reduce(open("a"), [{ type: "ready", ready: true }, { type: "release" }])
-    expect(fromSettling.phase).toBe("revealed")
-  })
-
   test("switching to a new session re-covers and restarts loading", () => {
-    const revealed = reduce(open("a"), [{ type: "ready", ready: true }, { type: "release" }])
+    const revealed = revealedA()
     expect(revealed.phase).toBe("revealed")
     const next = nextRevealGateState(revealed, { type: "session", sessionKey: "b" })
     expect(next.sessionKey).toBe("b")
@@ -153,14 +148,14 @@ describe("nextRevealGateState", () => {
   })
 
   test("re-emitting the same session key does not re-cover an already revealed timeline", () => {
-    const revealed = reduce(open("a"), [{ type: "ready", ready: true }, { type: "release" }])
+    const revealed = revealedA()
     const same = nextRevealGateState(revealed, { type: "session", sessionKey: "a" })
     expect(same.phase).toBe("revealed")
     expect(revealGateCovered(same)).toBe(false)
   })
 
   test("once revealed, later ready/frame/timeout events keep it revealed", () => {
-    const revealed = reduce(open("a"), [{ type: "ready", ready: true }, { type: "release" }])
+    const revealed = revealedA()
     const after = reduce(revealed, [
       { type: "ready", ready: false },
       { type: "frame", reconcilerActive: true },
@@ -250,19 +245,6 @@ describe("createRevealGateMachine", () => {
     ctx.timers.fire() // failsafe → reveal
     expect(ctx.covered()).toBe(false)
     expect(ctx.frames.size()).toBe(0)
-  })
-
-  test("release lifts the cover and stops the loop and timer", () => {
-    const ctx = makeMachine({ settleFrames: 2 })
-    ctx.machine.session("a")
-    ctx.setReady(true)
-    ctx.machine.notifyReady()
-    expect(ctx.frames.size()).toBe(1)
-
-    ctx.machine.release()
-    expect(ctx.covered()).toBe(false)
-    expect(ctx.frames.size()).toBe(0)
-    expect(ctx.timers.size()).toBe(0)
   })
 
   test("switching sessions re-covers and re-arms the settle watch when already ready", () => {

--- a/packages/app/src/pages/session/timeline-reveal-gate.ts
+++ b/packages/app/src/pages/session/timeline-reveal-gate.ts
@@ -42,7 +42,12 @@ export function nextRevealGateState(
   }
   if (event.type === "frame") {
     if (state.phase !== "settling") return state
-    if (event.reconcilerActive) return { ...state, stableFrames: 0 }
+    if (event.reconcilerActive) {
+      // Keep the same object while the reconciler stays busy at zero stable
+      // frames so the downstream signal does not churn every frame.
+      if (state.stableFrames === 0) return state
+      return { ...state, stableFrames: 0 }
+    }
     const settleFrames = options?.settleFrames ?? DEFAULT_SETTLE_FRAMES
     const stableFrames = state.stableFrames + 1
     if (stableFrames >= settleFrames) return { ...state, phase: "revealed", stableFrames }

--- a/packages/app/src/pages/session/timeline-reveal-gate.ts
+++ b/packages/app/src/pages/session/timeline-reveal-gate.ts
@@ -13,7 +13,6 @@ export type RevealGateEvent =
   | { type: "ready"; ready: boolean }
   | { type: "frame"; reconcilerActive: boolean }
   | { type: "timeout" }
-  | { type: "release" }
 
 export type RevealGateOptions = {
   /** Consecutive reconciler-inactive frames required before the cover lifts. */
@@ -60,12 +59,6 @@ export function nextRevealGateState(
     if (state.phase === "settling") return { ...state, phase: "revealed" }
     return state
   }
-  if (event.type === "release") {
-    // A user gesture (scroll, hash/message navigation) must never sit behind the
-    // cover — reveal now regardless of settle progress.
-    if (state.phase === "revealed") return state
-    return { ...state, phase: "revealed" }
-  }
   return state
 }
 
@@ -92,8 +85,6 @@ export type RevealGateMachine = {
   session: (sessionKey: string) => void
   /** Re-evaluate readiness (messages-ready signal changed). */
   notifyReady: () => void
-  /** Force-reveal now (a user gesture took over). */
-  release: () => void
   dispose: () => void
 }
 
@@ -160,11 +151,6 @@ export function createRevealGateMachine(input: RevealGateMachineInput): RevealGa
       syncReady()
     },
     notifyReady: syncReady,
-    release: () => {
-      dispatch({ type: "release" })
-      stopLoop()
-      stopTimer()
-    },
     dispose: () => {
       stopLoop()
       stopTimer()
@@ -190,8 +176,6 @@ export type TimelineRevealGateInput = {
 export type TimelineRevealGate = {
   /** True while the opening cover should stay up. */
   covered: () => boolean
-  /** Force-reveal now (user gesture took over). */
-  release: () => void
 }
 
 /**
@@ -220,6 +204,5 @@ export function createTimelineRevealGate(input: TimelineRevealGateInput): Timeli
 
   return {
     covered: () => revealGateCovered(state()),
-    release: machine.release,
   }
 }

--- a/packages/app/src/pages/session/timeline-reveal-gate.ts
+++ b/packages/app/src/pages/session/timeline-reveal-gate.ts
@@ -75,8 +75,8 @@ export type RevealGateMachineInput = {
   cancelFrame: (handle: number) => void
   setTimer: (callback: () => void, ms: number) => number
   clearTimer: (handle: number) => void
-  /** Called whenever the gate state changes (e.g. to drive a signal). */
-  onChange?: (state: RevealGateState) => void
+  /** Called only when the covered boolean flips (e.g. to drive a signal). */
+  onCoveredChange?: (covered: boolean) => void
 }
 
 export type RevealGateMachine = {
@@ -98,12 +98,21 @@ export type RevealGateMachine = {
  */
 export function createRevealGateMachine(input: RevealGateMachineInput): RevealGateMachine {
   let current: RevealGateState = { sessionKey: "", phase: "loading", stableFrames: 0 }
+  let lastCovered = revealGateCovered(current)
   let frameHandle: number | undefined
   let timerHandle: number | undefined
 
   const dispatch = (event: RevealGateEvent) => {
-    current = nextRevealGateState(current, event, { settleFrames: input.settleFrames })
-    input.onChange?.(current)
+    const next = nextRevealGateState(current, event, { settleFrames: input.settleFrames })
+    if (next === current) return
+    current = next
+    // Only surface a change when the cover boolean actually flips, so a busy
+    // settle (state churning between stable-frame counts while still covered)
+    // does not re-notify the UI and reset the opening skeleton's visible timer.
+    const covered = revealGateCovered(current)
+    if (covered === lastCovered) return
+    lastCovered = covered
+    input.onCoveredChange?.(covered)
   }
   const stopLoop = () => {
     if (frameHandle !== undefined) {
@@ -185,7 +194,9 @@ export type TimelineRevealGate = {
  * machine; this is thin reactive glue.
  */
 export function createTimelineRevealGate(input: TimelineRevealGateInput): TimelineRevealGate {
-  const [state, setState] = createSignal<RevealGateState>({ sessionKey: "", phase: "loading", stableFrames: 0 })
+  // The machine emits only on cover flips, so this signal re-renders the opening
+  // cover exactly when it must — never on the intermediate settle churn.
+  const [covered, setCovered] = createSignal(true)
   const machine = createRevealGateMachine({
     settleFrames: input.settleFrames ?? DEFAULT_SETTLE_FRAMES,
     timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
@@ -195,14 +206,12 @@ export function createTimelineRevealGate(input: TimelineRevealGateInput): Timeli
     cancelFrame: input.cancelFrame ?? ((handle) => cancelAnimationFrame(handle)),
     setTimer: input.setTimer ?? ((callback, ms) => setTimeout(callback, ms) as unknown as number),
     clearTimer: input.clearTimer ?? ((handle) => clearTimeout(handle)),
-    onChange: setState,
+    onCoveredChange: setCovered,
   })
 
   createEffect(on(input.sessionKey, (sessionKey) => machine.session(sessionKey)))
   createEffect(on(input.ready, () => machine.notifyReady(), { defer: true }))
   onCleanup(() => machine.dispose())
 
-  return {
-    covered: () => revealGateCovered(state()),
-  }
+  return { covered }
 }

--- a/packages/app/src/pages/session/timeline-reveal-gate.ts
+++ b/packages/app/src/pages/session/timeline-reveal-gate.ts
@@ -1,0 +1,220 @@
+import { createEffect, createSignal, on, onCleanup } from "solid-js"
+
+export type RevealGatePhase = "loading" | "settling" | "revealed"
+
+export type RevealGateState = {
+  sessionKey: string
+  phase: RevealGatePhase
+  stableFrames: number
+}
+
+export type RevealGateEvent =
+  | { type: "session"; sessionKey: string }
+  | { type: "ready"; ready: boolean }
+  | { type: "frame"; reconcilerActive: boolean }
+  | { type: "timeout" }
+  | { type: "release" }
+
+export type RevealGateOptions = {
+  /** Consecutive reconciler-inactive frames required before the cover lifts. */
+  settleFrames?: number
+}
+
+const DEFAULT_SETTLE_FRAMES = 2
+
+export function revealGateCovered(state: RevealGateState): boolean {
+  return state.phase !== "revealed"
+}
+
+export function nextRevealGateState(
+  previous: RevealGateState | undefined,
+  event: RevealGateEvent,
+  options?: RevealGateOptions,
+): RevealGateState {
+  if (event.type === "session") {
+    if (previous && previous.sessionKey === event.sessionKey) return previous
+    return { sessionKey: event.sessionKey, phase: "loading", stableFrames: 0 }
+  }
+  const state = previous ?? { sessionKey: "", phase: "loading", stableFrames: 0 }
+  if (event.type === "ready") {
+    if (event.ready && state.phase === "loading") return { ...state, phase: "settling", stableFrames: 0 }
+    return state
+  }
+  if (event.type === "frame") {
+    if (state.phase !== "settling") return state
+    if (event.reconcilerActive) return { ...state, stableFrames: 0 }
+    const settleFrames = options?.settleFrames ?? DEFAULT_SETTLE_FRAMES
+    const stableFrames = state.stableFrames + 1
+    if (stableFrames >= settleFrames) return { ...state, phase: "revealed", stableFrames }
+    return { ...state, stableFrames }
+  }
+  if (event.type === "timeout") {
+    // Failsafe only after the timeline has content: never lift the cover on a
+    // still-loading session, but cap how long a perpetually-resizing (streaming)
+    // timeline can hold it.
+    if (state.phase === "settling") return { ...state, phase: "revealed" }
+    return state
+  }
+  if (event.type === "release") {
+    // A user gesture (scroll, hash/message navigation) must never sit behind the
+    // cover — reveal now regardless of settle progress.
+    if (state.phase === "revealed") return state
+    return { ...state, phase: "revealed" }
+  }
+  return state
+}
+
+const DEFAULT_TIMEOUT_MS = 400
+
+export type RevealGateMachineInput = {
+  settleFrames: number
+  timeoutMs: number
+  /** Messages for the current session are loaded (route ready). */
+  ready: () => boolean
+  /** The scroll reconciler is dirty or pinning this frame. */
+  reconcilerActive: () => boolean
+  scheduleFrame: (callback: () => void) => number
+  cancelFrame: (handle: number) => void
+  setTimer: (callback: () => void, ms: number) => number
+  clearTimer: (handle: number) => void
+  /** Called whenever the gate state changes (e.g. to drive a signal). */
+  onChange?: (state: RevealGateState) => void
+}
+
+export type RevealGateMachine = {
+  state: () => RevealGateState
+  /** Open/switch to a session; re-covers and restarts the settle watch. */
+  session: (sessionKey: string) => void
+  /** Re-evaluate readiness (messages-ready signal changed). */
+  notifyReady: () => void
+  /** Force-reveal now (a user gesture took over). */
+  release: () => void
+  dispose: () => void
+}
+
+/**
+ * Framework-free core of the reveal gate: owns the frame loop and failsafe timer
+ * that decide when the opening cover lifts. Holds the cover until the freshly
+ * mounted timeline has settled — at least `settleFrames` consecutive frames with
+ * the reconciler quiet after messages are ready — so the first revealed frame is
+ * the settled bottom, not a mid-render premature bottom. `timeoutMs` caps the
+ * hold for perpetually-resizing (streaming) timelines.
+ */
+export function createRevealGateMachine(input: RevealGateMachineInput): RevealGateMachine {
+  let current: RevealGateState = { sessionKey: "", phase: "loading", stableFrames: 0 }
+  let frameHandle: number | undefined
+  let timerHandle: number | undefined
+
+  const dispatch = (event: RevealGateEvent) => {
+    current = nextRevealGateState(current, event, { settleFrames: input.settleFrames })
+    input.onChange?.(current)
+  }
+  const stopLoop = () => {
+    if (frameHandle !== undefined) {
+      input.cancelFrame(frameHandle)
+      frameHandle = undefined
+    }
+  }
+  const stopTimer = () => {
+    if (timerHandle !== undefined) {
+      input.clearTimer(timerHandle)
+      timerHandle = undefined
+    }
+  }
+  const pump = () => {
+    frameHandle = input.scheduleFrame(() => {
+      frameHandle = undefined
+      dispatch({ type: "frame", reconcilerActive: input.reconcilerActive() })
+      if (current.phase === "settling") pump()
+      else stopTimer()
+    })
+  }
+
+  // Entering `settling` (messages ready) is the only place the loop and timer
+  // arm. Re-run on every session switch so a session that is already ready still
+  // gets a fresh settle watch.
+  const syncReady = () => {
+    dispatch({ type: "ready", ready: input.ready() })
+    if (current.phase !== "settling") return
+    if (frameHandle === undefined) pump()
+    if (timerHandle === undefined) {
+      timerHandle = input.setTimer(() => {
+        timerHandle = undefined
+        dispatch({ type: "timeout" })
+        stopLoop()
+      }, input.timeoutMs)
+    }
+  }
+
+  return {
+    state: () => current,
+    session: (sessionKey) => {
+      dispatch({ type: "session", sessionKey })
+      stopLoop()
+      stopTimer()
+      syncReady()
+    },
+    notifyReady: syncReady,
+    release: () => {
+      dispatch({ type: "release" })
+      stopLoop()
+      stopTimer()
+    },
+    dispose: () => {
+      stopLoop()
+      stopTimer()
+    },
+  }
+}
+
+export type TimelineRevealGateInput = {
+  /** Stable timeline identity; a change re-covers and restarts loading. */
+  sessionKey: () => string
+  /** Messages for the current session are loaded (route ready). */
+  ready: () => boolean
+  /** The scroll reconciler is dirty or pinning this frame. */
+  reconcilerActive: () => boolean
+  settleFrames?: number
+  timeoutMs?: number
+  scheduleFrame?: (callback: () => void) => number
+  cancelFrame?: (handle: number) => void
+  setTimer?: (callback: () => void, ms: number) => number
+  clearTimer?: (handle: number) => void
+}
+
+export type TimelineRevealGate = {
+  /** True while the opening cover should stay up. */
+  covered: () => boolean
+  /** Force-reveal now (user gesture took over). */
+  release: () => void
+}
+
+/**
+ * Solid wrapper around {@link createRevealGateMachine}: bridges the session key
+ * and readiness signals into the machine and exposes `covered()` as a signal so
+ * the opening cover re-renders. The loop/timer logic lives in the framework-free
+ * machine; this is thin reactive glue.
+ */
+export function createTimelineRevealGate(input: TimelineRevealGateInput): TimelineRevealGate {
+  const [state, setState] = createSignal<RevealGateState>({ sessionKey: "", phase: "loading", stableFrames: 0 })
+  const machine = createRevealGateMachine({
+    settleFrames: input.settleFrames ?? DEFAULT_SETTLE_FRAMES,
+    timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    ready: input.ready,
+    reconcilerActive: input.reconcilerActive,
+    scheduleFrame: input.scheduleFrame ?? ((callback) => requestAnimationFrame(callback)),
+    cancelFrame: input.cancelFrame ?? ((handle) => cancelAnimationFrame(handle)),
+    setTimer: input.setTimer ?? ((callback, ms) => setTimeout(callback, ms) as unknown as number),
+    clearTimer: input.clearTimer ?? ((handle) => clearTimeout(handle)),
+    onChange: setState,
+  })
+
+  createEffect(on(input.sessionKey, (sessionKey) => machine.session(sessionKey)))
+  createEffect(on(input.ready, () => machine.notifyReady(), { defer: true }))
+  onCleanup(() => machine.dispose())
+
+  return {
+    covered: () => revealGateCovered(state()),
+    release: machine.release,
+  }
+}


### PR DESCRIPTION
## Summary

Opening or switching to a follow-latest session no longer shows the timeline land at a premature, mid-render bottom and then jump down to the true bottom.

The timeline now mounts and measures **behind the opening cover**, and the cover is driven by a new **reveal gate** instead of raw `routeReady`: it lifts only after the scroll reconciler has gone quiet (N consecutive idle frames), with a failsafe timeout for streaming timelines. The first frame the user sees is already the settled bottom; the premature→true-bottom correction happens entirely behind the cover.

Two atomic commits:
1. `feat(app)` — the framework-free reveal-gate state machine + Solid wrapper + unit tests.
2. `fix(app)` — wire it into `SessionMainView` (skeleton overlay + a new opacity reveal wrapper) + a real user-path E2E.

Review follow-ups (3 atomic commits): drop the unwired `release` path (wiring it to gestures would re-expose the jump on a streaming open), skip redundant gate churn while the reconciler is active, and poll for the revealed timeline instead of a fixed E2E wait.

## Why

`latest` is computed as `scrollHeight - clientHeight` (`session-timeline-scroll-anchors.ts`). During the virtualizer's progressive render, `scrollHeight` starts short (estimated row heights; markdown/tables/code measured async) and grows. The reconciler re-pins `latest` on every `content-resize`, so on open it pinned to a too-short bottom (painted), then re-pinned to the real, taller bottom — a visible viewport-sized downward jump. Reported in #595.

## Related Issue

#595

## Human Review Status

`Pending`

## Review Focus

- The gate state machine (`timeline-reveal-gate.ts`): `loading → settling → revealed`, reset on session switch, sticky once revealed, timeout failsafe.
- The `SessionMainView` wiring: cover and timeline opacity both driven by `timelineCovered()`; the `<Switch>` keeps the existing per-session remount (only the timeline branch gained an opacity wrapper).
- Scope decision: the session-switch remount is intentionally kept. Fully removing the initial loading blank would need the larger persistent-timeline change and is deferred.

## Risk Notes

- Renderer-only change; no platform/packaging/updater/signing/path/shell surface touched — macOS/Windows conditional item left unticked for that reason.
- No docs, release-notes, dependency, permission, or generated-file surface touched — that conditional item left unticked for that reason.
- The cover now holds a few extra frames (≤ `400ms` failsafe) on every follow-latest open; for fast settles the skeleton's `100ms` visible-delay means it never becomes visible, so the user sees a settled fade-in rather than a skeleton flash.

## How To Verify

```text
typecheck (bun run typecheck / tsgo -b): pass
lint (eslint timeline-reveal-gate.ts + session-main-view.tsx): exit 0, clean
unit: reveal-gate 15 + session-main-view 4 + session-opening-skeleton 1 = 20 pass
unit (whole src/pages/session): 479 pass, 3 fail — the 3 SessionReviewTab failures are pre-existing batch-pollution (identical 3 fail on a clean origin/dev checkout; pass in isolation), unrelated to this change
E2E (e2e/session/session-reveal-gate.spec.ts, real Chromium route): 1 passed (5.2s)
E2E fail-without-fix check: temporarily disabling the cover makes it fail on a visible off-bottom frame (distanceFromBottom 4081, top 0, height 4755)
visual: bun run snap session-opening-skeleton — desktop + narrow render correctly, no regression to the opening cover
```

## Screenshots or Recordings

The fix is temporal (absence of a scroll jump), so it is locked by the E2E rather than a static image: `session-reveal-gate.spec.ts` asserts every *visible* frame on a follow-latest open is already at the settled bottom, and fails without the cover. The opening-cover surface itself was visually checked via `bun run snap session-opening-skeleton` (desktop + narrow) with no regression.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced timeline reveal behavior during session opening to ensure content is fully settled before displaying, reducing visual jumpiness and layout shifts.

* **Tests**
  * Added comprehensive end-to-end and unit tests for the timeline reveal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
