### PR TITLE
fix(server): type workspace routing failures

### DIFF
--- a/packages/opencode/src/server/instance/workspace-routing.ts
+++ b/packages/opencode/src/server/instance/workspace-routing.ts
@@ -155,7 +155,13 @@ export function resolveWorkspaceRoute(input: {
       catch: workspaceRoutingFailure("workspace-adaptor", `Failed to resolve workspace adaptor: ${id}`),
     })
     const target = yield* Effect.tryPromise({
-      try: async () => adaptor.target(workspace),
+      try: async () => {
+        const next = await adaptor.target(workspace)
+        if (!next || (next.type !== "local" && next.type !== "remote")) {
+          throw new Error("Workspace adaptor returned an invalid target")
+        }
+        return next
+      },
       catch: workspaceRoutingFailure("workspace-target", `Failed to resolve workspace target: ${id}`),
     })
 

--- a/packages/opencode/src/server/instance/workspace-routing.ts
+++ b/packages/opencode/src/server/instance/workspace-routing.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { WorkspaceID } from "@/control-plane/schema"
 import type { Target } from "@/control-plane/types"
 import { Workspace } from "@/control-plane/workspace"
@@ -27,6 +27,34 @@ export type WorkspaceRouteResolution =
   | { action: "proxy-http"; target: Extract<Target, { type: "remote" }>; workspaceID: WorkspaceID }
   | { action: "pass-missing-session-delete" }
   | { action: "missing-workspace-error"; workspaceID: WorkspaceID }
