### PR TITLE
fix(app): converge desktop attachments on file paths

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -40,6 +40,7 @@ import { PromptContextItems } from "./prompt-input/context-items"
 import { PromptImageAttachments } from "./prompt-input/image-attachments"
 import { PromptDragOverlay } from "./prompt-input/drag-overlay"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
+import { showAttachmentInFolder } from "./prompt-input/attachment-reveal"
 
 interface PromptInputProps {
   class?: string
@@ -262,6 +263,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       openModelPicker()
     },
     readFileDataUrl: platform.readFileDataUrl,
+    filePathForBrowserFile: platform.filePathForBrowserFile,
+    saveAttachmentFile: platform.saveAttachmentFile,
+    statPaths: platform.statPaths,
     readClipboardImage: platform.readClipboardImage,
     // Path C dependencies (paste of `/<known-name> args` into empty input).
     imageAttachments,
@@ -417,6 +421,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             onKeyDown={handleKeyDown}
             handlePaste={handlePaste}
             addAttachments={addAttachments}
+            onFileAttachmentOpen={(path) => {
+              showAttachmentInFolder({ platform, directory: sdk.directory, path })
+            }}
           />
 
           <PromptActionBar

--- a/packages/app/src/components/prompt-input/attachment-reveal.test.ts
+++ b/packages/app/src/components/prompt-input/attachment-reveal.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { showAttachmentInFolder } from "./attachment-reveal"
+
+test("showAttachmentInFolder reveals relative prompt file paths under the session directory", () => {
+  const shown: string[] = []
+
+  showAttachmentInFolder({
+    platform: {
+      showItemInFolder: async (path) => {
+        shown.push(path)
+      },
+    },
+    directory: "/repo/main",
+    path: "src/foo.ts",
+  })
+
+  expect(shown).toEqual(["/repo/main/src/foo.ts"])
+})
+
+test("showAttachmentInFolder preserves absolute prompt file paths", () => {
+  const shown: string[] = []
+
+  showAttachmentInFolder({
+    platform: {
+      showItemInFolder: async (path) => {
+        shown.push(path)
+      },
+    },
+    directory: "/repo/main",
+    path: "/tmp/drop.pdf",
+  })
+
+  expect(shown).toEqual(["/tmp/drop.pdf"])
+})

--- a/packages/app/src/components/prompt-input/attachment-reveal.ts
+++ b/packages/app/src/components/prompt-input/attachment-reveal.ts
@@ -1,0 +1,11 @@
+import type { Platform } from "@/context/platform"
+import { toAbsoluteFilePath } from "./path-canonical"
+
+export function showAttachmentInFolder(input: {
+  platform: Pick<Platform, "showItemInFolder">
+  directory: string
+  path: string
+}) {
+  const absolutePath = toAbsoluteFilePath(input.directory, input.path)
+  void input.platform.showItemInFolder?.(absolutePath)
+}

