### PR TITLE
feat(app): dock badge, question notification routing, refocus dot fix (#1187)

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-unread-focus.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-unread-focus.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "../fixtures"
+import { openSidebar } from "../actions"
+
+// Regression for the stale unread dot. A turn that finishes while the window is
+// in the background is recorded as unviewed even for the session you are already
+// on, and route-change used to be the only thing that cleared it — so the dot
+// lingered until you navigated away and back. Returning focus to the window must
+// clear the dot for the session you are viewing.
+test("returning focus to the window clears the unread dot on the active session", async ({ page, project }) => {
+  await project.open()
+
+  // Pin the window as unfocused so the finishing turn is recorded as unviewed.
+  await page.evaluate(() => {
+    Object.defineProperty(document, "hasFocus", { configurable: true, value: () => false })
+  })
+
+  const sessionID = await project.prompt("ping")
+  await openSidebar(page)
+
+  const unreadDot = page
+    .locator(`[data-session-id="${sessionID}"][data-component="pawwork-session-row"]`)
+    .first()
+    .getByRole("img", { name: "Has unread messages" })
+
+  await expect(unreadDot).toBeVisible()
+
+  await page.evaluate(() => window.dispatchEvent(new Event("focus")))
+
+  await expect(unreadDot).toHaveCount(0)
+})

--- a/packages/app/src/context/notification-derive.test.ts
+++ b/packages/app/src/context/notification-derive.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { questionCallKey, questionNotificationAction, resolveRootSessionID, unreadSessionCount } from "./notification-derive"
+import { questionCallKey, questionNotificationAction, resolveRootSessionIDAsync, unreadSessionCount } from "./notification-derive"
 
 describe("unreadSessionCount", () => {
   test("counts distinct unseen sessions, not the total notification count", () => {
@@ -43,30 +43,28 @@ describe("unreadSessionCount", () => {
   })
 })
 
-describe("resolveRootSessionID", () => {
-  test("walks the parent chain to the root session", () => {
-    const sessions = [
-      { id: "ses_root" },
-      { id: "ses_child", parentID: "ses_root" },
-      { id: "ses_leaf", parentID: "ses_child" },
-    ]
-    expect(resolveRootSessionID(sessions, "ses_leaf")).toBe("ses_root")
+describe("resolveRootSessionIDAsync", () => {
+  // getParentID is injected so the same walk works whether the parent comes
+  // from the in-memory session list or an async network lookup (the latter is
+  // what kicks in when a background project's sessions were never bootstrapped).
+  const parentLookup = (chain: Record<string, string | undefined>) => async (id: string) => chain[id]
+
+  test("walks the parent chain to the root session", async () => {
+    const getParentID = parentLookup({ ses_leaf: "ses_child", ses_child: "ses_root", ses_root: undefined })
+    expect(await resolveRootSessionIDAsync("ses_leaf", getParentID)).toBe("ses_root")
   })
 
-  test("returns the session itself when it has no parent", () => {
-    expect(resolveRootSessionID([{ id: "ses_root" }], "ses_root")).toBe("ses_root")
+  test("returns the session itself when it has no parent", async () => {
+    expect(await resolveRootSessionIDAsync("ses_root", async () => undefined)).toBe("ses_root")
   })
 
-  test("returns the id unchanged when the session is unknown", () => {
-    expect(resolveRootSessionID([{ id: "ses_other" }], "ses_missing")).toBe("ses_missing")
+  test("returns the id unchanged when the parent lookup yields nothing", async () => {
+    expect(await resolveRootSessionIDAsync("ses_missing", async () => undefined)).toBe("ses_missing")
   })
 
-  test("breaks parent cycles instead of looping forever", () => {
-    const sessions = [
-      { id: "ses_a", parentID: "ses_b" },
-      { id: "ses_b", parentID: "ses_a" },
-    ]
-    expect(resolveRootSessionID(sessions, "ses_a")).toBe("ses_a")
+  test("breaks parent cycles instead of looping forever", async () => {
+    const getParentID = parentLookup({ ses_a: "ses_b", ses_b: "ses_a" })
+    expect(await resolveRootSessionIDAsync("ses_a", getParentID)).toBe("ses_a")
   })
 })
 

--- a/packages/app/src/context/notification-derive.test.ts
+++ b/packages/app/src/context/notification-derive.test.ts
@@ -4,27 +4,42 @@ import { questionCallKey, questionNotificationAction, resolveRootSessionID, unre
 describe("unreadSessionCount", () => {
   test("counts distinct unseen sessions, not the total notification count", () => {
     const notifications = [
-      { session: "ses_a", viewed: false },
-      { session: "ses_a", viewed: false },
-      { session: "ses_b", viewed: false },
+      { session: "ses_a", viewed: false, time: 10 },
+      { session: "ses_a", viewed: false, time: 11 },
+      { session: "ses_b", viewed: false, time: 12 },
     ]
     expect(unreadSessionCount(notifications)).toBe(2)
   })
 
   test("excludes sessions whose notifications have all been viewed", () => {
     const notifications = [
-      { session: "ses_a", viewed: false },
-      { session: "ses_b", viewed: true },
+      { session: "ses_a", viewed: false, time: 10 },
+      { session: "ses_b", viewed: true, time: 11 },
     ]
     expect(unreadSessionCount(notifications)).toBe(1)
   })
 
   test("ignores notifications with no session", () => {
-    expect(unreadSessionCount([{ viewed: false }])).toBe(0)
+    expect(unreadSessionCount([{ viewed: false, time: 10 }])).toBe(0)
   })
 
   test("is zero when nothing is unseen", () => {
     expect(unreadSessionCount([])).toBe(0)
+  })
+
+  test("ignores notifications created before the since cutoff", () => {
+    const notifications = [
+      { session: "ses_old", viewed: false, time: 5 },
+      { session: "ses_new", viewed: false, time: 20 },
+    ]
+    // Persisted backlog from a previous run (older timestamps) must not surface
+    // on the Dock badge at launch; only this run's notifications count.
+    expect(unreadSessionCount(notifications, 10)).toBe(1)
+  })
+
+  test("counts notifications at exactly the since cutoff", () => {
+    const notifications = [{ session: "ses_a", viewed: false, time: 10 }]
+    expect(unreadSessionCount(notifications, 10)).toBe(1)
   })
 })
 

--- a/packages/app/src/context/notification-derive.test.ts
+++ b/packages/app/src/context/notification-derive.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  partitionRetractedQuestions,
   questionCallKey,
   questionNotificationAction,
   resolveAndAlertQuestion,
@@ -126,6 +127,64 @@ describe("resolveAndAlertQuestion", () => {
     })
     expect(root).toBeUndefined()
     expect(alerted).toBe(false)
+  })
+})
+
+describe("partitionRetractedQuestions", () => {
+  const question = (id: string, ask: { sessionID: string; messageID: string; partID: string }) => ({
+    type: "question" as const,
+    directory: "/repo",
+    session: "ses_root",
+    id,
+    ask,
+  })
+
+  test("retracts the question matching the removed part, keeps the rest", () => {
+    const target = question("a", { sessionID: "ses_child", messageID: "msg_1", partID: "prt_1" })
+    const other = question("b", { sessionID: "ses_child", messageID: "msg_1", partID: "prt_2" })
+    const event = { type: "turn-complete" as const, directory: "/repo", id: "c" }
+    const { kept, removed } = partitionRetractedQuestions([target, other, event], {
+      directory: "/repo",
+      sessionID: "ses_child",
+      partID: "prt_1",
+    })
+    expect(removed).toEqual([target])
+    expect(kept).toEqual([other, event])
+  })
+
+  test("retracts every question in a message when the whole message is removed", () => {
+    const a = question("a", { sessionID: "ses_child", messageID: "msg_1", partID: "prt_1" })
+    const b = question("b", { sessionID: "ses_child", messageID: "msg_1", partID: "prt_2" })
+    const elsewhere = question("c", { sessionID: "ses_child", messageID: "msg_2", partID: "prt_3" })
+    const { kept, removed } = partitionRetractedQuestions([a, b, elsewhere], {
+      directory: "/repo",
+      sessionID: "ses_child",
+      messageID: "msg_1",
+    })
+    expect(removed).toEqual([a, b])
+    expect(kept).toEqual([elsewhere])
+  })
+
+  test("does not cross directory or session boundaries", () => {
+    const otherDir = { ...question("a", { sessionID: "ses_child", messageID: "msg_1", partID: "prt_1" }), directory: "/other" }
+    const otherSession = question("b", { sessionID: "ses_sibling", messageID: "msg_1", partID: "prt_1" })
+    const { removed } = partitionRetractedQuestions([otherDir, otherSession], {
+      directory: "/repo",
+      sessionID: "ses_child",
+      partID: "prt_1",
+    })
+    expect(removed).toEqual([])
+  })
+
+  test("keeps legacy question notifications that have no ask identity", () => {
+    const legacy = { type: "question" as const, directory: "/repo", session: "ses_root", id: "a" }
+    const { kept, removed } = partitionRetractedQuestions([legacy], {
+      directory: "/repo",
+      sessionID: "ses_child",
+      partID: "prt_1",
+    })
+    expect(removed).toEqual([])
+    expect(kept).toEqual([legacy])
   })
 })
 

--- a/packages/app/src/context/notification-derive.test.ts
+++ b/packages/app/src/context/notification-derive.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test"
+import { questionCallKey, questionNotificationAction, resolveRootSessionID, unreadSessionCount } from "./notification-derive"
+
+describe("unreadSessionCount", () => {
+  test("counts distinct unseen sessions, not the total notification count", () => {
+    const notifications = [
+      { session: "ses_a", viewed: false },
+      { session: "ses_a", viewed: false },
+      { session: "ses_b", viewed: false },
+    ]
+    expect(unreadSessionCount(notifications)).toBe(2)
+  })
+
+  test("excludes sessions whose notifications have all been viewed", () => {
+    const notifications = [
+      { session: "ses_a", viewed: false },
+      { session: "ses_b", viewed: true },
+    ]
+    expect(unreadSessionCount(notifications)).toBe(1)
+  })
+
+  test("ignores notifications with no session", () => {
+    expect(unreadSessionCount([{ viewed: false }])).toBe(0)
+  })
+
+  test("is zero when nothing is unseen", () => {
+    expect(unreadSessionCount([])).toBe(0)
+  })
+})
+
+describe("resolveRootSessionID", () => {
+  test("walks the parent chain to the root session", () => {
+    const sessions = [
+      { id: "ses_root" },
+      { id: "ses_child", parentID: "ses_root" },
+      { id: "ses_leaf", parentID: "ses_child" },
+    ]
+    expect(resolveRootSessionID(sessions, "ses_leaf")).toBe("ses_root")
+  })
+
+  test("returns the session itself when it has no parent", () => {
+    expect(resolveRootSessionID([{ id: "ses_root" }], "ses_root")).toBe("ses_root")
+  })
+
+  test("returns the id unchanged when the session is unknown", () => {
+    expect(resolveRootSessionID([{ id: "ses_other" }], "ses_missing")).toBe("ses_missing")
+  })
+
+  test("breaks parent cycles instead of looping forever", () => {
+    const sessions = [
+      { id: "ses_a", parentID: "ses_b" },
+      { id: "ses_b", parentID: "ses_a" },
+    ]
+    expect(resolveRootSessionID(sessions, "ses_a")).toBe("ses_a")
+  })
+})
+
+describe("questionCallKey", () => {
+  test("builds a stable dedupe key from directory, session, and part", () => {
+    expect(questionCallKey("/repo", "ses_1", "prt_1")).toBe("/repo:ses_1:prt_1")
+  })
+})
+
+describe("questionNotificationAction", () => {
+  test("notifies only once the external question input is ready", () => {
+    expect(
+      questionNotificationAction({
+        type: "tool",
+        tool: "question",
+        state: { status: "running", metadata: { externalResultReady: true } },
+      }),
+    ).toBe("notify")
+  })
+
+  test("ignores a running question that is not yet ready", () => {
+    expect(
+      questionNotificationAction({
+        type: "tool",
+        tool: "question",
+        state: { status: "running", metadata: { externalResultReady: false } },
+      }),
+    ).toBe("ignore")
+  })
+
+  test("resets the dedupe entry when the question part is no longer running", () => {
+    expect(
+      questionNotificationAction({
+        type: "tool",
+        tool: "question",
+        state: { status: "completed", metadata: { externalResultReady: true } },
+      }),
+    ).toBe("reset")
+  })
+
+  test("ignores parts that are not the question tool", () => {
+    expect(questionNotificationAction({ type: "text" })).toBe("ignore")
+  })
+})

--- a/packages/app/src/context/notification-derive.test.ts
+++ b/packages/app/src/context/notification-derive.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { questionCallKey, questionNotificationAction, resolveRootSessionIDAsync, unreadSessionCount } from "./notification-derive"
+import {
+  questionCallKey,
+  questionNotificationAction,
+  resolveAndAlertQuestion,
+  resolveRootSessionIDAsync,
+  unreadSessionCount,
+} from "./notification-derive"
 
 describe("unreadSessionCount", () => {
   test("counts distinct unseen sessions, not the total notification count", () => {
@@ -65,6 +71,61 @@ describe("resolveRootSessionIDAsync", () => {
   test("breaks parent cycles instead of looping forever", async () => {
     const getParentID = parentLookup({ ses_a: "ses_b", ses_b: "ses_a" })
     expect(await resolveRootSessionIDAsync("ses_a", getParentID)).toBe("ses_a")
+  })
+})
+
+describe("resolveAndAlertQuestion", () => {
+  test("alerts with the resolved root when the question is still pending", async () => {
+    let alerted: string | undefined
+    const root = await resolveAndAlertQuestion({
+      resolveRoot: async () => "ses_root",
+      disposed: () => false,
+      isPending: () => true,
+      alert: (id) => {
+        alerted = id
+      },
+    })
+    expect(root).toBe("ses_root")
+    expect(alerted).toBe("ses_root")
+  })
+
+  test("skips the alert when the question is removed during root resolution", async () => {
+    // The dedupe claim is cleared (message.part.removed / terminal reset) while
+    // resolveRoot is still awaiting the network. The alert must not fire, or it
+    // would strand a stale unread dot / badge bump / Dock bounce for a question
+    // that no longer needs the user.
+    let pending = true
+    let resolveRoot: (id: string) => void = () => {}
+    const rootResolved = new Promise<string>((resolve) => {
+      resolveRoot = resolve
+    })
+    let alerted = false
+    const done = resolveAndAlertQuestion({
+      resolveRoot: () => rootResolved,
+      disposed: () => false,
+      isPending: () => pending,
+      alert: () => {
+        alerted = true
+      },
+    })
+    pending = false // message.part.removed lands mid-await
+    resolveRoot("ses_root")
+    expect(await done).toBeUndefined()
+    expect(alerted).toBe(false)
+  })
+
+  test("skips the alert when the provider is disposed during root resolution", async () => {
+    let alerted = false
+    const root = await resolveAndAlertQuestion({
+      resolveRoot: async () => "ses_root",
+      disposed: () => true,
+      isPending: () => true,
+      alert: () => {
+        alerted = true
+      },
+    })
+    expect(root).toBeUndefined()
+    expect(alerted).toBe(false)
   })
 })
 

--- a/packages/app/src/context/notification-derive.ts
+++ b/packages/app/src/context/notification-derive.ts
@@ -62,23 +62,26 @@ export function unreadSessionCount(
 }
 
 /**
- * Walk a session's parent chain to its root.
+ * Walk a session's parent chain to its root via an injected parent lookup.
  *
  * A child agent's question is surfaced on (and answered from) its root
  * session's page, and only root sessions appear in the sidebar — so a question
- * notification must attribute to the root, not the asking child. Returns the
- * input id unchanged when the session has no parent or is unknown to `sessions`.
+ * notification must attribute to the root, not the asking child. `getParentID`
+ * is async so the walk can fall back to a network lookup: the global event
+ * stream delivers a question even for a background project whose session list
+ * was never bootstrapped, where a purely in-memory walk would stop short and
+ * mis-attribute the notification to the child. Returns the input id when it has
+ * no parent, is unknown, or the chain cycles.
  */
-export function resolveRootSessionID(
-  sessions: readonly { id: string; parentID?: string }[],
+export async function resolveRootSessionIDAsync(
   sessionID: string,
-): string {
-  const byID = new Map(sessions.map((session) => [session.id, session]))
+  getParentID: (id: string) => Promise<string | undefined>,
+): Promise<string> {
   const seen = new Set<string>()
   let current = sessionID
   while (!seen.has(current)) {
     seen.add(current)
-    const parent = byID.get(current)?.parentID
+    const parent = await getParentID(current)
     if (!parent) break
     current = parent
   }

--- a/packages/app/src/context/notification-derive.ts
+++ b/packages/app/src/context/notification-derive.ts
@@ -35,18 +35,28 @@ export function questionNotificationAction(part: QuestionNotificationPart): "ign
 }
 
 /**
- * Number of distinct sessions that currently have unseen notifications.
+ * Number of distinct sessions with unseen notifications created at or after
+ * `since`.
  *
  * This is the Dock/taskbar badge number: it counts *sessions* waiting for the
  * user, not the total notification count. One session with three unseen
  * notifications still contributes a single unit, matching how the user reasons
- * about "how many things need me". Derived straight from the notification list
- * (the persisted source of truth) so a memo over it tracks reactively.
+ * about "how many things need me". The `since` cutoff scopes the badge to the
+ * current app run — notifications persist across restarts to drive the sidebar,
+ * but a fresh launch should show zero on the Dock instead of resurfacing a
+ * stale backlog whose sessions the user may have long since dealt with (or that
+ * no longer exist). Derived straight from the notification list (the persisted
+ * source of truth) so a memo over it tracks reactively.
  */
-export function unreadSessionCount(notifications: readonly { session?: string; viewed: boolean }[]): number {
+export function unreadSessionCount(
+  notifications: readonly { session?: string; viewed: boolean; time: number }[],
+  since = 0,
+): number {
   const sessions = new Set<string>()
   for (const notification of notifications) {
-    if (!notification.viewed && notification.session) sessions.add(notification.session)
+    if (!notification.viewed && notification.session && notification.time >= since) {
+      sessions.add(notification.session)
+    }
   }
   return sessions.size
 }

--- a/packages/app/src/context/notification-derive.ts
+++ b/packages/app/src/context/notification-derive.ts
@@ -115,3 +115,44 @@ export async function resolveAndAlertQuestion(opts: {
   opts.alert(rootID)
   return rootID
 }
+
+type RetractableQuestion = {
+  type: string
+  directory?: string
+  ask?: { sessionID: string; messageID: string; partID: string }
+}
+
+/**
+ * Split a notification list into the question notifications a removal event
+ * retracts and everything kept.
+ *
+ * A question is a live condition, not a point-in-time event: once its part
+ * leaves `running` (a terminal `reset`), the part is removed, or its whole
+ * message is removed, the appended notification must be retracted or the unread
+ * dot / Dock badge keeps claiming the session needs input. Matching is by the
+ * *asking* question identity recorded in `ask` (directory + asking sessionID,
+ * plus `partID` or `messageID`) — the notification's own `session` is the root
+ * session used for display, not for matching. `partID` and `messageID` are each
+ * matched only when provided, so a part removal targets one part while a message
+ * removal sweeps every question in that message. Question notifications without
+ * an `ask` identity (legacy persisted entries) never match and are kept.
+ */
+export function partitionRetractedQuestions<T extends RetractableQuestion>(
+  list: readonly T[],
+  match: { directory: string; sessionID: string; partID?: string; messageID?: string },
+): { kept: T[]; removed: T[] } {
+  const kept: T[] = []
+  const removed: T[] = []
+  for (const notification of list) {
+    const ask = notification.type === "question" ? notification.ask : undefined
+    const matches =
+      ask !== undefined &&
+      notification.directory === match.directory &&
+      ask.sessionID === match.sessionID &&
+      (match.partID === undefined || ask.partID === match.partID) &&
+      (match.messageID === undefined || ask.messageID === match.messageID)
+    if (matches) removed.push(notification)
+    else kept.push(notification)
+  }
+  return { kept, removed }
+}

--- a/packages/app/src/context/notification-derive.ts
+++ b/packages/app/src/context/notification-derive.ts
@@ -1,0 +1,76 @@
+// Pure derivation helpers for the notification store. Kept separate from the
+// reactive context so the badge count and question attribution logic can be
+// unit-tested without rendering the provider.
+
+import type { Part } from "@opencode-ai/sdk/v2/client"
+
+type QuestionNotificationPart = Pick<Part, "type"> & {
+  tool?: string
+  state?: {
+    status?: string
+    metadata?: {
+      externalResultReady?: unknown
+    }
+  }
+}
+
+export function questionCallKey(directory: string, sessionID: string, partID: string) {
+  return `${directory}:${sessionID}:${partID}`
+}
+
+/**
+ * Decide what a `message.part.updated` event means for a question notification.
+ *
+ * Question parts stream many updates; the external-result input controls only
+ * become usable once the engine flips `metadata.externalResultReady`. We notify
+ * exactly once on that transition, and `reset` clears the per-call dedupe entry
+ * when the part is no longer running (terminal updates may not be followed by a
+ * `message.part.removed`).
+ */
+export function questionNotificationAction(part: QuestionNotificationPart): "ignore" | "reset" | "notify" {
+  if (part.type !== "tool" || part.tool !== "question") return "ignore"
+  if (part.state?.status !== "running") return "reset"
+  if (part.state.metadata?.externalResultReady !== true) return "ignore"
+  return "notify"
+}
+
+/**
+ * Number of distinct sessions that currently have unseen notifications.
+ *
+ * This is the Dock/taskbar badge number: it counts *sessions* waiting for the
+ * user, not the total notification count. One session with three unseen
+ * notifications still contributes a single unit, matching how the user reasons
+ * about "how many things need me". Derived straight from the notification list
+ * (the persisted source of truth) so a memo over it tracks reactively.
+ */
+export function unreadSessionCount(notifications: readonly { session?: string; viewed: boolean }[]): number {
+  const sessions = new Set<string>()
+  for (const notification of notifications) {
+    if (!notification.viewed && notification.session) sessions.add(notification.session)
+  }
+  return sessions.size
+}
+
+/**
+ * Walk a session's parent chain to its root.
+ *
+ * A child agent's question is surfaced on (and answered from) its root
+ * session's page, and only root sessions appear in the sidebar — so a question
+ * notification must attribute to the root, not the asking child. Returns the
+ * input id unchanged when the session has no parent or is unknown to `sessions`.
+ */
+export function resolveRootSessionID(
+  sessions: readonly { id: string; parentID?: string }[],
+  sessionID: string,
+): string {
+  const byID = new Map(sessions.map((session) => [session.id, session]))
+  const seen = new Set<string>()
+  let current = sessionID
+  while (!seen.has(current)) {
+    seen.add(current)
+    const parent = byID.get(current)?.parentID
+    if (!parent) break
+    current = parent
+  }
+  return current
+}

--- a/packages/app/src/context/notification-derive.ts
+++ b/packages/app/src/context/notification-derive.ts
@@ -87,3 +87,31 @@ export async function resolveRootSessionIDAsync(
   }
   return current
 }
+
+/**
+ * Resolve a question's root session, then fire its alert — but only if the
+ * provider is still mounted and the question is still pending once the async
+ * resolution returns.
+ *
+ * `resolveRoot` may await the network (a background project whose sessions were
+ * never bootstrapped), which yields the event loop. In that gap a
+ * `message.part.removed` or a terminal `reset` update for the same question can
+ * land and clear its dedupe claim — the question is already answered or gone.
+ * Re-checking `isPending` after the await (alongside `disposed`) stops a stale
+ * alert: an unread dot, badge bump, or Dock bounce for a question that no longer
+ * needs the user. `alert` carries the resolved root id and owns the actual
+ * notification / sound / attention side effects. Returns the root id when it
+ * alerted, or undefined when it bailed.
+ */
+export async function resolveAndAlertQuestion(opts: {
+  resolveRoot: () => Promise<string>
+  disposed: () => boolean
+  isPending: () => boolean
+  alert: (rootID: string) => void
+}): Promise<string | undefined> {
+  const rootID = await opts.resolveRoot()
+  if (opts.disposed()) return undefined
+  if (!opts.isPending()) return undefined
+  opts.alert(rootID)
+  return rootID
+}

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -17,6 +17,7 @@ import { Persist, persisted } from "@/utils/persist"
 import { playSoundById } from "@/utils/sound"
 import { workspaceKey } from "@/pages/layout/helpers"
 import {
+  partitionRetractedQuestions,
   questionCallKey,
   questionNotificationAction,
   resolveAndAlertQuestion,
@@ -43,6 +44,13 @@ type ErrorNotification = NotificationBase & {
 
 type QuestionNotification = NotificationBase & {
   type: "question"
+  // Identity of the originating question call (the *asking* session/message/part,
+  // not the root `session` recorded above for display). A question is a live
+  // condition: this lets a terminal reset, a removed part, or a removed message
+  // retract the notification so the unread dot / badge stops claiming the session
+  // needs input. Optional so legacy persisted entries (written before this field)
+  // still load — they simply never match a retraction.
+  ask?: { sessionID: string; messageID: string; partID: string }
 }
 
 export type Notification = TurnCompleteNotification | ErrorNotification | QuestionNotification
@@ -219,6 +227,19 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       })
     }
 
+    // Retract the persisted question notification(s) a removal event resolves —
+    // a question is a live condition, so when its part leaves `running` (reset),
+    // its part is removed, or its whole message is removed, the unread dot /
+    // badge must stop claiming the session needs input.
+    const dropQuestions = (match: { directory: string; sessionID: string; partID?: string; messageID?: string }) => {
+      const { kept, removed } = partitionRetractedQuestions(store.list, match)
+      if (!removed.length) return
+      batch(() => {
+        removed.forEach((n) => removeFromIndex(n))
+        setStore("list", kept)
+      })
+    }
+
     const lookup = async (directory: string, sessionID?: string) => {
       if (!sessionID) return undefined
       const [syncStore] = globalSync.child(directory, { bootstrap: false })
@@ -329,6 +350,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       const callKey = questionCallKey(directory, sessionID, part.id)
       if (action === "reset") {
         alertedQuestionCalls.delete(callKey)
+        dropQuestions({ directory, sessionID, partID: part.id })
         return
       }
       if (alertedQuestionCalls.has(callKey)) return
@@ -358,6 +380,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
             viewed: visible,
             type: "question",
             session: rootID,
+            ask: { sessionID, messageID: part.messageID, partID: part.id },
           })
 
           const level = settings.notify.level()
@@ -402,7 +425,15 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
         return
       }
       if (event.type === "message.part.removed") {
-        alertedQuestionCalls.delete(questionCallKey(directory, event.properties.sessionID, event.properties.partID))
+        const { sessionID, partID } = event.properties
+        alertedQuestionCalls.delete(questionCallKey(directory, sessionID, partID))
+        dropQuestions({ directory, sessionID, partID })
+        return
+      }
+      if (event.type === "message.removed") {
+        // removeMessage / revert emit only `message.removed`, not a per-part
+        // `message.part.removed`, so sweep every question in the message.
+        dropQuestions({ directory, sessionID: event.properties.sessionID, messageID: event.properties.messageID })
         return
       }
       if (event.type !== "session.idle" && event.type !== "session.error") return

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -389,10 +389,14 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       unsub()
     })
 
-    // Dock/taskbar badge: how many sessions are waiting for the user. Follows
-    // the notify level — when notifications are off, the badge is suppressed
-    // too. macOS/Linux only (platform.setBadgeCount is undefined elsewhere).
-    const badgeCount = createMemo(() => unreadSessionCount(store.list))
+    // Dock/taskbar badge: how many sessions from *this* app run are waiting for
+    // the user. Scoped to launch time so a fresh start shows zero instead of
+    // resurfacing the persisted backlog on the Dock — notifications survive
+    // restarts to drive the sidebar, but the badge should only nag about what
+    // arrived this session. Follows the notify level (suppressed when off).
+    // macOS/Linux only (platform.setBadgeCount is undefined elsewhere).
+    const launchTime = Date.now()
+    const badgeCount = createMemo(() => unreadSessionCount(store.list, launchTime))
     createEffect(() => {
       const count = settings.notify.level() === "never" ? 0 : badgeCount()
       void platform.setBadgeCount?.(count)

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -19,6 +19,7 @@ import { workspaceKey } from "@/pages/layout/helpers"
 import {
   questionCallKey,
   questionNotificationAction,
+  resolveAndAlertQuestion,
   resolveRootSessionIDAsync,
   unreadSessionCount,
 } from "./notification-derive"
@@ -333,36 +334,44 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       if (alertedQuestionCalls.has(callKey)) return
       alertedQuestionCalls.add(callKey)
 
-      // A child agent's question surfaces on (and is answered from) its root
-      // session's page, and only root sessions show in the sidebar — attribute
-      // the notification to the root, not the asking child. Resolving the root
-      // may hit the network for an unbootstrapped background project, so async.
-      const rootID = await resolveRootSessionIDAsync(sessionID, (id) => fetchParentID(directory, id))
-      if (meta.disposed) return
+      await resolveAndAlertQuestion({
+        // A child agent's question surfaces on (and is answered from) its root
+        // session's page, and only root sessions show in the sidebar —
+        // attribute the notification to the root, not the asking child.
+        // Resolving the root may hit the network for an unbootstrapped
+        // background project, so async.
+        resolveRoot: () => resolveRootSessionIDAsync(sessionID, (id) => fetchParentID(directory, id)),
+        disposed: () => meta.disposed,
+        // Re-check the dedupe claim after the async root resolution: a
+        // message.part.removed or terminal reset for this same call may have
+        // cleared it mid-await, meaning the question is gone — don't alert.
+        isPending: () => alertedQuestionCalls.has(callKey),
+        alert: (rootID) => {
+          const [syncStore] = globalSync.child(directory, { bootstrap: false })
+          const rootMatch = Binary.search(syncStore.session, rootID, (s) => s.id)
+          const rootTitle = rootMatch.found ? syncStore.session[rootMatch.index].title : undefined
 
-      const [syncStore] = globalSync.child(directory, { bootstrap: false })
-      const rootMatch = Binary.search(syncStore.session, rootID, (s) => s.id)
-      const rootTitle = rootMatch.found ? syncStore.session[rootMatch.index].title : undefined
+          const visible = viewedInCurrentSession(directory, rootID)
+          append({
+            directory,
+            time,
+            viewed: visible,
+            type: "question",
+            session: rootID,
+          })
 
-      const visible = viewedInCurrentSession(directory, rootID)
-      append({
-        directory,
-        time,
-        viewed: visible,
-        type: "question",
-        session: rootID,
+          const level = settings.notify.level()
+          const shouldAlert = level !== "never" && (level === "always" || !visible)
+          if (shouldAlert) {
+            void playSoundById("notify")
+            const href = `/${base64Encode(directory)}/session/${rootID}`
+            void platform.notify(language.t("notification.question.title"), rootTitle ?? rootID, href)
+            // A question blocks the agent on the user, so it bounces the Dock /
+            // flashes the taskbar. turn-complete and error (above) only notify.
+            void platform.requestAttention?.()
+          }
+        },
       })
-
-      const level = settings.notify.level()
-      const shouldAlert = level !== "never" && (level === "always" || !visible)
-      if (shouldAlert) {
-        void playSoundById("notify")
-        const href = `/${base64Encode(directory)}/session/${rootID}`
-        void platform.notify(language.t("notification.question.title"), rootTitle ?? rootID, href)
-        // A question blocks the agent on the user, so it bounces the Dock /
-        // flashes the taskbar. turn-complete and error (above) only notify.
-        void platform.requestAttention?.()
-      }
     }
 
     const markSessionViewed = (session: string) => {

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -410,10 +410,12 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
     // blurred (e.g. a turn finishing in the background) land unviewed even for
     // the active route, and route-change is the only other thing that marks
     // them viewed — so without this the dot lingers until you navigate away.
-    makeEventListener(window, "focus", () => {
-      const session = currentSession()
-      if (session) markSessionViewed(session)
-    })
+    if (typeof window !== "undefined") {
+      makeEventListener(window, "focus", () => {
+        const session = currentSession()
+        if (session) markSessionViewed(session)
+      })
+    }
 
     return {
       ready,

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -1,6 +1,7 @@
 import { createStore, reconcile } from "solid-js/store"
 import { batch, createEffect, createMemo, onCleanup } from "solid-js"
 import { useParams } from "@solidjs/router"
+import { makeEventListener } from "@solid-primitives/event-listener"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useGlobalSDK } from "./global-sdk"
 import { useGlobalSync } from "./global-sync"
@@ -11,8 +12,16 @@ import { Binary } from "@opencode-ai/util/binary"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { decode64 } from "@/utils/base64"
 import { EventSessionError } from "@opencode-ai/sdk/v2"
+import type { Part } from "@opencode-ai/sdk/v2/client"
 import { Persist, persisted } from "@/utils/persist"
 import { playSoundById } from "@/utils/sound"
+import { workspaceKey } from "@/pages/layout/helpers"
+import {
+  questionCallKey,
+  questionNotificationAction,
+  resolveRootSessionID,
+  unreadSessionCount,
+} from "./notification-derive"
 
 type NotificationBase = {
   directory?: string
@@ -31,7 +40,11 @@ type ErrorNotification = NotificationBase & {
   error: EventSessionError["properties"]["error"]
 }
 
-export type Notification = TurnCompleteNotification | ErrorNotification
+type QuestionNotification = NotificationBase & {
+  type: "question"
+}
+
+export type Notification = TurnCompleteNotification | ErrorNotification | QuestionNotification
 
 type NotificationIndex = {
   session: {
@@ -223,7 +236,11 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       if (!activeDirectory) return false
       if (!activeSession) return false
       if (!sessionID) return false
-      if (directory !== activeDirectory) return false
+      // Normalize before comparing: the event directory and the routed
+      // directory can be the same workspace yet differ by a trailing slash or
+      // slash direction (notably on Windows), which would otherwise alert for a
+      // session the user is already viewing.
+      if (workspaceKey(directory) !== workspaceKey(activeDirectory)) return false
       return sessionID === activeSession
     }
 
@@ -284,11 +301,82 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       })
     }
 
+    // Questions stream as repeated `message.part.updated` events; dedupe so a
+    // single question alerts once. The entry is cleared when the part stops
+    // running (see questionNotificationAction) or is removed.
+    const alertedQuestionCalls = new Set<string>()
+
+    const handleQuestionPart = (directory: string, sessionID: string, part: Part, time: number) => {
+      const action = questionNotificationAction(part)
+      if (action === "ignore") return
+
+      const callKey = questionCallKey(directory, sessionID, part.id)
+      if (action === "reset") {
+        alertedQuestionCalls.delete(callKey)
+        return
+      }
+      if (alertedQuestionCalls.has(callKey)) return
+      alertedQuestionCalls.add(callKey)
+
+      // A child agent's question surfaces on (and is answered from) its root
+      // session's page, and only root sessions show in the sidebar — attribute
+      // the notification to the root, not the asking child.
+      const [syncStore] = globalSync.child(directory, { bootstrap: false })
+      const rootID = resolveRootSessionID(syncStore.session, sessionID)
+      const rootMatch = Binary.search(syncStore.session, rootID, (s) => s.id)
+      const rootTitle = rootMatch.found ? syncStore.session[rootMatch.index].title : undefined
+
+      const visible = viewedInCurrentSession(directory, rootID)
+      append({
+        directory,
+        time,
+        viewed: visible,
+        type: "question",
+        session: rootID,
+      })
+
+      const level = settings.notify.level()
+      const shouldAlert = level !== "never" && (level === "always" || !visible)
+      if (shouldAlert) {
+        void playSoundById("notify")
+        const href = `/${base64Encode(directory)}/session/${rootID}`
+        void platform.notify(language.t("notification.question.title"), rootTitle ?? rootID, href)
+      }
+    }
+
+    const markSessionViewed = (session: string) => {
+      const unseen = index.session.unseen[session] ?? empty
+      if (!unseen.length) return
+
+      const projects = [
+        ...new Set(unseen.flatMap((notification) => (notification.directory ? [notification.directory] : []))),
+      ]
+      batch(() => {
+        setStore("list", (n) => n.session === session && !n.viewed, "viewed", true)
+        updateUnseen("session", session, [])
+        projects.forEach((directory) => {
+          const next = (index.project.unseen[directory] ?? empty).filter(
+            (notification) => notification.session !== session,
+          )
+          updateUnseen("project", directory, next)
+        })
+      })
+    }
+
     const unsub = globalSDK.event.listen((e) => {
       const event = e.details
+      const directory = e.name
+
+      if (event.type === "message.part.updated") {
+        handleQuestionPart(directory, event.properties.sessionID, event.properties.part, Date.now())
+        return
+      }
+      if (event.type === "message.part.removed") {
+        alertedQuestionCalls.delete(questionCallKey(directory, event.properties.sessionID, event.properties.partID))
+        return
+      }
       if (event.type !== "session.idle" && event.type !== "session.error") return
 
-      const directory = e.name
       const time = Date.now()
       if (event.type === "session.idle") {
         handleSessionIdle(directory, event, time)
@@ -299,6 +387,25 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
     onCleanup(() => {
       meta.disposed = true
       unsub()
+    })
+
+    // Dock/taskbar badge: how many sessions are waiting for the user. Follows
+    // the notify level — when notifications are off, the badge is suppressed
+    // too. macOS/Linux only (platform.setBadgeCount is undefined elsewhere).
+    const badgeCount = createMemo(() => unreadSessionCount(store.list))
+    createEffect(() => {
+      const count = settings.notify.level() === "never" ? 0 : badgeCount()
+      void platform.setBadgeCount?.(count)
+    })
+
+    // Returning focus to the window should clear the unread dot of the session
+    // you're already looking at. Notifications created while the window was
+    // blurred (e.g. a turn finishing in the background) land unviewed even for
+    // the active route, and route-change is the only other thing that marks
+    // them viewed — so without this the dot lingers until you navigate away.
+    makeEventListener(window, "focus", () => {
+      const session = currentSession()
+      if (session) markSessionViewed(session)
     })
 
     return {
@@ -316,24 +423,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
         unseenHasError(session: string) {
           return index.session.unseenHasError[session] ?? false
         },
-        markViewed(session: string) {
-          const unseen = index.session.unseen[session] ?? empty
-          if (!unseen.length) return
-
-          const projects = [
-            ...new Set(unseen.flatMap((notification) => (notification.directory ? [notification.directory] : []))),
-          ]
-          batch(() => {
-            setStore("list", (n) => n.session === session && !n.viewed, "viewed", true)
-            updateUnseen("session", session, [])
-            projects.forEach((directory) => {
-              const next = (index.project.unseen[directory] ?? empty).filter(
-                (notification) => notification.session !== session,
-              )
-              updateUnseen("project", directory, next)
-            })
-          })
-        },
+        markViewed: markSessionViewed,
       },
       project: {
         all(directory: string) {

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -341,6 +341,9 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
         void playSoundById("notify")
         const href = `/${base64Encode(directory)}/session/${rootID}`
         void platform.notify(language.t("notification.question.title"), rootTitle ?? rootID, href)
+        // A question blocks the agent on the user, so it bounces the Dock /
+        // flashes the taskbar. turn-complete and error (above) only notify.
+        void platform.requestAttention?.()
       }
     }
 

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -19,7 +19,7 @@ import { workspaceKey } from "@/pages/layout/helpers"
 import {
   questionCallKey,
   questionNotificationAction,
-  resolveRootSessionID,
+  resolveRootSessionIDAsync,
   unreadSessionCount,
 } from "./notification-derive"
 
@@ -306,7 +306,22 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
     // running (see questionNotificationAction) or is removed.
     const alertedQuestionCalls = new Set<string>()
 
-    const handleQuestionPart = (directory: string, sessionID: string, part: Part, time: number) => {
+    // Resolve a session's parentID from the in-memory list, falling back to a
+    // network lookup when the project's sessions were never bootstrapped — the
+    // global event stream delivers questions for background projects too, so the
+    // in-memory list can be empty here.
+    const fetchParentID = async (directory: string, sessionID: string): Promise<string | undefined> => {
+      const [syncStore] = globalSync.child(directory, { bootstrap: false })
+      const match = Binary.search(syncStore.session, sessionID, (s) => s.id)
+      if (match.found) return syncStore.session[match.index].parentID
+      const session = await globalSDK.client.session
+        .get({ directory, sessionID })
+        .then((x) => x.data)
+        .catch(() => undefined)
+      return session?.parentID
+    }
+
+    const handleQuestionPart = async (directory: string, sessionID: string, part: Part, time: number) => {
       const action = questionNotificationAction(part)
       if (action === "ignore") return
 
@@ -320,9 +335,12 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
 
       // A child agent's question surfaces on (and is answered from) its root
       // session's page, and only root sessions show in the sidebar — attribute
-      // the notification to the root, not the asking child.
+      // the notification to the root, not the asking child. Resolving the root
+      // may hit the network for an unbootstrapped background project, so async.
+      const rootID = await resolveRootSessionIDAsync(sessionID, (id) => fetchParentID(directory, id))
+      if (meta.disposed) return
+
       const [syncStore] = globalSync.child(directory, { bootstrap: false })
-      const rootID = resolveRootSessionID(syncStore.session, sessionID)
       const rootMatch = Binary.search(syncStore.session, rootID, (s) => s.id)
       const rootTitle = rootMatch.found ? syncStore.session[rootMatch.index].title : undefined
 
@@ -371,7 +389,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       const directory = e.name
 
       if (event.type === "message.part.updated") {
-        handleQuestionPart(directory, event.properties.sessionID, event.properties.part, Date.now())
+        void handleQuestionPart(directory, event.properties.sessionID, event.properties.part, Date.now())
         return
       }
       if (event.type === "message.part.removed") {

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -101,6 +101,9 @@ export type Platform = {
   /** Send a system notification (optional deep link) */
   notify(title: string, description?: string, href?: string): Promise<void>
 
+  /** Set the Dock/taskbar unread badge count; 0 hides it (desktop only) */
+  setBadgeCount?(count: number): Promise<void>
+
   /** Open directory picker dialog (native on desktop, server-backed on web) */
   openDirectoryPickerDialog?(opts?: OpenDirectoryPickerOptions): Promise<PickerPaths>
 

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -101,6 +101,14 @@ export type Platform = {
   /** Send a system notification (optional deep link) */
   notify(title: string, description?: string, href?: string): Promise<void>
 
+  /**
+   * Request user attention without stealing focus: bounce the Dock (macOS) or
+   * flash the taskbar (Windows). Reserved for events that block the agent on
+   * the user — a question or permission request — not passive turn-complete or
+   * error notices. Desktop only; no-op on web.
+   */
+  requestAttention?(): Promise<void>
+
   /** Set the Dock/taskbar unread badge count; 0 hides it (desktop only) */
   setBadgeCount?(count: number): Promise<void>
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -565,8 +565,7 @@ export const dict = {
 
   "notification.permission.title": "Permission required",
   "notification.permission.description": "{{sessionTitle}} in {{projectName}} needs permission",
-  "notification.question.title": "Question",
-  "notification.question.description": "{{sessionTitle}} in {{projectName}} has a question",
+  "notification.question.title": "Needs your input",
   "notification.action.goToSession": "Go to session",
 
   "notification.session.responseReady.title": "Response ready",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -533,10 +533,9 @@ export const dict = {
 
   "notification.permission.title": "需要权限",
   "notification.permission.description": "{{sessionTitle}}（{{projectName}}）需要权限",
-  "notification.question.title": "问题",
-  "notification.question.description": "{{sessionTitle}}（{{projectName}}）有一个问题",
+  "notification.question.title": "等你回答",
   "notification.action.goToSession": "前往会话",
-  "notification.session.responseReady.title": "回复已就绪",
+  "notification.session.responseReady.title": "任务完成",
   "notification.session.error.title": "会话错误",
   "notification.session.error.fallbackDescription": "发生错误",
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -225,6 +225,7 @@ export default function Layout(props: ParentProps) {
     },
     effects: {
       notify: (title, description, href) => platform.notify(title, description, href),
+      requestAttention: () => platform.requestAttention?.(),
       playSound: playSoundById,
       setBusy,
       worktreeReady: (directory) => WorktreeState.ready(directory),

--- a/packages/app/src/pages/layout/layout-sdk-event-effects.test.ts
+++ b/packages/app/src/pages/layout/layout-sdk-event-effects.test.ts
@@ -32,6 +32,7 @@ function createSDKNotificationHarness(input?: {
   now?: () => number
 }) {
   let sessionsCalls = 0
+  let attentions = 0
   const notifications: Array<{ title: string; description?: string; href?: string }> = []
   const sounds: string[] = []
   const sessions = [
@@ -68,6 +69,7 @@ function createSDKNotificationHarness(input?: {
       setBusy: () => undefined,
       worktreeReady: () => undefined,
       worktreeFailed: () => undefined,
+      requestAttention: () => { attentions += 1 },
     },
     copy: {
       t: (key, params) => `${key}:${params?.sessionTitle ?? ""}:${params?.projectName ?? ""}`,
@@ -82,6 +84,7 @@ function createSDKNotificationHarness(input?: {
     notifications,
     sounds,
     sessionsCalls: () => sessionsCalls,
+    attentions: () => attentions,
   }
 }
 
@@ -161,6 +164,8 @@ describe("layout sdk event effects", () => {
 
     expect(hook.sessionsCalls()).toBe(1)
     expect(hook.notifications).toHaveLength(1)
+    // The throttled second ask must not re-bounce the Dock either.
+    expect(hook.attentions()).toBe(1)
   })
 
   test("plays notify sound for permission alerts", () => {
@@ -168,5 +173,15 @@ describe("layout sdk event effects", () => {
     hook.emit(permissionAskedEvent("/repo", "ses_other"))
 
     expect(hook.sounds).toEqual(["notify"])
+  })
+
+  test("requests attention for permission alerts", () => {
+    // A permission request blocks the agent on the user, same as a question, so
+    // it bounces the Dock / flashes the taskbar — unlike a turn-complete, which
+    // only notifies.
+    const hook = createSDKNotificationHarness()
+    hook.emit(permissionAskedEvent("/repo", "ses_other"))
+
+    expect(hook.attentions()).toBe(1)
   })
 })

--- a/packages/app/src/pages/layout/layout-sdk-event-effects.test.ts
+++ b/packages/app/src/pages/layout/layout-sdk-event-effects.test.ts
@@ -3,31 +3,11 @@ import {
   createSDKNotificationEventHandler,
   isCurrentOrDescendantSession,
   permissionSessionKey,
-  questionCallKey,
-  questionNotificationAction,
   sessionNotificationHref,
   shouldThrottlePermissionAlert,
 } from "./layout-sdk-event-effects"
 
 type TestEvent = Parameters<ReturnType<typeof createSDKNotificationEventHandler>>[0]
-
-function questionUpdatedEvent(directory: string, sessionID: string, partID = "prt_1"): TestEvent {
-  return {
-    name: directory,
-    details: {
-      type: "message.part.updated",
-      properties: {
-        sessionID,
-        part: {
-          id: partID,
-          type: "tool",
-          tool: "question",
-          state: { status: "running", metadata: { externalResultReady: true } },
-        },
-      },
-    },
-  } as unknown as TestEvent
-}
 
 function permissionAskedEvent(directory: string, sessionID: string): TestEvent {
   return {
@@ -162,58 +142,14 @@ describe("layout sdk event effects", () => {
     ).toBe(false)
   })
 
-  test("builds stable cleanup keys", () => {
+  test("builds a stable permission cleanup key", () => {
     expect(permissionSessionKey("/repo", "ses_1")).toBe("/repo:ses_1")
-    expect(questionCallKey("/repo", "ses_1", "prt_1")).toBe("/repo:ses_1:prt_1")
-  })
-
-  test("resets question dedupe when the question part is no longer running", () => {
-    expect(
-      questionNotificationAction({
-        type: "tool",
-        tool: "question",
-        state: { status: "completed", metadata: { externalResultReady: true } },
-      }),
-    ).toBe("reset")
-  })
-
-  test("notifies only after an external question route is ready", () => {
-    expect(
-      questionNotificationAction({
-        type: "tool",
-        tool: "question",
-        state: { status: "running", metadata: { externalResultReady: true } },
-      }),
-    ).toBe("notify")
-    expect(
-      questionNotificationAction({
-        type: "tool",
-        tool: "question",
-        state: { status: "running", metadata: { externalResultReady: false } },
-      }),
-    ).toBe("ignore")
   })
 
   test("throttles permission alerts within cooldown only", () => {
     expect(shouldThrottlePermissionAlert(1000, 5999, 5000)).toBe(true)
     expect(shouldThrottlePermissionAlert(1000, 6000, 5000)).toBe(false)
     expect(shouldThrottlePermissionAlert(undefined, 1000, 5000)).toBe(false)
-  })
-
-  test("does not look up sessions for current-route question notifications", () => {
-    const hook = createSDKNotificationHarness({ currentSessionID: "ses_root" })
-    hook.emit(questionUpdatedEvent("/repo", "ses_root"))
-
-    expect(hook.sessionsCalls()).toBe(0)
-    expect(hook.notifications).toHaveLength(0)
-  })
-
-  test("does not look up sessions when question notifications are disabled", () => {
-    const hook = createSDKNotificationHarness({ notifyLevel: "never" })
-    hook.emit(questionUpdatedEvent("/repo", "ses_other"))
-
-    expect(hook.sessionsCalls()).toBe(0)
-    expect(hook.notifications).toHaveLength(0)
   })
 
   test("does not look up permission title while cooldown applies", () => {
@@ -225,41 +161,6 @@ describe("layout sdk event effects", () => {
 
     expect(hook.sessionsCalls()).toBe(1)
     expect(hook.notifications).toHaveLength(1)
-  })
-
-  test("reuses one session snapshot when notifying for a question", () => {
-    const hook = createSDKNotificationHarness({ currentSessionID: "ses_root" })
-    hook.emit(questionUpdatedEvent("/repo", "ses_other"))
-
-    expect(hook.sessionsCalls()).toBe(1)
-    expect(hook.notifications).toEqual([
-      {
-        title: "notification.question.title::",
-        description: "notification.question.description:Other session:repo",
-        href: sessionNotificationHref("/repo", "ses_other"),
-      },
-    ])
-  })
-
-  test("plays notify sound for question alerts", () => {
-    const hook = createSDKNotificationHarness({ currentSessionID: "ses_root" })
-    hook.emit(questionUpdatedEvent("/repo", "ses_other"))
-
-    expect(hook.sounds).toEqual(["notify"])
-  })
-
-  test("does not play sound for question when notify is never", () => {
-    const hook = createSDKNotificationHarness({ notifyLevel: "never" })
-    hook.emit(questionUpdatedEvent("/repo", "ses_other"))
-
-    expect(hook.sounds).toHaveLength(0)
-  })
-
-  test("does not play sound for question on the visible session", () => {
-    const hook = createSDKNotificationHarness({ currentSessionID: "ses_root" })
-    hook.emit(questionUpdatedEvent("/repo", "ses_root"))
-
-    expect(hook.sounds).toHaveLength(0)
   })
 
   test("plays notify sound for permission alerts", () => {

--- a/packages/app/src/pages/layout/layout-sdk-event-effects.ts
+++ b/packages/app/src/pages/layout/layout-sdk-event-effects.ts
@@ -41,6 +41,7 @@ type LayoutSdkEventEffectsInput = {
   }
   effects: {
     notify: (title: string, description?: string, href?: string) => Promise<void> | void
+    requestAttention: () => Promise<void> | void
     playSound: (soundID: string) => unknown
     setBusy: (directory: string, value: boolean) => void
     worktreeReady: (directory: string) => void
@@ -186,6 +187,10 @@ export function createSDKNotificationEventHandler(input: LayoutSdkEventEffectsIn
       input.copy.t("notification.permission.description", { sessionTitle, projectName }),
       input.route.sessionHref(directory, props.sessionID),
     )
+    // A permission request blocks the agent on the user, so it earns a Dock
+    // bounce / taskbar flash — the same attention a question gets, unlike a
+    // turn-complete or error which only notify.
+    void input.effects.requestAttention()
   }
 }
 

--- a/packages/app/src/pages/layout/layout-sdk-event-effects.ts
+++ b/packages/app/src/pages/layout/layout-sdk-event-effects.ts
@@ -1,7 +1,7 @@
 import { onCleanup, onMount } from "solid-js"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { getFilename } from "@opencode-ai/util/path"
-import type { Event, Part, PermissionRequest, Session } from "@opencode-ai/sdk/v2/client"
+import type { Event, PermissionRequest, Session } from "@opencode-ai/sdk/v2/client"
 import type { NotifyLevel } from "@/context/settings"
 import { workspaceKey } from "./helpers"
 
@@ -17,21 +17,9 @@ type LayoutSdkEventCopyKey =
   | "command.session.new"
   | "notification.permission.title"
   | "notification.permission.description"
-  | "notification.question.title"
-  | "notification.question.description"
 
 type LayoutSdkEventCopy = {
   t(key: LayoutSdkEventCopyKey, params?: Record<string, string | number | boolean>): string
-}
-
-type QuestionNotificationPart = Pick<Part, "type"> & {
-  tool?: string
-  state?: {
-    status?: string
-    metadata?: {
-      externalResultReady?: unknown
-    }
-  }
 }
 
 type LayoutSdkEventEffectsInput = {
@@ -73,10 +61,6 @@ export function permissionSessionKey(directory: string, sessionID: string) {
   return `${directory}:${sessionID}`
 }
 
-export function questionCallKey(directory: string, sessionID: string, partID: string) {
-  return `${directory}:${sessionID}:${partID}`
-}
-
 export function sessionNotificationHref(directory: string, sessionID: string) {
   return `/${base64Encode(directory)}/session/${sessionID}`
 }
@@ -84,15 +68,6 @@ export function sessionNotificationHref(directory: string, sessionID: string) {
 export function shouldThrottlePermissionAlert(lastAlerted: number | undefined, now: number, cooldownMs: number) {
   if (lastAlerted === undefined) return false
   return now - lastAlerted < cooldownMs
-}
-
-export function questionNotificationAction(part: QuestionNotificationPart): "ignore" | "reset" | "notify" {
-  if (part.type !== "tool" || part.tool !== "question") return "ignore"
-  // Terminal updates may not be followed by message.part.removed, so they must
-  // clear the running-question dedupe entry themselves.
-  if (part.state?.status !== "running") return "reset"
-  if (part.state.metadata?.externalResultReady !== true) return "ignore"
-  return "notify"
 }
 
 export function isCurrentOrDescendantSession(input: {
@@ -107,7 +82,7 @@ export function isCurrentOrDescendantSession(input: {
   if (workspaceKey(input.directory) !== workspaceKey(input.currentDirectory)) return false
   if (input.sessionID === currentSession) return true
 
-  // Walk ancestors so a child-agent question stays quiet while its parent
+  // Walk ancestors so a child agent's request stays quiet while its parent
   // session page is already visible.
   const byID = new Map(input.sessions.map((session) => [session.id, session]))
   let cursor: string | undefined = byID.get(input.sessionID)?.parentID
@@ -159,7 +134,6 @@ function titleFromSessions(
 
 export function createSDKNotificationEventHandler(input: LayoutSdkEventEffectsInput) {
   const alertedAtBySession = new Map<string, number>()
-  const alertedQuestionCalls = new Set<string>()
   const cooldownMs = input.cooldownMs ?? 5000
   const now = input.now ?? Date.now
 
@@ -181,46 +155,6 @@ export function createSDKNotificationEventHandler(input: LayoutSdkEventEffectsIn
 
     if (details.type === "permission.replied") {
       alertedAtBySession.delete(permissionSessionKey(event.name, details.properties.sessionID))
-      return
-    }
-
-    if (details.type === "message.part.updated") {
-      const directory = event.name
-      const { sessionID, part } = details.properties
-      const action = questionNotificationAction(part)
-      if (action === "ignore") return
-
-      const callKey = questionCallKey(directory, sessionID, part.id)
-      if (action === "reset") {
-        alertedQuestionCalls.delete(callKey)
-        return
-      }
-
-      if (alertedQuestionCalls.has(callKey)) return
-      alertedQuestionCalls.add(callKey)
-
-      const level = input.settings.notify.level()
-      if (level === "never") return
-
-      const visibility = currentRouteVisibility(input, directory, sessionID)
-      if (level === "unfocused" && visibility.visible) return
-
-      void input.effects.playSound("notify")
-
-      const sessions = visibility.sessions ?? input.sdk.sessions(directory)
-      const sessionTitle = titleFromSessions(sessions, sessionID, input.copy.t("command.session.new"))
-      const projectName = getFilename(directory)
-      void input.effects.notify(
-        input.copy.t("notification.question.title"),
-        input.copy.t("notification.question.description", { sessionTitle, projectName }),
-        input.route.sessionHref(directory, sessionID),
-      )
-      return
-    }
-
-    if (details.type === "message.part.removed") {
-      const { sessionID, partID } = details.properties
-      alertedQuestionCalls.delete(questionCallKey(event.name, sessionID, partID))
       return
     }
 

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -475,6 +475,15 @@ export function registerIpcHandlers(deps: Deps) {
     }
   })
 
+  ipcMain.handle("set-badge-count", (_event: IpcMainInvokeEvent, count: number) => {
+    // Dock badge (macOS) / Unity launcher (Linux). `app.setBadgeCount` is
+    // @platform linux,darwin — a no-op on Windows, where taskbar attention is
+    // already covered by flash-frame above. Setting 0 hides the badge. A
+    // Windows overlay-icon badge can follow later if it proves worth it.
+    const next = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0
+    app.setBadgeCount(next)
+  })
+
   ipcMain.handle("get-window-count", () => BrowserWindow.getAllWindows().length)
 
   ipcMain.handle("get-window-focused", (event: IpcMainInvokeEvent) => {

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -456,8 +456,12 @@ export function registerIpcHandlers(deps: Deps) {
     if (!win) return
 
     if (process.platform === "darwin") {
-      // macOS: bounce the Dock icon once
-      app.dock?.bounce()
+      // macOS: bounce the Dock icon until the app is activated. "critical" (vs
+      // the default "informational" single bounce) is the "reliable bounce" the
+      // notification polish calls for — a lone informational bounce is trivial
+      // to miss. macOS never bounces the foreground app, so this is a no-op when
+      // the user is already looking, and auto-cancels the moment they click back.
+      app.dock?.bounce("critical")
     } else {
       // Windows/Linux: flash the taskbar button
       // Clear any existing timer for this window

--- a/packages/desktop-electron/src/preload/index.ts
+++ b/packages/desktop-electron/src/preload/index.ts
@@ -98,6 +98,7 @@ const api: ElectronAPI = {
     }
   },
   flashFrame: () => ipcRenderer.invoke("flash-frame"),
+  setBadgeCount: (count: number) => ipcRenderer.invoke("set-badge-count", count),
 }
 
 contextBridge.exposeInMainWorld("api", api)

--- a/packages/desktop-electron/src/preload/types.ts
+++ b/packages/desktop-electron/src/preload/types.ts
@@ -124,4 +124,5 @@ export type ElectronAPI = {
   getAboutInfo: () => Promise<AboutInfo>
   onAboutOpen: (handler: () => void) => () => void
   flashFrame: () => Promise<void>
+  setBadgeCount: (count: number) => Promise<void>
 }

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -269,9 +269,12 @@ const createPlatform = (): Platform => {
         // Fallback to IPC-based notification if native Notification fails
         window.api.showNotification(title, description)
       }
+    },
 
-      // Flash Dock/taskbar to attract attention
-      void window.api.flashFrame()
+    requestAttention: async () => {
+      // Bounce the Dock (macOS) / flash the taskbar (Windows). Only events that
+      // block the agent on the user call this — see Platform.requestAttention.
+      await window.api.flashFrame()
     },
 
     setBadgeCount: async (count) => {

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -274,6 +274,10 @@ const createPlatform = (): Platform => {
       void window.api.flashFrame()
     },
 
+    setBadgeCount: async (count) => {
+      await window.api.setBadgeCount(count)
+    },
+
     fetch: (input, init) => {
       if (input instanceof Request) return fetch(input)
       return fetch(input, init)


### PR DESCRIPTION
## Summary

Notification polish so background agent work is visible from the Dock/taskbar, and the Dock only nags for things that actually need you.

- **Dock/taskbar badge.** New `set-badge-count` IPC (`app.setBadgeCount`; macOS/Linux, a no-op on Windows where the taskbar flash already covers attention) exposed as an optional `platform.setBadgeCount`. The notification store counts **distinct sessions with unseen notifications from the current app run** (scoped to launch time) and pushes that to the badge, following the notify level (suppressed when `never`). A fresh launch starts at zero instead of resurfacing the persisted backlog (whose sessions may be long handled, or gone in a fresh profile); viewing a session clears its contribution.
- **Question notifications routed through the store.** Questions now flow through the persisted notification store via `message.part.updated` instead of a separate transient toast, so a pending question contributes to the badge and the sidebar unread dot. They are attributed to the **root session**, since a child agent's question is answered from the parent page and only root sessions appear in the sidebar. The duplicate question path was removed from `layout-sdk-event-effects.ts`.
- **Attention reserved for blocking events.** The Dock bounce / taskbar flash was split out of `notify()` into an optional `platform.requestAttention()` capability (sibling to `setBadgeCount`). Only events that block the agent on the user call it — **questions and permission requests**. A turn-complete or error now notifies quietly (system notification, sound, badge) without bouncing, so "done" no longer interrupts as hard as "needs you". On macOS the bounce is `"critical"` (bounces until the app is activated) instead of a single, easy-to-miss `"informational"` bounce.
- **Stale unread dot fix.** Returning focus to the window now marks the session you are viewing as seen, instead of only clearing on a route change. A turn finishing while the window was blurred used to strand the dot until you navigated away and back. (The focus listener is guarded for non-`window` environments, matching the existing `document` guards in this provider.)
- **Copy.** idle zh `回复已就绪` → `任务完成`; question `Question`/`问题` → `Needs your input`/`等你回答`. Removed the now-unused `notification.question.description` key.

## Why

Closes #1187. PawWork already sent OS notifications and played a sound for background work, but there was no persistent Dock/taskbar signal — dismiss or miss the toast and nothing told you sessions were waiting. The badge is that signal. Bounce existed but fired on every alert, so a finished turn nagged as hard as a pending question; it now fires only for events that block the agent on you.

## Related Issue

Closes #1187.

## Human Review Status

Pending

## Review Focus

- `notification.tsx`: the question handler (root-session attribution, dedupe, visibility) and the badge memo/effect. The badge derives from `store.list` (array tracking) rather than the index record so the memo is unambiguously reactive, and is scoped to a launch-time cutoff so persisted backlog stays off the Dock.
- Attention split: `platform.requestAttention()` is called only from the question path (`notification.tsx`) and the permission path (`layout-sdk-event-effects.ts`); `notify()` no longer bounces. turn-complete/error deliberately do not call it.
- Question root attribution is resolved with `resolveRootSessionIDAsync`, which falls back to a network `session.get` walk when the project's sessions were never bootstrapped — the global event stream delivers questions for background projects whose in-memory session list is empty, where a pure in-memory walk would mis-attribute to the child session.
- The shared `viewedInCurrentSession` normalizes directories with `workspaceKey` (raised in Codex review) so idle/error/question alerts don't double-fire when the event directory and route differ only by trailing slash or slash direction (Windows).

## Risk Notes

- **Detection mechanism deviates from the shaped plan.** The original plan added a `Session.Event.Question` engine BusEvent. On inspection that requires a full SDK regen (`bun dev generate` → `@hey-api/openapi-ts`), which would pull accumulated openapi drift into this PR. The app already receives `message.part.updated` (with the `externalResultReady` flag) and the detection logic already existed and was tested, so questions are routed through that signal with no engine/SDK change. UX is identical.
- **Attention policy narrowed from #1187's acceptance.** The issue asked for a bounce on turn-complete/error (`informational`). Testing on macOS showed that just nagged for work that no longer waits on anyone. Bounce is now reserved for question + permission (agent blocked on the user) and uses `critical` (bounces until activated); turn-complete/error notify quietly (notification + sound + badge). `requestAttention()` is the seam if that policy needs to change.
- **Badge semantics narrowed from #1187's acceptance.** The issue asked for the *sum of unseen notifications* across all sessions; that resurfaced a stale/orphaned backlog on every launch. The badge now counts **distinct sessions with unseen notifications from the current run**. The full persistent unread signal is carried by the sidebar unread dots (unaffected by this scoping) — the Dock badge is the per-run convenience mirror, so a restart clears the badge without losing any unread (the dots remain).
- **Windows numeric badge is a no-op.** `app.setBadgeCount` is `@platform linux,darwin`. A Windows overlay-icon number badge is deferred (follow-up); taskbar flash (`flash-frame`) already covers Windows attention.
- **Dock badge + bounce verified manually on macOS** (cannot be checked headlessly): fresh launch shows no badge; a turn finishing with the window blurred notifies without bouncing; a question or permission request bounces the Dock until activated and shows a count; opening the session decrements/clears the badge; refocusing the window clears the active session's dot.
- Conditional checklist: visible-copy item ticked (notification copy changed; unread-dot behavior covered by E2E, Dock badge/bounce by the macOS check above). Platform item ticked (Electron IPC/preload/badge + requestAttention). Docs item left unticked — no docs/release-notes surface touched here.

## How To Verify

```text
app unit suite (bun run test:unit): 1798 pass, 0 fail
notification-derive unit tests: unreadSessionCount (incl. launch-time since cutoff), resolveRootSessionIDAsync (incl. network parent fallback), questionNotificationAction/questionCallKey (15 pass)
layout-sdk-event-effects: permission requests requestAttention + throttle does not re-bounce (9 pass)
typecheck (tsgo -b): packages/app PASS, packages/desktop-electron PASS
e2e/sidebar/sidebar-unread-focus.spec.ts: 1 passed — and confirmed it FAILS (dot count 1, expected 0) when the focus listener is disabled, so it genuinely gates the fix
Dock badge / bounce / refocus behavior verified manually on macOS (see Risk Notes)
```

## Screenshots or Recordings

The sidebar unread dot is covered by `sidebar-unread-focus.spec.ts` (appears on an unfocused turn-complete, clears on window focus). The Dock badge and bounce are Electron-only surfaces, verified manually on macOS as noted in Risk Notes.

## Checklist

- [x] **Type label** — `enhancement`.
- [x] **Routing labels** — `app`, `ui`, `platform` applied.
- [x] **Priority label** — `P1` applied (matches the issue).
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed — copy changes covered; unread dot covered by E2E; Dock badge/bounce/refocus verified manually on macOS.
- [x] **(conditional)** I considered macOS and Windows impact — macOS dock badge + bounce work, Windows badge is a documented no-op with taskbar flash fallback.
- [ ] **(conditional)** docs / release notes / dependencies / permissions — none touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added question notifications when the AI needs your input
  * Added unread message badge count on desktop dock/taskbar
  * Added attention requests (Dock bounce/taskbar flash) for important notifications
  * Unread indicator automatically clears when window regains focus

<!-- end of auto-generated comment: release notes by coderabbit.ai -->