### PR TITLE
feat: defer lsp behind tool_info

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -44,6 +44,7 @@ export type StreamInput = {
   messages: ModelMessage[]
   small?: boolean
   tools: Record<string, Tool>
+  availableDeferredTools?: ReadonlySet<string>
   retries?: number
   connectTimeoutMs?: number
   streamTimeoutMs?: number
@@ -358,13 +359,6 @@ const live: Layer.Layer<
         }),
       )
 
-      // Same availability rule the registry uses to card/expose deferred tools
-      // (prompt.ts deferredAvailable): a deferred tool the user disabled or a
-      // permission rule denied can't be activated via tool_info, so the repair
-      // hint below must not route the model there.
-      const deferredRuleset = Permission.merge(input.agent.permission, input.permission ?? [])
-      const deferredAvailable = (id: string) =>
-        input.user.tools?.[id] !== false && !Permission.disabled([id], deferredRuleset).has(id)
       return streamText({
         onError(error) {
           l.error("stream error", {
@@ -383,13 +377,9 @@ const live: Layer.Layer<
               toolName: lower,
             }
           }
-          const deferredHint = buildDeferredHint(failed.toolCall.toolName, deferredAvailable)
           return {
             ...failed.toolCall,
-            input: JSON.stringify({
-              tool: failed.toolCall.toolName,
-              error: failed.error.message + deferredHint,
-            }),
+            input: buildInvalidToolRepairInput(input, failed.toolCall.toolName, failed.error.message),
             toolName: "invalid",
           }
         },
@@ -693,6 +683,23 @@ export function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permi
     Permission.merge(input.agent.permission, input.permission ?? []),
   )
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
+}
+
+export function buildInvalidToolRepairInput(
+  input: Pick<StreamInput, "agent" | "availableDeferredTools" | "permission" | "user">,
+  toolName: string,
+  errorMessage: string,
+) {
+  const deferredRuleset = Permission.merge(input.agent.permission, input.permission ?? [])
+  const deferredAvailable = (id: string) =>
+    (input.availableDeferredTools?.has(id) ?? true) &&
+    input.user.tools?.[id] !== false &&
+    !Permission.disabled([id], deferredRuleset).has(id)
+  const deferredHint = buildDeferredHint(toolName, deferredAvailable)
+  return JSON.stringify({
+    tool: toolName,
+    error: errorMessage + deferredHint,
+  })
 }
 
 // Check if messages contain any tool-call content

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -15,7 +15,7 @@ import { SystemPrompt } from "./system"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
-import { buildDeferredHint } from "../tool/tool-info"
+import { TOOL_INFO_ID, buildDeferredHint } from "../tool/tool-info"
 import { Bus } from "@/bus"
 import { Wildcard } from "@/util/wildcard"
 import { SessionID } from "@/session/schema"
