### PR TITLE
fix(app): show automations from all open projects

### DIFF
--- a/packages/app/e2e/automations/automations-panel.spec.ts
+++ b/packages/app/e2e/automations/automations-panel.spec.ts
@@ -152,7 +152,9 @@ test("automations panel: lists automations from every open project", async ({ pa
     const surface = await openAutomations(page)
     const rows = surface.locator('[data-action="automation-row"]')
     await expect(rows).toHaveCount(1)
-    await expect(rows.first()).toContainText("Cross-project digest")
+    const row = rows.first()
+    await expect(row).toContainText("Cross-project digest")
+    await expect(row).toContainText(getFilename(other))
 
     await surface.locator(`[data-action="automation-toggle-active"][data-automation-id="${created.id}"]`).click({ force: true })
     await expect
@@ -162,7 +164,7 @@ test("automations panel: lists automations from every open project", async ({ pa
       })
       .toBe(true)
 
-    await rows.first().click()
+    await row.click()
     const detail = surface.locator('[data-component="automation-detail"]')
     await expect(detail.getByRole("heading", { name: "Cross-project digest" })).toBeVisible()
     await expect(detail.getByText(getFilename(other))).toBeVisible()

--- a/packages/app/e2e/automations/automations-panel.spec.ts
+++ b/packages/app/e2e/automations/automations-panel.spec.ts
@@ -145,6 +145,8 @@ test("automations panel: lists automations from every open project", async ({ pa
 
     const otherSDK = backend.sdk(other)
     const otherProjectID = (await otherSDK.project.current()).data!.id
+    const otherProjectName = "External Automation Project"
+    await otherSDK.project.update({ projectID: otherProjectID, name: otherProjectName })
     const created = (await otherSDK.automation.create(
       recurring(otherProjectID, "Cross-project digest", "Summarize the other project.", "0 9 * * 1-5"),
     )).data!
@@ -154,7 +156,8 @@ test("automations panel: lists automations from every open project", async ({ pa
     await expect(rows).toHaveCount(1)
     const row = rows.first()
     await expect(row).toContainText("Cross-project digest")
-    await expect(row).toContainText(getFilename(other))
+    await expect(row).toContainText(otherProjectName)
+    await expect(row).not.toContainText(getFilename(other))
 
     await surface.locator(`[data-action="automation-toggle-active"][data-automation-id="${created.id}"]`).click({ force: true })
     await expect
@@ -175,7 +178,7 @@ test("automations panel: lists automations from every open project", async ({ pa
     await row.click()
     const detail = surface.locator('[data-component="automation-detail"]')
     await expect(detail.getByRole("heading", { name: "Cross-project digest" })).toBeVisible()
-    await expect(detail.getByText(getFilename(other))).toBeVisible()
+    await expect(detail.getByText(otherProjectName)).toBeVisible()
     await expect(detail.getByText("Paused")).toBeVisible()
     await expect.poll(() => runListRequests).toBe(1)
 

--- a/packages/app/e2e/automations/automations-panel.spec.ts
+++ b/packages/app/e2e/automations/automations-panel.spec.ts
@@ -145,19 +145,36 @@ test("automations panel: lists automations from every open project", async ({ pa
 
     const otherSDK = backend.sdk(other)
     const otherProjectID = (await otherSDK.project.current()).data!.id
-    await otherSDK.automation.create(
+    const created = (await otherSDK.automation.create(
       recurring(otherProjectID, "Cross-project digest", "Summarize the other project.", "0 9 * * 1-5"),
-    )
+    )).data!
 
     const surface = await openAutomations(page)
     const rows = surface.locator('[data-action="automation-row"]')
     await expect(rows).toHaveCount(1)
     await expect(rows.first()).toContainText("Cross-project digest")
 
+    await surface.locator(`[data-action="automation-toggle-active"][data-automation-id="${created.id}"]`).click({ force: true })
+    await expect
+      .poll(async () => {
+        const items = (await otherSDK.automation.list()).data?.items ?? []
+        return items.find((automation) => automation.id === created.id)?.paused ?? false
+      })
+      .toBe(true)
+
     await rows.first().click()
     const detail = surface.locator('[data-component="automation-detail"]')
     await expect(detail.getByRole("heading", { name: "Cross-project digest" })).toBeVisible()
     await expect(detail.getByText(getFilename(other))).toBeVisible()
+    await expect(detail.getByText("Paused")).toBeVisible()
+
+    await detail.locator('[data-action="automation-toggle-active"]').click()
+    await expect
+      .poll(async () => {
+        const items = (await otherSDK.automation.list()).data?.items ?? []
+        return items.find((automation) => automation.id === created.id)?.paused ?? true
+      })
+      .toBe(false)
   } finally {
     await cleanupTestProject(other, { serverUrl: backend.url })
   }

--- a/packages/app/e2e/automations/automations-panel.spec.ts
+++ b/packages/app/e2e/automations/automations-panel.spec.ts
@@ -164,11 +164,20 @@ test("automations panel: lists automations from every open project", async ({ pa
       })
       .toBe(true)
 
+    // Opening detail loads the run history once. Toggling pause/resume updates
+    // the definition, but should not reload runs unless the shown automation
+    // identity changes.
+    let runListRequests = 0
+    page.on("request", (request) => {
+      if (request.url().includes(`/automation/${created.id}/runs`)) runListRequests++
+    })
+
     await row.click()
     const detail = surface.locator('[data-component="automation-detail"]')
     await expect(detail.getByRole("heading", { name: "Cross-project digest" })).toBeVisible()
     await expect(detail.getByText(getFilename(other))).toBeVisible()
     await expect(detail.getByText("Paused")).toBeVisible()
+    await expect.poll(() => runListRequests).toBe(1)
 
     await detail.locator('[data-action="automation-toggle-active"]').click()
     await expect
@@ -177,6 +186,8 @@ test("automations panel: lists automations from every open project", async ({ pa
         return items.find((automation) => automation.id === created.id)?.paused ?? true
       })
       .toBe(false)
+    await page.waitForTimeout(250)
+    expect(runListRequests).toBe(1)
   } finally {
     await cleanupTestProject(other, { serverUrl: backend.url })
   }

--- a/packages/app/e2e/automations/automations-panel.spec.ts
+++ b/packages/app/e2e/automations/automations-panel.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test"
+import { getFilename } from "@opencode-ai/util/path"
 import { test, expect } from "../fixtures"
-import { openSidebar } from "../actions"
+import { cleanupTestProject, createTestProject, openSidebar } from "../actions"
 
 type ModelKey = { providerID: string; modelID: string }
 
@@ -133,6 +134,33 @@ test("automations panel: create manually adds an automation", async ({ page, pro
 
   await detail.locator('[data-action="automation-detail-back"]').click()
   await expect(surface.locator('[data-action="automation-row"]')).toHaveCount(1)
+})
+
+test("automations panel: lists automations from every open project", async ({ page, project, backend }) => {
+  test.setTimeout(120_000)
+
+  const other = await createTestProject({ serverUrl: backend.url })
+  try {
+    await project.open({ extra: [other] })
+
+    const otherSDK = backend.sdk(other)
+    const otherProjectID = (await otherSDK.project.current()).data!.id
+    await otherSDK.automation.create(
+      recurring(otherProjectID, "Cross-project digest", "Summarize the other project.", "0 9 * * 1-5"),
+    )
+
+    const surface = await openAutomations(page)
+    const rows = surface.locator('[data-action="automation-row"]')
+    await expect(rows).toHaveCount(1)
+    await expect(rows.first()).toContainText("Cross-project digest")
+
+    await rows.first().click()
+    const detail = surface.locator('[data-component="automation-detail"]')
+    await expect(detail.getByRole("heading", { name: "Cross-project digest" })).toBeVisible()
+    await expect(detail.getByText(getFilename(other))).toBeVisible()
+  } finally {
+    await cleanupTestProject(other, { serverUrl: backend.url })
+  }
 })
 
 test("automations panel: schedule picker opens, selects, and layers escape", async ({ page, project }) => {

--- a/packages/app/e2e/snap/automations-surface.snap.ts
+++ b/packages/app/e2e/snap/automations-surface.snap.ts
@@ -64,8 +64,8 @@ test("automations-surface", async ({ page, project }) => {
   await card.locator('[data-action="automation-create-prompt"]').fill("Draft release notes from PRs merged since the last tag.")
   const createCard = await page.screenshot()
 
-  await card.locator('[data-action="automation-schedule-trigger"]').click()
-  await page.locator('[data-action="automation-frequency-trigger"]').waitFor({ state: "visible", timeout: 10_000 })
+  await card.locator('[data-action="automation-time"]').click()
+  await page.locator('[data-action="automation-time-hour"]').first().waitFor({ state: "visible", timeout: 10_000 })
   const schedulePopover = await page.screenshot()
 
   const shots: Shot[] = [

--- a/packages/app/src/pages/automations/automation-detail.tsx
+++ b/packages/app/src/pages/automations/automation-detail.tsx
@@ -4,7 +4,6 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { Button } from "@opencode-ai/ui/button"
 import { showToast } from "@opencode-ai/ui/toast"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { getFilename } from "@opencode-ai/util/path"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { formatServerError } from "@/utils/server-errors"
@@ -101,6 +100,7 @@ function PreviousRuns(props: {
 export function AutomationDetail(props: {
   automation: Accessor<AutomationDefinition>
   directory: Accessor<string>
+  projectName: Accessor<string>
   onBack: () => void
   onOpenRun: (sessionID: string) => void
 }): JSX.Element {
@@ -264,7 +264,7 @@ export function AutomationDetail(props: {
           </DetailGroup>
 
           <DetailGroup heading={t("automations.detail.detailsHeading")}>
-            <InfoRow label={t("automations.detail.project")} value={getFilename(props.directory())} />
+            <InfoRow label={t("automations.detail.project")} value={props.projectName()} />
             <InfoRow label={t("automations.detail.repeats")} value={formatScheduleSummary(props.automation(), t)} />
             <InfoRow label={t("automations.detail.model")} value={props.automation().model.modelID} />
             <Show when={reasoningLabel()}>

--- a/packages/app/src/pages/automations/automation-list.tsx
+++ b/packages/app/src/pages/automations/automation-list.tsx
@@ -4,50 +4,61 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { useLanguage } from "@/context/language"
 import { formatScheduleSummary } from "./automation-schedule"
 
+type AutomationListItem = {
+  definition: AutomationDefinition
+  projectName: string
+}
+
 export function AutomationList(props: {
-  automations: Accessor<AutomationDefinition[]>
+  items: Accessor<AutomationListItem[]>
   onSelect: (id: string) => void
   onToggleActive: (automation: AutomationDefinition) => void
 }): JSX.Element {
   const language = useLanguage()
   return (
     <ul data-component="automation-list" class="flex flex-col gap-0.5">
-      <For each={props.automations()}>
-        {(automation) => (
-          <li class="group/automation relative">
-            <button
-              type="button"
-              data-action="automation-row"
-              data-automation-id={automation.id}
-              onClick={() => props.onSelect(automation.id)}
-              class="w-full h-[36px] flex items-center gap-3 px-2.5 rounded-md hover:bg-row-hover-overlay focus-visible:bg-row-hover-overlay transition-colors text-left focus:outline-none"
-              classList={{ "opacity-55": automation.paused }}
-            >
-              <span class="shrink-0 w-4 h-4 flex items-center">
-                <Icon
-                  name={automation.paused ? "circle-ban-sign" : "schedule"}
-                  class={automation.paused ? "text-icon-weak" : "text-icon-base"}
-                />
-              </span>
-              <span class="text-h3 text-fg-strong min-w-0 flex-1 truncate">{automation.title}</span>
-              <span class="shrink-0 text-body text-fg-weak group-hover/automation:opacity-0 group-focus-within/automation:opacity-0">
-                {formatScheduleSummary(automation, language.t)}
-              </span>
-            </button>
-            <button
-              type="button"
-              data-action="automation-toggle-active"
-              data-automation-id={automation.id}
-              onClick={(event) => {
-                event.stopPropagation()
-                props.onToggleActive(automation)
-              }}
-              class="absolute right-2.5 top-1/2 -translate-y-1/2 rounded px-1.5 py-0.5 text-caption text-fg-weak opacity-0 transition-colors hover:bg-row-hover-overlay hover:text-fg-strong focus-visible:opacity-100 focus:outline-none group-hover/automation:opacity-100"
-            >
-              {automation.paused ? language.t("automations.action.resume") : language.t("automations.action.pause")}
-            </button>
-          </li>
-        )}
+      <For each={props.items()}>
+        {(item) => {
+          const automation = item.definition
+          return (
+            <li class="group/automation relative">
+              <button
+                type="button"
+                data-action="automation-row"
+                data-automation-id={automation.id}
+                onClick={() => props.onSelect(automation.id)}
+                class="w-full h-[44px] flex items-center gap-3 px-2.5 rounded-md hover:bg-row-hover-overlay focus-visible:bg-row-hover-overlay transition-colors text-left focus:outline-none"
+                classList={{ "opacity-55": automation.paused }}
+              >
+                <span class="shrink-0 w-4 h-4 flex items-center">
+                  <Icon
+                    name={automation.paused ? "circle-ban-sign" : "schedule"}
+                    class={automation.paused ? "text-icon-weak" : "text-icon-base"}
+                  />
+                </span>
+                <span class="min-w-0 flex flex-1 flex-col gap-0.5">
+                  <span class="truncate text-h3 text-fg-strong">{automation.title}</span>
+                  <span class="truncate text-caption text-fg-weak">{item.projectName}</span>
+                </span>
+                <span class="shrink-0 text-body text-fg-weak group-hover/automation:opacity-0 group-focus-within/automation:opacity-0">
+                  {formatScheduleSummary(automation, language.t)}
+                </span>
+              </button>
+              <button
+                type="button"
+                data-action="automation-toggle-active"
+                data-automation-id={automation.id}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  props.onToggleActive(automation)
+                }}
+                class="absolute right-2.5 top-1/2 -translate-y-1/2 rounded px-1.5 py-0.5 text-caption text-fg-weak opacity-0 transition-colors hover:bg-row-hover-overlay hover:text-fg-strong focus-visible:opacity-100 focus:outline-none group-hover/automation:opacity-100"
+              >
+                {automation.paused ? language.t("automations.action.resume") : language.t("automations.action.pause")}
+              </button>
+            </li>
+          )
+        }}
       </For>
     </ul>
   )

--- a/packages/app/src/pages/automations/automations-surface.tsx
+++ b/packages/app/src/pages/automations/automations-surface.tsx
@@ -7,6 +7,8 @@ import { showToast } from "@opencode-ai/ui/toast"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
+import { useLayout } from "@/context/layout"
+import { workspaceKey } from "@/pages/layout/helpers"
 import { formatServerError } from "@/utils/server-errors"
 import { AutomationList } from "./automation-list"
 import { AutomationDetail } from "./automation-detail"
@@ -39,6 +41,11 @@ function AutomationsEmpty(props: { onUseTemplate: (template: AutomationTemplate)
   )
 }
 
+type AutomationItem = {
+  definition: AutomationDefinition
+  directory: string
+}
+
 export function AutomationsSurface(props: {
   directory: Accessor<string>
   projectID: Accessor<string | undefined>
@@ -49,6 +56,7 @@ export function AutomationsSurface(props: {
 }): JSX.Element {
   const globalSync = useGlobalSync()
   const language = useLanguage()
+  const layout = useLayout()
   const dialog = useDialog()
   const [selectedID, setSelectedID] = createSignal<string | undefined>()
 
@@ -85,27 +93,58 @@ export function AutomationsSurface(props: {
     onCleanup(() => document.removeEventListener("keydown", onEscape, true))
   })
 
-  const automations = createMemo(() => {
-    const directory = props.directory()
-    if (!directory) return []
-    const [store] = globalSync.child(directory, { bootstrap: false })
-    return Object.values(store.automation).sort((a, b) =>
-      a.updatedAt !== b.updatedAt ? b.updatedAt - a.updatedAt : a.id < b.id ? 1 : -1,
+  const automationDirectories = createMemo(() => {
+    const directories: string[] = []
+    const seen = new Set<string>()
+    const add = (directory: string | undefined) => {
+      if (!directory) return
+      const key = workspaceKey(directory)
+      if (seen.has(key)) return
+      seen.add(key)
+      directories.push(directory)
+    }
+
+    for (const project of layout.projects.list()) {
+      if (project.id === "global") continue
+      add(project.worktree)
+    }
+    add(props.directory())
+    return directories
+  })
+
+  const automationItems = createMemo(() => {
+    const items: AutomationItem[] = []
+    for (const directory of automationDirectories()) {
+      const [store] = globalSync.child(directory)
+      for (const definition of Object.values(store.automation)) {
+        items.push({ definition, directory })
+      }
+    }
+    return items.sort((a, b) =>
+      a.definition.updatedAt !== b.definition.updatedAt
+        ? b.definition.updatedAt - a.definition.updatedAt
+        : a.definition.id < b.definition.id
+          ? 1
+          : -1,
     )
   })
+
+  const automations = createMemo(() => automationItems().map((item) => item.definition))
+
+  const itemForAutomation = (id: string) => automationItems().find((item) => item.definition.id === id)
 
   const selected = createMemo(() => {
     const id = selectedID()
     if (!id) return undefined
-    return automations().find((automation) => automation.id === id)
+    return itemForAutomation(id)
   })
 
   const toggleActive = async (automation: AutomationDefinition) => {
-    const directory = props.directory()
-    if (!directory) return
+    const item = itemForAutomation(automation.id)
+    if (!item) return
     try {
-      if (automation.paused) await globalSync.automation.resume(directory, automation.id)
-      else await globalSync.automation.pause(directory, automation.id)
+      if (automation.paused) await globalSync.automation.resume(item.directory, automation.id)
+      else await globalSync.automation.pause(item.directory, automation.id)
     } catch (error) {
       showToast({
         variant: "error",
@@ -177,10 +216,10 @@ export function AutomationsSurface(props: {
             </div>
           }
         >
-          {(automation) => (
+          {(item) => (
             <AutomationDetail
-              automation={automation}
-              directory={props.directory}
+              automation={() => item().definition}
+              directory={() => item().directory}
               onBack={() => setSelectedID(undefined)}
               onOpenRun={props.onOpenRun}
             />

--- a/packages/app/src/pages/automations/automations-surface.tsx
+++ b/packages/app/src/pages/automations/automations-surface.tsx
@@ -5,6 +5,7 @@ import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { showToast } from "@opencode-ai/ui/toast"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { getFilename } from "@opencode-ai/util/path"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
@@ -44,6 +45,7 @@ function AutomationsEmpty(props: { onUseTemplate: (template: AutomationTemplate)
 type AutomationItem = {
   definition: AutomationDefinition
   directory: string
+  projectName: string
 }
 
 export function AutomationsSurface(props: {
@@ -117,7 +119,7 @@ export function AutomationsSurface(props: {
     for (const directory of automationDirectories()) {
       const [store] = globalSync.child(directory)
       for (const definition of Object.values(store.automation)) {
-        items.push({ definition, directory })
+        items.push({ definition, directory, projectName: getFilename(directory) })
       }
     }
     return items.sort((a, b) =>
@@ -128,8 +130,6 @@ export function AutomationsSurface(props: {
           : -1,
     )
   })
-
-  const automations = createMemo(() => automationItems().map((item) => item.definition))
 
   const itemForAutomation = (id: string) => automationItems().find((item) => item.definition.id === id)
 
@@ -210,8 +210,8 @@ export function AutomationsSurface(props: {
                   </Popover.Portal>
                 </Popover>
               </div>
-              <Show when={automations().length > 0} fallback={<AutomationsEmpty onUseTemplate={openCreate} />}>
-                <AutomationList automations={automations} onSelect={setSelectedID} onToggleActive={toggleActive} />
+              <Show when={automationItems().length > 0} fallback={<AutomationsEmpty onUseTemplate={openCreate} />}>
+                <AutomationList items={automationItems} onSelect={setSelectedID} onToggleActive={toggleActive} />
               </Show>
             </div>
           }

--- a/packages/app/src/pages/automations/automations-surface.tsx
+++ b/packages/app/src/pages/automations/automations-surface.tsx
@@ -5,11 +5,10 @@ import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { showToast } from "@opencode-ai/ui/toast"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { getFilename } from "@opencode-ai/util/path"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
-import { workspaceKey } from "@/pages/layout/helpers"
+import { displayName, workspaceKey } from "@/pages/layout/helpers"
 import { formatServerError } from "@/utils/server-errors"
 import { AutomationList } from "./automation-list"
 import { AutomationDetail } from "./automation-detail"
@@ -44,6 +43,11 @@ function AutomationsEmpty(props: { onUseTemplate: (template: AutomationTemplate)
 
 type AutomationItem = {
   definition: AutomationDefinition
+  directory: string
+  projectName: string
+}
+
+type AutomationDirectory = {
   directory: string
   projectName: string
 }
@@ -96,19 +100,19 @@ export function AutomationsSurface(props: {
   })
 
   const automationDirectories = createMemo(() => {
-    const directories: string[] = []
+    const directories: AutomationDirectory[] = []
     const seen = new Set<string>()
-    const add = (directory: string | undefined) => {
+    const add = (directory: string | undefined, projectName?: string) => {
       if (!directory) return
       const key = workspaceKey(directory)
       if (seen.has(key)) return
       seen.add(key)
-      directories.push(directory)
+      directories.push({ directory, projectName: projectName ?? displayName({ worktree: directory }) })
     }
 
     for (const project of layout.projects.list()) {
       if (project.id === "global") continue
-      add(project.worktree)
+      add(project.worktree, displayName(project))
     }
     add(props.directory())
     return directories
@@ -116,10 +120,10 @@ export function AutomationsSurface(props: {
 
   const automationItems = createMemo(() => {
     const items: AutomationItem[] = []
-    for (const directory of automationDirectories()) {
+    for (const { directory, projectName } of automationDirectories()) {
       const [store] = globalSync.child(directory)
       for (const definition of Object.values(store.automation)) {
-        items.push({ definition, directory, projectName: getFilename(directory) })
+        items.push({ definition, directory, projectName })
       }
     }
     return items.sort((a, b) =>
@@ -220,6 +224,7 @@ export function AutomationsSurface(props: {
             <AutomationDetail
               automation={() => item().definition}
               directory={() => item().directory}
+              projectName={() => item().projectName}
               onBack={() => setSelectedID(undefined)}
               onOpenRun={props.onOpenRun}
             />


### PR DESCRIPTION
## Summary

Fixes the Automations surface so it shows automations from every open project instead of only the currently routed project.

The global list now also shows each automation's project display name as a small secondary line, so same-titled automations from different open projects are distinguishable before opening detail. The detail view uses the same project display name source, including custom project names.

No related issue: this regression was reported from the installed app manual-create flow.

## Why

Manual automation creation can target any open project through the Folder picker. The create path was succeeding, including Weekdays schedules, but the Automations surface still read only `globalSync.child(currentDirectory).automation`. That made a newly created automation disappear whenever it was filed under another open project.

Once the list became global, each row also needed a lightweight project label; otherwise users could see automations from several open projects without knowing which project owns each one. The label reuses the layout project's display name instead of recomputing a basename locally, so renamed projects render consistently in list and detail.

## Related Issue

No issue. Regression reported directly from manual Automation creation.

## Human Review Status

Pending

## Review Focus

Please focus on whether the surface consistently uses each automation's owner directory for list actions, detail, pause/resume, delete, run-now, and run history, while keeping the global list limited to open PawWork projects. Also check the two-line list row treatment and shared project display name handling.

## Risk Notes

The list intentionally covers open projects known to the PawWork layout, not every historical project in the local database. Opening the Automations surface now bootstraps automation stores for open projects so their definitions can be listed.

Rows are slightly taller to fit the project name. The snap grid was reviewed to confirm the secondary label, schedule text, and hover pause action do not overlap.

Skipped conditional checklist items:

- Platform/packaging impact: no platform, packaging, updater, signing, path, shell, or permission surface was touched.
- Docs/release/deps/local files: no docs, release notes, dependencies, permissions, credentials, generated shipped content, or local file behavior was touched.

## How To Verify

```text
Diff check: git diff --check origin/dev...HEAD passed.
Lint: bun run lint passed.
Typecheck: bun --cwd packages/app typecheck passed.
Focused E2E: bun --cwd packages/app playwright test automations/automations-panel.spec.ts --workers=1 passed, 13 tests.
Visual check: bun run snap automations-surface passed; generated grid reviewed at docs/design/preview/screenshots/automations-surface.png with the list row project labels, hover action, detail, create card, and time picker rendering normally.
```

## Screenshots or Recordings

`bun run snap automations-surface` generated `docs/design/preview/screenshots/automations-surface.png`; the grid was reviewed locally. The list view now shows project display names as small secondary text under automation titles.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
