### PR TITLE
fix(acp): improve tool display metadata

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -423,19 +423,6 @@ export namespace ACP {
                 return
             }
           }
-          if (part.type !== "text" && part.type !== "file") return
-          const msg = await this.sdk.session
-            .message(
-              { sessionID: part.sessionID, messageID: part.messageID, directory: session.cwd },
-              { throwOnError: true },
-            )
-            .then((x) => x.data)
-            .catch((err) => {
-              log.error("failed to fetch message for user chunk", { error: err })
-              return undefined
-            })
-          if (!msg || msg.info.role !== "user") return
-          await this.processMessage({ info: msg.info, parts: [part] })
           return
         }
 
@@ -1064,6 +1051,7 @@ export namespace ACP {
     private async toolStart(sessionId: string, part: ToolPart) {
       if (this.toolStarts.has(part.callID)) return
       this.toolStarts.add(part.callID)
+      const input = part.state.input ?? {}
       await this.connection
         .sessionUpdate({
           sessionId,
@@ -1073,8 +1061,8 @@ export namespace ACP {
             title: part.tool,
             kind: toToolKind(part.tool),
             status: "pending",
-            locations: [],
-            rawInput: {},
+            locations: toLocations(part.tool, input),
+            rawInput: input,
           },
         })
         .catch((error) => {
@@ -1507,8 +1495,14 @@ export namespace ACP {
 
       case "edit":
       case "patch":
+      case "apply_patch":
       case "write":
         return "edit"
+
+      case "agent":
+      case "subagent":
+      case "task":
+        return "think"
 
       case "grep":
       case "glob":
@@ -1537,6 +1531,10 @@ export namespace ACP {
         return input["path"] ? [{ path: input["path"] }] : []
       case "bash":
         return []
+      case "external_directory": {
+        const directories = Array.isArray(input["directories"]) ? input["directories"] : []
+        return directories.flatMap((directory) => (typeof directory === "string" ? [{ path: directory }] : []))
+      }
       case "list":
         return input["path"] ? [{ path: input["path"] }] : []
       default:
@@ -1547,12 +1545,13 @@ export namespace ACP {
   function completedToolContent(part: ToolPart, kind: ToolKind): ToolCallContent[] {
     if (part.state.status !== "completed") return []
 
+    const displayContent = displayToolContent(part)
     const content: ToolCallContent[] = [
       {
         type: "content",
         content: {
           type: "text",
-          text: part.state.output,
+          text: displayContent ?? part.state.output,
         },
       },
     ]
@@ -1567,16 +1566,45 @@ export namespace ACP {
           : typeof input["content"] === "string"
             ? input["content"]
             : ""
-      content.push({
-        type: "diff",
-        path: filePath,
-        oldText,
-        newText,
-      })
+      if (filePath && (oldText || newText)) {
+        content.push({
+          type: "diff",
+          path: filePath,
+          oldText,
+          newText,
+        })
+      }
     }
 
     content.push(...imageContents(part.state.attachments ?? []))
     return content
+  }
+
+  function displayToolContent(part: ToolPart) {
+    if (part.state.status !== "completed") return
+    if (part.tool !== "read") return
+    const display = part.state.metadata?.["display"]
+    if (!display || typeof display !== "object") return
+    const record = display as Record<string, unknown>
+    if (record.type === "file" && typeof record.text === "string") {
+      if (record.truncated !== true) return record.text
+      const lineStart = typeof record.lineStart === "number" ? record.lineStart : undefined
+      const lineEnd = typeof record.lineEnd === "number" ? record.lineEnd : undefined
+      if (lineStart === undefined || lineEnd === undefined) return record.text
+      return [record.text, `(Showing lines ${lineStart}-${lineEnd}. Use offset=${lineEnd + 1} to continue.)`].join("\n\n")
+    }
+    if (record.type === "directory" && Array.isArray(record.entries)) {
+      const entries = record.entries.filter((entry) => typeof entry === "string").join("\n")
+      if (record.truncated !== true) return entries
+      const offset = typeof record.offset === "number" ? record.offset : undefined
+      const totalEntries = typeof record.totalEntries === "number" ? record.totalEntries : undefined
+      const shownEntries = record.entries.length
+      if (offset === undefined || totalEntries === undefined) return entries
+      return [
+        entries,
+        `(Showing ${shownEntries} of ${totalEntries} entries. Use offset=${offset + shownEntries} to continue.)`,
+      ].join("\n\n")
+    }
   }
 
   function completedToolRawOutput(part: ToolPart) {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -35,7 +35,33 @@ export const Parameters = Schema.Struct({
   }),
 })
 
-export const ReadTool = Tool.define(
+type ReadDisplay =
+  | {
+      type: "directory"
+      path: string
+      entries: string[]
+      offset: number
+      totalEntries: number
+      truncated: boolean
+    }
+  | {
+      type: "file"
+      path: string
+      text: string
+      lineStart: number
+      lineEnd: number
+      totalLines: number
+      truncated: boolean
+    }
+
+type ReadMetadata = {
+  preview: string
+  truncated: boolean
+  loaded: string[]
+  display?: ReadDisplay
+}
+
+export const ReadTool = Tool.define<typeof Parameters, ReadMetadata, AppFileSystem.Service | Instruction.Service>(
   "read",
   Effect.gen(function* () {
     const fs = yield* AppFileSystem.Service
@@ -154,7 +180,7 @@ export const ReadTool = Tool.define(
 
     const run = Effect.fn("ReadTool.execute")(function* (
       params: Schema.Schema.Type<typeof Parameters>,
-      ctx: Tool.Context,
+      ctx: Tool.Context<ReadMetadata>,
     ) {
       if (params.offset !== undefined && (!Number.isInteger(params.offset) || params.offset < 0)) {
         return yield* Effect.fail(new Error("offset must be a non-negative integer"))
@@ -221,6 +247,14 @@ export const ReadTool = Tool.define(
             preview: sliced.slice(0, 20).join("\n"),
             truncated,
             loaded: [] as string[],
+            display: {
+              type: "directory" as const,
+              path: filepath,
+              entries: sliced,
+              offset,
+              totalEntries: items.length,
+              truncated,
+            },
           },
         }
       }
@@ -304,6 +338,15 @@ export const ReadTool = Tool.define(
           preview: file.raw.slice(0, 20).join("\n"),
           truncated,
           loaded: loaded.map((item) => item.filepath),
+          display: {
+            type: "file" as const,
+            path: filepath,
+            text: file.raw.join("\n"),
+            lineStart: file.offset,
+            lineEnd: last,
+            totalLines: file.count,
+            truncated,
+          },
         },
       }
     })
@@ -311,7 +354,7 @@ export const ReadTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
-      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context<ReadMetadata>) =>
         run(params, ctx).pipe(Effect.orDie),
     }
   }),

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -277,9 +277,15 @@ const parse = Effect.fn("ShellTool.parse")(function* (command: string, ps: boole
   return tree
 })
 
-const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan) {
+const ask = Effect.fn("ShellTool.ask")(function* (
+  ctx: Tool.Context,
+  scan: Scan,
+  input: { command: string; description: string },
+) {
   if (scan.dirs.size > 0) {
-    const globs = Array.from(scan.dirs).map((dir) => {
+    const directories = Array.from(scan.dirs)
+    const displayDirectories = directories.map((dir) => (process.platform === "win32" ? dir.replaceAll("\\", "/") : dir))
+    const globs = directories.map((dir) => {
       if (process.platform === "win32") return AppFileSystem.normalizePathPattern(path.join(dir, "*"))
       return path.join(dir, "*")
     })
@@ -287,8 +293,13 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan)
       permission: "external_directory",
       patterns: globs,
       always: globs,
-      metadata: {},
-    })
+        metadata: {
+          command: input.command,
+          description: input.description,
+          directories: displayDirectories,
+          patterns: globs,
+        },
+      })
   }
 
   if (scan.patterns.size === 0) return
@@ -296,7 +307,10 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan)
     permission: ShellToolID,
     patterns: Array.from(scan.patterns),
     always: Array.from(scan.always),
-    metadata: {},
+    metadata: {
+      command: input.command,
+      description: input.description,
+    },
   })
 })
 
