### PR TITLE
refactor: share message part contracts

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -20,8 +20,7 @@ import { dropSessionCaches } from "./session-cache"
 import { message as clean } from "@/utils/diffs"
 import type { createBlockerTerminalCache } from "./blocker-terminal-cache"
 import type { TodoHydrateCoordinator } from "./todo-hydrate-coordinator"
-
-const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
+import { shouldStoreMessagePart } from "../message-part-storage"
 
 // A recurring automation that fails this many times in a row earns one subtle
 // toast on the rising edge. The threshold and the rising-edge gate keep SSE
@@ -320,7 +319,7 @@ export function applyDirectoryEvent(input: {
     }
     case "message.part.updated": {
       const part = (event.properties as { part: Part }).part
-      if (SKIP_PARTS.has(part.type)) break
+      if (!shouldStoreMessagePart(part)) break
       const todo = todoSnapshotFromPart(part)
       if (todo) {
         const accepted = acceptLiveTodo({

--- a/packages/app/src/context/message-part-storage.test.ts
+++ b/packages/app/src/context/message-part-storage.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { shouldStoreMessagePart } from "./message-part-storage"
+import type { Part } from "@opencode-ai/sdk/v2/client"
+
+const part = (type: Part["type"]) => ({ type }) as Pick<Part, "type">
+
+describe("shouldStoreMessagePart", () => {
+  test("skips transient message part types that are not rendered from stored state", () => {
+    expect(shouldStoreMessagePart(part("patch"))).toBe(false)
+    expect(shouldStoreMessagePart(part("step-start"))).toBe(false)
+    expect(shouldStoreMessagePart(part("step-finish"))).toBe(false)
+  })
+
+  test("keeps durable message part types", () => {
+    expect(shouldStoreMessagePart(part("text"))).toBe(true)
+    expect(shouldStoreMessagePart(part("tool"))).toBe(true)
+  })
+})

--- a/packages/app/src/context/message-part-storage.ts
+++ b/packages/app/src/context/message-part-storage.ts
@@ -1,0 +1,7 @@
+import type { Part } from "@opencode-ai/sdk/v2/client"
+
+const SKIPPED_MESSAGE_PART_TYPES = new Set<Part["type"]>(["patch", "step-start", "step-finish"])
+
+export function shouldStoreMessagePart(part: Pick<Part, "type">) {
+  return !SKIPPED_MESSAGE_PART_TYPES.has(part.type)
+}

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -15,8 +15,7 @@ import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { dropSessionCaches } from "./global-sync/session-cache"
 import type { TodoHydrateReason } from "./global-sync/todo-hydrate-coordinator"
 import { diffs as list, message as clean } from "@/utils/diffs"
-
-const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
+import { shouldStoreMessagePart } from "./message-part-storage"
 
 function sortParts(parts: Part[]) {
   return parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id))
@@ -405,7 +404,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           batch(() => {
             input.setStore("message", input.sessionID, reconcile(message, { key: "id" }))
             for (const p of next.part) {
-              const filtered = p.part.filter((x) => !SKIP_PARTS.has(x.type))
+              const filtered = p.part.filter(shouldStoreMessagePart)
               if (filtered.length) input.setStore("part", p.id, filtered)
             }
             setMeta("limit", key, message.length)

--- a/packages/app/src/pages/session/session-turn-changes.tsx
+++ b/packages/app/src/pages/session/session-turn-changes.tsx
@@ -5,6 +5,7 @@ import { Dialog } from "@opencode-ai/ui/dialog"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { showToast } from "@opencode-ai/ui/toast"
 import type { Message as MessageType } from "@opencode-ai/sdk/v2"
+import type { TurnChangeDisplay } from "@opencode-ai/ui/session-turn-changes"
 import { useLanguage } from "@/context/language"
 import { useServer } from "@/context/server"
 import {
@@ -16,38 +17,7 @@ import {
 
 type Translate = (key: string, params?: Record<string, unknown>) => string
 
-type TurnChangeFile = {
-  path: string
-  openPath?: string
-  status: "added" | "modified" | "deleted"
-  additions?: number
-  deletions?: number
-  patch?: string
-  sensitive?: boolean
-  binary?: boolean
-  large?: boolean
-  restoreAvailable?: boolean
-  expandable: boolean
-  restoreState: "applied" | "undone" | "redo_invalidated"
-}
-
-type TurnChangeBase = {
-  sessionID: string
-  turnID?: string
-  messageID?: string
-  truncated?: boolean
-  omittedCount?: number
-  skippedCount?: number
-}
-
-export type TurnChangeDisplay =
-  | (TurnChangeBase & { kind: "empty" })
-  | (TurnChangeBase & { kind: "uncaptured"; count: number })
-  | (TurnChangeBase & {
-      kind: "captured" | "mixed"
-      count?: number
-      files: TurnChangeFile[]
-    })
+export type { TurnChangeDisplay } from "@opencode-ai/ui/session-turn-changes"
 
 export function buildTurnFetchInput(sessionID: string | undefined, messages: MessageType[]): TurnFetchInput | null {
   if (!sessionID) return null

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
     "./context/*": "./src/context/*.tsx",
     "./styles": "./src/styles/index.css",
     "./styles/tailwind": "./src/styles/tailwind/index.css",
+    "./session-turn-changes": "./src/components/session-turn-changes.ts",
     "./tool-contract": "./src/components/tool-contract.ts",
     "./theme": "./src/theme/index.ts",
     "./theme/*": "./src/theme/*.ts",


### PR DESCRIPTION
## Summary

Consolidates message part storage filtering into one app helper and makes the UI `TurnChangeDisplay` type the single source for the app/session turn-change contract. There is no related issue; this is a contract cleanup PR from the repository-wide abstraction review goal.

## Why

The same skipped message part set was duplicated across the paged load path and live event reducer, and the app carried a second copy of the UI turn-change display union. Those copies were small, but they were contract-shaped and easy to drift when new part types or turn-change fields are added.

## Related Issue

No related issue.

## Human Review Status

Pending

## Review Focus

Please check that `shouldStoreMessagePart` preserves the existing filtering behavior for both message load and live event paths, and that the `TurnChangeDisplay` type ownership now correctly lives in the UI package without introducing a runtime dependency.

## Risk Notes

No visible UI or copy changed. The `TurnChangeDisplay` app import is type-only and the new UI package subpath exports an existing type/helper module. No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local files changed.

## How To Verify

```text
RED first: packages/app: bun test src/context/message-part-storage.test.ts -> failed because ./message-part-storage did not exist
packages/app: bun test src/context/message-part-storage.test.ts -> 2 passed
packages/app: bun test src/context/message-part-storage.test.ts src/context/sync-message-resolution.test.ts src/context/global-sync/event-reducer.test.ts src/pages/session/session-turn-changes.test.ts -> 40 passed
packages/ui: bun test src/components/session-turn-turn-changes.test.ts -> 3 passed
packages/app: bun run typecheck -> passed
packages/ui: bun run typecheck -> passed
Staged diff: git diff --cached --check -> passed before commit
Fresh eye review: 019ead0f-11d3-7420-a53f-9835a6a60052 -> no P0/P1/P2/P3 findings
```

## Screenshots or Recordings

Not applicable: no visible UI or copy changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
