### PR TITLE
fix(mcp): serialize auth and keep dynamic config

### DIFF
--- a/packages/opencode/src/mcp/auth.ts
+++ b/packages/opencode/src/mcp/auth.ts
@@ -3,6 +3,7 @@ import z from "zod"
 import { Global } from "@opencode-ai/core/global"
 import { Effect, Layer, Context } from "effect"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { makeRuntime } from "@/effect/run-service"
 
 export namespace McpAuth {
@@ -32,6 +33,7 @@ export namespace McpAuth {
   export type Entry = z.infer<typeof Entry>
 
   const filepath = path.join(Global.Path.data, "mcp-auth.json")
+  const lockKey = `mcp-auth:${filepath}`
 
   export interface Interface {
     readonly all: () => Effect.Effect<Record<string, Entry>>
@@ -55,12 +57,17 @@ export namespace McpAuth {
     Service,
     Effect.gen(function* () {
       const fs = yield* AppFileSystem.Service
+      const flock = yield* EffectFlock.Service
 
-      const all = Effect.fn("McpAuth.all")(function* () {
+      const read = Effect.fn("McpAuth.read")(function* () {
         return yield* fs.readJson(filepath).pipe(
           Effect.map((data) => data as Record<string, Entry>),
           Effect.catch(() => Effect.succeed({} as Record<string, Entry>)),
         )
+      })
+
+      const all = Effect.fn("McpAuth.all")(function* () {
+        return yield* flock.withLock(read(), lockKey).pipe(Effect.orDie)
       })
 
       const get = Effect.fn("McpAuth.get")(function* (mcpName: string) {
@@ -76,32 +83,53 @@ export namespace McpAuth {
         return entry
       })
 
+      const mutate = Effect.fn("McpAuth.mutate")(function* (
+        update: (data: Record<string, Entry>) => Record<string, Entry> | undefined,
+      ) {
+        yield* flock.withLock(
+          Effect.gen(function* () {
+            const data = yield* read()
+            const next = update(data)
+            if (next) yield* fs.writeJson(filepath, next, 0o600).pipe(Effect.orDie)
+          }),
+          lockKey,
+        ).pipe(Effect.orDie)
+      })
+
       const set = Effect.fn("McpAuth.set")(function* (mcpName: string, entry: Entry, serverUrl?: string) {
-        const data = yield* all()
-        if (serverUrl) entry.serverUrl = serverUrl
-        yield* fs.writeJson(filepath, { ...data, [mcpName]: entry }, 0o600).pipe(Effect.orDie)
+        yield* mutate((data) => ({
+          ...data,
+          [mcpName]: serverUrl ? { ...entry, serverUrl } : { ...entry },
+        }))
       })
 
       const remove = Effect.fn("McpAuth.remove")(function* (mcpName: string) {
-        const data = yield* all()
-        delete data[mcpName]
-        yield* fs.writeJson(filepath, data, 0o600).pipe(Effect.orDie)
+        yield* mutate((data) => {
+          const next = { ...data }
+          delete next[mcpName]
+          return next
+        })
       })
 
       const updateField = <K extends keyof Entry>(field: K, spanName: string) =>
         Effect.fn(`McpAuth.${spanName}`)(function* (mcpName: string, value: NonNullable<Entry[K]>, serverUrl?: string) {
-          const entry = (yield* get(mcpName)) ?? {}
-          entry[field] = value
-          yield* set(mcpName, entry, serverUrl)
+          yield* mutate((data) => {
+            const entry = { ...(data[mcpName] ?? {}) }
+            entry[field] = value
+            if (serverUrl) entry.serverUrl = serverUrl
+            return { ...data, [mcpName]: entry }
+          })
         })
 
       const clearField = <K extends keyof Entry>(field: K, spanName: string) =>
         Effect.fn(`McpAuth.${spanName}`)(function* (mcpName: string) {
-          const entry = yield* get(mcpName)
-          if (entry) {
+          yield* mutate((data) => {
+            const current = data[mcpName]
+            if (!current) return undefined
+            const entry = { ...current }
             delete entry[field]
-            yield* set(mcpName, entry)
-          }
+            return { ...data, [mcpName]: entry }
+          })
         })
 
       const updateTokens = updateField("tokens", "updateTokens")
@@ -141,7 +169,7 @@ export namespace McpAuth {
     }),
   )
 
-  export const defaultLayer = layer.pipe(Layer.provide(AppFileSystem.defaultLayer))
+  export const defaultLayer = layer.pipe(Layer.provide(EffectFlock.defaultLayer), Layer.provide(AppFileSystem.defaultLayer))
 
   const { runPromise } = makeRuntime(Service, defaultLayer)
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -309,6 +309,7 @@ export namespace MCP {
     status: Record<string, Status>
     clients: Record<string, MCPClient>
     defs: Record<string, MCPToolDef[]>
+    config: Record<string, Config.Mcp>
   }
 
   export interface Interface {
@@ -581,6 +582,7 @@ export namespace MCP {
             status: {},
             clients: {},
             defs: {},
+            config: {},
           }
 
           yield* Effect.forEach(
@@ -664,7 +666,7 @@ export namespace MCP {
         const s = yield* InstanceState.get(state)
 
         const cfg = yield* cfgSvc.get()
-        const config = cfg.mcp ?? {}
+        const config = { ...(cfg.mcp ?? {}), ...s.config }
         const result: Record<string, Status> = {}
 
         for (const [key, mcp] of Object.entries(config)) {
@@ -695,8 +697,9 @@ export namespace MCP {
       })
 
       const add = Effect.fn("MCP.add")(function* (name: string, mcp: Config.Mcp) {
-        yield* createAndStore(name, mcp)
         const s = yield* InstanceState.get(state)
+        s.config[name] = mcp
+        yield* createAndStore(name, mcp)
         return { status: s.status }
       })
 
@@ -728,7 +731,7 @@ export namespace MCP {
           connectedClients,
           ([clientName, client]) =>
             Effect.gen(function* () {
-              const mcpConfig = config[clientName]
+              const mcpConfig = s.config[clientName] ?? config[clientName]
               const entry = mcpConfig && isMcpConfigured(mcpConfig) ? mcpConfig : undefined
 
               const listed = s.defs[clientName]
@@ -828,6 +831,9 @@ export namespace MCP {
       })
 
       const getMcpConfig = Effect.fnUntraced(function* (mcpName: string) {
+        const s = yield* InstanceState.get(state)
+        const dynamicConfig = s.config[mcpName]
+        if (dynamicConfig) return dynamicConfig
         const cfg = yield* cfgSvc.get()
         const mcpConfig = cfg.mcp?.[mcpName]
         if (!mcpConfig || !isMcpConfigured(mcpConfig)) return undefined
@@ -1039,7 +1045,7 @@ export namespace MCP {
   // --- Per-service runtime ---
 
   export const defaultLayer = layer.pipe(
-    Layer.provide(McpAuth.layer),
+    Layer.provide(McpAuth.defaultLayer),
     Layer.provide(Bus.layer),
     Layer.provide(Config.defaultLayer),
     Layer.provide(CrossSpawnSpawner.defaultLayer),

--- a/packages/opencode/test/mcp/auth.test.ts
+++ b/packages/opencode/test/mcp/auth.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import { setTimeout as sleep } from "node:timers/promises"
+import { Effect, Layer } from "effect"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { McpAuth } from "../../src/mcp/auth"
+
+function authFile() {
+  let raw = ""
+
+  const layer = Layer.effect(
+    AppFileSystem.Service,
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+
+      return AppFileSystem.Service.of({
+        ...fs,
+        readJson: (file) =>
+          file.endsWith("mcp-auth.json")
+            ? Effect.try({
+                try: () => {
+                  if (!raw) throw new Error("mcp-auth.json missing")
+                  return JSON.parse(raw)
+                },
+                catch: (cause) => new AppFileSystem.FileSystemError({ method: "readJson", cause }),
+              })
+            : fs.readJson(file),
+        writeJson: (file, value, mode) =>
+          file.endsWith("mcp-auth.json")
+            ? Effect.promise(async () => {
+                await sleep(10)
+                raw = JSON.stringify(value, null, 2)
+              })
+            : fs.writeJson(file, value, mode),
+      })
+    }),
+  ).pipe(Layer.provide(AppFileSystem.defaultLayer))
+
+  return { layer }
+}
+
+function authService(layer: Layer.Layer<AppFileSystem.Service>) {
+  return McpAuth.Service.use((auth) => Effect.succeed(auth)).pipe(
+    Effect.provide(
+      McpAuth.layer.pipe(
+        Layer.provide(EffectFlock.defaultLayer),
+        Layer.provide(layer),
+      ),
+    ),
+  )
+}
+
+test("serializes concurrent auth file mutations", async () => {
+  const file = authFile()
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const first = yield* authService(file.layer)
+      const second = yield* authService(file.layer)
+
+      yield* Effect.all(
+        [
+          first.updateTokens("posthog", { accessToken: "access-token" }, "https://mcp.posthog.com/mcp"),
+          second.updateClientInfo("posthog", { clientId: "client-id" }, "https://mcp.posthog.com/mcp"),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      const entry = yield* first.get("posthog")
+      expect(entry?.tokens?.accessToken).toBe("access-token")
+      expect(entry?.clientInfo?.clientId).toBe("client-id")
+      expect(entry?.serverUrl).toBe("https://mcp.posthog.com/mcp")
+    }),
+  )
+})

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -29,6 +29,7 @@ interface MockClientState {
     { resources: Array<{ name: string; uri: string; description?: string }>; nextCursor?: string | null }
   >
   callToolSignals: Array<AbortSignal | undefined>
+  callToolTimeouts: Array<number | undefined>
   closed: boolean
   notificationHandlers: Map<unknown, (...args: any[]) => any>
 }
@@ -64,6 +65,7 @@ function getOrCreateClientState(name?: string): MockClientState {
       promptPages: {},
       resourcePages: {},
       callToolSignals: [],
+      callToolTimeouts: [],
       closed: false,
       notificationHandlers: new Map(),
     }
@@ -199,8 +201,9 @@ mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return { resources: this._state?.resources ?? [] }
     }
 
-    async callTool(_args: unknown, _schema: unknown, options?: { signal?: AbortSignal }) {
+    async callTool(_args: unknown, _schema: unknown, options?: { signal?: AbortSignal; timeout?: number }) {
       this._state?.callToolSignals.push(options?.signal)
+      this._state?.callToolTimeouts.push(options?.timeout)
       return { content: [] }
     }
 
@@ -599,6 +602,46 @@ test(
 
     expect(firstState.closed).toBe(true)
     expect(secondState.closed).toBe(false)
+  }),
+)
+
+test(
+  "dynamically added servers keep config for status reconnect and tool timeout",
+  withInstance({}, async () => {
+    lastCreatedClientName = "dynamic-server"
+    const serverState = getOrCreateClientState("dynamic-server")
+
+    await MCP.add("dynamic-server", {
+      type: "local",
+      command: ["echo", "test"],
+      timeout: 1234,
+    })
+
+    expect((await MCP.status())["dynamic-server"]?.status).toBe("connected")
+
+    const tools = await MCP.tools()
+    const tool = tools["dynamic-server_test_tool"] as unknown as {
+      execute: (args: unknown, options?: { abortSignal?: AbortSignal }) => any
+    }
+    await tool.execute({})
+    expect(serverState.callToolTimeouts).toEqual([1234])
+
+    await MCP.disconnect("dynamic-server")
+    expect((await MCP.status())["dynamic-server"]?.status).toBe("disabled")
+
+    clientStates.delete("dynamic-server")
+    lastCreatedClientName = "dynamic-server"
+    const reconnectedState = getOrCreateClientState("dynamic-server")
+
+    await MCP.connect("dynamic-server")
+    expect((await MCP.status())["dynamic-server"]?.status).toBe("connected")
+
+    const reconnectedTools = await MCP.tools()
+    const reconnectedTool = reconnectedTools["dynamic-server_test_tool"] as unknown as {
+      execute: (args: unknown, options?: { abortSignal?: AbortSignal }) => any
+    }
+    await reconnectedTool.execute({})
+    expect(reconnectedState.callToolTimeouts).toEqual([1234])
   }),
 )
 


### PR DESCRIPTION
## Summary

Serialize MCP auth file mutations and keep dynamically added MCP server config in the MCP service state.

This PR has no PawWork issue because it is part of the upstream-value Line A MCP reliability queue. It ports the relevant behavior from upstream PRs anomalyco/opencode#29852 and anomalyco/opencode#29452.

## Why

Concurrent MCP OAuth/auth updates could read the same stale auth file snapshot and overwrite each other. Dynamically added MCP servers also lost their config after add(), so status, reconnect, and tool timeout handling could not see the runtime-added server definition.

## Related Issue

No PawWork issue. Upstream references: anomalyco/opencode#29852 and anomalyco/opencode#29452.

## Human Review Status

Pending

## Review Focus

Please focus on whether the auth read-modify-write lock keeps the existing McpAuth error contract intact, and whether the dynamic MCP config state is used only for runtime-added servers without changing static config behavior.

## Risk Notes

Skipped conditional checklist items:

- Visible UI or copy check: no visible UI or copy changed.
- macOS and Windows platform check: no platform, packaging, updater, signing, path, shell, or permissions surface changed.
- Docs/release/dependency/local-file check: no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes are part of this PR.

## How To Verify

```text
bun test test/mcp/auth.test.ts --timeout 30000: 1 pass, 0 fail
bun test test/mcp/lifecycle.test.ts --timeout 30000: 26 pass, 0 fail
bun test test/mcp --timeout 30000: 46 pass, 0 fail
bun run typecheck: tsgo --noEmit passed
git diff --check: no whitespace errors
```

## Screenshots or Recordings

Not applicable. No visible UI changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