@@ -686,12 +686,14 @@ export function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permi
 }
 
 export function buildInvalidToolRepairInput(
-  input: Pick<StreamInput, "agent" | "availableDeferredTools" | "permission" | "user">,
+  input: Pick<StreamInput, "agent" | "availableDeferredTools" | "permission" | "tools" | "user">,
   toolName: string,
   errorMessage: string,
 ) {
   const deferredRuleset = Permission.merge(input.agent.permission, input.permission ?? [])
+  const toolInfoAvailable = input.tools[TOOL_INFO_ID] !== undefined
   const deferredAvailable = (id: string) =>
+    toolInfoAvailable &&
     (input.availableDeferredTools?.has(id) ?? true) &&
     input.user.tools?.[id] !== false &&
     !Permission.disabled([id], deferredRuleset).has(id)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -729,6 +729,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const deferredRuleset = Permission.merge(input.agent.permission, input.session.permission ?? [])
       const deferredAvailable = (id: string) =>
         input.tools?.[id] !== false && !Permission.disabled([id], deferredRuleset).has(id)
+      const availableDeferredTools = yield* registry.availableDeferred({ deferredAvailable })
 
       const context = (args: any, options: ToolExecutionOptions): Tool.Context => ({
         sessionID: input.session.id,
@@ -1039,7 +1040,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         tools[key] = item
       }
 
-      return tools
+      return { tools, availableDeferredTools }
     })
 
     const handleSubtask = Effect.fn("SessionPrompt.handleSubtask")(function* (input: {
@@ -2269,7 +2270,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
             const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
 
-            const tools = yield* resolveTools({
+            const resolvedTools = yield* resolveTools({
               agent,
               session,
               model,
@@ -2278,6 +2279,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               bypassAgentCheck,
               messages: msgs,
             })
+            const tools = resolvedTools.tools
 
             if (lastUser.format?.type === "json_schema") {
               tools["StructuredOutput"] = createStructuredOutputTool({
@@ -2379,6 +2381,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               system,
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
               tools,
+              availableDeferredTools: resolvedTools.availableDeferredTools,
               model,
               toolChoice: format.type === "json_schema" ? "required" : undefined,
             })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -729,7 +729,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const deferredRuleset = Permission.merge(input.agent.permission, input.session.permission ?? [])
       const deferredAvailable = (id: string) =>
         input.tools?.[id] !== false && !Permission.disabled([id], deferredRuleset).has(id)
-      const availableDeferredTools = yield* registry.availableDeferred({ deferredAvailable })
+      const availableDeferredTools = yield* registry.availableDeferred({ activatedTools, deferredAvailable })
 
       const context = (args: any, options: ToolExecutionOptions): Tool.Context => ({
         sessionID: input.session.id,

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -41,9 +41,6 @@ export const AutomateParameters = Schema.Struct({
   variant: Schema.optional(Schema.NonEmptyString),
 })
 
-export const AutomateDescription =
-  "Create an Automation that re-runs a prompt on a schedule. Provide a title, the prompt, and a 5-field cron expression; project, timezone, and model default to the current session. By default each run executes in its own fresh background session. Set continueSession true to instead run it as a loop inside THIS conversation: every run is appended to the current chat and sees the previous ones, so the user follows it here and pauses or deletes it from the Automations panel — and deleting this conversation deletes the automation with it. It repeats until paused or deleted. This only stores the definition; it does not run the prompt now."
-
 export function formatAutomateValidationError(error: unknown) {
   const detail =
     error instanceof ValidationError
@@ -94,7 +91,8 @@ export function createAutomateDefinition(
   automation: Automation.Interface,
 ): Tool.DefWithoutID<typeof AutomateParameters, { automationDefinition: Automation.Definition }> {
   return {
-    description: AutomateDescription,
+    description:
+      "Create an Automation that re-runs a prompt on a schedule. Provide a title, the prompt, and a 5-field cron expression; project, timezone, and model default to the current session. By default each run executes in its own fresh background session. Set continueSession true to instead run it as a loop inside THIS conversation: every run is appended to the current chat and sees the previous ones, so the user follows it here and pauses or deletes it from the Automations panel — and deleting this conversation deletes the automation with it. It repeats until paused or deleted. This only stores the definition; it does not run the prompt now.",
     parameters: AutomateParameters,
     formatValidationError: formatAutomateValidationError,
     execute: (params, ctx) =>

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -41,6 +41,9 @@ export const AutomateParameters = Schema.Struct({
   variant: Schema.optional(Schema.NonEmptyString),
 })
 
+export const AutomateDescription =
+  "Create an Automation that re-runs a prompt on a schedule. Provide a title, the prompt, and a 5-field cron expression; project, timezone, and model default to the current session. By default each run executes in its own fresh background session. Set continueSession true to instead run it as a loop inside THIS conversation: every run is appended to the current chat and sees the previous ones, so the user follows it here and pauses or deletes it from the Automations panel — and deleting this conversation deletes the automation with it. It repeats until paused or deleted. This only stores the definition; it does not run the prompt now."
+
 export function formatAutomateValidationError(error: unknown) {
   const detail =
     error instanceof ValidationError
@@ -91,8 +94,7 @@ export function createAutomateDefinition(
   automation: Automation.Interface,
 ): Tool.DefWithoutID<typeof AutomateParameters, { automationDefinition: Automation.Definition }> {
   return {
-    description:
-      "Create an Automation that re-runs a prompt on a schedule. Provide a title, the prompt, and a 5-field cron expression; project, timezone, and model default to the current session. By default each run executes in its own fresh background session. Set continueSession true to instead run it as a loop inside THIS conversation: every run is appended to the current chat and sees the previous ones, so the user follows it here and pauses or deletes it from the Automations panel — and deleting this conversation deletes the automation with it. It repeats until paused or deleted. This only stores the definition; it does not run the prompt now.",
+    description: AutomateDescription,
     parameters: AutomateParameters,
     formatValidationError: formatAutomateValidationError,
     execute: (params, ctx) =>

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -86,6 +86,7 @@ export namespace ToolRegistry {
     readonly all: () => Effect.Effect<Tool.Def[]>
     readonly named: () => Effect.Effect<{ agent: AgentDef; read: ReadDef }>
     readonly availableDeferred: (input: {
+      activatedTools?: ReadonlySet<string>
       deferredAvailable?: (id: string) => boolean
     }) => Effect.Effect<ReadonlySet<string>>
     readonly tools: (model: {
@@ -377,13 +378,16 @@ export namespace ToolRegistry {
       })
 
       const deferredAvailability = Effect.fn("ToolRegistry.deferredAvailability")(function* (input: {
+        activatedTools?: ReadonlySet<string>
         deferredAvailable?: (id: string) => boolean
       }) {
         const allTools = yield* all()
         const registeredToolIDs = new Set(allTools.map((tool) => tool.id))
         const isDeferredAvailable = (id: string) =>
           registeredToolIDs.has(id) && (input.deferredAvailable?.(id) ?? true)
-        const availableDeferred = [...DEFERRED_TOOL_IDS].filter(isDeferredAvailable)
+        const availableDeferred = [...DEFERRED_TOOL_IDS].filter(
+          (id) => isDeferredAvailable(id) && !(input.activatedTools?.has(id) ?? false),
+        )
         return { allTools, availableDeferred, isDeferredAvailable }
       })
 
@@ -396,7 +400,7 @@ export namespace ToolRegistry {
 
       const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
         const webSearchEnabled = yield* settings.webSearchEnabled()
-        const { allTools, isDeferredAvailable } = yield* deferredAvailability(input)
+        const { allTools, availableDeferred, isDeferredAvailable } = yield* deferredAvailability(input)
         const filtered = allTools.filter((tool) => {
           if (tool.id === WebSearchTool.id) return webSearchEnabled
 
@@ -412,10 +416,6 @@ export namespace ToolRegistry {
 
           return true
         })
-
-        const availableDeferredTools = [...DEFERRED_TOOL_IDS].filter(
-          (id) => isDeferredAvailable(id) && !(input.activatedTools?.has(id) ?? false),
-        )
 
         return yield* Effect.forEach(
           filtered,
@@ -445,7 +445,7 @@ export namespace ToolRegistry {
               description: [
                 output.description,
                 tool.id === AgentTool.id ? yield* describeTask(input.agent) : undefined,
-                tool.id === TOOL_INFO_ID ? buildCardList(availableDeferredTools) : undefined,
+                tool.id === TOOL_INFO_ID ? buildCardList(availableDeferred) : undefined,
               ]
                 .filter(Boolean)
                 .join("\n"),
@@ -513,6 +513,7 @@ export namespace ToolRegistry {
   }
 
   export async function availableDeferred(input: {
+    activatedTools?: ReadonlySet<string>
     deferredAvailable?: (id: string) => boolean
   }): Promise<ReadonlySet<string>> {
     return runPromise((svc) => svc.availableDeferred(input))

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -85,6 +85,9 @@ export namespace ToolRegistry {
     readonly ids: () => Effect.Effect<string[]>
     readonly all: () => Effect.Effect<Tool.Def[]>
     readonly named: () => Effect.Effect<{ agent: AgentDef; read: ReadDef }>
+    readonly availableDeferred: (input: {
+      deferredAvailable?: (id: string) => boolean
+    }) => Effect.Effect<ReadonlySet<string>>
     readonly tools: (model: {
       providerID: ProviderID
       modelID: ModelID
@@ -373,12 +376,27 @@ export namespace ToolRegistry {
         return ["Available agent types and the tools they have access to:", description].join("\n")
       })
 
-      const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
-        const webSearchEnabled = yield* settings.webSearchEnabled()
+      const deferredAvailability = Effect.fn("ToolRegistry.deferredAvailability")(function* (input: {
+        deferredAvailable?: (id: string) => boolean
+      }) {
         const allTools = yield* all()
         const registeredToolIDs = new Set(allTools.map((tool) => tool.id))
         const isDeferredAvailable = (id: string) =>
           registeredToolIDs.has(id) && (input.deferredAvailable?.(id) ?? true)
+        const availableDeferred = [...DEFERRED_TOOL_IDS].filter(isDeferredAvailable)
+        return { allTools, availableDeferred, isDeferredAvailable }
+      })
+
+      const availableDeferred: Interface["availableDeferred"] = Effect.fn("ToolRegistry.availableDeferred")(function* (
+        input,
+      ) {
+        const availability = yield* deferredAvailability(input)
+        return new Set(availability.availableDeferred)
+      })
+
+      const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
+        const webSearchEnabled = yield* settings.webSearchEnabled()
+        const { allTools, isDeferredAvailable } = yield* deferredAvailability(input)
         const filtered = allTools.filter((tool) => {
           if (tool.id === WebSearchTool.id) return webSearchEnabled
 
@@ -395,7 +413,7 @@ export namespace ToolRegistry {
           return true
         })
 
-        const availableDeferred = [...DEFERRED_TOOL_IDS].filter(
+        const availableDeferredTools = [...DEFERRED_TOOL_IDS].filter(
           (id) => isDeferredAvailable(id) && !(input.activatedTools?.has(id) ?? false),
         )
 
@@ -427,7 +445,7 @@ export namespace ToolRegistry {
               description: [
                 output.description,
                 tool.id === AgentTool.id ? yield* describeTask(input.agent) : undefined,
-                tool.id === TOOL_INFO_ID ? buildCardList(availableDeferred) : undefined,
+                tool.id === TOOL_INFO_ID ? buildCardList(availableDeferredTools) : undefined,
               ]
                 .filter(Boolean)
                 .join("\n"),
@@ -449,7 +467,7 @@ export namespace ToolRegistry {
         yield* InstanceState.invalidate(state)
       })
 
-      return Service.of({ ids, all, named, tools, invalidate })
+      return Service.of({ ids, all, named, availableDeferred, tools, invalidate })
     }),
   )
 
@@ -492,6 +510,12 @@ export namespace ToolRegistry {
     deferredAvailable?: (id: string) => boolean
   }): Promise<(Tool.Def & { id: string })[]> {
     return runPromise((svc) => svc.tools(input))
+  }
+
+  export async function availableDeferred(input: {
+    deferredAvailable?: (id: string) => boolean
+  }): Promise<ReadonlySet<string>> {
+    return runPromise((svc) => svc.availableDeferred(input))
   }
 
   export async function invalidate() {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -375,7 +375,11 @@ export namespace ToolRegistry {
 
       const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
         const webSearchEnabled = yield* settings.webSearchEnabled()
-        const filtered = (yield* all()).filter((tool) => {
+        const allTools = yield* all()
+        const registeredToolIDs = new Set(allTools.map((tool) => tool.id))
+        const isDeferredAvailable = (id: string) =>
+          registeredToolIDs.has(id) && (input.deferredAvailable?.(id) ?? true)
+        const filtered = allTools.filter((tool) => {
           if (tool.id === WebSearchTool.id) return webSearchEnabled
 
           const usePatch =
@@ -385,15 +389,14 @@ export namespace ToolRegistry {
           if (tool.id === EditTool.id || tool.id === WriteTool.id) return !usePatch
 
           if (DEFERRED_TOOL_IDS.has(tool.id)) {
-            const available = input.deferredAvailable?.(tool.id) ?? true
-            return available && (input.activatedTools?.has(tool.id) ?? false)
+            return isDeferredAvailable(tool.id) && (input.activatedTools?.has(tool.id) ?? false)
           }
 
           return true
         })
 
         const availableDeferred = [...DEFERRED_TOOL_IDS].filter(
-          (id) => (input.deferredAvailable?.(id) ?? true) && !(input.activatedTools?.has(id) ?? false),
+          (id) => isDeferredAvailable(id) && !(input.activatedTools?.has(id) ?? false),
         )
 
         return yield* Effect.forEach(
@@ -405,6 +408,20 @@ export namespace ToolRegistry {
               parameters: tool.parameters,
             }
             yield* plugin.trigger("tool.definition", { toolID: tool.id }, output)
+            const execute: Tool.Def["execute"] =
+              tool.id === TOOL_INFO_ID
+                ? ((args, ctx) => {
+                    const contextDeferredAvailable = ctx.extra?.["deferredAvailable"] as
+                      | ((id: string) => boolean)
+                      | undefined
+                    const deferredAvailable = (id: string) =>
+                      isDeferredAvailable(id) && (contextDeferredAvailable?.(id) ?? true)
+                    return tool.execute(args, {
+                      ...ctx,
+                      extra: { ...ctx.extra, deferredAvailable },
+                    })
+                  })
+                : tool.execute
             return {
               id: tool.id,
               description: [
@@ -415,7 +432,7 @@ export namespace ToolRegistry {
                 .filter(Boolean)
                 .join("\n"),
               parameters: output.parameters,
-              execute: tool.execute,
+              execute,
               formatValidationError: tool.formatValidationError,
             }
           }),

--- a/packages/opencode/src/tool/tool-info.ts
+++ b/packages/opencode/src/tool/tool-info.ts
@@ -1,10 +1,13 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import * as EffectZod from "@/util/effect-zod"
+import { AutomateDescription, AutomateParameters } from "./automate"
 import { Parameters as EnterWorktreeParameters } from "./enter-worktree"
 import EnterWorktreeDescription from "./enter-worktree.txt"
 import { Parameters as ExitWorktreeParameters } from "./exit-worktree"
 import ExitWorktreeDescription from "./exit-worktree.txt"
+import { Parameters as LspParameters } from "./lsp"
+import LspDescription from "./lsp.txt"
 import { ProviderTransform } from "../provider/transform"
 import type { Provider } from "../provider/provider"
 import type { MessageV2 } from "../session/message-v2"
@@ -18,6 +21,12 @@ export const TOOL_INFO_ID = "tool_info"
 // instead of the full .txt).
 const DEFERRED = [
   {
+    id: "automate" as const,
+    card: "Create a scheduled automation that re-runs a prompt later or on a recurring cron schedule.",
+    description: AutomateDescription,
+    parameters: AutomateParameters as unknown as Tool.Def["parameters"],
+  },
+  {
     id: "enter-worktree" as const,
     card: "Switch the session into an isolated git worktree to work on a branch in parallel without disturbing the main checkout. Use when a task needs its own branch/worktree.",
     description: EnterWorktreeDescription,
@@ -28,6 +37,12 @@ const DEFERRED = [
     card: "Leave the current worktree and return the session to the project root.",
     description: ExitWorktreeDescription,
     parameters: ExitWorktreeParameters as unknown as Tool.Def["parameters"],
+  },
+  {
+    id: "lsp" as const,
+    card: "Use language-server code intelligence for definitions, references, hover, and symbol navigation.",
+    description: LspDescription,
+    parameters: LspParameters as unknown as Tool.Def["parameters"],
   },
 ] as const
 

--- a/packages/opencode/src/tool/tool-info.ts
+++ b/packages/opencode/src/tool/tool-info.ts
@@ -1,7 +1,6 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import * as EffectZod from "@/util/effect-zod"
-import { AutomateDescription, AutomateParameters } from "./automate"
 import { Parameters as EnterWorktreeParameters } from "./enter-worktree"
 import EnterWorktreeDescription from "./enter-worktree.txt"
 import { Parameters as ExitWorktreeParameters } from "./exit-worktree"
@@ -20,12 +19,6 @@ export const TOOL_INFO_ID = "tool_info"
 // Cards are one-line summaries shown in tool_info's description (one-line budget
 // instead of the full .txt).
 const DEFERRED = [
-  {
-    id: "automate" as const,
-    card: "Create a scheduled automation that re-runs a prompt later or on a recurring cron schedule.",
-    description: AutomateDescription,
-    parameters: AutomateParameters as unknown as Tool.Def["parameters"],
-  },
   {
     id: "enter-worktree" as const,
     card: "Switch the session into an isolated git worktree to work on a branch in parallel without disturbing the main checkout. Use when a task needs its own branch/worktree.",

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -120,6 +120,52 @@ describe("session.llm.hasToolCalls", () => {
   })
 })
 
+describe("session.llm.buildInvalidToolRepairInput", () => {
+  const agent = {
+    name: "build",
+    mode: "primary",
+    permission: [],
+    options: {},
+  } satisfies Agent.Info
+  const user = { tools: {} } as MessageV2.User
+
+  test("omits deferred hint when tool_info is not available", () => {
+    const repair = JSON.parse(
+      LLM.buildInvalidToolRepairInput(
+        {
+          agent,
+          availableDeferredTools: new Set(["lsp"]),
+          permission: [],
+          tools: {},
+          user,
+        },
+        "lsp",
+        "Unknown tool: lsp",
+      ),
+    ) as { error: string }
+
+    expect(repair.error).not.toContain('call tool_info with name="lsp"')
+  })
+
+  test("includes deferred hint when tool_info can load the deferred tool", () => {
+    const repair = JSON.parse(
+      LLM.buildInvalidToolRepairInput(
+        {
+          agent,
+          availableDeferredTools: new Set(["lsp"]),
+          permission: [],
+          tools: { tool_info: {} as never },
+          user,
+        },
+        "lsp",
+        "Unknown tool: lsp",
+      ),
+    ) as { error: string }
+
+    expect(repair.error).toContain('call tool_info with name="lsp"')
+  })
+})
+
 type Capture = {
   url: URL
   headers: Headers

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -45,7 +45,7 @@ describe("tool.registry", () => {
     })
   })
 
-  test("exposes automate now that the Automations panel ships", async () => {
+  test("registers automate but defers it out of the default model surface", async () => {
     await using tmp = await tmpdir()
 
     await withMockedConfigInstall(async () => {
@@ -54,6 +54,16 @@ describe("tool.registry", () => {
         fn: async () => {
           const ids = await ToolRegistry.ids()
           expect(ids).toContain("automate")
+
+          const tools = await ToolRegistry.tools({
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-5"),
+            agent: { name: "build", mode: "primary", permission: [], options: {} },
+          })
+          const surface = tools.map((tool) => tool.id)
+          expect(surface).not.toContain("automate")
+          const card = tools.find((tool) => tool.id === "tool_info")!.description
+          expect(card).toContain("automate")
         },
       })
     })
@@ -813,7 +823,7 @@ describe("tool.registry", () => {
     })
   })
 
-  test("includes lsp tool when Settings.lspEnabled=true", async () => {
+  test("registers lsp when Settings.lspEnabled=true but defers it out of the default model surface", async () => {
     await using tmp = await tmpdir()
     await Settings.setLspEnabled(true)
     try {
@@ -822,6 +832,16 @@ describe("tool.registry", () => {
         fn: async () => {
           const ids = await ToolRegistry.ids()
           expect(ids).toContain("lsp")
+
+          const tools = await ToolRegistry.tools({
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-5"),
+            agent: { name: "build", mode: "primary", permission: [], options: {} },
+          })
+          const surface = tools.map((tool) => tool.id)
+          expect(surface).not.toContain("lsp")
+          const card = tools.find((tool) => tool.id === "tool_info")!.description
+          expect(card).toContain("lsp")
         },
       })
     } finally {
@@ -921,52 +941,114 @@ describe("tool.registry", () => {
     }
   })
 
-  test("defers worktree tools until activated, and advertises them via tool_info", async () => {
+  test("does not advertise lsp as deferred when Settings.lspEnabled=false", async () => {
     await using tmp = await tmpdir()
+    await Settings.setLspEnabled(false)
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        // Default: deferred worktree tools are not in the surface; tool_info is,
-        // and advertises both as cards.
-        const def = await ToolRegistry.tools({
+        const tools = await ToolRegistry.tools({
           providerID: ProviderID.make("openai"),
           modelID: ModelID.make("gpt-5"),
           agent: { name: "build", mode: "primary", permission: [], options: {} },
         })
-        const defIds = def.map((tool) => tool.id)
-        expect(defIds).not.toContain("enter-worktree")
-        expect(defIds).not.toContain("exit-worktree")
-        expect(defIds).toContain("tool_info")
-        const card = def.find((tool) => tool.id === "tool_info")!.description
-        expect(card).toContain("enter-worktree")
-        expect(card).toContain("exit-worktree")
-
-        // Activated: enter-worktree becomes callable; tool_info stops listing it.
-        const act = await ToolRegistry.tools({
-          providerID: ProviderID.make("openai"),
-          modelID: ModelID.make("gpt-5"),
-          agent: { name: "build", mode: "primary", permission: [], options: {} },
-          activatedTools: new Set(["enter-worktree"]),
-        })
-        const actIds = act.map((tool) => tool.id)
-        expect(actIds).toContain("enter-worktree")
-        expect(actIds).not.toContain("exit-worktree")
-        const actCard = act.find((tool) => tool.id === "tool_info")!.description
-        expect(actCard).not.toContain("enter-worktree")
-        expect(actCard).toContain("exit-worktree")
-
-        // Permission-disabled: even activated, it stays hidden and uncarded.
-        const denied = await ToolRegistry.tools({
-          providerID: ProviderID.make("openai"),
-          modelID: ModelID.make("gpt-5"),
-          agent: { name: "build", mode: "primary", permission: [], options: {} },
-          activatedTools: new Set(["enter-worktree"]),
-          deferredAvailable: () => false,
-        })
-        expect(denied.map((tool) => tool.id)).not.toContain("enter-worktree")
-        expect(denied.find((tool) => tool.id === "tool_info")!.description).toContain("No deferred tools")
+        const card = tools.find((tool) => tool.id === "tool_info")!.description
+        expect(card).not.toContain("lsp")
       },
     })
+  })
+
+  test("rejects direct tool_info activation for lsp when Settings.lspEnabled=false", async () => {
+    await using tmp = await tmpdir()
+    await Settings.setLspEnabled(false)
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tools = await ToolRegistry.tools({
+          providerID: ProviderID.make("openai"),
+          modelID: ModelID.make("gpt-5"),
+          agent: { name: "build", mode: "primary", permission: [], options: {} },
+        })
+        const toolInfo = tools.find((tool) => tool.id === "tool_info")!
+        const ctx = {
+          sessionID: SessionID.descending(),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+          extra: {},
+        }
+
+        await expect(Effect.runPromise(toolInfo.execute({ name: "lsp" }, ctx))).rejects.toThrow(
+          'Deferred tool "lsp" is not available in this context.',
+        )
+      },
+    })
+  })
+
+  test("defers low-frequency tools until activated, and advertises them via tool_info", async () => {
+    await using tmp = await tmpdir()
+    await Settings.setLspEnabled(true)
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          // Default: deferred low-frequency tools are not in the surface; tool_info is,
+          // and advertises each available tool as a card.
+          const def = await ToolRegistry.tools({
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-5"),
+            agent: { name: "build", mode: "primary", permission: [], options: {} },
+          })
+          const defIds = def.map((tool) => tool.id)
+          expect(defIds).not.toContain("automate")
+          expect(defIds).not.toContain("enter-worktree")
+          expect(defIds).not.toContain("exit-worktree")
+          expect(defIds).not.toContain("lsp")
+          expect(defIds).toContain("tool_info")
+          const card = def.find((tool) => tool.id === "tool_info")!.description
+          expect(card).toContain("automate")
+          expect(card).toContain("enter-worktree")
+          expect(card).toContain("exit-worktree")
+          expect(card).toContain("lsp")
+
+          // Activated: selected tools become callable; tool_info stops listing them.
+          const act = await ToolRegistry.tools({
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-5"),
+            agent: { name: "build", mode: "primary", permission: [], options: {} },
+            activatedTools: new Set(["automate", "enter-worktree", "lsp"]),
+          })
+          const actIds = act.map((tool) => tool.id)
+          expect(actIds).toContain("automate")
+          expect(actIds).toContain("enter-worktree")
+          expect(actIds).not.toContain("exit-worktree")
+          expect(actIds).toContain("lsp")
+          const actCard = act.find((tool) => tool.id === "tool_info")!.description
+          expect(actCard).not.toContain("automate")
+          expect(actCard).not.toContain("enter-worktree")
+          expect(actCard).toContain("exit-worktree")
+          expect(actCard).not.toContain("lsp")
+
+          // Permission-disabled: even activated, it stays hidden and uncarded.
+          const denied = await ToolRegistry.tools({
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-5"),
+            agent: { name: "build", mode: "primary", permission: [], options: {} },
+            activatedTools: new Set(["automate", "enter-worktree", "lsp"]),
+            deferredAvailable: () => false,
+          })
+          expect(denied.map((tool) => tool.id)).not.toContain("automate")
+          expect(denied.map((tool) => tool.id)).not.toContain("enter-worktree")
+          expect(denied.map((tool) => tool.id)).not.toContain("lsp")
+          expect(denied.find((tool) => tool.id === "tool_info")!.description).toContain("No deferred tools")
+        },
+      })
+    } finally {
+      await Settings.setLspEnabled(false)
+    }
   })
 
   test("tool_info hands back exactly the schema the activated tool will expose, untruncated", async () => {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -47,7 +47,7 @@ describe("tool.registry", () => {
     })
   })
 
-  test("registers automate but defers it out of the default model surface", async () => {
+  test("keeps automate on the default model surface", async () => {
     await using tmp = await tmpdir()
 
     await withMockedConfigInstall(async () => {
@@ -63,9 +63,9 @@ describe("tool.registry", () => {
             agent: { name: "build", mode: "primary", permission: [], options: {} },
           })
           const surface = tools.map((tool) => tool.id)
-          expect(surface).not.toContain("automate")
+          expect(surface).toContain("automate")
           const card = tools.find((tool) => tool.id === "tool_info")!.description
-          expect(card).toContain("automate")
+          expect(card).not.toContain("automate")
         },
       })
     })
@@ -1017,14 +1017,14 @@ describe("tool.registry", () => {
     })
   })
 
-  test("defers low-frequency tools until activated, and advertises them via tool_info", async () => {
+  test("defers lsp and worktree tools until activated, and advertises them via tool_info", async () => {
     await using tmp = await tmpdir()
     await Settings.setLspEnabled(true)
     try {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          // Default: deferred low-frequency tools are not in the surface; tool_info is,
+          // Default: deferred tools are not in the surface; tool_info is,
           // and advertises each available tool as a card.
           const def = await ToolRegistry.tools({
             providerID: ProviderID.make("openai"),
@@ -1032,13 +1032,13 @@ describe("tool.registry", () => {
             agent: { name: "build", mode: "primary", permission: [], options: {} },
           })
           const defIds = def.map((tool) => tool.id)
-          expect(defIds).not.toContain("automate")
+          expect(defIds).toContain("automate")
           expect(defIds).not.toContain("enter-worktree")
           expect(defIds).not.toContain("exit-worktree")
           expect(defIds).not.toContain("lsp")
           expect(defIds).toContain("tool_info")
           const card = def.find((tool) => tool.id === "tool_info")!.description
-          expect(card).toContain("automate")
+          expect(card).not.toContain("automate")
           expect(card).toContain("enter-worktree")
           expect(card).toContain("exit-worktree")
           expect(card).toContain("lsp")
@@ -1048,7 +1048,7 @@ describe("tool.registry", () => {
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
-            activatedTools: new Set(["automate", "enter-worktree", "lsp"]),
+            activatedTools: new Set(["enter-worktree", "lsp"]),
           })
           const actIds = act.map((tool) => tool.id)
           expect(actIds).toContain("automate")
@@ -1066,10 +1066,10 @@ describe("tool.registry", () => {
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
-            activatedTools: new Set(["automate", "enter-worktree", "lsp"]),
+            activatedTools: new Set(["enter-worktree", "lsp"]),
             deferredAvailable: () => false,
           })
-          expect(denied.map((tool) => tool.id)).not.toContain("automate")
+          expect(denied.map((tool) => tool.id)).toContain("automate")
           expect(denied.map((tool) => tool.id)).not.toContain("enter-worktree")
           expect(denied.map((tool) => tool.id)).not.toContain("lsp")
           expect(denied.find((tool) => tool.id === "tool_info")!.description).toContain("No deferred tools")

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -12,6 +12,8 @@ import { ProviderTransform } from "../../src/provider"
 import { localToolImportSpec, ToolRegistry } from "../../src/tool/registry"
 import { Settings } from "../../src/settings"
 import { MessageID, SessionID } from "../../src/session/schema"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { LLM } from "../../src/session/llm"
 import * as EffectZod from "../../src/util/effect-zod"
 import { Npm } from "@opencode-ai/core/npm"
 
@@ -984,6 +986,33 @@ describe("tool.registry", () => {
         await expect(Effect.runPromise(toolInfo.execute({ name: "lsp" }, ctx))).rejects.toThrow(
           'Deferred tool "lsp" is not available in this context.',
         )
+      },
+    })
+  })
+
+  test("omits deferred repair hint for lsp when Settings.lspEnabled=false", async () => {
+    await using tmp = await tmpdir()
+    await Settings.setLspEnabled(false)
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const availableDeferredTools = await ToolRegistry.availableDeferred({
+          deferredAvailable: () => true,
+        })
+        const repair = JSON.parse(
+          LLM.buildInvalidToolRepairInput(
+            {
+              agent: { name: "build", mode: "primary", permission: [], options: {} },
+              availableDeferredTools,
+              permission: [],
+              user: { tools: {} } as MessageV2.User,
+            },
+            "lsp",
+            "Unknown tool: lsp",
+          ),
+        ) as { error: string }
+
+        expect(repair.error).not.toContain('call tool_info with name="lsp"')
       },
     })
   })

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -1005,6 +1005,7 @@ describe("tool.registry", () => {
               agent: { name: "build", mode: "primary", permission: [], options: {} },
               availableDeferredTools,
               permission: [],
+              tools: { tool_info: {} as never },
               user: { tools: {} } as MessageV2.User,
             },
             "lsp",
@@ -1015,6 +1016,39 @@ describe("tool.registry", () => {
         expect(repair.error).not.toContain('call tool_info with name="lsp"')
       },
     })
+  })
+
+  test("omits deferred repair hint for lsp after it is activated", async () => {
+    await using tmp = await tmpdir()
+    await Settings.setLspEnabled(true)
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const availableDeferredTools = await ToolRegistry.availableDeferred({
+            activatedTools: new Set(["lsp"]),
+            deferredAvailable: () => true,
+          })
+          const repair = JSON.parse(
+            LLM.buildInvalidToolRepairInput(
+              {
+                agent: { name: "build", mode: "primary", permission: [], options: {} },
+                availableDeferredTools,
+                permission: [],
+                tools: { tool_info: {} as never },
+                user: { tools: {} } as MessageV2.User,
+              },
+              "lsp",
+              "Invalid input",
+            ),
+          ) as { error: string }
+
+          expect(repair.error).not.toContain('call tool_info with name="lsp"')
+        },
+      })
+    } finally {
+      await Settings.setLspEnabled(false)
+    }
   })
 
   test("defers lsp and worktree tools until activated, and advertises them via tool_info", async () => {

--- a/packages/opencode/test/tool/tool-info.test.ts
+++ b/packages/opencode/test/tool/tool-info.test.ts
@@ -25,8 +25,8 @@ function assistant(parts: unknown[]): MessageV2.WithParts {
 }
 
 describe("tool-info", () => {
-  test("DEFERRED_TOOL_IDS is exactly the low-frequency tool set", () => {
-    expect([...DEFERRED_TOOL_IDS].sort()).toEqual(["automate", "enter-worktree", "exit-worktree", "lsp"])
+  test("DEFERRED_TOOL_IDS is exactly the worktree tools plus lsp", () => {
+    expect([...DEFERRED_TOOL_IDS].sort()).toEqual(["enter-worktree", "exit-worktree", "lsp"])
   })
 
   test("deriveActivatedTools picks only completed tool_info calls for deferred tools", () => {
@@ -51,8 +51,8 @@ describe("tool-info", () => {
   })
 
   test("buildCardList lists available deferred tools with their cards", () => {
-    const list = buildCardList(["automate", "enter-worktree", "exit-worktree", "lsp"])
-    expect(list).toContain("automate")
+    const list = buildCardList(["enter-worktree", "exit-worktree", "lsp"])
+    expect(list).not.toContain("automate")
     expect(list).toContain("enter-worktree")
     expect(list).toContain("exit-worktree")
     expect(list).toContain("lsp")
@@ -117,7 +117,7 @@ describe("tool-info", () => {
     expect(canonicalDeferredId("enter-worktree")).toBe("enter-worktree")
     expect(canonicalDeferredId("Enter-Worktree")).toBe("enter-worktree")
     expect(canonicalDeferredId("ENTER-WORKTREE")).toBe("enter-worktree")
-    expect(canonicalDeferredId("Automate")).toBe("automate")
+    expect(canonicalDeferredId("Automate")).toBeUndefined()
     expect(canonicalDeferredId("LSP")).toBe("lsp")
     expect(canonicalDeferredId("read")).toBeUndefined()
   })

--- a/packages/opencode/test/tool/tool-info.test.ts
+++ b/packages/opencode/test/tool/tool-info.test.ts
@@ -25,8 +25,8 @@ function assistant(parts: unknown[]): MessageV2.WithParts {
 }
 
 describe("tool-info", () => {
-  test("DEFERRED_TOOL_IDS is exactly the two worktree tools", () => {
-    expect([...DEFERRED_TOOL_IDS].sort()).toEqual(["enter-worktree", "exit-worktree"])
+  test("DEFERRED_TOOL_IDS is exactly the low-frequency tool set", () => {
+    expect([...DEFERRED_TOOL_IDS].sort()).toEqual(["automate", "enter-worktree", "exit-worktree", "lsp"])
   })
 
   test("deriveActivatedTools picks only completed tool_info calls for deferred tools", () => {
@@ -51,9 +51,11 @@ describe("tool-info", () => {
   })
 
   test("buildCardList lists available deferred tools with their cards", () => {
-    const list = buildCardList(["enter-worktree", "exit-worktree"])
+    const list = buildCardList(["automate", "enter-worktree", "exit-worktree", "lsp"])
+    expect(list).toContain("automate")
     expect(list).toContain("enter-worktree")
     expect(list).toContain("exit-worktree")
+    expect(list).toContain("lsp")
     expect(list).toContain("isolated git worktree")
   })
 
@@ -115,6 +117,8 @@ describe("tool-info", () => {
     expect(canonicalDeferredId("enter-worktree")).toBe("enter-worktree")
     expect(canonicalDeferredId("Enter-Worktree")).toBe("enter-worktree")
     expect(canonicalDeferredId("ENTER-WORKTREE")).toBe("enter-worktree")
+    expect(canonicalDeferredId("Automate")).toBe("automate")
+    expect(canonicalDeferredId("LSP")).toBe("lsp")
     expect(canonicalDeferredId("read")).toBeUndefined()
   })
 


### PR DESCRIPTION
## Summary

Adds `lsp` to the deferred tool catalog served through `tool_info`, so it stays out of the default model tool surface until explicitly activated.

There is no linked issue; this is a direct maintainer-requested follow-up to expand the deferred tool list. `automate` is intentionally left on the default model surface for now and is not included in this PR's deferred catalog change.

## Why

`lsp` is a lower-frequency tool with a comparatively large schema/description. Deferring it keeps the default tool prompt smaller while preserving on-demand access through the existing `tool_info` activation flow.

`lsp` also keeps its existing settings gate: when LSP is disabled, it is neither advertised in `tool_info` nor activatable through a direct `tool_info({ name: "lsp" })` call. Invalid-tool repair hints use the same registry-aware deferred availability set, so a direct mistaken `lsp` call does not route the model back to `tool_info` when LSP is disabled.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please check that the registry-level availability gate matches the intended deferred behavior:

- `lsp` is hidden from the default model surface when LSP is enabled.
- Activated deferred tools become callable on the next step.
- Disabled or permission-denied deferred tools stay hidden and cannot be activated via `tool_info`.
- `lsp` is only advertised, activatable, and repair-hinted when `Settings.lspEnabled()` is true.
- `automate` remains on the default model surface and is not advertised by `tool_info`.

## Risk Notes

Behavior change: models must now call `tool_info` before using `lsp`. This is intentional for a lower-frequency code-intelligence tool, but it changes the first-step availability of `lsp` when LSP is enabled.

Skipped conditional checklist items:

- Visible UI/manual screenshot check: not applicable; this changes tool registration and model-facing descriptions, not a rendered UI surface.
- macOS/Windows manual platform check: not applicable; no platform, packaging, updater, shell, signing, or installer path changed.

No dependencies, generated files, docs, release notes, credentials, or destructive behavior changed. Permission-related behavior and the disabled-LSP repair hint path are covered by focused tests.

## How To Verify

```text
Focused deferred tool tests: bun test --timeout 30000 test/tool/tool-info.test.ts test/tool/registry.test.ts
Result: 46 pass, 0 fail, 123 expect() calls

Focused LLM repair tests: bun test --timeout 30000 test/session/llm.test.ts
Result: 19 pass, 0 fail, 44 expect() calls

Typecheck: bun run typecheck
Result: tsgo --noEmit completed successfully

Whitespace check: git diff --check
Result: no whitespace errors
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the LSP tool as a conditionally available option.
  * Improved deferred tool availability tracking and visibility in tool discovery.

* **Bug Fixes**
  * Enhanced error messages when tools are unavailable, with more accurate suggestions based on current context.
  * Fixed tool availability calculations to properly gate conditional tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->