### PR TITLE
fix(session): route MCP isError results into the tool-error channel

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -961,7 +961,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                       yield* input.processor.recordToolExecutionStarted({ tool: key, toolCallID: opts.toolCallId })
                     }
                     try {
-                      const result = yield* Effect.promise(() => execute(args, opts))
+                      const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.promise(() =>
+                        execute(args, opts),
+                      )
+                      if (result.isError === true) {
+                        // record the failure before completion is marked, so run
+                        // observability and the loop gate see isError as a failed execution
+                        const failure = parseMcpToolResult(key, result)
+                        const error = new Error(
+                          failure.kind === "error" ? failure.message : `MCP tool ${key} reported an error`,
+                        )
+                        if (input.processor.recordToolExecutionFailed) {
+                          yield* input.processor.recordToolExecutionFailed({ toolCallID: opts.toolCallId, error })
+                        }
+                        return yield* Effect.fail(error)
+                      }
                       if (input.processor.recordToolExecutionCompleted) {
                         yield* input.processor.recordToolExecutionCompleted({ toolCallID: opts.toolCallId })
                       }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -991,29 +991,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 }),
               )
 
-              const textParts: string[] = []
-              const attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[] = []
-              for (const contentItem of result.content) {
-                if (contentItem.type === "text") textParts.push(contentItem.text)
-                else if (contentItem.type === "image") {
-                  attachments.push({
-                    type: "file",
-                    mime: contentItem.mimeType,
-                    url: `data:${contentItem.mimeType};base64,${contentItem.data}`,
-                  })
-                } else if (contentItem.type === "resource") {
-                  const { resource } = contentItem
-                  if (resource.text) textParts.push(resource.text)
-                  if (resource.blob) {
-                    attachments.push({
-                      type: "file",
-                      mime: resource.mimeType ?? "application/octet-stream",
-                      url: `data:${resource.mimeType ?? "application/octet-stream"};base64,${resource.blob}`,
-                      filename: resource.uri,
-                    })
-                  }
-                }
+              const parsed = parseMcpToolResult(key, result)
+              if (parsed.kind === "error") {
+                return yield* Effect.fail(new Error(parsed.message))
               }
+              const { textParts, attachments } = parsed
 
               const truncated = yield* truncate.output(textParts.join("\n\n"), {}, input.agent)
               const metadata = {
@@ -2979,6 +2961,62 @@ export type CommandInput = z.infer<typeof CommandInput>
 
 export async function command(input: CommandInput) {
   return runPromise((svc) => svc.command(CommandInput.parse(input)))
+}
+
+type McpContentItem =
+  | { type: "text"; text: string }
+  | { type: "image"; mimeType: string; data: string }
+  | { type: "resource"; resource: { text?: string; blob?: string; mimeType?: string; uri: string } }
+  | { type: string }
+
+export type McpToolOutcome =
+  | { kind: "error"; message: string }
+  | {
+      kind: "ok"
+      textParts: string[]
+      attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[]
+    }
+
+// MCP signals tool failure via `isError` on a normally-returned result — the SDK
+// client does not throw for it, and the AI SDK only emits tool-error for thrown
+// errors. Surfacing it as an error outcome here routes the call into the regular
+// tool-error channel (error-state part, error fingerprint for the loop gate)
+// instead of recording a completed success.
+/** @internal Exported for testing */
+export function parseMcpToolResult(
+  key: string,
+  result: { isError?: boolean; content: McpContentItem[] },
+): McpToolOutcome {
+  const textParts: string[] = []
+  const attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[] = []
+  for (const contentItem of result.content) {
+    if (contentItem.type === "text" && "text" in contentItem) textParts.push(contentItem.text)
+    else if (contentItem.type === "image" && "data" in contentItem) {
+      attachments.push({
+        type: "file",
+        mime: contentItem.mimeType,
+        url: `data:${contentItem.mimeType};base64,${contentItem.data}`,
+      })
+    } else if (contentItem.type === "resource" && "resource" in contentItem) {
+      const { resource } = contentItem
+      if (resource.text) textParts.push(resource.text)
+      if (resource.blob) {
+        attachments.push({
+          type: "file",
+          mime: resource.mimeType ?? "application/octet-stream",
+          url: `data:${resource.mimeType ?? "application/octet-stream"};base64,${resource.blob}`,
+          filename: resource.uri,
+        })
+      }
+    }
+  }
+  if (result.isError === true) {
+    return {
+      kind: "error",
+      message: textParts.join("\n\n").trim() || `MCP tool ${key} reported an error without details`,
+    }
+  }
+  return { kind: "ok", textParts, attachments }
 }
 
 /** @internal Exported for testing */

--- a/packages/opencode/test/session/prompt-mcp-result.test.ts
+++ b/packages/opencode/test/session/prompt-mcp-result.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { parseMcpToolResult } from "../../src/session/prompt"
+
+describe("parseMcpToolResult", () => {
+  test("returns ok with text and attachments for a successful result", () => {
+    const parsed = parseMcpToolResult("server_tool", {
+      content: [
+        { type: "text", text: "hello" },
+        { type: "image", mimeType: "image/png", data: "aGk=" },
+        { type: "resource", resource: { uri: "res://a", text: "resource text" } },
+      ],
+    })
+    expect(parsed.kind).toBe("ok")
+    if (parsed.kind !== "ok") return
+    expect(parsed.textParts).toEqual(["hello", "resource text"])
+    expect(parsed.attachments).toEqual([{ type: "file", mime: "image/png", url: "data:image/png;base64,aGk=" }])
+  })
+
+  test("returns error with the text content when isError is set", () => {
+    const parsed = parseMcpToolResult("server_tool", {
+      isError: true,
+      content: [{ type: "text", text: "tool exploded: bad input" }],
+    })
+    expect(parsed).toEqual({ kind: "error", message: "tool exploded: bad input" })
+  })
+
+  test("returns a fallback message when isError carries no text", () => {
+    const parsed = parseMcpToolResult("server_tool", { isError: true, content: [] })
+    expect(parsed).toEqual({ kind: "error", message: "MCP tool server_tool reported an error without details" })
+  })
+
+  test("isError false behaves like success", () => {
+    const parsed = parseMcpToolResult("server_tool", {
+      isError: false,
+      content: [{ type: "text", text: "fine" }],
+    })
+    expect(parsed.kind).toBe("ok")
+  })
+})


### PR DESCRIPTION
## Summary

The generic MCP tool wrapper in `session/prompt.ts` ignored the MCP spec's `isError` flag, recording failed MCP tool calls as completed successes. This PR:

- extracts the result-content conversion into `parseMcpToolResult()` (exported for testing, mirroring the existing `createStructuredOutputTool` precedent), and
- fails the execute effect when `result.isError === true`, using the result's text content as the error message, so the call enters the regular tool-error channel.

## Why

Verified in #1223 (Finding 3): `@modelcontextprotocol/sdk` returns (does not throw on) `isError: true` results, and the AI SDK only emits `tool-error` for thrown errors, so the flag was silently dropped. Consequences: (a) the repeated-failure loop gate never accumulated an error fingerprint for MCP tools — a persistently failing MCP tool could be retried indefinitely with identical input; (b) the UI rendered failed calls as completed. The bundled exa wrapper (`tool/mcp-exa.ts:136`) already handles `isError` this way; this brings the generic path in line.

## Related Issue

#1223 (Finding 3)

## Human Review Status

Pending

## Review Focus

- The conversion loop in `parseMcpToolResult` is a verbatim extraction of the previous inline loop (text/image/resource handling unchanged); the only new behavior is the `isError` branch.
- Failure message: joined text content, with a fallback when the failing result carries no text.
- The plugin `tool.execute.after` hook still fires before the isError check (it sees the raw MCP result, as before).

## Risk Notes

- Behavior change: MCP results with `isError: true` now produce an error-state tool part instead of a completed one. Models still see the error text (now via `errorText` instead of `output`). Sessions relying on the old completed-state rendering will show these as errors — which is the correct state.
- Skipped conditional checklist items: no visible UI/copy change (state rendering is existing error styling), no platform surface, no docs/deps/permissions surface.

## How To Verify

```text
bun test test/session/prompt-mcp-result.test.ts (packages/opencode): 4 pass / 0 fail (new)
bun test test/session/loop-gate.test.ts test/session/prompt.test.ts: 32 pass / 0 fail (adjacent suites)
bun run typecheck (packages/opencode, tsgo --noEmit): clean
```

## Screenshots or Recordings

Not applicable (no UI change).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

