### PR TITLE
fix(mcp): respect catalog capabilities and aborts

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -124,12 +124,45 @@ export namespace MCP {
   type PromptInfo = Awaited<ReturnType<MCPClient["listPrompts"]>>["prompts"][number]
   type ResourceInfo = Awaited<ReturnType<MCPClient["listResources"]>>["resources"][number]
   type McpEntry = NonNullable<Config.Info["mcp"]>[string]
+  const MAX_LIST_PAGES = 1_000
 
   function isMcpConfigured(entry: McpEntry): entry is Config.Mcp {
     return typeof entry === "object" && entry !== null && "type" in entry
   }
 
   const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "_")
+
+  function getCapabilities(client: MCPClient) {
+    return (
+      client as {
+        getServerCapabilities?: () => { tools?: unknown; prompts?: unknown; resources?: unknown } | undefined
+      }
+    ).getServerCapabilities?.()
+  }
+
+  function hasCapability(client: MCPClient, key: "tools" | "prompts" | "resources") {
+    return getCapabilities(client)?.[key] !== undefined
+  }
+
+  async function paginate<T, R extends { nextCursor?: string }>(
+    list: (cursor?: string) => Promise<R>,
+    items: (result: R) => T[],
+  ) {
+    const result: T[] = []
+    const cursors = new Set<string>()
+    let cursor: string | undefined
+
+    for (let pageCount = 0; pageCount < MAX_LIST_PAGES; pageCount++) {
+      const page = await list(cursor)
+      result.push(...items(page))
+      if (page.nextCursor === undefined) return result
+      if (cursors.has(page.nextCursor)) throw new Error(`MCP list returned duplicate cursor: ${page.nextCursor}`)
+      cursors.add(page.nextCursor)
+      cursor = page.nextCursor
+    }
+
+    throw new Error(`MCP list exceeded ${MAX_LIST_PAGES} pages`)
+  }
 
   function remoteURL(key: string, value: string) {
     if (URL.canParse(value)) return new URL(value)
@@ -151,7 +184,7 @@ export namespace MCP {
     return dynamicTool({
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
-      execute: async (args: unknown) => {
+      execute: async (args: unknown, options) => {
         return client.callTool(
           {
             name: mcpTool.name,
@@ -160,6 +193,7 @@ export namespace MCP {
           CallToolResultSchema,
           {
             resetTimeoutOnProgress: true,
+            signal: options?.abortSignal,
             timeout,
           },
         )
@@ -187,31 +221,37 @@ export namespace MCP {
 
   function listTools(key: string, client: MCPClient, timeout: number) {
     return Effect.tryPromise({
-      try: () => withTimeout(client.listTools(), timeout),
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-    }).pipe(
-      Effect.map((result) => result.tools),
-      Effect.catch((error) => {
-        if (!isOutputSchemaValidationError(error)) return Effect.fail(error)
+      try: () =>
+        paginate(
+          async (cursor) => {
+            const params = cursor === undefined ? undefined : { cursor }
+            try {
+              return await withTimeout(client.listTools(params), timeout)
+            } catch (error) {
+              if (!(error instanceof Error) || !isOutputSchemaValidationError(error)) throw error
 
-        log.warn("failed to validate MCP tool output schemas, retrying without output schema validation", {
-          key,
-          error,
-        })
-        return Effect.tryPromise({
-          try: () => withTimeout(client.request({ method: "tools/list" }, TolerantListToolsResultSchema), timeout),
-          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-        }).pipe(
-          Effect.map((result) =>
-            result.tools.map((tool) => ({
-              name: tool.name,
-              description: tool.description,
-              inputSchema: tool.inputSchema,
-            })),
-          ),
-        )
-      }),
-    )
+              log.warn("failed to validate MCP tool output schemas, retrying without output schema validation", {
+                key,
+                error,
+              })
+              const result = await withTimeout(
+                client.request({ method: "tools/list", params }, TolerantListToolsResultSchema),
+                timeout,
+              )
+              return {
+                ...result,
+                tools: result.tools.map((tool) => ({
+                  name: tool.name,
+                  description: tool.description,
+                  inputSchema: tool.inputSchema,
+                })),
+              }
+            }
+          },
+          (result) => result.tools,
+        ),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    })
   }
 
   function defs(key: string, client: MCPClient, timeout?: number) {
@@ -476,7 +516,7 @@ export namespace MCP {
           return { status } satisfies CreateResult
         }
 
-        const listed = yield* defs(key, mcpClient, mcp.timeout)
+        const listed = hasCapability(mcpClient, "tools") ? yield* defs(key, mcpClient, mcp.timeout) : []
         if (!listed) {
           yield* Effect.tryPromise(() => mcpClient.close()).pipe(Effect.ignore)
           return { status: { status: "failed", error: "Failed to get tools" } } satisfies CreateResult
@@ -514,6 +554,8 @@ export namespace MCP {
       )
 
       function watch(s: State, name: string, client: MCPClient, bridge: EffectBridgeShape, timeout?: number) {
+        if (!hasCapability(client, "tools")) return
+
         client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
           log.info("tools list changed notification received", { server: name })
           if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
@@ -717,12 +759,32 @@ export namespace MCP {
 
       const prompts = Effect.fn("MCP.prompts")(function* () {
         const s = yield* InstanceState.get(state)
-        return yield* collectFromConnected(s, (c) => c.listPrompts().then((r) => r.prompts), "prompts")
+        return yield* collectFromConnected(
+          s,
+          (client) =>
+            hasCapability(client, "prompts")
+              ? paginate(
+                  (cursor) => client.listPrompts(cursor === undefined ? undefined : { cursor }),
+                  (result) => result.prompts,
+                )
+              : Promise.resolve([]),
+          "prompts",
+        )
       })
 
       const resources = Effect.fn("MCP.resources")(function* () {
         const s = yield* InstanceState.get(state)
-        return yield* collectFromConnected(s, (c) => c.listResources().then((r) => r.resources), "resources")
+        return yield* collectFromConnected(
+          s,
+          (client) =>
+            hasCapability(client, "resources")
+              ? paginate(
+                  (cursor) => client.listResources(cursor === undefined ? undefined : { cursor }),
+                  (result) => result.resources,
+                )
+              : Promise.resolve([]),
+          "resources",
+        )
       })
 
       const withClient = Effect.fnUntraced(function* <A>(
@@ -845,7 +907,11 @@ export namespace MCP {
             return { status: "failed", error: "MCP config not found after auth" } as Status
           }
 
-          const listed = client ? yield* defs(mcpName, client, mcpConfig.timeout) : undefined
+          const listed = client
+            ? hasCapability(client, "tools")
+              ? yield* defs(mcpName, client, mcpConfig.timeout)
+              : []
+            : undefined
           if (!client || !listed) {
             yield* Effect.tryPromise(() => client?.close() ?? Promise.resolve()).pipe(Effect.ignore)
             return { status: "failed", error: "Failed to get tools" } as Status

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -135,16 +135,19 @@ export namespace MCP {
   function getCapabilities(client: MCPClient) {
     return (
       client as {
-        getServerCapabilities?: () => { tools?: unknown; prompts?: unknown; resources?: unknown } | undefined
+        getServerCapabilities?: () =>
+          | { tools?: unknown | null; prompts?: unknown | null; resources?: unknown | null }
+          | null
+          | undefined
       }
     ).getServerCapabilities?.()
   }
 
   function hasCapability(client: MCPClient, key: "tools" | "prompts" | "resources") {
-    return getCapabilities(client)?.[key] !== undefined
+    return getCapabilities(client)?.[key] != null
   }
 
-  async function paginate<T, R extends { nextCursor?: string }>(
+  async function paginate<T, R extends { nextCursor?: string | null }>(
     list: (cursor?: string) => Promise<R>,
     items: (result: R) => T[],
   ) {
@@ -155,7 +158,7 @@ export namespace MCP {
     for (let pageCount = 0; pageCount < MAX_LIST_PAGES; pageCount++) {
       const page = await list(cursor)
       result.push(...items(page))
-      if (page.nextCursor === undefined) return result
+      if (page.nextCursor == null) return result
       if (cursors.has(page.nextCursor)) throw new Error(`MCP list returned duplicate cursor: ${page.nextCursor}`)
       cursors.add(page.nextCursor)
       cursor = page.nextCursor

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -4,8 +4,11 @@ import { test, expect, mock, beforeEach } from "bun:test"
 
 // Per-client state for controlling mock behavior
 interface MockClientState {
+  capabilities: { tools?: object; prompts?: object; resources?: object }
   tools: Array<{ name: string; description?: string; inputSchema: object; outputSchema?: object }>
   listToolsCalls: number
+  listPromptsCalls: number
+  listResourcesCalls: number
   requestCalls: number
   listToolsShouldFail: boolean
   listToolsError: string
@@ -13,6 +16,19 @@ interface MockClientState {
   listResourcesShouldFail: boolean
   prompts: Array<{ name: string; description?: string }>
   resources: Array<{ name: string; uri: string; description?: string }>
+  toolPages: Record<
+    string,
+    {
+      tools: Array<{ name: string; description?: string; inputSchema: object; outputSchema?: object }>
+      nextCursor?: string
+    }
+  >
+  promptPages: Record<string, { prompts: Array<{ name: string; description?: string }>; nextCursor?: string }>
+  resourcePages: Record<
+    string,
+    { resources: Array<{ name: string; uri: string; description?: string }>; nextCursor?: string }
+  >
+  callToolSignals: Array<AbortSignal | undefined>
   closed: boolean
   notificationHandlers: Map<unknown, (...args: any[]) => any>
 }
@@ -32,8 +48,11 @@ function getOrCreateClientState(name?: string): MockClientState {
   let state = clientStates.get(key)
   if (!state) {
     state = {
+      capabilities: { tools: {}, prompts: {}, resources: {} },
       tools: [{ name: "test_tool", description: "A test tool", inputSchema: { type: "object", properties: {} } }],
       listToolsCalls: 0,
+      listPromptsCalls: 0,
+      listResourcesCalls: 0,
       requestCalls: 0,
       listToolsShouldFail: false,
       listToolsError: "listTools failed",
@@ -41,6 +60,10 @@ function getOrCreateClientState(name?: string): MockClientState {
       listResourcesShouldFail: false,
       prompts: [],
       resources: [],
+      toolPages: {},
+      promptPages: {},
+      resourcePages: {},
+      callToolSignals: [],
       closed: false,
       notificationHandlers: new Map(),
     }
@@ -127,32 +150,58 @@ mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       this._state?.notificationHandlers.set(schema, handler)
     }
 
-    async listTools() {
+    getServerCapabilities() {
+      return this._state?.capabilities
+    }
+
+    async listTools(params?: { cursor?: string }) {
       if (this._state) this._state.listToolsCalls++
       if (this._state?.listToolsShouldFail) {
         throw new Error(this._state.listToolsError)
       }
+      const page = this._state?.toolPages[params === undefined ? "initial" : (params.cursor ?? "")]
+      if (page) return page
       return { tools: this._state?.tools ?? [] }
     }
 
-    async request(request: { method: string }, schema: { parse: (value: unknown) => unknown }) {
+    async request(
+      request: { method: string; params?: { cursor?: string } },
+      schema: { parse: (value: unknown) => unknown },
+    ) {
       if (this._state) this._state.requestCalls++
-      if (request.method === "tools/list") return schema.parse({ tools: this._state?.tools ?? [] })
+      if (request.method === "tools/list") {
+        return schema.parse(
+          this._state?.toolPages[request.params === undefined ? "initial" : (request.params.cursor ?? "")] ?? {
+            tools: this._state?.tools ?? [],
+          },
+        )
+      }
       throw new Error(`unsupported request: ${request.method}`)
     }
 
-    async listPrompts() {
+    async listPrompts(params?: { cursor?: string }) {
+      if (this._state) this._state.listPromptsCalls++
       if (this._state?.listPromptsShouldFail) {
         throw new Error("listPrompts failed")
       }
+      const page = this._state?.promptPages[params === undefined ? "initial" : (params.cursor ?? "")]
+      if (page) return page
       return { prompts: this._state?.prompts ?? [] }
     }
 
-    async listResources() {
+    async listResources(params?: { cursor?: string }) {
+      if (this._state) this._state.listResourcesCalls++
       if (this._state?.listResourcesShouldFail) {
         throw new Error("listResources failed")
       }
+      const page = this._state?.resourcePages[params === undefined ? "initial" : (params.cursor ?? "")]
+      if (page) return page
       return { resources: this._state?.resources ?? [] }
+    }
+
+    async callTool(_args: unknown, _schema: unknown, options?: { signal?: AbortSignal }) {
+      this._state?.callToolSignals.push(options?.signal)
+      return { content: [] }
     }
 
     async close() {
@@ -264,6 +313,115 @@ test(
     expect(Object.keys(after).some((key) => key.includes("next_tool"))).toBe(true)
     expect(Object.keys(after).some((key) => key.includes("test_tool"))).toBe(false)
     expect(serverState.listToolsCalls).toBe(2)
+  }),
+)
+
+test(
+  "capabilities prevent unsupported catalog calls",
+  withInstance({}, async () => {
+    lastCreatedClientName = "resource-only-server"
+    const serverState = getOrCreateClientState("resource-only-server")
+    serverState.capabilities = { resources: {} }
+    serverState.resources = [{ name: "docs", uri: "docs://readme" }]
+
+    const addResult = await MCP.add("resource-only-server", {
+      type: "local",
+      command: ["echo", "test"],
+    })
+
+    expect((addResult.status as any)["resource-only-server"]?.status ?? (addResult.status as any).status).toBe(
+      "connected",
+    )
+    expect(serverState.listToolsCalls).toBe(0)
+    expect(serverState.notificationHandlers.size).toBe(0)
+    expect(await MCP.tools()).toEqual({})
+    expect(Object.keys(await MCP.resources())).toEqual(["resource-only-server:docs"])
+    expect(serverState.listResourcesCalls).toBe(1)
+    expect(serverState.listPromptsCalls).toBe(0)
+
+    lastCreatedClientName = "tools-only-server"
+    const toolsOnlyState = getOrCreateClientState("tools-only-server")
+    toolsOnlyState.capabilities = { tools: {} }
+
+    await MCP.add("tools-only-server", {
+      type: "local",
+      command: ["echo", "test"],
+    })
+
+    expect(Object.keys(await MCP.tools())).toEqual(["tools-only-server_test_tool"])
+    expect(await MCP.prompts()).toEqual({})
+    expect(toolsOnlyState.listPromptsCalls).toBe(0)
+    expect(toolsOnlyState.listResourcesCalls).toBe(0)
+  }),
+)
+
+test(
+  "catalog listing follows cursors and stops duplicate cursors",
+  withInstance({}, async () => {
+    lastCreatedClientName = "paged-server"
+    const pagedState = getOrCreateClientState("paged-server")
+    pagedState.toolPages = {
+      initial: { tools: [{ name: "tool-one", inputSchema: { type: "object", properties: {} } }], nextCursor: "t2" },
+      t2: { tools: [{ name: "tool-two", inputSchema: { type: "object", properties: {} } }] },
+    }
+    pagedState.promptPages = {
+      initial: { prompts: [{ name: "prompt-one" }], nextCursor: "p2" },
+      p2: { prompts: [{ name: "prompt-two" }] },
+    }
+    pagedState.resourcePages = {
+      initial: { resources: [{ name: "resource-one", uri: "test://one" }], nextCursor: "" },
+      "": { resources: [{ name: "resource-two", uri: "test://two" }] },
+    }
+
+    await MCP.add("paged-server", {
+      type: "local",
+      command: ["echo", "test"],
+    })
+
+    expect(Object.keys(await MCP.tools())).toEqual(["paged-server_tool-one", "paged-server_tool-two"])
+    expect(Object.keys(await MCP.prompts())).toEqual(["paged-server:prompt-one", "paged-server:prompt-two"])
+    expect(Object.keys(await MCP.resources())).toEqual(["paged-server:resource-one", "paged-server:resource-two"])
+    expect(pagedState.listToolsCalls).toBe(2)
+    expect(pagedState.listPromptsCalls).toBe(2)
+    expect(pagedState.listResourcesCalls).toBe(2)
+
+    lastCreatedClientName = "looping-server"
+    const loopingState = getOrCreateClientState("looping-server")
+    loopingState.toolPages = {
+      initial: { tools: [], nextCursor: "repeat" },
+      repeat: { tools: [], nextCursor: "repeat" },
+    }
+
+    const addResult = await MCP.add("looping-server", {
+      type: "local",
+      command: ["echo", "test"],
+    })
+
+    expect((addResult.status as any)["looping-server"]?.status ?? (addResult.status as any).status).toBe("failed")
+    expect(loopingState.listToolsCalls).toBe(2)
+  }),
+)
+
+test(
+  "tool execution forwards abort signals to MCP callTool",
+  withInstance({}, async () => {
+    lastCreatedClientName = "abort-server"
+    const serverState = getOrCreateClientState("abort-server")
+
+    await MCP.add("abort-server", {
+      type: "local",
+      command: ["echo", "test"],
+    })
+
+    const tools = await MCP.tools()
+    const tool = tools["abort-server_test_tool"] as unknown as {
+      execute: (args: unknown, options: { abortSignal: AbortSignal }) => any
+    }
+    const controller = new AbortController()
+
+    await tool.execute({}, { abortSignal: controller.signal })
+
+    expect(serverState.callToolSignals).toEqual([controller.signal])
   }),
 )
 

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -4,7 +4,7 @@ import { test, expect, mock, beforeEach } from "bun:test"
 
 // Per-client state for controlling mock behavior
 interface MockClientState {
-  capabilities: { tools?: object; prompts?: object; resources?: object }
+  capabilities: { tools?: object | null; prompts?: object | null; resources?: object | null }
   tools: Array<{ name: string; description?: string; inputSchema: object; outputSchema?: object }>
   listToolsCalls: number
   listPromptsCalls: number
@@ -20,13 +20,13 @@ interface MockClientState {
     string,
     {
       tools: Array<{ name: string; description?: string; inputSchema: object; outputSchema?: object }>
-      nextCursor?: string
+      nextCursor?: string | null
     }
   >
-  promptPages: Record<string, { prompts: Array<{ name: string; description?: string }>; nextCursor?: string }>
+  promptPages: Record<string, { prompts: Array<{ name: string; description?: string }>; nextCursor?: string | null }>
   resourcePages: Record<
     string,
-    { resources: Array<{ name: string; uri: string; description?: string }>; nextCursor?: string }
+    { resources: Array<{ name: string; uri: string; description?: string }>; nextCursor?: string | null }
   >
   callToolSignals: Array<AbortSignal | undefined>
   closed: boolean
@@ -352,6 +352,19 @@ test(
     expect(await MCP.prompts()).toEqual({})
     expect(toolsOnlyState.listPromptsCalls).toBe(0)
     expect(toolsOnlyState.listResourcesCalls).toBe(0)
+
+    lastCreatedClientName = "null-tools-server"
+    const nullToolsState = getOrCreateClientState("null-tools-server")
+    nullToolsState.capabilities = { tools: null, resources: {} }
+    nullToolsState.resources = [{ name: "null-docs", uri: "docs://null" }]
+
+    await MCP.add("null-tools-server", {
+      type: "local",
+      command: ["echo", "test"],
+    })
+
+    expect(nullToolsState.listToolsCalls).toBe(0)
+    expect(Object.keys(await MCP.resources())).toContain("null-tools-server:null-docs")
   }),
 )
 
@@ -370,7 +383,7 @@ test(
     }
     pagedState.resourcePages = {
       initial: { resources: [{ name: "resource-one", uri: "test://one" }], nextCursor: "" },
-      "": { resources: [{ name: "resource-two", uri: "test://two" }] },
+      "": { resources: [{ name: "resource-two", uri: "test://two" }], nextCursor: null },
     }
 
     await MCP.add("paged-server", {

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -21,6 +21,7 @@ let simulateAuthFlow = true
 // When true, the mock transport connects without a 401 — simulating stored
 // tokens still being valid so OAuth completes with no browser redirect.
 let connectSucceedsImmediately = false
+let serverCapabilities: { tools?: object; resources?: object } = { tools: {} }
 
 // Mock the transport constructors to simulate OAuth auto-auth on 401
 mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
@@ -91,6 +92,10 @@ mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
 
     setNotificationHandler() {}
 
+    getServerCapabilities() {
+      return serverCapabilities
+    }
+
     async listTools() {
       return { tools: [{ name: "test_tool", inputSchema: { type: "object", properties: {} } }] }
     }
@@ -108,6 +113,7 @@ beforeEach(() => {
   transportCalls.length = 0
   simulateAuthFlow = true
   connectSucceedsImmediately = false
+  serverCapabilities = { tools: {} }
 })
 
 // Import modules after mocking


### PR DESCRIPTION
## Summary

Teach MCP catalog handling to respect advertised server capabilities, follow paginated tool, prompt, and resource catalogs, and forward tool execution abort signals into `client.callTool`.

No PawWork issue is linked; this is upstream-value Line A1 for anomalyco/opencode #31271, #31442, and #31455.

## Why

Some MCP servers expose only prompts or resources, but PawWork still tried to list tools and install tool-change handlers. Catalog listing also stopped after the first page, and canceled tool executions did not pass the parent abort signal to MCP.

## Related Issue

No PawWork issue. Upstream references: https://github.com/anomalyco/opencode/pull/31271, https://github.com/anomalyco/opencode/pull/31442, https://github.com/anomalyco/opencode/pull/31455.

## Human Review Status

Pending

## Review Focus

Please focus on the MCP capability checks around connect/auth flows, pagination cursor handling, and whether the tolerant `tools/list` fallback still strips unsupported output schemas without losing pagination.

## Risk Notes

Skipped conditional checklist items:

- Visible UI check: no visible UI or copy changed.
- Platform check: no platform, packaging, updater, signing, path, shell, or permission surface changed.
- Docs/deps/release/local-file check: no docs, release notes, dependencies, credentials, generated content, or local file behavior changed.

## How To Verify

```text
Regression RED: new lifecycle tests failed before implementation for capabilities, pagination, and abort signal propagation.
MCP tests: bun test test/mcp --timeout 30000 -> 44 passed.
Focused lifecycle retest: bun test test/mcp/lifecycle.test.ts --timeout 30000 -> 25 passed.
Typecheck: bun run typecheck in packages/opencode -> passed.
Diff check: git diff --check -> no whitespace errors.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
