### PR TITLE
fix(ui): preserve server-ranked file picker results

### DIFF
--- a/packages/app/src/components/command-palette/command-palette-dialog.tsx
+++ b/packages/app/src/components/command-palette/command-palette-dialog.tsx
@@ -198,6 +198,7 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
         items={items}
         key={(item) => item.id}
         filterKeys={["title", "description", "category"]}
+        skipFilter={(item) => item.type === "file"}
         sortBy={(a, b) => {
           if (!filesOnly() && !grouped()) return 0
           if (a.type !== "session" || b.type !== "session") return 0

--- a/packages/app/src/components/prompt-input/popover-controllers.ts
+++ b/packages/app/src/components/prompt-input/popover-controllers.ts
@@ -97,6 +97,7 @@ export function createPopoverControllers(deps: PopoverControllersDeps): PopoverC
     },
     key: atKey,
     filterKeys: ["display"],
+    skipFilter: (item) => !item.recent,
     groupBy: (item) => (item.recent ? "recent" : "file"),
     sortGroupsBy: (a, b) => (a.category === "recent" ? -1 : b.category === "recent" ? 1 : 0),
     onSelect: handleAtSelect,

--- a/packages/ui/src/components/line-comment.tsx
+++ b/packages/ui/src/components/line-comment.tsx
@@ -240,6 +240,7 @@ export const LineCommentEditor = (props: LineCommentEditorProps) => {
     },
     key: (item) => item.path,
     filterKeys: ["path"],
+    skipFilter: () => true,
     onSelect: selectMention,
   })
 

--- a/packages/ui/src/hooks/filter-list-items.ts
+++ b/packages/ui/src/hooks/filter-list-items.ts
@@ -1,0 +1,19 @@
+import fuzzysort from "fuzzysort"
+
+export function filterListItems<T>(
+  items: T[],
+  needle: string,
+  filterKeys?: string[],
+  skipFilter?: (item: T) => boolean,
+) {
+  if (!needle) return items
+
+  const filterable = skipFilter ? items.filter((item) => !skipFilter(item)) : items
+  const skipped = skipFilter ? items.filter(skipFilter) : []
+  const filtered =
+    !filterKeys && Array.isArray(filterable) && filterable.every((item) => typeof item === "string")
+      ? (fuzzysort.go(needle, filterable).map((item) => item.target) as T[])
+      : fuzzysort.go(needle, filterable, { keys: filterKeys! }).map((item) => item.obj)
+
+  return skipped.length ? [...filtered, ...skipped] : filtered
+}

--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -1,8 +1,8 @@
-import fuzzysort from "fuzzysort"
 import { entries, flatMap, groupBy, map, pipe } from "remeda"
 import { createEffect, createMemo, createResource, on } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createList } from "solid-list"
+import { filterListItems } from "./filter-list-items"
 
 export interface FilteredListProps<T> {
   items: T[] | ((filter: string) => T[] | Promise<T[]>)
@@ -12,6 +12,7 @@ export interface FilteredListProps<T> {
   groupBy?: (x: T) => string
   sortBy?: (a: T, b: T) => number
   sortGroupsBy?: (a: { category: string; items: T[] }, b: { category: string; items: T[] }) => number
+  skipFilter?: (item: T) => boolean
   onSelect?: (value: T | undefined, index: number) => void
   noInitialSelection?: boolean
 }
@@ -34,11 +35,7 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
       const result = pipe(
         all,
         (x) => {
-          if (!needle) return x
-          if (!props.filterKeys && Array.isArray(x) && x.every((e) => typeof e === "string")) {
-            return fuzzysort.go(needle, x).map((x) => x.target) as T[]
-          }
-          return fuzzysort.go(needle, x, { keys: props.filterKeys! }).map((x) => x.obj)
+          return filterListItems(x, needle, props.filterKeys, props.skipFilter)
         },
         groupBy((x) => (props.groupBy ? props.groupBy(x) : "")),
         entries(),

--- a/packages/ui/test/use-filtered-list.test.ts
+++ b/packages/ui/test/use-filtered-list.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { filterListItems } from "../src/hooks/filter-list-items"
+
+describe("useFilteredList", () => {
+  test("keeps skipped async results while filtering ordinary items", () => {
+    type Item = { id: string; title: string; serverRanked?: boolean }
+    const result = filterListItems<Item>(
+      [
+        { id: "command", title: "Open Settings" },
+        { id: "file", title: "src/file-without-local-match.ts", serverRanked: true },
+      ],
+      "unlikely-query",
+      ["title"],
+      (item) => item.serverRanked === true,
+    )
+
+    expect(result.map((item) => item.id)).toEqual(["file"])
+  })
+})

--- a/packages/ui/test/use-filtered-list.test.ts
+++ b/packages/ui/test/use-filtered-list.test.ts
@@ -16,4 +16,19 @@ describe("useFilteredList", () => {
 
     expect(result.map((item) => item.id)).toEqual(["file"])
   })
+
+  test("appends skipped results after ordinary fuzzy matches", () => {
+    type Item = { id: string; title: string; serverRanked?: boolean }
+    const result = filterListItems<Item>(
+      [
+        { id: "command", title: "Open Settings" },
+        { id: "file", title: "src/file-without-local-match.ts", serverRanked: true },
+      ],
+      "Open",
+      ["title"],
+      (item) => item.serverRanked === true,
+    )
+
+    expect(result.map((item) => item.id)).toEqual(["command", "file"])
+  })
 })


### PR DESCRIPTION
## Summary

Preserve server-ranked file search results in PawWork pickers by allowing file rows to opt out of the local fuzzy refilter step.

This PR ports the UI hunk from upstream anomalyco/opencode#31366 only. It adds a narrow `skipFilter` path to the shared filtered-list hook and enables it for command palette file rows, prompt `@` server results, and line-comment mentions.

## Why

File search results are already ranked by the server-side search path. The UI then ran `fuzzysort` again with the same user query, which could hide valid server-returned files when their display text did not locally fuzzymatch the query.

## Related Issue

Upstream anomalyco/opencode#31366. No PawWork issue exists for this small upstream-value port.

## Human Review Status

Pending

## Review Focus

Please check that `skipFilter` is only enabled for server-ranked file results, while ordinary command/session/local list filtering still uses the existing fuzzy behavior.

## Risk Notes

Low UI behavior risk. File picker rows can remain visible even when the local display text does not fuzzymatch, but ordinary local results still filter. No platform, packaging, permissions, docs, dependencies, generated files, or persistence surfaces were changed.

## How To Verify

```text
RED: bun test --conditions browser test/use-filtered-list.test.ts from packages/ui failed because skipped file results were filtered out before the implementation.
Focused test: bun run --cwd packages/ui test test/use-filtered-list.test.ts -> 2 passed, including the CodeRabbit follow-up order case.
UI typecheck: bun run --cwd packages/ui typecheck -> pass.
App typecheck: bun run --cwd packages/app typecheck -> pass.
Whitespace: git diff --check -> pass.
Fresh-eye review: no actionable P0-P3 findings.
Visible picker check: bun run --cwd packages/app snap command-palette-header -> 1 passed; generated docs/design/preview/screenshots/command-palette-header.png and manually inspected light/dark command palette output.
```

## Screenshots or Recordings

Ran the existing command palette snap target and inspected the generated light/dark grid at `docs/design/preview/screenshots/command-palette-header.png`. The picker opens, renders list content, and has no blank or overlapping state; the fixture's bottom server-unreachable toast is unrelated to this filtering change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
