### PR TITLE
fix(tool): evaluate grep permissions on requested path

### DIFF
--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -12,7 +12,7 @@ type Kind = "file" | "directory"
 type Options = {
   bypass?: boolean
   kind?: Kind
-  permissionPath?: string
+  checkRequestedPath?: boolean
 }
 
 type PermissionPathFs = {
@@ -160,19 +160,12 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
       : process.platform === "win32"
       ? path.win32.dirname(resolved)
       : path.dirname(resolved)
-  const permissionFull = options?.permissionPath
-    ? process.platform === "win32"
-      ? windowsPermissionPath(options.permissionPath, ins.directory)
-      : path.isAbsolute(options.permissionPath)
-      ? options.permissionPath
-      : `${ins.directory.replace(/\/+$/, "")}/${options.permissionPath}`
-    : undefined
-  const permissionDir = permissionFull
+  const permissionDir = options?.checkRequestedPath
     ? kind === "directory"
-      ? permissionFull
+      ? full
       : process.platform === "win32"
-      ? path.win32.dirname(permissionFull)
-      : path.dirname(permissionFull)
+      ? path.win32.dirname(full)
+      : path.dirname(full)
     : dir
   const glob =
     process.platform === "win32"

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -179,7 +179,7 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
     metadata: {
       filepath: full,
       realpath: resolved,
-      parentDir: dir,
+      parentDir: permissionDir,
     },
   })
   return full

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -12,6 +12,7 @@ type Kind = "file" | "directory"
 type Options = {
   bypass?: boolean
   kind?: Kind
+  permissionPath?: string
 }
 
 type PermissionPathFs = {
@@ -159,10 +160,24 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
       : process.platform === "win32"
       ? path.win32.dirname(resolved)
       : path.dirname(resolved)
+  const permissionFull = options?.permissionPath
+    ? process.platform === "win32"
+      ? windowsPermissionPath(options.permissionPath, ins.directory)
+      : path.isAbsolute(options.permissionPath)
+      ? options.permissionPath
+      : `${ins.directory.replace(/\/+$/, "")}/${options.permissionPath}`
+    : undefined
+  const permissionDir = permissionFull
+    ? kind === "directory"
+      ? permissionFull
+      : process.platform === "win32"
+      ? path.win32.dirname(permissionFull)
+      : path.dirname(permissionFull)
+    : dir
   const glob =
     process.platform === "win32"
-      ? AppFileSystem.normalizePathPattern(path.win32.join(dir, "*"), { base: ins.directory })
-      : path.join(dir, "*").replaceAll("\\", "/")
+      ? AppFileSystem.normalizePathPattern(path.win32.join(permissionDir, "*"), { base: ins.directory })
+      : path.join(permissionDir, "*").replaceAll("\\", "/")
 
   yield* ctx.ask({
     permission: "external_directory",

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -52,17 +52,16 @@ export const GrepTool = Tool.define(
           })
 
           const ins = yield* InstanceState.context
-          let search = AppFileSystem.resolve(
-            path.isAbsolute(params.path ?? ins.directory)
-              ? (params.path ?? ins.directory)
-              : path.join(ins.directory, params.path ?? "."),
-            { base: ins.directory },
-          )
+          const requested = path.isAbsolute(params.path ?? ins.directory)
+            ? (params.path ?? ins.directory)
+            : path.join(ins.directory, params.path ?? ".")
+          const search = AppFileSystem.resolve(requested, { base: ins.directory })
+          const requestedInfo = yield* fs.stat(requested).pipe(Effect.catch(() => Effect.succeed(undefined)))
           const info = yield* fs.stat(search).pipe(Effect.catch(() => Effect.succeed(undefined)))
-          search =
-            (yield* assertExternalDirectoryEffect(ctx, search, {
-              kind: info?.type === "Directory" ? "directory" : "file",
-            })) ?? search
+          yield* assertExternalDirectoryEffect(ctx, requested, {
+            kind: requestedInfo?.type === "Directory" ? "directory" : "file",
+            permissionPath: requested,
+          })
           const cwd = info?.type === "Directory" ? search : path.dirname(search)
           const file = info?.type === "Directory" ? undefined : [path.relative(cwd, search)]
 

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -60,7 +60,7 @@ export const GrepTool = Tool.define(
           const info = yield* fs.stat(search).pipe(Effect.catch(() => Effect.succeed(undefined)))
           yield* assertExternalDirectoryEffect(ctx, requested, {
             kind: requestedInfo?.type === "Directory" ? "directory" : "file",
-            permissionPath: requested,
+            checkRequestedPath: true,
           })
           const cwd = info?.type === "Directory" ? search : path.dirname(search)
           const file = info?.type === "Directory" ? undefined : [path.relative(cwd, search)]

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import fs from "node:fs/promises"
 import { Effect, Layer, ManagedRuntime, Stream } from "effect"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import { GrepTool } from "../../src/tool/grep"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import { SessionID, MessageID } from "../../src/session/schema"
+import { Permission } from "../../src/permission"
+import type * as Tool from "../../src/tool/tool"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { Truncate } from "../../src/tool/truncate"
 import { Agent } from "../../src/agent/agent"
@@ -218,6 +221,60 @@ describe("tool.grep", () => {
       })
     })
   })
