### PR TITLE
feat(automate): expose continueSession to continue an automation's session

### DIFF
--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -26,13 +26,16 @@ const Prompt = Schema.NonEmptyString.check(Schema.isMaxLength(Automation.MAX_PRO
 // old `where` and `rhythm` unions triggered in function-calling schemas).
 // execute() translates this into the frozen Automation.CreateInput. Only
 // title/prompt/cron are required; project, timezone, and model fall back to the
-// calling session's context. Interval/sub-minute cadence stays a UI/SDK
-// power-user feature and is intentionally off the AI surface.
+// calling session's context. recurring and continueSession are the two
+// orthogonal behavioral opt-ins; both default to the safe side (recurring on,
+// continueSession off). Interval/sub-minute cadence stays a UI/SDK power-user
+// feature and is intentionally off the AI surface.
 export const AutomateParameters = Schema.Struct({
   title: Title,
   prompt: Prompt,
   cron: CronExpression,
   recurring: Schema.optional(Schema.Boolean),
+  continueSession: Schema.optional(Schema.Boolean),
   timezone: Schema.optional(Timezone),
   model: Schema.optional(Schema.NonEmptyString),
   variant: Schema.optional(Schema.NonEmptyString),
@@ -45,8 +48,9 @@ export function formatAutomateValidationError(error: unknown) {
       : String(error)
   return [
     "Invalid automate input.",
-    "Expected: { title, prompt, cron, recurring?, timezone?, model?, variant? }.",
+    "Expected: { title, prompt, cron, recurring?, continueSession?, timezone?, model?, variant? }.",
     'cron is a 5-field cron expression (e.g. "0 9 * * *" = 09:00 daily). recurring defaults to true; set it false for a one-shot that fires at the next cron match.',
+    "continueSession defaults to false (each run starts a fresh session); set it true so a recurring automation continues in its own persistent session and remembers prior runs.",
     'timezone defaults to the host timezone. model, when given, is a "providerID/modelID" string and otherwise defaults to this session\'s model; variant is an optional reasoning-effort key for that model.',
     'Example: { title: "Daily repo brief", prompt: "Summarize repo changes.", cron: "0 9 * * *" }.',
     detail,
@@ -88,7 +92,7 @@ export function createAutomateDefinition(
 ): Tool.DefWithoutID<typeof AutomateParameters, { automationDefinition: Automation.Definition }> {
   return {
     description:
-      "Create an Automation that re-runs a prompt on a schedule. Provide a title, the prompt, and a 5-field cron expression; project, timezone, and model default to the current session. Each run starts a fresh session and repeats until the user pauses or deletes it in the Automations panel. This only stores the definition; it does not run the prompt now.",
+      "Create an Automation that re-runs a prompt on a schedule. Provide a title, the prompt, and a 5-field cron expression; project, timezone, and model default to the current session. By default each run starts a fresh session; set continueSession true so a recurring automation keeps working in one persistent session that remembers prior runs (the automation's own working thread, not this chat). It repeats until the user pauses or deletes it in the Automations panel. This only stores the definition; it does not run the prompt now.",
     parameters: AutomateParameters,
     formatValidationError: formatAutomateValidationError,
     execute: (params, ctx) =>
@@ -119,10 +123,15 @@ export function createAutomateDefinition(
         const now = Date.now()
         const parsed = yield* Effect.try({
           try: () => {
+            // context defaults to "fresh" (a new session per run). continueSession
+            // opts into "continue", reusing the automation's own persistent
+            // session so a recurring run remembers prior runs. Default-fresh is
+            // the safe side: defaulting to continue would let a recurring
+            // automation silently grow its session unbounded across many fires.
             const common = {
               title: params.title,
               prompt: params.prompt,
-              context: "fresh" as const,
+              context: params.continueSession ? ("continue" as const) : ("fresh" as const),
               where: { projectID: Instance.project.id },
               timezone,
               model,

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -81,6 +81,17 @@ describe("automate tool", () => {
     expect(decoded).toEqual({ title: "Daily repo brief", prompt: "Summarize repo changes.", cron: "0 9 * * *" })
   })
 
+  test("decode keeps continueSession on the surface", () => {
+    const decoded = Schema.decodeUnknownSync(AutomateParameters)({
+      title: "Daily repo brief",
+      prompt: "Summarize repo changes.",
+      cron: "0 9 * * *",
+      continueSession: true,
+    })
+
+    expect(decoded.continueSession).toBe(true)
+  })
+
   test("creates a recurring cron automation, defaulting project/timezone/model to the session", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
@@ -314,6 +325,53 @@ describe("automate tool", () => {
 
         const definition = result.metadata.automationDefinition
         expect(definition.sourceSessionID).toBe(sourceSessionID)
+        expect(definition.automationSessionID).toBeUndefined()
+      },
+    })
+  })
+
+  test("defaults to a fresh session per run when continueSession is omitted", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = createAutomateDefinition(fakeProviderInterface, automation)
+        const result = await Effect.runPromise(
+          tool.execute(
+            { title: "Daily repo brief", prompt: "Summarize repo changes.", cron: "0 9 * * *" },
+            ctx(SessionID.descending()),
+          ),
+        )
+
+        expect(result.metadata.automationDefinition.context).toBe("fresh")
+      },
+    })
+  })
+
+  test("continueSession:true continues in its own session and still ignores a spoofed automationSessionID", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = createAutomateDefinition(fakeProviderInterface, automation)
+        const spoof = { automationSessionID: SessionID.descending() } as Record<string, unknown>
+        const result = await Effect.runPromise(
+          tool.execute(
+            {
+              title: "Standup digest",
+              prompt: "Continue the running digest.",
+              cron: "0 9 * * *",
+              continueSession: true,
+              ...spoof,
+            },
+            ctx(SessionID.descending()),
+          ),
+        )
+
+        const definition = result.metadata.automationDefinition
+        expect(definition.context).toBe("continue")
+        // continue picks the reuse path at run time; the persistent session ID is
+        // bound by the runner after the first run, never from tool input.
         expect(definition.automationSessionID).toBeUndefined()
       },
     })

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -92,6 +92,26 @@ describe("automate tool", () => {
     expect(decoded.continueSession).toBe(true)
   })
 
+  test("decode strips a spoofed automationSessionID even alongside continueSession", () => {
+    const decoded = Schema.decodeUnknownSync(AutomateParameters)({
+      title: "Standup digest",
+      prompt: "Continue the running digest.",
+      cron: "0 9 * * *",
+      continueSession: true,
+      automationSessionID: SessionID.descending(),
+    })
+
+    // continueSession is on the surface; automationSessionID is not. Decode is
+    // the boundary tool.ts runs before execute, so the spoof is dropped here —
+    // a model that opts into continue still cannot name the session to reuse.
+    expect(decoded).toEqual({
+      title: "Standup digest",
+      prompt: "Continue the running digest.",
+      cron: "0 9 * * *",
+      continueSession: true,
+    })
+  })
+
   test("creates a recurring cron automation, defaulting project/timezone/model to the session", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
@@ -348,13 +368,12 @@ describe("automate tool", () => {
     })
   })
 
-  test("continueSession:true continues in its own session and still ignores a spoofed automationSessionID", async () => {
+  test("continueSession:true maps to context continue and leaves the session unbound at creation", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
         const tool = createAutomateDefinition(fakeProviderInterface, automation)
-        const spoof = { automationSessionID: SessionID.descending() } as Record<string, unknown>
         const result = await Effect.runPromise(
           tool.execute(
             {
@@ -362,7 +381,6 @@ describe("automate tool", () => {
               prompt: "Continue the running digest.",
               cron: "0 9 * * *",
               continueSession: true,
-              ...spoof,
             },
             ctx(SessionID.descending()),
           ),
@@ -370,9 +388,40 @@ describe("automate tool", () => {
 
         const definition = result.metadata.automationDefinition
         expect(definition.context).toBe("continue")
-        // continue picks the reuse path at run time; the persistent session ID is
-        // bound by the runner after the first run, never from tool input.
+        // The persistent session is bound by the runner after the first run, never
+        // at creation, so a brand-new continue definition has no session yet. (The
+        // decode test above proves a model cannot smuggle one in via the surface.)
         expect(definition.automationSessionID).toBeUndefined()
+      },
+    })
+  })
+
+  test("continueSession on a one-shot is allowed and maps to a continue one-shot (orthogonal, not rejected)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = createAutomateDefinition(fakeProviderInterface, automation)
+        const result = await Effect.runPromise(
+          tool.execute(
+            {
+              title: "One-off digest",
+              prompt: "Summarize once.",
+              cron: "0 9 * * *",
+              recurring: false,
+              continueSession: true,
+            },
+            ctx(SessionID.descending()),
+          ),
+        )
+
+        const definition = result.metadata.automationDefinition
+        // continueSession stays orthogonal to recurring: the flat surface adds no
+        // cross-field rule. A one-shot fires once with no prior session, so the
+        // runner creates fresh anyway — harmless, so the combo is intentionally
+        // not rejected. Pinned here to guard against a regression that adds one.
+        expect(definition.kind).toBe("oneshot")
+        expect(definition.context).toBe("continue")
       },
     })
   })


### PR DESCRIPTION
## Summary

Expose `continueSession` (optional boolean, default `false`) on the model-facing `automate` tool. When set, a recurring automation continues in its own persistent session across fires instead of starting a fresh session each run.

The runner already branches on `context === "continue" && automationSessionID` (`automation/runner.ts:55`) and the definition layer already binds `automationSessionID` after a successful run (`automation/index.ts`). The only thing pinned was the tool surface, which hardcoded `context: "fresh"`. This un-pins it as one flat scalar — no union/anyOf, matching the existing function-calling constraint documented in `automate.ts`.

- `AutomateParameters` gains `continueSession?: boolean`.
- `execute()` maps `continueSession -> context "continue" | "fresh"`. Default-fresh is the safe side: defaulting to continue would let a recurring automation grow its session unbounded across many fires.
- Tool description + validation copy teach the model when to set it and frame the persistent session as the automation's own working thread, not the current chat.
- No new cross-field validation: the tool never sets `where.worktree`, so the existing `continue + worktree` rejection can't be hit; `continue` on a one-shot is a harmless no-op (first/only fire has no prior session, so the runner creates fresh anyway).

This is the "Loop" surface decision shaped in #950. Codex independently read the runner/scheduler/snapshot/session paths and confirmed no "fresh-per-fire" assumption breaks under continue; the only residual notes (first-run failure does not bind a session; a user manually opening the persistent session could interleave with automation runs) are pre-existing and not introduced here.

## Why

A recurring automation could only ever start over each run. Long-running work (a digest that builds on yesterday, an investigation that resumes) needs the automation to remember its prior runs. The backend supported it; only the model couldn't ask for it.

## Related Issue

#950 (umbrella: unified automation & loop). Cross-linked in #1175.

## Human Review Status

Pending

## Review Focus

The `execute()` mapping and the default-`false` rationale. Confirm the field stays a flat scalar (no schema regression on the LLM surface) and that `continue` cannot let a model inject the session to continue into (`automationSessionID` is off-surface and still ignored under `continueSession: true`).

## Risk Notes

Behavior change is opt-in and default-off, so existing automations are unaffected. Conditional checklist items left unticked:

- UI/copy item — no visible UI or user-facing copy changed; only the model-facing tool description and validation strings.
- Platform item — no platform/packaging/updater/paths/shell/permissions surface touched; engine-only change.
- Docs/release/deps item — no docs, dependencies, permissions, or credentials touched. Release-note wording for this capability is handled in the release flow, not here.

## How To Verify

```text
bun test test/tool/automate.test.ts: 20 pass, 0 fail
  (3 new: decode keeps continueSession; default -> context "fresh";
   continueSession:true -> context "continue" with spoofed automationSessionID still ignored)
bun test test/server/automation-runner.test.ts: 22 pass, 0 fail
  (existing continue-reuse path unaffected)
tsgo --noEmit: clean
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a session continuation control for automations so users can choose whether runs continue an existing session or start fresh.
* **Documentation / Messaging**
  * Validation and descriptive text updated to clarify defaults and the meaning of the session continuation option.
* **Tests**
  * Expanded test coverage to verify session-continuation behavior and ensure session IDs are not retained at creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->