+
+const WorkspaceRoutingErrorReason = Schema.Union([
+  Schema.Literal("session-workspace"),
+  Schema.Literal("workspace-id"),
+  Schema.Literal("workspace-record"),
+  Schema.Literal("workspace-sync"),
+  Schema.Literal("workspace-adaptor"),
+  Schema.Literal("workspace-target"),
+  Schema.Literal("unexpected-local-decision"),
+])
+
+export class WorkspaceRoutingError extends Schema.TaggedErrorClass<WorkspaceRoutingError>()("WorkspaceRoutingError", {
+  reason: WorkspaceRoutingErrorReason,
+  message: Schema.String,
+  cause: Schema.optional(Schema.Defect()),
+}) {}
+
+const workspaceRoutingFailure =
+  (reason: WorkspaceRoutingError["reason"], message: string) =>
+  (cause: unknown) => {
+    const causeMessage =
+      cause instanceof Error ? cause.message : typeof cause === "string" && cause.length > 0 ? cause : undefined
+    return new WorkspaceRoutingError({
+      reason,
+      message: causeMessage ? `${message}: ${causeMessage}` : message,
+      cause,
+    })
+  }
 
 export function isLocalCachedRoute(method: string, pathname: string) {
   for (const rule of LOCAL_ROUTE_RULES) {
@@ -71,76 +99,95 @@ export function resolveWorkspaceRoute(input: {
   ensureConfig: boolean
   isPawWork: boolean
   isWebSocketUpgrade?: boolean
-}): Effect.Effect<WorkspaceRouteResolution, unknown> {
-  return Effect.tryPromise({
-    try: async () => {
-      const sessionWorkspaceID = await getSessionWorkspace(input.pathname)
-      const workspaceID = sessionWorkspaceID || input.workspaceID
+}): Effect.Effect<WorkspaceRouteResolution, WorkspaceRoutingError> {
+  return Effect.gen(function* () {
+    const sessionWorkspaceID = yield* Effect.tryPromise({
+      try: () => getSessionWorkspace(input.pathname),
+      catch: workspaceRoutingFailure("session-workspace", "Failed to resolve session workspace"),
+    })
+    const workspaceID = sessionWorkspaceID || input.workspaceID
 
-      if (!workspaceID) {
-        const createLegacyConfig = shouldCreateLegacyConfigBeforeNoWorkspacePath({
-          pathname: input.pathname,
-          ensureConfig: input.ensureConfig,
-          isPawWork: input.isPawWork,
-        })
-        return {
-          action: "provide-local-context",
-          directory: input.directory,
-          createLegacyConfig: createLegacyConfig || undefined,
-        }
-      }
-
-      const id = WorkspaceID.make(workspaceID)
-      const workspace = await Workspace.record(id)
-
-      if (!workspace) {
-        const decision = classifyWorkspaceRoute({
-          method: input.method,
-          pathname: input.pathname,
-          target: "missing",
-        })
-        if (decision.action === "pass-missing-session-delete") {
-          return { action: "pass-missing-session-delete" }
-        }
-        return { action: "missing-workspace-error", workspaceID: id }
-      }
-
-      Workspace.ensureSync(workspace, input.directory)
-
-      const adaptor = await Workspace.resolveAdaptor({
-        ...workspace,
-        hint: input.directory,
+    if (!workspaceID) {
+      const createLegacyConfig = shouldCreateLegacyConfigBeforeNoWorkspacePath({
+        pathname: input.pathname,
+        ensureConfig: input.ensureConfig,
+        isPawWork: input.isPawWork,
       })
-      const target = await adaptor.target(workspace)
-
-      if (target.type === "local") {
-        const decision = classifyWorkspaceRoute({
-          method: input.method,
-          pathname: input.pathname,
-          target: target.type,
-        })
-        if (decision.action !== "provide-local-workspace") {
-          throw new Error(`Unexpected local workspace routing decision: ${decision.action}`)
-        }
-        return {
-          action: "provide-local-context",
-          directory: target.directory,
-          workspaceID: id,
-        }
+      return {
+        action: "provide-local-context",
+        directory: input.directory,
+        createLegacyConfig: createLegacyConfig || undefined,
       }
+    }
 
+    const id = yield* Effect.try({
+      try: () => WorkspaceID.make(workspaceID),
+      catch: workspaceRoutingFailure("workspace-id", `Invalid workspace id: ${workspaceID}`),
+    })
+    const workspace = yield* Effect.tryPromise({
+      try: () => Workspace.record(id),
+      catch: workspaceRoutingFailure("workspace-record", `Failed to read workspace: ${id}`),
+    })
+
+    if (!workspace) {
+      const decision = classifyWorkspaceRoute({
+        method: input.method,
+        pathname: input.pathname,
+        target: "missing",
+      })
+      if (decision.action === "pass-missing-session-delete") {
+        return { action: "pass-missing-session-delete" }
+      }
+      return { action: "missing-workspace-error", workspaceID: id }
+    }
+
+    yield* Effect.try({
+      try: () => Workspace.ensureSync(workspace, input.directory),
+      catch: workspaceRoutingFailure("workspace-sync", `Failed to start workspace sync: ${id}`),
+    })
+
+    const adaptor = yield* Effect.tryPromise({
+      try: () =>
+        Workspace.resolveAdaptor({
+          ...workspace,
+          hint: input.directory,
+        }),
+      catch: workspaceRoutingFailure("workspace-adaptor", `Failed to resolve workspace adaptor: ${id}`),
+    })
+    const target = yield* Effect.tryPromise({
+      try: async () => adaptor.target(workspace),
+      catch: workspaceRoutingFailure("workspace-target", `Failed to resolve workspace target: ${id}`),
+    })
+
+    if (target.type === "local") {
       const decision = classifyWorkspaceRoute({
         method: input.method,
         pathname: input.pathname,
         target: target.type,
-        isWebSocketUpgrade: input.isWebSocketUpgrade,
       })
+      if (decision.action !== "provide-local-workspace") {
+        return yield* new WorkspaceRoutingError({
+          reason: "unexpected-local-decision",
+          message: `Unexpected local workspace routing decision: ${decision.action}`,
+        })
+      }
+      return {
+        action: "provide-local-context",
+        directory: target.directory,
+        workspaceID: id,
+      }
+    }
 
-      if (decision.action === "serve-local-cache") return { action: "serve-local-cache" }
-      if (decision.action === "proxy-websocket") return { action: "proxy-websocket", target }
-      return { action: "proxy-http", target, workspaceID: id }
-    },
-    catch: (error) => error,
+    const decision = classifyWorkspaceRoute({
+      method: input.method,
+      pathname: input.pathname,
+      target: target.type,
+      isWebSocketUpgrade: input.isWebSocketUpgrade,
+    })
+
+    if (decision.action === "serve-local-cache") return { action: "serve-local-cache" }
+    if (decision.action === "proxy-websocket") return { action: "proxy-websocket", target }
+    return { action: "proxy-http", target, workspaceID: id }
   })
 }
 

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -89,6 +89,7 @@ async function writeRemoteWorkspacePlugin(input: {
   url: string
   branch?: string | null
   targetError?: string
+  targetValue?: string
 }) {
   const type = `plug-${Math.random().toString(36).slice(2)}`
   const file = path.join(input.dir, "plugin.ts")
@@ -106,6 +107,8 @@ async function writeRemoteWorkspacePlugin(input: {
       "    target() {",
       input.targetError
         ? `      throw new Error(${JSON.stringify(input.targetError)})`
+        : input.targetValue
+          ? `      return ${input.targetValue}`
         : `      return { type: "remote", url: ${JSON.stringify(input.url)} }`,
       "    },",
       "  })",
@@ -572,6 +575,40 @@ describe("workspace router", () => {
       // redacted to a constant so the internal failure never leaks to clients (ErrorMiddleware).
       expect(body.data.message).toBe("Unexpected server error. Check server logs for details.")
       expect(JSON.stringify(body)).not.toContain(message)
+    } finally {
+      ensureSync.mockRestore()
+    }
+  })
+
+  test("keeps malformed remote targets in the Effect failure channel", async () => {
+    await using tmp = await tmpdir({
+      init: (dir) => writeRemoteWorkspacePlugin({ dir, url: "http://127.0.0.1:9", targetValue: "undefined" }),
+    })
+    const workspace = await persistRemoteWorkspace({ directory: tmp.path, type: tmp.extra.type })
+    await Instance.disposeAll()
+
+    const ensureSync = disableWorkspaceSync()
+
+    try {
+      const exit = await AppRuntime.runPromiseExit(
+        resolveWorkspaceRoute({
+          method: "GET",
+          pathname: "/path",
+          directory: tmp.path,
+          workspaceID: workspace.id,
+          ensureConfig: false,
+          isPawWork: true,
+        }),
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasFails(exit.cause)).toBe(true)
+        expect(Cause.hasDies(exit.cause)).toBe(false)
+        const error = Cause.squash(exit.cause)
+        expect(error).toBeInstanceOf(WorkspaceRoutingError)
+        expect((error as WorkspaceRoutingError).reason).toBe("workspace-target")
+      }
     } finally {
       ensureSync.mockRestore()
     }

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -13,7 +13,7 @@ import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin"
 import { Server } from "../../src/server/server"
 import { WorkspaceRouterMiddleware } from "../../src/server/instance/middleware"
-import { resolveWorkspaceRoute } from "../../src/server/instance/workspace-routing"
+import { resolveWorkspaceRoute, WorkspaceRoutingError } from "../../src/server/instance/workspace-routing"
 import { WorkspaceID } from "../../src/control-plane/schema"
 import { Workspace } from "../../src/control-plane/workspace"
 import { WorkspaceTable } from "../../src/control-plane/workspace.sql"
@@ -554,8 +554,9 @@ describe("workspace router", () => {
         expect(Cause.hasFails(exit.cause)).toBe(true)
         expect(Cause.hasDies(exit.cause)).toBe(false)
         const error = Cause.squash(exit.cause)
-        expect(error).toBeInstanceOf(Error)
-        expect((error as Error).message).toContain(message)
+        expect(error).toBeInstanceOf(WorkspaceRoutingError)
+        expect((error as WorkspaceRoutingError).reason).toBe("workspace-target")
+        expect((error as WorkspaceRoutingError).message).toContain(message)
       }
 
       const response = await Server.Default().app.request(`/path?workspace=${workspace.id}`, {
@@ -570,6 +571,7 @@ describe("workspace router", () => {
       // The Effect failure channel above still carries the real message; the HTTP body is
       // redacted to a constant so the internal failure never leaks to clients (ErrorMiddleware).
       expect(body.data.message).toBe("Unexpected server error. Check server logs for details.")
+      expect(JSON.stringify(body)).not.toContain(message)
     } finally {
       ensureSync.mockRestore()
     }


### PR DESCRIPTION
## Summary

Typed the workspace routing resolver's expected infrastructure failures as `WorkspaceRoutingError` while keeping the existing Hono route boundary and HTTP behavior unchanged.

## Why

Phase 1 of #936 is about moving real user-failure paths into Effect's typed failure channel before any HttpApi/default-server work. `resolveWorkspaceRoute` was still a broad `Effect.tryPromise(..., catch: error => error)` boundary, so adaptor/target failures were Effect failures but still untyped.

## Related Issue

Closes none. Advances #936.

## Human Review Status

Pending

## Review Focus

Please check that `Session.get` failure swallowing remains scoped to session workspace lookup only, and that non-session workspace failures now become `WorkspaceRoutingError` without changing the Hono response contract.

## Risk Notes

No route paths, SDK/OpenAPI output, HttpApi code, proxy behavior, or middleware response mapping changed.

Skipped conditional checklist items:
- Visible UI/copy check: not applicable, no UI or copy changed.
- macOS/Windows platform check: not applicable, no platform, packaging, updater, signing, shell, or permissions surface changed.
- Docs/release/dependency/generated/local-file item: not applicable, no such surface changed.

## How To Verify

```text
Claude plan review: completed; two reported blockers were checked before implementation. resolveWorkspaceRoute is exported, and Session.get failure swallowing is scoped to Session.get(...).catch(() => undefined).

Fresh-eye review: completed. One P2 finding was reproduced and fixed: malformed adaptor targets now stay in the typed WorkspaceRoutingError failure channel instead of escaping as defects.

bun --cwd packages/opencode test test/server/workspace-routing-decision.test.ts
Result: 7 pass, 0 fail.

bun --cwd packages/opencode test test/server/workspace-router.test.ts
Result: 18 pass, 0 fail. Remote target failures and malformed target values now assert WorkspaceRoutingError in the Effect failure channel, no dies, and unchanged redacted Hono 500 body.

bun --cwd packages/opencode test test/server/route-inventory-harness.test.ts
Result: 11 pass, 0 fail.

cd packages/opencode && bun run typecheck
Result: passed.

git diff --check
Result: no whitespace errors.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