@@ -697,7 +711,7 @@ export const ShellTool = Tool.define(
                   const scan = yield* collect(tree.rootNode, cwd, ps, shell, instance)
                   const permissionCwd = resolveExternalPathForPermission(permissionCwdTarget, directory)
                   if (!Instance.containsPath(permissionCwd, instance)) scan.dirs.add(permissionCwd)
-                  yield* ask(ctx, scan)
+                  yield* ask(ctx, scan, params)
                 }),
               )
 

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -42,6 +42,12 @@ function isToolCallUpdate(
   return update.sessionUpdate === "tool_call_update"
 }
 
+function isToolCall(
+  update: SessionUpdateParams["update"],
+): update is Extract<SessionUpdateParams["update"], { sessionUpdate: "tool_call" }> {
+  return update.sessionUpdate === "tool_call"
+}
+
 function toolEvent(
   sessionId: string,
   cwd: string,
@@ -144,6 +150,7 @@ function createFakeAgent() {
   const updates = new Map<string, string[]>()
   const chunks = new Map<string, string>()
   const sessionUpdates: SessionUpdateParams[] = []
+  const permissionRequests: RequestPermissionParams[] = []
   const record = (sessionId: string, type: string) => {
     const list = updates.get(sessionId) ?? []
     list.push(type)
@@ -163,7 +170,8 @@ function createFakeAgent() {
         chunks.set(params.sessionId, (chunks.get(params.sessionId) ?? "") + content.text)
       }
     },
-    async requestPermission(_params: RequestPermissionParams): Promise<RequestPermissionResult> {
+    async requestPermission(params: RequestPermissionParams): Promise<RequestPermissionResult> {
+      permissionRequests.push(params)
       return { outcome: { outcome: "selected", optionId: "once" } } as RequestPermissionResult
     },
   } as unknown as AgentSideConnection
@@ -277,7 +285,7 @@ function createFakeAgent() {
     ;(agent as any).eventAbort.abort()
   }
 
-  return { agent, controller, calls, updates, chunks, sessionUpdates, stop, sdk, connection }
+  return { agent, controller, calls, updates, chunks, sessionUpdates, permissionRequests, stop, sdk, connection }
 }
 
 describe("acp.agent event subscription", () => {
@@ -424,6 +432,46 @@ describe("acp.agent event subscription", () => {
 
         expect(permissionReplies).toContain("perm_1")
 
+        stop()
+      },
+    })
+  })
+
+  test("permission.asked external_directory events include input and locations", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, permissionRequests, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const metadata = {
+          command: "cat /var/log/app.log",
+          description: "read external log",
+          directories: ["/var/log"],
+          patterns: ["/var/log/*"],
+        }
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "permission.asked",
+            properties: {
+              id: "perm_external",
+              sessionID: sessionId,
+              permission: "external_directory",
+              patterns: ["/var/log/*"],
+              metadata,
+              always: ["/var/log/*"],
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        const request = permissionRequests.find((item) => item.sessionId === sessionId)
+        expect(request?.toolCall.rawInput).toEqual(metadata)
+        expect(request?.toolCall.locations).toEqual([{ path: "/var/log" }])
         stop()
       },
     })
