### PR TITLE
fix(provider): update kimi-k2.6 and kimi-k2.5 context window to 1M

### DIFF
--- a/packages/opencode/src/provider/pawwork-providers.ts
+++ b/packages/opencode/src/provider/pawwork-providers.ts
@@ -66,13 +66,13 @@ export const PAWWORK_PROVIDER_OVERLAYS: Record<string, ModelsDev.Provider> = {
         interleaved: { field: "reasoning_content" },
       }),
       [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[8]]: textModel("deepseek-v3.2", "DeepSeek V3.2", 128000, 4096),
-      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[9]]: textModel("kimi-k2.6", "Kimi K2.6", 262144, 32768, {
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[9]]: textModel("kimi-k2.6", "Kimi K2.6", 1048576, 32768, {
         attachment: true,
         reasoning: true,
         interleaved: { field: "reasoning_content" },
         modalities: { input: ["text", "image", "video"], output: ["text"] },
       }),
-      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[10]]: textModel("kimi-k2.5", "Kimi K2.5", 262144, 32768, {
+      [VOLCENGINE_PLAN_VISIBLE_MODEL_IDS[10]]: textModel("kimi-k2.5", "Kimi K2.5", 1048576, 32768, {
         attachment: true,
         reasoning: true,
         interleaved: { field: "reasoning_content" },


### PR DESCRIPTION
Fixes #1213

## Problem

The Volcano Engine Coding Plan overlay in `pawwork-providers.ts` hardcodes the context window for `kimi-k2.6` and `kimi-k2.5` as 262,144 (256K), while both models officially support 1,048,576 (1M) tokens.

This causes the context usage panel to show an incorrect context window and triggers auto-compaction prematurely.

## Change

- `kimi-k2.6`: `context` 262,144 → 1,048,576
- `kimi-k2.5`: `context` 262,144 → 1,048,576

## Verification

Aligned with the moonshotai official catalog (`models.dev`) which lists both models with `context: 1048576`.

## Files Changed

- `packages/opencode/src/provider/pawwork-providers.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the kimi-k2.6 model with increased input context capacity, enabling support for larger inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->