### PR TITLE
test(app): scope UI module test stubs

### DIFF
--- a/packages/app/src/components/file-tree.test.ts
+++ b/packages/app/src/components/file-tree.test.ts
@@ -20,18 +20,6 @@ beforeAll(async () => {
       },
     }),
   }))
-  mock.module("@opencode-ai/ui/collapsible", () => ({
-    Collapsible: {
-      Trigger: (props: { children?: unknown }) => props.children,
-      Content: (props: { children?: unknown }) => props.children,
-    },
-  }))
-  mock.module("@opencode-ai/ui/file-icon", () => ({ FileIcon: () => null }))
-  mock.module("@opencode-ai/ui/icon", () => ({ Icon: () => null }))
-  mock.module("@opencode-ai/ui/tooltip", () => ({
-    Tooltip: (props: { children?: unknown }) => props.children,
-    TooltipKeybind: (_props: any) => null,
-  }))
   const mod = await import("./file-tree")
   shouldListRoot = mod.shouldListRoot
   shouldListExpanded = mod.shouldListExpanded

--- a/packages/app/src/components/prompt-input/send-button.test.tsx
+++ b/packages/app/src/components/prompt-input/send-button.test.tsx
@@ -1,4 +1,5 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
+import * as uiIcon from "@opencode-ai/ui/icon"
 
 let SendButton: typeof import("./send-button").SendButton
 const originalReact = (globalThis as any).React
@@ -6,9 +7,7 @@ const originalReact = (globalThis as any).React
 type Node = { type: any; props: Record<string, any>; children: Node[] }
 
 beforeAll(async () => {
-  mock.module("@opencode-ai/ui/icon", () => ({
-    Icon: (props: any) => ({ type: "Icon", props: props ?? {}, children: [] }) as Node,
-  }))
+  spyOn(uiIcon, "Icon").mockImplementation((props: any) => ({ type: "Icon", props: props ?? {}, children: [] }) as any)
   SendButton = (await import("./send-button")).SendButton
 })
 

--- a/packages/app/src/context/comments.test.ts
+++ b/packages/app/src/context/comments.test.ts
@@ -9,12 +9,6 @@ beforeAll(async () => {
     useNavigate: () => () => undefined,
     useParams: () => ({}),
   }))
-  mock.module("@opencode-ai/ui/context", () => ({
-    createSimpleContext: () => ({
-      use: () => undefined,
-      provider: () => undefined,
-    }),
-  }))
   const mod = await import("./comments")
   createCommentSessionForTest = mod.createCommentSessionForTest
 })

--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -11,12 +11,6 @@ beforeAll(async () => {
     useNavigate: () => () => undefined,
     useParams: () => ({}),
   }))
-  mock.module("@opencode-ai/ui/context", () => ({
-    createSimpleContext: () => ({
-      use: () => undefined,
-      provider: () => undefined,
-    }),
-  }))
   const mod = await import("./prompt")
   createPromptBinding = mod.createPromptBinding
   DEFAULT_PROMPT = mod.DEFAULT_PROMPT

--- a/packages/app/src/context/terminal.test.ts
+++ b/packages/app/src/context/terminal.test.ts
@@ -9,12 +9,6 @@ beforeAll(async () => {
     useNavigate: () => () => undefined,
     useParams: () => ({}),
   }))
-  mock.module("@opencode-ai/ui/context", () => ({
-    createSimpleContext: () => ({
-      use: () => undefined,
-      provider: () => undefined,
-    }),
-  }))
   const mod = await import("./terminal")
   getWorkspaceTerminalCacheKey = mod.getWorkspaceTerminalCacheKey
   getLegacyTerminalStorageKeys = mod.getLegacyTerminalStorageKeys


### PR DESCRIPTION
## Summary

Remove unnecessary `@opencode-ai/ui/*` `mock.module(...)` stubs from helper-only app tests and convert the `SendButton` icon stub to a scoped `spyOn`.

## Why

`mock.module(...)` is a persistent Bun registry override, so shared UI module stubs can leak into later test files in the same process. This is the first small slice of #1084: it eliminates the low-risk parent-process UI stubs that can be removed or scoped without widening the review boundary.

## Related Issue

Closes part of #1084.

## Human Review Status

Pending

## Review Focus

Please check that this PR stays limited to test harness hygiene and that the deferred files below are reasonable follow-up boundaries rather than hidden misses.

## Risk Notes

`session-context-usage.test.ts` is left unchanged because its UI mocks run inside a separate `runBrowserCheck` Bun subprocess, not the parent app test process. `session-side-panel.test.tsx` is left unchanged because it already fails strict standalone due to an unrelated internal `@/context/command` mock/preheat issue. `pawwork-worktree-badge.test.tsx` and `review-tab.test.tsx` are also left unchanged in this PR after investigation showed that namespace-importing their real UI modules hits Kobalte/Solid client-only import behavior; handling those requires a separate test-shape decision.

No visible UI or copy changed, no platform/packaging surface changed, and no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local-only files changed.

## How To Verify

```text
Install: bun install --frozen-lockfile (first attempt hit tree-sitter-powershell SIGKILL; retry succeeded)
Standalone file-tree: 3 pass, 0 fail
Standalone send-button: 4 pass, 0 fail
Standalone comments: 7 pass, 0 fail
Standalone prompt: 14 pass, 0 fail
Standalone terminal: 4 pass, 0 fail
Targeted rg: no mock.module("@opencode-ai/ui/..." remains in the five migrated files
App unit suite: bun run test:unit -> 1811 pass, 0 fail
App typecheck: bun run typecheck -> tsgo -b passed
Diff check: git diff --check passed
```

## Screenshots or Recordings

Not applicable; test-only change with no visible UI or copy change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
