### PR TITLE
fix(tool): avoid duplicating skill catalog

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -127,7 +127,6 @@ export namespace ToolRegistry {
       const config = yield* Config.Service
       const plugin = yield* Plugin.Service
       const agents = yield* Agent.Service
-      const skill = yield* Skill.Service
       const truncate = yield* Truncate.Service
       const settings = yield* Settings.Service
 
@@ -359,26 +358,6 @@ export namespace ToolRegistry {
         return (yield* all()).map((tool) => tool.id)
       })
 
-      const describeSkill = Effect.fn("ToolRegistry.describeSkill")(function* (agent: Agent.Info) {
-        const list = yield* skill.available(agent)
-        const visible = Skill.displayable(list)
-        if (visible.length === 0) return Skill.fmt(visible, { verbose: false })
-        return [
-          "Load a specialized skill that provides domain-specific instructions and workflows.",
-          "",
-          "When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.",
-          "",
-          "The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.",
-          "",
-          'Tool output includes a `<skill_content name="...">` block with the loaded content.',
-          "",
-          "The following skills provide specialized sets of instructions for particular tasks",
-          "Invoke this tool to load a skill when a task matches one of the available skills listed below:",
-          "",
-          Skill.fmt(visible, { verbose: false }),
-        ].join("\n")
-      })
-
       const describeTask = Effect.fn("ToolRegistry.describeTask")(function* (agent: Agent.Info) {
         const items = (yield* agents.list()).filter((item) => item.mode !== "primary")
         const filtered = items.filter(
@@ -431,7 +410,6 @@ export namespace ToolRegistry {
               description: [
                 output.description,
                 tool.id === AgentTool.id ? yield* describeTask(input.agent) : undefined,
-                tool.id === SkillTool.id ? yield* describeSkill(input.agent) : undefined,
                 tool.id === TOOL_INFO_ID ? buildCardList(availableDeferred) : undefined,
               ]
                 .filter(Boolean)

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -29,7 +29,7 @@ afterEach(async () => {
 })
 
 describe("tool.skill", () => {
-  test("description lists skill location URL", async () => {
+  test("description does not duplicate the available skill catalog", async () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
@@ -59,7 +59,9 @@ description: Skill for tool tests.
             modelID: "gpt-5" as any,
             agent: { name: "build", mode: "primary" as const, permission: [], options: {} },
           }).then((tools) => tools.find((tool) => tool.id === SkillTool.id)?.description ?? "")
-          expect(desc).toContain(`**tool-skill**: Skill for tool tests.`)
+          expect(desc).toContain("Load a specialized skill")
+          expect(desc).not.toContain("tool-skill")
+          expect(desc).not.toContain("Skill for tool tests.")
         },
       })
     } finally {
@@ -67,7 +69,7 @@ description: Skill for tool tests.
     }
   })
 
-  test("description sorts skills by name and is stable across calls", async () => {
+  test("description is stable across calls without listing available skills", async () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
@@ -109,14 +111,9 @@ description: ${description}
           const second = await load()
 
           expect(first).toBe(second)
-
-          const alpha = first.indexOf("**alpha-skill**: Alpha skill.")
-          const middle = first.indexOf("**middle-skill**: Middle skill.")
-          const zeta = first.indexOf("**zeta-skill**: Zeta skill.")
-
-          expect(alpha).toBeGreaterThan(-1)
-          expect(middle).toBeGreaterThan(alpha)
-          expect(zeta).toBeGreaterThan(middle)
+          expect(first).not.toContain("alpha-skill")
+          expect(first).not.toContain("middle-skill")
+          expect(first).not.toContain("zeta-skill")
         },
       })
     } finally {
@@ -124,7 +121,7 @@ description: ${description}
     }
   })
 
-  test("description uses empty state when only manual skills are available", async () => {
+  test("description omits manual-only skills without appending an empty catalog", async () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
@@ -163,7 +160,8 @@ name: manual-skill
             agent,
           }).then((tools) => tools.find((tool) => tool.id === SkillTool.id)?.description ?? "")
 
-          expect(desc).toContain("No skills are currently available.")
+          expect(desc).toContain("Load a specialized skill")
+          expect(desc).not.toContain("No skills are currently available.")
           expect(desc).not.toContain("manual-skill")
           expect(desc).not.toContain("The following skills provide specialized sets of instructions")
         },


### PR DESCRIPTION
## Summary

Stop appending the full available skill catalog to the `skill` tool definition.

## Why

The skill catalog is already exposed through the system/discovery path. Duplicating it inside the tool definition makes the prompt heavier and can make skill availability appear in two places that drift in wording or filtering behavior.

## Related Issue

Ports the behavior from upstream anomalyco/opencode#31269. There is no local PawWork issue for this narrow upstream-value PR.

## Human Review Status

Pending

## Review Focus

Please check that the registry only removes the duplicated catalog from the `skill` tool definition and does not change skill execution or the skill tool's base description.

## Risk Notes

Harness/tool-description behavior changed for `skill`. No visible UI changed, so the UI check is not applicable. No docs, release notes, dependencies, credentials, deletion behavior, generated content, or local file changes are included. No platform/packaging surface was touched.

## How To Verify

```text
RED: bun test test/tool/skill.test.ts failed because the skill tool description still contained `tool-skill` from the duplicated catalog.
Focused skill tests: bun test test/tool/skill.test.ts -> 4 pass, 0 fail.
Typecheck: bun run typecheck in packages/opencode -> passed.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.