### PR TITLE
fix(agent): preserve caller variant for subagents

### DIFF
--- a/packages/opencode/src/tool/agent.ts
+++ b/packages/opencode/src/tool/agent.ts
@@ -251,6 +251,7 @@ export const AgentTool = Tool.define(
         modelID: msg.info.modelID,
         providerID: msg.info.providerID,
       }
+      const variant = next.model ? undefined : msg.info.variant
 
       // Cap-rejection check happens before any slot is reserved or expensive work begins.
       // The TooManyActive failure is mapped to a synthesized status: failed output instead.
@@ -475,6 +476,7 @@ export const AgentTool = Tool.define(
                       messageID: MessageID.ascending(),
                       sessionID: nextSession.id,
                       model: { modelID: model.modelID, providerID: model.providerID },
+                      variant,
                       agent: next.name,
                       // Availability-only: structural constraints on the subagent (no nested
                       // dispatch, no worktree switching, no todos unless its agent allows them, no

--- a/packages/opencode/test/tool/agent.test.ts
+++ b/packages/opencode/test/tool/agent.test.ts
@@ -38,14 +38,17 @@ const it = testEffect(
   ),
 )
 
-const seedAssistant = Effect.fn("AgentToolTest.seedAssistant")(function* (sessionID: SessionID) {
+const seedAssistant = Effect.fn("AgentToolTest.seedAssistant")(function* (
+  sessionID: SessionID,
+  opts?: { variant?: string },
+) {
   const session = yield* Session.Service
   const user = yield* session.updateMessage({
     id: MessageID.ascending(),
     role: "user",
     sessionID,
     agent: "build",
-    model: ref,
+    model: { ...ref, variant: opts?.variant },
     time: { created: Date.now() },
   })
   const assistant: MessageV2.Assistant = {
@@ -60,6 +63,7 @@ const seedAssistant = Effect.fn("AgentToolTest.seedAssistant")(function* (sessio
     tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
     modelID: ref.modelID,
     providerID: ref.providerID,
+    variant: opts?.variant,
     time: { created: Date.now() },
   }
   yield* session.updateMessage(assistant)
@@ -346,6 +350,92 @@ describe("tool.agent", () => {
         expect(child.createdByAgentTool).toBe(true)
         expect(child.subagentType).toBe("general")
       }),
+    ),
+  )
+
+  it.live("execute preserves the caller variant for unpinned subagents", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Pinned" })
+        const assistant = yield* seedAssistant(chat.id, { variant: "high" })
+        const tool = yield* AgentTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+        yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            callID: "call_test_" + Math.random().toString(36).slice(2),
+            extra: { promptOps, bypassAgentCheck: true },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(seen?.model).toEqual(ref)
+        expect(seen?.variant).toBe("high")
+      }),
+    ),
+  )
+
+  it.live("execute does not preserve the caller variant for model-pinned subagents", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* Session.Service
+          const chat = yield* sessions.create({ title: "Pinned" })
+          const assistant = yield* seedAssistant(chat.id, { variant: "high" })
+          const tool = yield* AgentTool
+          const def = yield* tool.init()
+          let seen: SessionPrompt.PromptInput | undefined
+          const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+          yield* def.execute(
+            {
+              description: "inspect bug",
+              prompt: "look into the cache key path",
+              subagent_type: "scout",
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              callID: "call_test_" + Math.random().toString(36).slice(2),
+              extra: { promptOps, bypassAgentCheck: true },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+
+          expect(seen?.model).toEqual({
+            providerID: ProviderID.make("test"),
+            modelID: ModelID.make("pinned-model"),
+          })
+          expect(seen?.variant).toBeUndefined()
+        }),
+      {
+        config: {
+          agent: {
+            scout: {
+              mode: "subagent",
+              model: "test/pinned-model",
+            },
+          },
+        },
+      },
     ),
   )
 


### PR DESCRIPTION
## Summary

Preserve the caller assistant's model variant when the agent tool dispatches an unpinned subagent. This PR covers upstream-value Line D D2 (#30630) and keeps the change limited to direct delegated agent dispatch.

## Why

Queued subtask replay already keeps the caller variant, but direct agent tool dispatch only forwarded provider and model IDs. That meant a high/xhigh/max caller could silently lose its selected variant inside an unpinned subagent. Model-pinned subagents still keep their own model choice and do not inherit the caller variant.

## Related Issue

Covers the Line D D2 follow-up from the upstream-value audit for upstream #30630.

## Human Review Status

Pending

## Review Focus

Please check that `variant` is forwarded only for unpinned subagents and stays omitted when the target subagent config pins its own model.

## Risk Notes

Behavior risk is limited to direct agent-tool subagent dispatch. Skipped checklist items: no visible UI or copy changed; no platform, packaging, updater, signing, path, shell, or permission surface changed; no docs, release notes, dependencies, credentials, deletion behavior, generated content, or local file behavior changed.

## How To Verify

```text
Regression red: bun test test/tool/agent.test.ts -t "execute preserves the caller variant for unpinned subagents" failed before the fix with seen.variant undefined.
Focused tests: bun test test/tool/agent.test.ts passed, 26 passed, 1 skipped.
Typecheck: bun run typecheck passed in packages/opencode.
Diff check: git diff --check passed.
Fresh-eye: reviewer subagent inspected origin/dev...HEAD and found no P0-P3 actionable issues.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.