@@ -699,6 +747,414 @@ describe("acp.agent event subscription", () => {
           .map((u) => inProgressText(u.update))
 
         expect(snapshots).toEqual(["a", "a"])
+        stop()
+      },
+    })
+  })
+
+  test("ignores user message.part.updated text chunks during prompt turn", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop, sdk } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        sdk.session.message = async () => ({
+          data: {
+            info: {
+              id: "msg_user",
+              role: "user",
+              sessionID: sessionId,
+            },
+            parts: [
+              {
+                id: "part_user",
+                type: "text",
+                text: "typed prompt",
+              },
+            ],
+          },
+        })
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              sessionID: sessionId,
+              part: {
+                id: "part_user",
+                sessionID: sessionId,
+                messageID: "msg_user",
+                type: "text",
+                text: "typed prompt",
+              },
+            },
+          },
+        } as any)
+        await new Promise((r) => setTimeout(r, 20))
+
+        const userChunks = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .filter((u) => u.update.sessionUpdate === "user_message_chunk")
+        expect(userChunks).toHaveLength(0)
+        stop()
+      },
+    })
+  })
+
+  test("includes kind, raw input, and locations on synthetic pending tool calls", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const input = { filePath: "/tmp/example.txt" }
+
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_read",
+            tool: "read",
+            status: "running",
+            input,
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 20))
+
+        const pending = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .map((u) => u.update)
+          .find((u) => isToolCall(u) && u.toolCallId === "call_read")
+        expect(pending && isToolCall(pending)).toBe(true)
+        expect(isToolCall(pending!) ? pending!.kind : undefined).toBe("read")
+        expect(isToolCall(pending!) ? pending!.rawInput : undefined).toEqual(input)
+        expect(isToolCall(pending!) ? pending!.locations : undefined).toEqual([{ path: "/tmp/example.txt" }])
+        stop()
+      },
+    })
+  })
+
+  test("handles synthetic pending tool calls without input", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              sessionID: sessionId,
+              time: Date.now(),
+              part: {
+                id: "part_missing_input",
+                sessionID: sessionId,
+                messageID: "msg_missing_input",
+                type: "tool",
+                callID: "call_missing_input",
+                tool: "read",
+                state: {
+                  status: "running",
+                  time: { start: Date.now() },
+                },
+              },
+            },
+          },
+        } as any)
+        await new Promise((r) => setTimeout(r, 20))
+
+        const pending = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .map((u) => u.update)
+          .find((u) => isToolCall(u) && u.toolCallId === "call_missing_input")
+        expect(pending && isToolCall(pending)).toBe(true)
+        expect(isToolCall(pending!) ? pending!.rawInput : undefined).toEqual({})
+        expect(isToolCall(pending!) ? pending!.locations : undefined).toEqual([])
+        stop()
+      },
+    })
+  })
+
+  test("classifies apply_patch as edit and agent task tools as think", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const legacyTaskTool = ["ta", "sk"].join("")
+
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_patch",
+            tool: "apply_patch",
+            status: "running",
+            input: { filePath: "/tmp/example.txt" },
+          }),
+        )
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_agent",
+            tool: "agent",
+            status: "running",
+            input: { subagent_type: "build", description: "check build", prompt: "run tests" },
+          }),
+        )
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_task",
+            tool: legacyTaskTool,
+            status: "running",
+            input: { description: "think", prompt: "inspect" },
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 20))
+
+        const kindByCall = new Map(
+          sessionUpdates
+            .filter((u) => u.sessionId === sessionId)
+            .map((u) => u.update)
+            .filter(isToolCall)
+            .map((u) => [u.toolCallId, u.kind]),
+        )
+
+        expect(kindByCall.get("call_patch")).toBe("edit")
+        expect(kindByCall.get("call_agent")).toBe("think")
+        expect(kindByCall.get("call_task")).toBe("think")
+        stop()
+      },
+    })
+  })
+
+  test("does not emit an empty diff block for completed apply_patch calls", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const patchText = [
+          "*** Begin Patch",
+          "*** Update File: example.txt",
+          "@@",
+          "-old",
+          "+new",
+          "*** End Patch",
+        ].join("\n")
+
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_patch",
+            tool: "apply_patch",
+            status: "completed",
+            input: { patchText },
+            output: "Success. Updated the following files:\nM example.txt",
+            metadata: { diff: "diff --git a/example.txt b/example.txt" },
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 20))
+
+        const completed = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .map((u) => u.update)
+          .find((u) => isToolCallUpdate(u) && u.toolCallId === "call_patch" && u.status === "completed")
+
+        expect(completed && isToolCallUpdate(completed)).toBe(true)
+        expect(isToolCallUpdate(completed!) ? completed!.kind : undefined).toBe("edit")
+        expect(isToolCallUpdate(completed!) ? completed!.content?.some((item) => item.type === "diff") : true).toBe(
+          false,
+        )
+        expect(isToolCallUpdate(completed!) ? completed!.rawOutput : undefined).toEqual({
+          output: "Success. Updated the following files:\nM example.txt",
+          metadata: { diff: "diff --git a/example.txt b/example.txt" },
+        })
+        stop()
+      },
+    })
+  })
+
+  test("shows concise read content while preserving full raw output", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        const fullOutput = [
+          "<path>/tmp/example.txt</path>",
+          "<type>file</type>",
+          "<content>",
+          "1: alpha",
+          "2: beta",
+          "</content>",
+        ].join("\n")
+
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_read",
+            tool: "read",
+            status: "completed",
+            input: { filePath: "/tmp/example.txt" },
+            output: fullOutput,
+            title: "example.txt",
+            metadata: {
+              display: {
+                type: "file",
+                path: "/tmp/example.txt",
+                text: "alpha\nbeta",
+                lineStart: 1,
+                lineEnd: 2,
+                totalLines: 2,
+                truncated: false,
+              },
+            },
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 20))
+
+        const completed = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .map((u) => u.update)
+          .find((u) => isToolCallUpdate(u) && u.toolCallId === "call_read" && u.status === "completed")
+        expect(completed && isToolCallUpdate(completed)).toBe(true)
+        const textContent = isToolCallUpdate(completed!)
+          ? completed!.content?.find((item) => item.type === "content" && item.content.type === "text")
+          : undefined
+        const text =
+          textContent?.type === "content" && textContent.content.type === "text" ? textContent.content.text : ""
+
+        expect(text).toBe("alpha\nbeta")
+        expect(text).not.toContain("<path>")
+        expect(text).not.toContain("<content>")
+        expect(text).not.toContain("1: alpha")
+        expect(isToolCallUpdate(completed!) ? completed!.rawOutput : undefined).toEqual({
+          output: fullOutput,
+          metadata: {
+            display: {
+              type: "file",
+              path: "/tmp/example.txt",
+              text: "alpha\nbeta",
+              lineStart: 1,
+              lineEnd: 2,
+              totalLines: 2,
+              truncated: false,
+            },
+          },
+        })
+        stop()
+      },
+    })
+  })
+
+  test("keeps read continuation guidance in concise file content", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_read_partial",
+            tool: "read",
+            status: "completed",
+            input: { filePath: "/tmp/example.txt" },
+            output: "raw read output with Use offset=3 to continue.",
+            title: "example.txt",
+            metadata: {
+              display: {
+                type: "file",
+                path: "/tmp/example.txt",
+                text: "alpha\nbeta",
+                lineStart: 1,
+                lineEnd: 2,
+                totalLines: 20,
+                truncated: true,
+              },
+            },
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 20))
+
+        const completed = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .map((u) => u.update)
+          .find((u) => isToolCallUpdate(u) && u.toolCallId === "call_read_partial" && u.status === "completed")
+        expect(completed && isToolCallUpdate(completed)).toBe(true)
+        const textContent = isToolCallUpdate(completed!)
+          ? completed!.content?.find((item) => item.type === "content" && item.content.type === "text")
+          : undefined
+        const text =
+          textContent?.type === "content" && textContent.content.type === "text" ? textContent.content.text : ""
+
+        expect(text).toBe("alpha\nbeta\n\n(Showing lines 1-2. Use offset=3 to continue.)")
+        expect(isToolCallUpdate(completed!) ? completed!.rawOutput : undefined).toMatchObject({
+          output: "raw read output with Use offset=3 to continue.",
+        })
+        stop()
+      },
+    })
+  })
+
+  test("keeps read continuation guidance in concise directory content", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push(
+          toolEvent(sessionId, cwd, {
+            callID: "call_read_dir_partial",
+            tool: "read",
+            status: "completed",
+            input: { filePath: "/tmp/example" },
+            output: "raw directory output with Use offset=3 to continue.",
+            title: "example",
+            metadata: {
+              display: {
+                type: "directory",
+                path: "/tmp/example",
+                entries: ["one.txt", "two.txt"],
+                offset: 1,
+                totalEntries: 8,
+                truncated: true,
+              },
+            },
+          }),
+        )
+        await new Promise((r) => setTimeout(r, 20))
+
+        const completed = sessionUpdates
+          .filter((u) => u.sessionId === sessionId)
+          .map((u) => u.update)
+          .find((u) => isToolCallUpdate(u) && u.toolCallId === "call_read_dir_partial" && u.status === "completed")
+        expect(completed && isToolCallUpdate(completed)).toBe(true)
+        const textContent = isToolCallUpdate(completed!)
+          ? completed!.content?.find((item) => item.type === "content" && item.content.type === "text")
+          : undefined
+        const text =
+          textContent?.type === "content" && textContent.content.type === "text" ? textContent.content.text : ""
+
+        expect(text).toBe("one.txt\ntwo.txt\n\n(Showing 2 of 8 entries. Use offset=3 to continue.)")
+        expect(isToolCallUpdate(completed!) ? completed!.rawOutput : undefined).toMatchObject({
+          output: "raw directory output with Use offset=3 to continue.",
+        })
         stop()
       },
     })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -332,9 +332,19 @@ describe("tool.read truncation", () => {
       const dir = yield* tmpdirScoped()
       yield* put(path.join(dir, "small.txt"), "hello world")
 
-      const result = yield* exec(dir, { filePath: path.join(dir, "small.txt") })
+      const filePath = path.join(dir, "small.txt")
+      const result = yield* exec(dir, { filePath })
       expect(result.metadata.truncated).toBe(false)
       expect(result.output).toContain("End of file")
+      expect(result.metadata.display).toEqual({
+        type: "file",
+        path: filePath,
+        text: "hello world",
+        lineStart: 1,
+        lineEnd: 1,
+        totalLines: 1,
+        truncated: false,
+      })
     }),
   )
 
