### PR TITLE
fix(tool): reject unsafe edit matches

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -371,8 +371,8 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
         const actualBlockSize = j - i + 1
         if (Math.abs(actualBlockSize - searchBlockSize) <= maxLineDelta) {
           candidates.push({ startLine: i, endLine: j })
+          break // Only match the first valid occurrence of the last line
         }
-        break // Only match the first occurrence of the last line
       }
     }
   }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -97,20 +97,12 @@ export const EditTool = Tool.define(
               if (params.oldString === "") {
                 const existed = yield* afs.existsSafe(filePath)
                 existedBefore = existed
-                // Reject directory targets up front instead of failing inside
-                // Bom.readFile / writeWithDirs with an opaque internal error.
                 if (existed) {
-                  const stat = yield* afs.stat(filePath).pipe(
-                    Effect.catchIf(
-                      (err) => "reason" in err && err.reason._tag === "NotFound",
-                      () => Effect.succeed(undefined),
-                    ),
+                  throw new Error(
+                    "oldString cannot be empty when editing an existing file. Provide the exact text to replace, or use write for an intentional full-file replacement.",
                   )
-                  if (stat?.type === "Directory") {
-                    return yield* Effect.fail(new Error(`Path is a directory, not a file: ${filePath}`))
-                  }
                 }
-                const source = existed ? yield* Bom.readFile(afs, filePath) : { bom: false, text: "" }
+                const source = { bom: false, text: "" }
                 const next = Bom.split(params.newString)
                 // Only preserve the existing file's BOM. Letting `next.bom` add
                 // a new one would mutate file bytes the diff preview cannot
@@ -281,8 +273,8 @@ export const EditTool = Tool.define(
 export type Replacer = (content: string, find: string) => Generator<string, void, unknown>
 
 // Similarity thresholds for block anchor fallback matching
-const SINGLE_CANDIDATE_SIMILARITY_THRESHOLD = 0.0
-const MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD = 0.3
+const SINGLE_CANDIDATE_SIMILARITY_THRESHOLD = 0.65
+const MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD = 0.65
 
 /**
  * Levenshtein distance algorithm implementation
@@ -364,6 +356,7 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
   const firstLineSearch = searchLines[0].trim()
   const lastLineSearch = searchLines[searchLines.length - 1].trim()
   const searchBlockSize = searchLines.length
+  const maxLineDelta = Math.max(1, Math.floor(searchBlockSize * 0.25))
 
   // Collect all candidate positions where both anchors match
   const candidates: Array<{ startLine: number; endLine: number }> = []
@@ -375,7 +368,10 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
     // Look for the matching last line after this first line
     for (let j = i + 2; j < originalLines.length; j++) {
       if (originalLines[j].trim() === lastLineSearch) {
-        candidates.push({ startLine: i, endLine: j })
+        const actualBlockSize = j - i + 1
+        if (Math.abs(actualBlockSize - searchBlockSize) <= maxLineDelta) {
+          candidates.push({ startLine: i, endLine: j })
+        }
         break // Only match the first occurrence of the last line
       }
     }
@@ -392,7 +388,7 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
     const actualBlockSize = endLine - startLine + 1
 
     let similarity = 0
-    let linesToCheck = Math.min(searchBlockSize - 2, actualBlockSize - 2) // Middle lines only
+    const linesToCheck = Math.min(searchBlockSize - 2, actualBlockSize - 2) // Middle lines only
 
     if (linesToCheck > 0) {
       for (let j = 1; j < searchBlockSize - 1 && j < actualBlockSize - 1; j++) {
@@ -441,7 +437,7 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
     const actualBlockSize = endLine - startLine + 1
 
     let similarity = 0
-    let linesToCheck = Math.min(searchBlockSize - 2, actualBlockSize - 2) // Middle lines only
+    const linesToCheck = Math.min(searchBlockSize - 2, actualBlockSize - 2) // Middle lines only
 
     if (linesToCheck > 0) {
       for (let j = 1; j < searchBlockSize - 1 && j < actualBlockSize - 1; j++) {
@@ -743,6 +739,11 @@ export function replace(content: string, oldString: string, newString: string, r
   if (oldString === newString) {
     throw new Error("No changes to apply: oldString and newString are identical.")
   }
+  if (oldString === "") {
+    throw new Error(
+      "oldString cannot be empty when editing an existing file. Provide the exact text to replace, or use write for an intentional full-file replacement.",
+    )
+  }
 
   let notFound = true
 
@@ -761,6 +762,11 @@ export function replace(content: string, oldString: string, newString: string, r
       const index = content.indexOf(search)
       if (index === -1) continue
       notFound = false
+      if (isDisproportionateMatch(search, oldString)) {
+        throw new Error(
+          "Refusing replacement because the matched span is much larger than oldString. Re-read the file and provide the full exact oldString for the intended replacement.",
+        )
+      }
       if (replaceAll) {
         // Function replacer: a string replacement argument has its $-patterns
         // ($$, $&, $`, $') interpreted, silently corrupting newString.
@@ -778,4 +784,12 @@ export function replace(content: string, oldString: string, newString: string, r
     )
   }
   throw new Error("Found multiple matches for oldString. Provide more surrounding context to make the match unique.")
+}
+
+function isDisproportionateMatch(search: string, oldString: string) {
+  const oldLines = oldString.split("\n").length
+  const searchLines = search.split("\n").length
+  if (searchLines >= Math.max(oldLines + 3, oldLines * 2)) return true
+  if (oldLines === 1) return false
+  return search.trim().length > Math.max(oldString.trim().length + 500, oldString.trim().length * 4)
 }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -356,7 +356,6 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
   const firstLineSearch = searchLines[0].trim()
   const lastLineSearch = searchLines[searchLines.length - 1].trim()
   const searchBlockSize = searchLines.length
-  const maxLineDelta = Math.max(1, Math.floor(searchBlockSize * 0.25))
 
   // Collect all candidate positions where both anchors match
   const candidates: Array<{ startLine: number; endLine: number }> = []
@@ -369,7 +368,7 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
     for (let j = i + 2; j < originalLines.length; j++) {
       if (originalLines[j].trim() === lastLineSearch) {
         const actualBlockSize = j - i + 1
-        if (Math.abs(actualBlockSize - searchBlockSize) <= maxLineDelta) {
+        if (actualBlockSize === searchBlockSize) {
           candidates.push({ startLine: i, endLine: j })
           break // Only match the first valid occurrence of the last line
         }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -670,8 +670,7 @@ export const ContextAwareReplacer: Replacer = function* (content, find) {
         const blockLines = contentLines.slice(i, j + 1)
         const block = blockLines.join("\n")
 
-        // Check if the middle content has reasonable similarity
-        // (simple heuristic: at least 50% of non-empty lines should match when trimmed)
+        // Check if the middle content has reasonable similarity.
         if (blockLines.length === findLines.length) {
           let matchingLines = 0
           let totalNonEmptyLines = 0
@@ -688,7 +687,10 @@ export const ContextAwareReplacer: Replacer = function* (content, find) {
             }
           }
 
-          if (totalNonEmptyLines === 0 || matchingLines / totalNonEmptyLines >= 0.5) {
+          if (
+            totalNonEmptyLines === 0 ||
+            matchingLines / totalNonEmptyLines >= MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD
+          ) {
             yield block
             break // Only match the first occurrence
           }
@@ -790,6 +792,5 @@ function isDisproportionateMatch(search: string, oldString: string) {
   const oldLines = oldString.split("\n").length
   const searchLines = search.split("\n").length
   if (searchLines >= Math.max(oldLines + 3, oldLines * 2)) return true
-  if (oldLines === 1) return false
   return search.trim().length > Math.max(oldString.trim().length + 500, oldString.trim().length * 4)
 }

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -439,6 +439,47 @@ describe("tool.edit", () => {
       ),
     )
 
+    it.live("rejects nested block-anchor candidates with shorter line counts", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "nested-short-candidate.ts")
+          const original = [
+            "function configure() {",
+            "  if (enabled) {",
+            "    keepImportantState()",
+            "  }",
+            "  finalize()",
+            "}",
+          ].join("\n")
+          yield* Effect.promise(() => fs.writeFile(filepath, original, "utf-8"))
+
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: [
+                "function configure() {",
+                "  if (enabled) {",
+                "    keepImportantState()",
+                "  cleanup()",
+                "}",
+              ].join("\n"),
+              newString: [
+                "function configure() {",
+                "  if (enabled) {",
+                "    keepImportantState()",
+                "  done()",
+                "}",
+              ].join("\n"),
+            },
+            "Could not find oldString",
+          )
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(content).toBe(original)
+        }),
+      ),
+    )
+
     it.live("replaces all occurrences with replaceAll option", () =>
       provideTmpdirInstance((dir) =>
         Effect.gen(function* () {

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -214,6 +214,28 @@ describe("tool.edit", () => {
       ),
     )
 
+    it.live("rejects empty oldString on existing files and leaves content unchanged", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "existing-empty-old-string.txt")
+          const original = "\ufeffusing System;\n"
+          yield* Effect.promise(() => fs.writeFile(filepath, original, "utf-8"))
+
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: "",
+              newString: "using Up;\n",
+            },
+            "oldString cannot be empty",
+          )
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(content).toBe(original)
+        }),
+      ),
+    )
+
     it.live("throws error when file does not exist", () =>
       provideTmpdirInstance((dir) =>
         expectRunFailure(
@@ -259,6 +281,57 @@ describe("tool.edit", () => {
             },
             "Could not find oldString",
           )
+        }),
+      ),
+    )
+
+    it.live("rejects loose block-anchor matches and leaves content unchanged", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.ts")
+          const original = [
+            "function configure() {",
+            "  keepImportantState()",
+            "  removeAllUserData()",
+            "  archiveBackups()",
+            "  auditLog()",
+            "}",
+          ].join("\n")
+          yield* Effect.promise(() => fs.writeFile(filepath, original, "utf-8"))
+
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: ["function configure() {", "  const enabled = true", "}"].join("\n"),
+              newString: ["function configure() {", "  const enabled = false", "}"].join("\n"),
+            },
+            "Could not find oldString",
+          )
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(content).toBe(original)
+        }),
+      ),
+    )
+
+    it.live("rejects block-anchor matches with unrelated middle content", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "unrelated-middle.ts")
+          const original = ["function configure() {", "  removeAllUserData()", "}"].join("\n")
+          yield* Effect.promise(() => fs.writeFile(filepath, original, "utf-8"))
+
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: ["function configure() {", "  const enabled = true", "}"].join("\n"),
+              newString: ["function configure() {", "  const enabled = false", "}"].join("\n"),
+            },
+            "Could not find oldString",
+          )
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(content).toBe(original)
         }),
       ),
     )

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -336,6 +336,60 @@ describe("tool.edit", () => {
       ),
     )
 
+    it.live("rejects context-aware matches that keep only half of the middle lines", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "half-middle-match.ts")
+          const original = [
+            "function configure() {",
+            "  keepImportantState()",
+            "  removeAllUserData()",
+            "}",
+          ].join("\n")
+          yield* Effect.promise(() => fs.writeFile(filepath, original, "utf-8"))
+
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: ["function configure() {", "  keepImportantState()", "  const enabled = true", "}"].join("\n"),
+              newString: [
+                "function configure() {",
+                "  keepImportantState()",
+                "  const enabled = false",
+                "}",
+              ].join("\n"),
+            },
+            "Could not find oldString",
+          )
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(content).toBe(original)
+        }),
+      ),
+    )
+
+    it.live("rejects single-line whitespace matches with disproportionate spans", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "long-whitespace.txt")
+          const original = `prefix foo${" ".repeat(1000)}bar suffix`
+          yield* Effect.promise(() => fs.writeFile(filepath, original, "utf-8"))
+
+          yield* expectRunFailure(
+            {
+              filePath: filepath,
+              oldString: "foo bar",
+              newString: "baz",
+            },
+            "matched span is much larger than oldString",
+          )
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(content).toBe(original)
+        }),
+      ),
+    )
+
     it.live("replaces all occurrences with replaceAll option", () =>
       provideTmpdirInstance((dir) =>
         Effect.gen(function* () {

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -390,6 +390,55 @@ describe("tool.edit", () => {
       ),
     )
 
+    it.live("continues past short nested block anchors to find a valid outer match", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "nested-block.ts")
+          const original = [
+            "function configure() {",
+            "  if (enabled) {",
+            "    keepImportantState()",
+            "  }",
+            "  finalize()",
+            "}",
+          ].join("\n")
+          yield* Effect.promise(() => fs.writeFile(filepath, original, "utf-8"))
+
+          yield* run({
+            filePath: filepath,
+            oldString: [
+              "function configure() {",
+              "  if (enabled) {",
+              "    keepImportantState()",
+              "  }",
+              "  finish()",
+              "}",
+            ].join("\n"),
+            newString: [
+              "function configure() {",
+              "  if (enabled) {",
+              "    keepImportantState()",
+              "  }",
+              "  cleanup()",
+              "}",
+            ].join("\n"),
+          })
+
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(content).toBe(
+            [
+              "function configure() {",
+              "  if (enabled) {",
+              "    keepImportantState()",
+              "  }",
+              "  cleanup()",
+              "}",
+            ].join("\n"),
+          )
+        }),
+      ),
+    )
+
     it.live("replaces all occurrences with replaceAll option", () =>
       provideTmpdirInstance((dir) =>
         Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Reject unsafe edit matches that can unintentionally replace an existing file or a much larger fuzzy-matched block.

## Why

The edit tool still allowed `oldString: ""` against an existing file, which turns a targeted edit into a full-file replacement. Its block-anchor fallback also accepted low-confidence matches based mostly on shared first and last lines, which could replace unrelated or much larger content.

## Related Issue

Ports the behavior from upstream anomalyco/opencode#30932. There is no local PawWork issue for this narrow upstream-value PR.

## Human Review Status

Pending

## Review Focus

Please check that the edit tool rejects only unsafe matches while preserving normal exact edits, new-file creation with empty `oldString`, `replaceAll`, line-ending preservation, and `$` replacement behavior from #1224.

## Risk Notes

Harness/tool behavior changed for unsafe edit requests. No visible UI changed, so the UI check is not applicable. No docs, release notes, dependencies, credentials, generated content, or local file changes are included. No platform/packaging surface was touched.

## How To Verify

```text
RED: bun test test/tool/edit.test.ts failed before the implementation because an existing file edit with empty oldString succeeded instead of failing.
RED: bun test test/tool/edit.test.ts failed before the block-anchor guard because a loose anchor match replaced unrelated content.
RED: bun test test/tool/edit.test.ts failed before the threshold guard because a same-size block with unrelated middle content was accepted.
RED: bun test test/tool/edit.test.ts failed before the context-aware guard because a half-matching middle block was accepted.
RED: bun test test/tool/edit.test.ts failed before the single-line span guard because a short whitespace-normalized oldString replaced a much larger span.
RED: bun test test/tool/edit.test.ts failed before the nested-anchor scan fix because an inner closing anchor stopped the outer candidate search.
RED: bun test test/tool/edit.test.ts failed before the exact-span guard because a shorter nested block candidate was accepted.
Focused edit tests: bun test test/tool/edit.test.ts -> 36 pass, 0 fail.
Typecheck: bun run typecheck in packages/opencode -> passed.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Edit tool now rejects empty search strings in existing files
  * Prevents disproportionately large replacement matches through improved validation

* **Improvements**
  * Tightened block-anchor matching logic for more accurate replacements
  * Enhanced similarity thresholds to reduce false-positive matches

* **Tests**
  * Added comprehensive test coverage for edit rejection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->