### PR TITLE
fix: share unbiased identifier suffix generation

### DIFF
--- a/packages/app/src/utils/id.ts
+++ b/packages/app/src/utils/id.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { randomBase62 } from "@opencode-ai/util/base62"
 
 const prefixes = {
   session: "ses",
@@ -61,7 +62,7 @@ function create(prefix: Prefix, descending: boolean, timestamp?: number): string
     timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
   }
 
-  return prefixes[prefix] + "_" + bytesToHex(timeBytes) + randomBase62(LENGTH - 12)
+  return prefixes[prefix] + "_" + bytesToHex(timeBytes) + randomBase62(LENGTH - 12, getRandomBytes)
 }
 
 function bytesToHex(bytes: Uint8Array): string {
@@ -70,16 +71,6 @@ function bytesToHex(bytes: Uint8Array): string {
     hex += bytes[i].toString(16).padStart(2, "0")
   }
   return hex
-}
-
-function randomBase62(length: number): string {
-  const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-  const bytes = getRandomBytes(length)
-  let result = ""
-  for (let i = 0; i < length; i += 1) {
-    result += chars[bytes[i] % 62]
-  }
-  return result
 }
 
 function getRandomBytes(length: number): Uint8Array {

--- a/packages/core/src/util/base62.ts
+++ b/packages/core/src/util/base62.ts
@@ -1,0 +1,16 @@
+const CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const MAX_UNBIASED_BYTE = Math.floor(256 / CHARS.length) * CHARS.length
+
+export function randomBase62(length: number, randomBytes: (length: number) => ArrayLike<number>): string {
+  let result = ""
+  while (result.length < length) {
+    const bytes = randomBytes(length - result.length)
+    for (let i = 0; i < bytes.length; i++) {
+      const byte = bytes[i]
+      if (byte >= MAX_UNBIASED_BYTE) continue
+      result += CHARS[byte % CHARS.length]
+      if (result.length === length) break
+    }
+  }
+  return result
+}

--- a/packages/core/src/util/identifier.ts
+++ b/packages/core/src/util/identifier.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "crypto"
+import { randomBase62 } from "./base62"
 
 export namespace Identifier {
   const LENGTH = 26
@@ -12,20 +13,6 @@ export namespace Identifier {
 
   export function descending() {
     return create(true)
-  }
-
-  function randomBase62(length: number): string {
-    const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-    let result = ""
-    while (result.length < length) {
-      const bytes = randomBytes(length - result.length)
-      for (const byte of bytes) {
-        if (byte >= 248) continue
-        result += chars[byte % 62]
-        if (result.length === length) break
-      }
-    }
-    return result
   }
 
   export function create(descending: boolean, timestamp?: number): string {
@@ -46,6 +33,6 @@ export namespace Identifier {
       timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
     }
 
-    return timeBytes.toString("hex") + randomBase62(LENGTH - 12)
+    return timeBytes.toString("hex") + randomBase62(LENGTH - 12, randomBytes)
   }
 }

--- a/packages/core/test/util/base62.test.ts
+++ b/packages/core/test/util/base62.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+
+describe("randomBase62", () => {
+  test("skips biased bytes before mapping to base62", async () => {
+    const { randomBase62 } = await import("../../src/util/base62")
+    let calls = 0
+
+    const value = randomBase62(4, (size) => {
+      calls += 1
+      if (calls === 1) return [248, ...Array.from({ length: size - 1 }, () => 61)]
+      return Array.from({ length: size }, () => 61)
+    })
+
+    expect(value).toBe("zzzz")
+    expect(calls).toBe(2)
+  })
+})

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -1,5 +1,6 @@
 import z from "zod"
 import { randomBytes } from "crypto"
+import { randomBase62 } from "@opencode-ai/core/util/base62"
 
 export namespace Identifier {
   const prefixes = {
@@ -37,7 +38,6 @@ export namespace Identifier {
 
   const LENGTH = 26
 
-  // State for monotonic ID generation
   let lastTimestamp = 0
   let counter = 0
 
@@ -60,16 +60,6 @@ export namespace Identifier {
     return given
   }
 
-  function randomBase62(length: number): string {
-    const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-    let result = ""
-    const bytes = randomBytes(length)
-    for (let i = 0; i < length; i++) {
-      result += chars[bytes[i] % 62]
-    }
-    return result
-  }
-
   export function create(prefix: Prefix, descending: boolean, timestamp?: number): string {
     const currentTimestamp = timestamp ?? Date.now()
 
@@ -88,7 +78,7 @@ export namespace Identifier {
       timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
     }
 
-    return prefixes[prefix] + "_" + timeBytes.toString("hex") + randomBase62(LENGTH - 12)
+    return prefixes[prefix] + "_" + timeBytes.toString("hex") + randomBase62(LENGTH - 12, randomBytes)
   }
 
   /** Extract timestamp from an ascending ID. Does not work with descending IDs. */

--- a/packages/util/src/base62.ts
+++ b/packages/util/src/base62.ts
@@ -1,0 +1,1 @@
+export { randomBase62 } from "@opencode-ai/core/util/base62"

--- a/packages/util/src/identifier.ts
+++ b/packages/util/src/identifier.ts
@@ -1,9 +1,9 @@
 import { randomBytes } from "crypto"
+import { randomBase62 } from "@opencode-ai/core/util/base62"
 
 export namespace Identifier {
   const LENGTH = 26
 
-  // State for monotonic ID generation
   let lastTimestamp = 0
   let counter = 0
 
@@ -13,16 +13,6 @@ export namespace Identifier {
 
   export function descending() {
     return create(true)
-  }
-
-  function randomBase62(length: number): string {
-    const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-    let result = ""
-    const bytes = randomBytes(length)
-    for (let i = 0; i < length; i++) {
-      result += chars[bytes[i] % 62]
-    }
-    return result
   }
 
   export function create(descending: boolean, timestamp?: number): string {
@@ -43,6 +33,6 @@ export namespace Identifier {
       timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
     }
 
-    return timeBytes.toString("hex") + randomBase62(LENGTH - 12)
+    return timeBytes.toString("hex") + randomBase62(LENGTH - 12, randomBytes)
   }
 }

--- a/packages/util/test/compat-surface.test.ts
+++ b/packages/util/test/compat-surface.test.ts
@@ -9,6 +9,8 @@ import { fn as utilFn } from "@opencode-ai/util/fn"
 import { fn as coreFn } from "@opencode-ai/core/util/fn"
 import { Identifier as coreIdentifier } from "@opencode-ai/core/util/identifier"
 import { Identifier as utilIdentifier } from "@opencode-ai/util/identifier"
+import { randomBase62 as utilRandomBase62 } from "@opencode-ai/util/base62"
+import { randomBase62 as coreRandomBase62 } from "@opencode-ai/core/util/base62"
 import { iife as utilIife } from "@opencode-ai/util/iife"
 import { iife as coreIife } from "@opencode-ai/core/util/iife"
 import { lazy as utilLazy } from "@opencode-ai/util/lazy"
@@ -54,6 +56,9 @@ test("core util surface stays aligned with compatibility util surface", async ()
 
   expect(typeof utilIdentifier.ascending()).toBe("string")
   expect(typeof coreIdentifier.ascending()).toBe("string")
+  expect(utilRandomBase62(4, (size) => [248, ...Array.from({ length: size }, () => 61)])).toBe(
+    coreRandomBase62(4, (size) => [248, ...Array.from({ length: size }, () => 61)]),
+  )
   expect(utilModule.resolve("node:path", process.cwd())).toBe(coreModule.resolve("node:path", process.cwd()))
 
   expect(await utilRetry(async () => "ok", { attempts: 1 })).toBe(await coreRetry(async () => "ok", { attempts: 1 }))


### PR DESCRIPTION
## Summary

Share one unbiased base62 suffix mapper across the identifier implementations used by core, util, opencode, and the app renderer.

No related issue; this fixes drift found during contract-cleanup review.

## Why

`@opencode-ai/core` already used rejection sampling to avoid modulo bias when mapping random bytes to base62 characters. The util, opencode, and app identifier implementations still used `byte % 62` directly, so the same contract had drifted across package and runtime boundaries.

## Related Issue

No issue. This is PR1 of the bounded contract-cleanup Goal.

## Human Review Status

Pending

## Review Focus

Please focus on whether `randomBase62` is the right single source for the byte-to-base62 mapping, and whether the app/browser path still keeps only the random byte source local.

## Risk Notes

No visible UI or copy changed; the visible UI checklist item is intentionally left unticked.
No docs, release notes, dependency, permission, credential, deletion, generated content, or local file changes are relevant; that conditional checklist item is intentionally left unticked.
Platform/runtime impact was considered: Node callers still provide `crypto.randomBytes`, while the app renderer still provides its existing browser/fallback byte source.

Fresh eye review: read-only subagent found no P0/P1/P2/P3 issues on the staged diff.

## How To Verify

```text
packages/core: bun test test/util/base62.test.ts test/util/identifier.test.ts -> 2 passed
packages/util: bun test test/compat-surface.test.ts -> 1 passed
packages/core: bun run typecheck -> passed
packages/util: bun run typecheck -> passed
packages/opencode: bun run typecheck -> passed
packages/app: bun run typecheck -> passed
packages/opencode: bun test test/session/id-monotonicity.test.ts test/tool/truncation.test.ts -> 21 passed
git diff --cached --check -> passed
Fresh eye subagent -> no findings
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted random Base62 string generation into a shared utility to eliminate duplicate code across packages, improving code maintainability and consistency throughout the codebase.

* **Tests**
  * Added test coverage validating the shared Base62 random generator utility handles edge cases correctly and produces expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->