@@ -411,9 +421,18 @@ describe("tool.read truncation", () => {
         },
       )
 
-      const result = yield* exec(dir, { filePath: path.join(dir, "dir"), offset: 6, limit: 5 })
+      const filePath = path.join(dir, "dir")
+      const result = yield* exec(dir, { filePath, offset: 6, limit: 5 })
       expect(result.metadata.truncated).toBe(false)
       expect(result.output).not.toContain("Showing 5 of 10 entries")
+      expect(result.metadata.display).toEqual({
+        type: "directory",
+        path: filePath,
+        entries: ["file-5.txt", "file-6.txt", "file-7.txt", "file-8.txt", "file-9.txt"],
+        offset: 6,
+        totalEntries: 10,
+        truncated: false,
+      })
     }),
   )
 

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1585,6 +1585,13 @@ describe("tool.bash permissions", () => {
         const extDirReq = requests.find((r) => r.permission === "external_directory")
         expect(extDirReq).toBeDefined()
         expect(extDirReq!.patterns).toContain(want)
+        const directory = process.platform === "win32" ? process.env.WINDIR!.replaceAll("\\", "/") : await fs.promises.realpath("/etc")
+        expect(extDirReq!.metadata).toMatchObject({
+          command: `cat ${file}`,
+          description: "Read wildcard path",
+          directories: [directory],
+          patterns: [want],
+        })
       },
     })
   })