+
+  if (process.platform !== "win32") {
+    test("uses the requested alias path for external_directory permission", async () => {
+      await using outside = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "match.txt"), "needle\n")
+        },
+      })
+      await using project = await tmpdir({ git: true })
+
+      const alias = path.join(project.path, "alias")
+      await fs.symlink(outside.path, alias, "dir")
+
+      await Instance.provide({
+        directory: project.path,
+        fn: async () => {
+          const grep = await initGrep()
+          const ruleset = Permission.fromConfig({
+            grep: "allow",
+            external_directory: {
+              [path.join(alias, "*")]: "allow",
+            },
+          })
+          const asks: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+          const checkedCtx: Tool.Context = {
+            ...ctx,
+            ask: (request) =>
+              Effect.sync(() => {
+                asks.push(request)
+                const denied = request.patterns.find(
+                  (pattern) => Permission.evaluate(request.permission, pattern, ruleset).action !== "allow",
+                )
+                if (denied) throw new Error(`unexpected permission ask: ${request.permission} ${denied}`)
+              }),
+          }
+
+          const result = await Effect.runPromise(
+            grep.execute(
+              {
+                pattern: "needle",
+                path: alias,
+                include: "*.txt",
+              },
+              checkedCtx,
+            ),
+          )
+
+          expect(result.metadata.matches).toBe(1)
+          expect(result.output).toContain(path.join(outside.path, "match.txt"))
+          expect(asks.find((request) => request.permission === "external_directory")).toBeDefined()
+        },
+      })
+    })
+  }
 })
 
 describe("CRLF regex handling", () => {

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -270,7 +270,9 @@ describe("tool.grep", () => {
 
           expect(result.metadata.matches).toBe(1)
           expect(result.output).toContain(path.join(outside.path, "match.txt"))
-          expect(asks.find((request) => request.permission === "external_directory")).toBeDefined()
+          const externalDirectoryAsk = asks.find((request) => request.permission === "external_directory")
+          expect(externalDirectoryAsk).toBeDefined()
+          expect(externalDirectoryAsk!.metadata.parentDir).toBe(alias)
         },
       })
     })


### PR DESCRIPTION
## Summary

Fix grep external-directory permission evaluation so an allowed requested alias or symlink path is honored while grep still searches the resolved real path.

## Why

A grep path can be a user-approved alias that resolves outside the project. Before this change, grep resolved the path before asking for `external_directory`, so permission rules written for the requested alias could still prompt or deny based on the real path.

## Related Issue

Ports the behavior from upstream anomalyco/opencode#26958. There is no local PawWork issue for this narrow upstream-value PR.

## Human Review Status

Pending

## Review Focus

Please check the permission boundary: only grep opts into requested-path permission patterns, while the default shared helper behavior for shell/read/write remains realpath-based.

## Risk Notes

Permissions/path behavior changed for grep. No visible UI changed, so the UI check is not applicable. No docs, release notes, dependencies, credentials, deletion behavior, generated content, or local file changes are included. I considered macOS and Windows path impact; the regression test covers POSIX symlink behavior and the implementation uses the existing Windows path normalizer for the new optional permission path.

## How To Verify

```text
RED: bun test test/tool/grep.test.ts failed on the new alias-path permission regression because grep requested external_directory for the real path.
Focused grep tests: bun test test/tool/grep.test.ts -> 10 pass, 0 fail.
Shell symlink guard: bun test test/tool/shell.test.ts --test-name-pattern "asks for real external_directory when bash reads through tmp symlink" -> 1 pass, 53 filtered out, 0 fail.
Typecheck: bun run typecheck in packages/opencode -> passed.
External-directory helper tests: bun test test/tool/external-directory.test.ts -> 14 pass, 0 fail.
Review follow-up guard: bun test test/tool/shell.test.ts --test-name-pattern "asks for real external_directory when bash reads through tmp symlink" -> 1 pass, 53 filtered out, 0 fail.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.