--- a/packages/app/src/components/prompt-input/attachments.test.ts
+++ b/packages/app/src/components/prompt-input/attachments.test.ts
@@ -128,6 +128,138 @@ describe("pasteMode", () => {
 })
 
 describe("createPromptAttachments", () => {
+  test("adds picked media paths as deduped file attachments instead of data URL attachments", async () => {
+    const addedParts: unknown[] = []
+    const attachments = createPromptAttachments({
+      editor: () => ({}) as HTMLDivElement,
+      isDialogActive: () => false,
+      setDraggingType: () => undefined,
+      focusEditor: () => undefined,
+      addPart: (part) => {
+        addedParts.push(part)
+        return true
+      },
+      model: () => ({
+        capabilities: {
+          input: {
+            image: true,
+            pdf: true,
+          },
+        },
+      }),
+      openModelSelector: () => undefined,
+      readFileDataUrl: async () => "data:image/png;base64,aW1hZ2U=",
+    })
+
+    const result = await attachments.addPickedPaths([
+      "/Users/me/image.png",
+      "/Users/me/report.pdf",
+      "/Users/me/image.png",
+    ])
+
+    expect(result).toBe(true)
+    expect(addedParts).toEqual([
+      { type: "file", path: "/Users/me/image.png", content: "@image.png", start: 0, end: 10 },
+      { type: "file", path: "/Users/me/report.pdf", content: "@report.pdf", start: 0, end: 11 },
+    ])
+    expect(promptParts).toHaveLength(0)
+    expect(toasts).toHaveLength(0)
+  })
+
+  test("adds desktop dropped files from Electron file paths", async () => {
+    const addedParts: unknown[] = []
+    const attachments = createPromptAttachments({
+      editor: () => ({}) as HTMLDivElement,
+      isDialogActive: () => false,
+      setDraggingType: () => undefined,
+      focusEditor: () => undefined,
+      addPart: (part) => {
+        addedParts.push(part)
+        return true
+      },
+      model: () => ({
+        capabilities: {
+          input: {
+            pdf: false,
+          },
+        },
+      }),
+      openModelSelector: () => undefined,
+      filePathForBrowserFile: async () => "/Users/me/guide.pdf",
+    })
+
+    const result = await attachments.addAttachments([new File(["%PDF-1.7"], "guide.pdf", { type: "application/pdf" })])
+
+    expect(result).toBe(true)
+    expect(addedParts).toEqual([
+      { type: "file", path: "/Users/me/guide.pdf", content: "@guide.pdf", start: 0, end: 10 },
+    ])
+    expect(promptParts).toHaveLength(0)
+    expect(toasts).toHaveLength(0)
+  })
+
+  test("stores file sizes on path-backed attachments when available", async () => {
+    const addedParts: unknown[] = []
+    const attachments = createPromptAttachments({
+      editor: () => ({}) as HTMLDivElement,
+      isDialogActive: () => false,
+      setDraggingType: () => undefined,
+      focusEditor: () => undefined,
+      addPart: (part) => {
+        addedParts.push(part)
+        return true
+      },
+      model: () => undefined,
+      openModelSelector: () => undefined,
+      statPaths: async () => ({ "/Users/me/guide.pdf": { exists: true, size: 1536 } }),
+    })
+
+    const result = await attachments.addPickedPath("/Users/me/guide.pdf")
+
+    expect(result).toBe(true)
+    expect(addedParts).toEqual([
+      { type: "file", path: "/Users/me/guide.pdf", content: "@guide.pdf", start: 0, end: 10, size: 1536 },
+    ])
+  })
+
+  test("saves pathless pasted files before attaching them", async () => {
+    const addedParts: unknown[] = []
+    const attachments = createPromptAttachments({
+      editor: () => ({}) as HTMLDivElement,
+      isDialogActive: () => false,
+      setDraggingType: () => undefined,
+      focusEditor: () => undefined,
+      addPart: (part) => {
+        addedParts.push(part)
+        return true
+      },
+      model: () => ({
+        capabilities: {
+          input: {
+            image: true,
+          },
+        },
+      }),
+      openModelSelector: () => undefined,
+      saveAttachmentFile: async () => "/Users/me/Library/Application Support/PawWork/attachments/pasted-image.png",
+    })
+
+    const result = await attachments.addAttachment(new File(["image"], "pasted-image.png", { type: "image/png" }))
+
+    expect(result).toBe(true)
+    expect(addedParts).toEqual([
+      {
+        type: "file",
+        path: "/Users/me/Library/Application Support/PawWork/attachments/pasted-image.png",
+        content: "@pasted-image.png",
+        start: 0,
+        end: 17,
+      },
+    ])
+    expect(promptParts).toHaveLength(0)
+    expect(toasts).toHaveLength(0)
+  })
+
   test("reports a skipped file even when another dropped file is attached", async () => {
     const attachments = createPromptAttachments({
       editor: () => ({}) as HTMLDivElement,
@@ -155,7 +287,7 @@ describe("createPromptAttachments", () => {
     expect(toasts.map((toast) => toast.title)).toEqual(["prompt.toast.imageUnsupported.title"])
   })
 
-  test("reports a skipped picked path even when another picked path is attached", async () => {
+  test("does not block picked image paths on model media support", async () => {
     const addedParts: unknown[] = []
     const attachments = createPromptAttachments({
       editor: () => ({}) as HTMLDivElement,
@@ -179,12 +311,16 @@ describe("createPromptAttachments", () => {
     const result = await attachments.addPickedPaths(["/Users/me/report.docx", "/Users/me/image.png"])
 
     expect(result).toBe(true)
-    expect(addedParts).toHaveLength(1)
-    expect(toasts.map((toast) => toast.title)).toEqual(["prompt.toast.imageUnsupported.title"])
+    expect(addedParts).toEqual([
+      { type: "file", path: "/Users/me/report.docx", content: "@report.docx", start: 0, end: 12 },
+      { type: "file", path: "/Users/me/image.png", content: "@image.png", start: 0, end: 10 },
+    ])
+    expect(toasts).toHaveLength(0)
   })
 
-  test("does not downgrade picked direct media read failures to path mentions", async () => {
+  test("does not read picked media paths as data URL attachments", async () => {
     const addedParts: unknown[] = []
+    let readCalls = 0
     const attachments = createPromptAttachments({
       editor: () => ({}) as HTMLDivElement,
       isDialogActive: () => false,
@@ -202,45 +338,24 @@ describe("createPromptAttachments", () => {
         },
       }),
       openModelSelector: () => undefined,
-      readFileDataUrl: async () => null,
-    })
-
-    const result = await attachments.addPickedPath("/Users/me/image.png")
-
-    expect(result).toBe(false)
-    expect(addedParts).toHaveLength(0)
-    expect(promptParts).toHaveLength(0)
-    expect(toasts.map((toast) => toast.title)).toEqual(["prompt.toast.pasteUnsupported.title"])
-  })
-
-  test("reports thrown picked direct read failures", async () => {
-    const attachments = createPromptAttachments({
-      editor: () => ({}) as HTMLDivElement,
-      isDialogActive: () => false,
-      setDraggingType: () => undefined,
-      focusEditor: () => undefined,
-      addPart: () => true,
-      model: () => ({
-        capabilities: {
-          input: {
-            image: true,
-          },
-        },
-      }),
-      openModelSelector: () => undefined,
       readFileDataUrl: async () => {
+        readCalls++
         throw new Error("read failed")
       },
     })
 
     const result = await attachments.addPickedPath("/Users/me/image.png")
 
-    expect(result).toBe(false)
+    expect(result).toBe(true)
+    expect(readCalls).toBe(0)
+    expect(addedParts).toEqual([
+      { type: "file", path: "/Users/me/image.png", content: "@image.png", start: 0, end: 10 },
+    ])
     expect(promptParts).toHaveLength(0)
-    expect(toasts.map((toast) => toast.title)).toEqual(["prompt.toast.pasteUnsupported.title"])
+    expect(toasts).toHaveLength(0)
   })
 
-  test("reports picked direct read failures in path batches", async () => {
+  test("keeps picked path batches on the file-reference path", async () => {
     const addedParts: unknown[] = []
     const attachments = createPromptAttachments({
       editor: () => ({}) as HTMLDivElement,
@@ -265,8 +380,11 @@ describe("createPromptAttachments", () => {
     const result = await attachments.addPickedPaths(["/Users/me/report.docx", "/Users/me/image.png"])
 
     expect(result).toBe(true)
-    expect(addedParts).toHaveLength(1)
-    expect(toasts.map((toast) => toast.title)).toEqual(["prompt.toast.pasteUnsupported.title"])
+    expect(addedParts).toEqual([
+      { type: "file", path: "/Users/me/report.docx", content: "@report.docx", start: 0, end: 12 },
+      { type: "file", path: "/Users/me/image.png", content: "@image.png", start: 0, end: 10 },
+    ])
+    expect(toasts).toHaveLength(0)
   })
 
   test("accepts empty FileReader MIME when the routed MIME is known", async () => {

--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -66,6 +66,9 @@ type PromptAttachmentsInput = {
   model: () => ModelInputSupport
   openModelSelector: () => void
   readFileDataUrl?: (path: string, mime: string) => Promise<string | null>
+  filePathForBrowserFile?: (file: File) => Promise<string | null>
+  saveAttachmentFile?: (file: File) => Promise<string | null>
+  statPaths?: (paths: string[]) => Promise<Record<string, { size: number; exists: boolean }>>
   readClipboardImage?: () => Promise<File | null>
   // Path C (paste of `/<known-name> args` into structurally-empty input)
   // dependencies. Default to empty/false so callers that do not need pill
@@ -133,13 +136,33 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     return true
   }
 
-  const routePathFallback = (path: string) => {
+  const attachmentSize = async (path: string) => {
+    const stats = await input.statPaths?.([path]).catch(() => undefined)
+    const stat = stats?.[path]
+    return stat?.exists ? stat.size : undefined
+  }
+
+  const routePathFallback = async (path: string) => {
+    if (prompt.current().some((part) => part.type === "file" && part.path === path)) return true
     input.focusEditor()
-    const content = "@" + path
-    return input.addPart({ type: "file", path, content, start: 0, end: content.length })
+    const content = "@" + pathBasename(path)
+    const size = await attachmentSize(path)
+    return input.addPart({ type: "file", path, content, start: 0, end: content.length, size })
   }
 
   const add = async (file: File, toast = true): Promise<AddResult> => {
+    const filePath = await (async () => {
+      const recovered = await input.filePathForBrowserFile?.(file).catch(() => null)
+      if (recovered) return recovered
+      if (!input.saveAttachmentFile) return null
+      return input.saveAttachmentFile(file).catch(() => null)
+    })()
+    if (filePath) return addPickedPathResult(filePath, toast)
+    if (input.saveAttachmentFile) {
+      if (toast) pathRequired()
+      return { type: "path", reason: "unknown" }
+    }
+
     const route = await routeBrowserFile(file, input.model())
     if (route.type === "direct") {
       try {
@@ -193,30 +216,12 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     return found
   }
 
-  const addPickedPathResult = async (path: string, toast = true): Promise<AddResult> => {
+  const addPickedPathResult = async (path: string, toast = true, seen?: Set<string>): Promise<AddResult> => {
+    if (seen?.has(path)) return true
+    seen?.add(path)
+    if (await routePathFallback(path)) return true
     const route = routePickedPath(path, input.model())
-    if (route.type === "reject-image") {
-      if (toast) warnImageUnsupported()
-      return route
-    }
-
-    if (route.type === "direct") {
-      try {
-        const url = await input.readFileDataUrl?.(path, route.mime)
-        if (!url) {
-          if (toast) warn()
-          return false
-        }
-        const ok = await addDirect(pathBasename(path), route.mime, url)
-        if (!ok && toast) warn()
-        return ok
-      } catch {
-        if (toast) warn()
-        return false
-      }
-    }
-
-    if (routePathFallback(path)) return true
+    if (route.type === "direct") return false
     return route
   }
 
@@ -226,8 +231,9 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     let found = false
     let failure: AttachmentFailureRoute | undefined
     let directFailure = false
+    const seen = new Set<string>()
     for (const path of paths) {
-      const result = await addPickedPathResult(path, false)
+      const result = await addPickedPathResult(path, false, seen)
       if (result === true) {
         found = true
         continue

--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -52,6 +52,48 @@ const isFileAttachment = (part: Prompt[number]): part is FileAttachmentPart => p
 const isAgentAttachment = (part: Prompt[number]): part is AgentPart => part.type === "agent"
 const isSkillAttachment = (part: Prompt[number]): part is SkillAttachmentPart => part.type === "skill"
 
+function buildPromptFileParts(prompt: Prompt, sessionDirectory: string) {
+  return prompt.filter(isFileAttachment).map((attachment) => {
+    const path = toAbsoluteFilePath(sessionDirectory, attachment.path)
+    return {
+      id: Identifier.ascending("part"),
+      type: "file",
+      mime: "text/plain",
+      url: fileURL(path, attachment.selection),
+      filename: getFilename(attachment.path),
+      source: {
+        type: "file",
+        text: {
+          value: attachment.content,
+          start: attachment.start,
+          end: attachment.end,
+        },
+        path,
+      },
+    } satisfies PromptRequestPart
+  })
+}
+
+function buildLegacyImageParts(images: ImageAttachmentPart[]) {
+  return images.map((attachment) => {
+    return {
+      id: Identifier.ascending("part"),
+      type: "file",
+      mime: attachment.mime,
+      url: attachment.dataUrl,
+      filename: attachment.filename,
+    } satisfies PromptRequestPart
+  })
+}
+
+export function buildAttachmentRequestParts(input: {
+  prompt: Prompt
+  images: ImageAttachmentPart[]
+  sessionDirectory: string
+}) {
+  return [...buildPromptFileParts(input.prompt, input.sessionDirectory), ...buildLegacyImageParts(input.images)]
+}
+
 const toOptimisticPart = (part: PromptRequestPart, sessionID: string, messageID: string): Part => {
   if (part.type === "text") {
     return {
@@ -110,25 +152,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
     },
   ]
 
-  const files = input.prompt.filter(isFileAttachment).map((attachment) => {
-    const path = toAbsoluteFilePath(input.sessionDirectory, attachment.path)
-    return {
-      id: Identifier.ascending("part"),
-      type: "file",
-      mime: "text/plain",
-      url: fileURL(path, attachment.selection),
-      filename: getFilename(attachment.path),
-      source: {
-        type: "file",
-        text: {
-          value: attachment.content,
-          start: attachment.start,
-          end: attachment.end,
-        },
-        path,
-      },
-    } satisfies PromptRequestPart
-  })
+  const files = buildPromptFileParts(input.prompt, input.sessionDirectory)
 
   const agents = input.prompt.filter(isAgentAttachment).map((attachment) => {
     return {
@@ -215,15 +239,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
     ]
   })
 
-  const images = input.images.map((attachment) => {
-    return {
-      id: Identifier.ascending("part"),
-      type: "file",
-      mime: attachment.mime,
-      url: attachment.dataUrl,
-      filename: attachment.filename,
-    } satisfies PromptRequestPart
-  })
+  const images = buildLegacyImageParts(input.images)
 
   requestParts.push(...files, ...context, ...agents, ...skills, ...images)
 

--- a/packages/app/src/components/prompt-input/editor-serialize.test.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.test.ts
@@ -172,6 +172,31 @@ describe("inline skill pill", () => {
   })
 })
 
+describe("inline file pill", () => {
+  test("shows filename and size while preserving canonical content on parse", () => {
+    const pill = createPill({
+      type: "file",
+      path: "/Users/me/report.pdf",
+      content: "@report.pdf",
+      start: 0,
+      end: 11,
+      size: 1536,
+    })
+
+    expect(pill.textContent).toBe("@report.pdf 1.5 KB")
+    expect(pill.title).toContain("/Users/me/report.pdf")
+    expect(pill.title).toContain("1.5 KB")
+
+    const editor = document.createElement("div")
+    editor.appendChild(pill)
+    const result = parseEditorToParts(editor)
+
+    expect(result).toEqual([
+      { type: "file", path: "/Users/me/report.pdf", content: "@report.pdf", start: 0, end: 11, size: 1536 },
+    ])
+  })
+})
+
 describe("isNormalizedEditor skill-pill position independence", () => {
   test("a skill pill mid-stream stays normalized (no rebuild)", () => {
     const editor = document.createElement("div")

--- a/packages/app/src/components/prompt-input/editor-serialize.ts
+++ b/packages/app/src/components/prompt-input/editor-serialize.ts
@@ -7,6 +7,15 @@ import { resolveCommandIconSvg } from "@opencode-ai/ui/command-icon"
 import { createTextFragment } from "./editor-dom"
 import "./command-pill.css"
 
+function formatFileSize(size: number | undefined) {
+  if (size === undefined || !Number.isFinite(size) || size < 0) return ""
+  if (size < 1024) return `${size} B`
+  const kb = size / 1024
+  if (kb < 1024) return `${Number.isInteger(kb) ? kb.toFixed(0) : kb.toFixed(1)} KB`
+  const mb = kb / 1024
+  return `${Number.isInteger(mb) ? mb.toFixed(0) : mb.toFixed(1)} MB`
+}
+
 /** Build the DOM node for a slash-command pill (contenteditable=false). */
 export function createCommandMark(part: TextPart & { command: NonNullable<TextPart["command"]> }): HTMLSpanElement {
   const cmd = part.command
@@ -37,7 +46,14 @@ export function createCommandMark(part: TextPart & { command: NonNullable<TextPa
 export function createPill(part: FileAttachmentPart | AgentPart | SkillAttachmentPart): HTMLSpanElement {
   const pill = document.createElement("span")
   pill.setAttribute("data-type", part.type)
-  if (part.type === "file") pill.setAttribute("data-path", part.path)
+  if (part.type === "file") {
+    const size = formatFileSize(part.size)
+    pill.setAttribute("data-path", part.path)
+    pill.setAttribute("data-content", part.content)
+    if (part.size !== undefined) pill.setAttribute("data-size", String(part.size))
+    pill.title = size ? `${part.path}\n${size}` : part.path
+    pill.textContent = size ? `${part.content} ${size}` : part.content
+  }
   if (part.type === "agent") pill.setAttribute("data-name", part.name)
   if (part.type === "skill") {
     pill.setAttribute("data-name", part.name)
@@ -55,7 +71,7 @@ export function createPill(part: FileAttachmentPart | AgentPart | SkillAttachmen
     labelSpan.setAttribute("data-cmd-label", "true")
     labelSpan.textContent = part.content.replace(/^\//, "")
     pill.appendChild(labelSpan)
-  } else {
+  } else if (part.type !== "file") {
     pill.textContent = part.content
   }
   pill.setAttribute("contenteditable", "false")
@@ -139,14 +155,17 @@ export function parseEditorToParts(editor: HTMLElement): Prompt {
   }
 
   const pushFile = (file: HTMLElement) => {
-    const content = file.textContent ?? ""
-    parts.push({
+    const content = file.dataset.content ?? file.textContent ?? ""
+    const size = file.dataset.size ? Number(file.dataset.size) : undefined
+    const part: FileAttachmentPart = {
       type: "file",
       path: file.dataset.path!,
       content,
       start: position,
       end: position + content.length,
-    })
+    }
+    if (Number.isFinite(size)) part.size = size
+    parts.push(part)
     position += content.length
   }
 

--- a/packages/app/src/components/prompt-input/editor-surface.tsx
+++ b/packages/app/src/components/prompt-input/editor-surface.tsx
@@ -25,6 +25,7 @@ export interface PromptEditorSurfaceProps {
   onKeyDown: (event: KeyboardEvent) => void
   handlePaste: (event: ClipboardEvent) => void
   addAttachments: (files: File[]) => void
+  onFileAttachmentOpen?: (path: string) => void
 }
 
 export function PromptEditorSurface(props: PromptEditorSurfaceProps) {
@@ -50,6 +51,14 @@ export function PromptEditorSurface(props: PromptEditorSurfaceProps) {
           autocomplete="off"
           onInput={props.onInput}
           onCopy={props.onCopy}
+          onClick={(event) => {
+            const target = event.target
+            if (!(target instanceof HTMLElement)) return
+            const pill = target.closest('[data-type="file"][data-path]')
+            if (!(pill instanceof HTMLElement) || !pill.dataset.path) return
+            event.preventDefault()
+            props.onFileAttachmentOpen?.(pill.dataset.path)
+          }}
           onPaste={(event) => {
             const hasFiles = Array.from(event.clipboardData?.items ?? []).some((item) => item.kind === "file")
             if (!props.actionReady() && hasFiles) {

--- a/packages/app/src/components/prompt-input/send-followup-draft.test.ts
+++ b/packages/app/src/components/prompt-input/send-followup-draft.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test"
 import { sendFollowupDraft } from "./send-followup-draft"
 
 const commandCalls: Array<Record<string, unknown>> = []
+const promptAsyncCalls: Array<Record<string, unknown>> = []
 
 const clientFor = () => ({
   session: {
@@ -9,11 +10,16 @@ const clientFor = () => ({
       commandCalls.push(input)
       return { data: undefined }
     },
+    promptAsync: async (input: Record<string, unknown>) => {
+      promptAsyncCalls.push(input)
+      return { data: undefined }
+    },
   },
 })
 
 beforeEach(() => {
   commandCalls.length = 0
+  promptAsyncCalls.length = 0
 })
 
 describe("sendFollowupDraft", () => {
@@ -44,5 +50,80 @@ describe("sendFollowupDraft", () => {
     })
 
     expect(commandCalls.at(-1)?.locale).toBe("zh-Hans")
+  })
+
+  test("sends file attachment parts with slash-command followups", async () => {
+    await sendFollowupDraft({
+      client: clientFor() as any,
+      globalSync: {
+        child: () => [{}, () => undefined],
+      } as any,
+      sync: {
+        data: { command: [{ name: "summarize" }], command_ready: true },
+        session: {
+          optimistic: {
+            add: () => undefined,
+            remove: () => undefined,
+          },
+        },
+      } as any,
+      draft: {
+        sessionID: "session-1",
+        sessionDirectory: "/repo/main",
+        prompt: [
+          { type: "text", content: "/summarize ", start: 0, end: 11 },
+          { type: "file", path: "guide.pdf", content: "@guide.pdf", start: 11, end: 21 },
+        ],
+        context: [],
+        agent: "agent",
+        model: { providerID: "provider", modelID: "model" },
+        locale: "zh-Hans",
+      },
+    })
+
+    expect(commandCalls.at(-1)?.parts).toEqual([
+      {
+        id: expect.any(String),
+        type: "file",
+        mime: "text/plain",
+        url: "file:///repo/main/guide.pdf",
+        filename: "guide.pdf",
+        source: {
+          type: "file",
+          text: { value: "@guide.pdf", start: 11, end: 21 },
+          path: "/repo/main/guide.pdf",
+        },
+      },
+    ])
+  })
+
+  test("sends file attachment parts with normal followups", async () => {
+    await sendFollowupDraft({
+      client: clientFor() as any,
+      globalSync: {
+        child: () => [{}, () => undefined],
+      } as any,
+      sync: {
+        data: { command: [], command_ready: true },
+        session: {
+          optimistic: {
+            add: () => undefined,
+            remove: () => undefined,
+          },
+        },
+      } as any,
+      draft: {
+        sessionID: "session-1",
+        sessionDirectory: "/repo/main",
+        prompt: [{ type: "file", path: "guide.pdf", content: "@guide.pdf", start: 0, end: 10 }],
+        context: [],
+        agent: "agent",
+        model: { providerID: "provider", modelID: "model" },
+        locale: "zh-Hans",
+      },
+    })
+
+    const parts = promptAsyncCalls.at(-1)?.parts as Array<Record<string, unknown>>
+    expect(parts.some((part) => part.type === "file" && part.url === "file:///repo/main/guide.pdf")).toBe(true)
   })
 })

--- a/packages/app/src/components/prompt-input/send-followup-draft.ts
+++ b/packages/app/src/components/prompt-input/send-followup-draft.ts
@@ -5,7 +5,7 @@ import type { useGlobalSync } from "@/context/global-sync"
 import type { useSDK } from "@/context/sdk"
 import type { useSync } from "@/context/sync"
 import { Identifier } from "@/utils/id"
-import { buildRequestParts } from "./build-request-parts"
+import { buildAttachmentRequestParts, buildRequestParts } from "./build-request-parts"
 import { reportInvariantBreach } from "./invariant"
 import { followupCommandText, type FollowupDraft } from "./followup-draft"
 
@@ -24,6 +24,12 @@ const draftImages = (prompt: Prompt) => prompt.filter((part): part is ImageAttac
 export async function sendFollowupDraft(input: FollowupSendInput) {
   const text = followupCommandText(input.draft)
   const images = draftImages(input.draft.prompt)
+  const commandParts = () =>
+    buildAttachmentRequestParts({
+      prompt: input.draft.prompt,
+      images,
+      sessionDirectory: input.draft.sessionDirectory,
+    })
   const [, setStore] = input.globalSync.child(input.draft.sessionDirectory)
 
   const setBusy = () => {
@@ -70,13 +76,7 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
           model: `${input.draft.model.providerID}/${input.draft.model.modelID}`,
           locale: input.draft.locale,
           variant: input.draft.variant,
-          parts: images.map((attachment) => ({
-            id: Identifier.ascending("part"),
-            type: "file" as const,
-            mime: attachment.mime,
-            url: attachment.dataUrl,
-            filename: attachment.filename,
-          })),
+          parts: commandParts(),
         })
         return true
       } catch (err) {
@@ -107,13 +107,7 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
         model: `${input.draft.model.providerID}/${input.draft.model.modelID}`,
         locale: input.draft.locale,
         variant: input.draft.variant,
-        parts: images.map((attachment) => ({
-          id: Identifier.ascending("part"),
-          type: "file" as const,
-          mime: attachment.mime,
-          url: attachment.dataUrl,
-          filename: attachment.filename,
-        })),
+        parts: commandParts(),
       })
       return true
     } catch (err) {

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -749,6 +749,36 @@ describe("prompt submit worktree selection", () => {
     expect(promptAsyncCalls.at(-1)?.locale).toBe("pt-BR")
   })
 
+  test("allows attachment-only promptAsync submits", async () => {
+    params = { id: "session-existing" }
+    promptValue = [{ type: "file", path: "guide.pdf", content: "@guide.pdf", start: 0, end: 10 }]
+
+    const submit = createPromptSubmit({
+      navigate: (path) => navigateImpl(path),
+      routeParams: () => params,
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => promptAsyncCalls.length > 0)
+
+    const parts = promptAsyncCalls.at(-1)?.parts as Array<Record<string, unknown>>
+    expect(parts.some((part) => part.type === "file" && part.url === "file:///repo/main/guide.pdf")).toBe(true)
+  })
+
   test("queues locale on followup drafts", async () => {
     params = { id: "session-existing" }
     const queued: Array<Record<string, unknown>> = []
@@ -807,6 +837,52 @@ describe("prompt submit worktree selection", () => {
     await waitForCall(() => commandCalls.length > 0)
 
     expect(commandCalls.at(-1)?.locale).toBe("nb-NO")
+  })
+
+  test("sends file attachment parts with direct slash-command submits", async () => {
+    params = { id: "session-existing" }
+    commandDefinitions.push({ name: "summarize" })
+    promptValue = [
+      { type: "text", content: "/summarize ", start: 0, end: 11 },
+      { type: "file", path: "guide.pdf", content: "@guide.pdf", start: 11, end: 21 },
+    ]
+
+    const submit = createPromptSubmit({
+      navigate: (path) => navigateImpl(path),
+      routeParams: () => params,
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await waitForCall(() => commandCalls.length > 0)
+
+    expect(commandCalls.at(-1)?.parts).toEqual([
+      {
+        id: expect.any(String),
+        type: "file",
+        mime: "text/plain",
+        url: "file:///repo/main/guide.pdf",
+        filename: "guide.pdf",
+        source: {
+          type: "file",
+          text: { value: "@guide.pdf", start: 11, end: 21 },
+          path: "/repo/main/guide.pdf",
+        },
+      },
+    ])
   })
 
   test("clears prompt source scope on successful new-session submit", async () => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -26,6 +26,7 @@ import { sendFollowupDraft } from "./send-followup-draft"
 import { createAbort, pending } from "./submit-abort"
 import { createPromptDraftLifecycle } from "./prompt-draft-lifecycle"
 import { createWaitForWorktree } from "./wait-for-worktree"
+import { buildAttachmentRequestParts } from "./build-request-parts"
 
 type PromptSubmitInput = {
   sessionID?: Accessor<string | undefined>
@@ -283,6 +284,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     // Note: it is only meaningful for the prompt-submit path (where comment
     // context items exist); the queue branch ignores it.
     const commentItems = context.filter((item) => item.type === "file" && !!item.comment?.trim())
+    const commandParts = () => buildAttachmentRequestParts({ prompt: currentPrompt, images, sessionDirectory })
 
     // Owner-backed drafts leave the live draft owner before the async send
     // settles; the owner only represents editable unsent draft state, and
@@ -369,13 +371,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             model: `${model.providerID}/${model.modelID}`,
             locale,
             variant,
-            parts: images.map((attachment) => ({
-              id: Identifier.ascending("part"),
-              type: "file" as const,
-              mime: attachment.mime,
-              url: attachment.dataUrl,
-              filename: attachment.filename,
-            })),
+            parts: commandParts(),
           })
           .then(() => {
             lifecycle.confirmOwnerCleared()
@@ -406,13 +402,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             model: `${model.providerID}/${model.modelID}`,
             locale,
             variant,
-            parts: images.map((attachment) => ({
-              id: Identifier.ascending("part"),
-              type: "file" as const,
-              mime: attachment.mime,
-              url: attachment.dataUrl,
-              filename: attachment.filename,
-            })),
+            parts: commandParts(),
           })
           .then(() => {
             lifecycle.confirmOwnerCleared()

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -124,6 +124,12 @@ export type Platform = {
   /** Read a local file as a data URL. Undefined on web, callers must keep a path fallback. */
   readFileDataUrl?(path: string, mime: string): Promise<string | null>
 
+  /** Recover the local path behind a desktop browser File object, when Electron exposes one. */
+  filePathForBrowserFile?(file: File): Promise<string | null>
+
+  /** Persist pathless pasted or dragged content to app-managed local storage and return its path. */
+  saveAttachmentFile?(file: File): Promise<string | null>
+
   /** Save file picker dialog (desktop only) */
   saveFilePickerDialog?(opts?: SaveFilePickerOptions): Promise<string | null>
 

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -30,6 +30,7 @@ export interface TextPart extends PartBase {
 export interface FileAttachmentPart extends PartBase {
   type: "file"
   path: string
+  size?: number
   selection?: FileSelection
 }
 

--- a/packages/desktop-electron/src/main/attachment-filename.test.ts
+++ b/packages/desktop-electron/src/main/attachment-filename.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { safeAttachmentName } from "./attachment-filename"
+
+describe("safeAttachmentName", () => {
+  test("replaces invalid filename characters", () => {
+    expect(safeAttachmentName('a<b>:"|?*.txt')).toBe("a_b______.txt")
+  })
+
+  test("removes trailing dots and spaces for Windows compatibility", () => {
+    expect(safeAttachmentName("report.pdf. ")).toBe("report.pdf")
+  })
+
+  test("prefixes Windows reserved basenames", () => {
+    expect(safeAttachmentName("CON")).toBe("_CON")
+    expect(safeAttachmentName("nul.txt")).toBe("_nul.txt")
+    expect(safeAttachmentName("LPT1")).toBe("_LPT1")
+  })
+
+  test("falls back when the sanitized name is empty", () => {
+    expect(safeAttachmentName("... ")).toBe("attachment")
+    expect(safeAttachmentName("")).toBe("attachment")
+  })
+})

--- a/packages/desktop-electron/src/main/attachment-filename.ts
+++ b/packages/desktop-electron/src/main/attachment-filename.ts
@@ -1,0 +1,14 @@
+import path from "node:path"
+
+const WINDOWS_RESERVED_BASENAME = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i
+
+export function safeAttachmentName(name: unknown) {
+  const fallback = "attachment"
+  if (typeof name !== "string" || name.trim().length === 0) return fallback
+
+  let base = path.basename(name).replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_").replace(/[. ]+$/g, "")
+  base = base.slice(0, 160).replace(/[. ]+$/g, "")
+  if (base.length === 0) return fallback
+  if (WINDOWS_RESERVED_BASENAME.test(base)) base = `_${base}`
+  return base
+}

--- a/packages/desktop-electron/src/main/attachment-ipc-source.test.ts
+++ b/packages/desktop-electron/src/main/attachment-ipc-source.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+const mainIpc = readFileSync(resolve(import.meta.dir, "ipc.ts"), "utf8")
+const preload = readFileSync(resolve(import.meta.dir, "../preload/index.ts"), "utf8")
+const preloadTypes = readFileSync(resolve(import.meta.dir, "../preload/types.ts"), "utf8")
+const renderer = readFileSync(resolve(import.meta.dir, "../renderer/index.tsx"), "utf8")
+
+describe("attachment IPC source contract", () => {
+  test("exposes Electron file path recovery to the sandboxed renderer", () => {
+    expect(preload).toContain("webUtils")
+    expect(preload).toContain("webUtils.getPathForFile")
+    expect(preloadTypes).toContain("filePathForBrowserFile")
+    expect(renderer).toContain("filePathForBrowserFile")
+  })
+
+  test("registers managed attachment saving through preload, renderer, and main IPC", () => {
+    expect(mainIpc).toContain('"save-attachment-file"')
+    expect(mainIpc).toContain("ArrayBuffer.isView")
+    expect(preload).toContain('"save-attachment-file"')
+    expect(preloadTypes).toContain("saveAttachmentFile")
+    expect(renderer).toContain("saveAttachmentFile")
+  })
+})

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises"
 import path from "node:path"
 import { execFile } from "node:child_process"
+import { randomUUID } from "node:crypto"
 import { BrowserWindow, Notification, app, clipboard, dialog, ipcMain, shell } from "electron"
 import type { IpcMainEvent, IpcMainInvokeEvent } from "electron"
 
@@ -40,6 +41,19 @@ function normalizeAttachmentPath(filepath: unknown) {
   if (typeof filepath !== "string" || filepath.length === 0) return
   if (/^[\\/]{2}[^\\/]+[\\/][^\\/]+/.test(filepath)) return filepath
   return path.resolve(filepath)
+}
+
+function safeAttachmentName(name: unknown) {
+  const fallback = "attachment"
+  if (typeof name !== "string" || name.trim().length === 0) return fallback
+  const base = path.basename(name).replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_")
+  return base.length > 0 ? base.slice(0, 160) : fallback
+}
+
+function attachmentBuffer(payload: unknown) {
+  if (payload instanceof ArrayBuffer) return Buffer.from(payload)
+  if (ArrayBuffer.isView(payload)) return Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength)
+  return null
 }
 
 type Deps = {
@@ -333,6 +347,25 @@ export function registerIpcHandlers(deps: Deps) {
       return null
     }
   })
+
+  ipcMain.handle(
+    "save-attachment-file",
+    async (event: IpcMainInvokeEvent, name: string, _mime: string, payload: ArrayBuffer | ArrayBufferView) => {
+      try {
+        const buffer = attachmentBuffer(payload)
+        if (!buffer || buffer.byteLength === 0 || buffer.byteLength > MAX_ATTACHMENT_BYTES) return null
+        const dir = path.join(app.getPath("userData"), "attachments")
+        await fs.mkdir(dir, { recursive: true })
+        const filepath = path.join(dir, `${Date.now()}-${randomUUID()}-${safeAttachmentName(name)}`)
+        await fs.writeFile(filepath, buffer, { flag: "wx" })
+        approveAttachmentPaths(event.sender, filepath)
+        return filepath
+      } catch (err) {
+        console.warn("save-attachment-file failed", err)
+        return null
+      }
+    },
+  )
 
   ipcMain.handle(
     "save-file-picker",

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -16,6 +16,7 @@ import type {
   WindowConfig,
   WslConfig,
 } from "../preload/types"
+import { safeAttachmentName } from "./attachment-filename"
 import { attachmentPathMime } from "./attachment-mime"
 import { getStore } from "./store"
 import { attachRendererDiagnosticsToSessionExport, fetchExport } from "./server-client"
@@ -41,13 +42,6 @@ function normalizeAttachmentPath(filepath: unknown) {
   if (typeof filepath !== "string" || filepath.length === 0) return
   if (/^[\\/]{2}[^\\/]+[\\/][^\\/]+/.test(filepath)) return filepath
   return path.resolve(filepath)
-}
-
-function safeAttachmentName(name: unknown) {
-  const fallback = "attachment"
-  if (typeof name !== "string" || name.trim().length === 0) return fallback
-  const base = path.basename(name).replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_")
-  return base.length > 0 ? base.slice(0, 160) : fallback
 }
 
 function attachmentBuffer(payload: unknown) {

--- a/packages/desktop-electron/src/preload/index.ts
+++ b/packages/desktop-electron/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron"
+import { contextBridge, ipcRenderer, webUtils } from "electron"
 import { buildDesktopContext } from "@opencode-ai/app/desktop-api"
 import type { BrowserState } from "@opencode-ai/app/desktop-api"
 import type { DesktopContext, ElectronAPI, InitStep, SqliteMigrationProgress } from "./types"
@@ -75,6 +75,8 @@ const api: ElectronAPI = {
   openDirectoryPicker: (opts) => ipcRenderer.invoke("open-directory-picker", opts),
   openFilePicker: (opts) => ipcRenderer.invoke("open-file-picker", opts),
   readFileDataUrl: (path, mime) => ipcRenderer.invoke("read-file-data-url", path, mime),
+  filePathForBrowserFile: (file) => webUtils.getPathForFile(file),
+  saveAttachmentFile: (name, mime, buffer) => ipcRenderer.invoke("save-attachment-file", name, mime, buffer),
   saveFilePicker: (opts) => ipcRenderer.invoke("save-file-picker", opts),
   exportSession: (sessionID, directory, defaultName, title) =>
     ipcRenderer.invoke("export-session", sessionID, directory, defaultName, title),

--- a/packages/desktop-electron/src/preload/types.ts
+++ b/packages/desktop-electron/src/preload/types.ts
@@ -76,6 +76,8 @@ export type ElectronAPI = {
     extensions?: string[]
   }) => Promise<string | string[] | null>
   readFileDataUrl: (path: string, mime: string) => Promise<string | null>
+  filePathForBrowserFile: (file: File) => string
+  saveAttachmentFile: (name: string, mime: string, buffer: ArrayBuffer) => Promise<string | null>
   saveFilePicker: (opts?: { title?: string; defaultPath?: string }) => Promise<string | null>
   exportSession: (
     sessionID: string,

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -168,6 +168,17 @@ const createPlatform = (): Platform => {
       return window.api.readFileDataUrl(hostPath, mime).catch(() => null)
     },
 
+    async filePathForBrowserFile(file) {
+      const path = window.api.filePathForBrowserFile(file)
+      if (!path) return null
+      return handleWslPicker(path)
+    },
+
+    async saveAttachmentFile(file) {
+      const path = await window.api.saveAttachmentFile(file.name, file.type, await file.arrayBuffer()).catch(() => null)
+      return handleWslPicker(path)
+    },
+
     async saveFilePickerDialog(opts) {
       const result = await window.api.saveFilePicker({
         title: opts?.title ?? t("desktop.dialog.saveFile"),


### PR DESCRIPTION
## Summary

Converges desktop attachment entry points on path-backed file attachments instead of creating new data URL image attachments.

- Recovers Electron `File` paths via `webUtils.getPathForFile` and saves pathless pasted/dropped files into managed desktop storage before attaching.
- Keeps picked files, Finder/Explorer drops, paste/screenshot files, slash-command sends, and follow-up sends on the same `FileAttachmentPart` request path.
- Adds duplicate-path suppression, filename + size chip display, full-path tooltip details, and desktop show-in-folder reveal with relative paths resolved against the session directory.
- Preserves legacy data URL image attachments only for existing web/compatibility flows.

## Why

Issue #1238 calls out inconsistent desktop attachment behavior: some entry points required paths while others tried to create new data URL image payloads, attachments could be dropped from command/follow-up sends, and path-backed chips did not consistently expose desktop file actions.

## Related Issue

Closes #1238.

## Human Review Status

Pending

## Review Focus

Please focus on the desktop attachment boundary: Electron preload/main IPC path recovery and managed saving, path canonicalization for `FileAttachmentPart`, and command/follow-up request parts carrying file attachments without creating new data URL flows.

## Risk Notes

- Platform/path surface changed for macOS and Windows desktop attachment flows. The implementation keeps existing legacy data URL compatibility but routes new desktop-capable files through paths.
- Pathless pasted/dropped files are saved under Electron `userData/attachments`; there is no cleanup policy in this PR.
- The visible attachment chip state was verified through Chromium E2E and DOM serialization tests, but no static screenshot or recording is attached.

## How To Verify

```text
bun install --frozen-lockfile: ok
bun test --preload ./happydom.ts src/components/prompt-input/attachment-reveal.test.ts src/components/prompt-input/attachments.test.ts src/components/prompt-input/editor-serialize.test.ts src/components/prompt-input/submit.test.ts src/components/prompt-input/send-followup-draft.test.ts src/components/prompt-input/build-request-parts.test.ts: 98 passed
bun test src/main/attachment-filename.test.ts src/main/attachment-ipc-source.test.ts src/main/attachment-mime.test.ts: 11 passed
bun x playwright test e2e/prompt/prompt-drop-file.spec.ts --project=chromium --workers=1 --reporter=line: 2 passed
bun --cwd packages/app typecheck: passed
bun --cwd packages/desktop-electron typecheck: passed
bun run lint: passed
bun --cwd packages/desktop-electron build: passed; emitted existing Vite/eval warnings only
Fresh-eye subagent review: found relative-path reveal bug; fixed with attachment reveal canonicalization and tests
CodeRabbit inline review: found Windows managed filename sanitization gap; fixed with attachment filename helper and tests
PAWWORK_CI_SMOKE=true bun run dev:desktop: attempted, but electron-vite dev failed before launch with esbuild "The service was stopped"; desktop build above passed as fallback Electron-path verification
```

## Screenshots or Recordings

No screenshot attached. The changed visible chip behavior is covered by `prompt-drop-file.spec.ts` visible assertions and `editor-serialize.test.ts` DOM round-trip assertions for filename, size, and full-path tooltip data.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