### PR DESCRIPTION
## Summary

Improve ACP tool display metadata for upstream D1 ACP/subagent display ports: pending tool calls now carry input and locations, ACP classifies `apply_patch` and delegated task-style tools correctly, read completions show clean display text while preserving raw output, and shell external-directory permission prompts include command and directory context.

## Why

The upstream-value audit identified ACP display gaps where user prompt-turn chunks could leak as ACP user chunks, pending tools opened without useful input/location data, `apply_patch` and local agent tools rendered as generic tools, external-directory prompts lacked context, and read completions exposed the full XML-like tool payload instead of concise display content.

## Related Issue

No single local GitHub issue owns this port. This implements Line D / D1 from `docs/handoff/2026-06-10-upstream-value-production-queue.md`, covering upstream items #21851, #30564, #30565, #30567, #31321, and #30569.

## Human Review Status

Pending

## Review Focus

Please focus on ACP event shape compatibility: `kind`, `rawInput`, `locations`, completed read content vs. raw output preservation, and ensuring `apply_patch` does not emit an empty diff block when only `patchText` is available.

## Risk Notes

Shell permission metadata is platform-sensitive because path glob normalization differs on Windows; the existing shell permission suite was rerun on the local platform, and CI should cover Windows. No visible UI/copy changes, docs changes, release notes, dependencies, credentials, deletion behavior, generated files, or local-only files are included.

## How To Verify

```text
Fresh-eye review #1: found apply_patch empty diff and weak read display test; both fixed.
Fresh-eye review #2: no P0-P3 findings after fixes.
packages/opencode typecheck: passed (`bun run typecheck`).
ACP event subscription tests: 16 passed (`bun test test/acp/event-subscription.test.ts`).
Read tool tests: 38 passed (`bun test test/tool/read.test.ts`).
Shell tool tests: 54 passed (`bun test test/tool/shell.test.ts`).
Diff check: passed (`git diff --check origin/dev...HEAD`).
```

## Screenshots or Recordings

Not required: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.