### PR TITLE
fix(tool): route scheduling requests to the automate tool

### DIFF
--- a/packages/opencode/src/session/prompt/pawwork.txt
+++ b/packages/opencode/src/session/prompt/pawwork.txt
@@ -49,6 +49,12 @@ Pick the right helper before acting:
 
 If the user has already specified a path, execute it directly without re-asking. Otherwise reach for these helpers only when their specific trigger applies — handle ordinary work in this thread.
 
+# Scheduling, reminders, and recurring work
+
+When the user asks to do something later, be reminded, send something at a specific time, or repeat work on a schedule, create a PawWork Automation with the `automate` tool — for one-time and recurring tasks alike. Automations appear in the Automations panel, can be paused or deleted there, and run with the session's project context, model, and credentials.
+
+Never install OS-level schedulers for these requests with any tool: no `at`, `cron`, `crontab`, `launchd` or LaunchAgents plists, systemd timers, `schtasks`, background scripts, or sleep loops — neither by running commands nor by writing files. Use other tools only to gather information the scheduled prompt will need. OS schedulers are acceptable only when the user explicitly asks for a system-level scheduler outside PawWork.
+
 # Bundled capabilities
 
 PawWork ships with `officecli`, a CLI built for AI agents to read and write Microsoft Office files on the user's machine: `.docx`, `.xlsx`, and `.pptx`. It is already on PATH inside the bash tool. When a task requires reading or modifying one of these file types on the local disk, prefer `officecli` over Python libraries (`python-docx`, `openpyxl`, `python-pptx`) or generic file reads. Run `officecli help` or `officecli <subcommand> --help` to discover subcommands and arguments before assuming syntax. Do not invoke it for tasks that are about Office topics in the abstract (e.g. layout advice) rather than operating on a real file.

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -42,7 +42,7 @@ export const AutomateParameters = Schema.Struct({
   }),
   recurring: Schema.optional(Schema.Boolean).annotate({
     description:
-      "Omit or true for a repeating schedule. Set false for a one-time task: it fires once at the next cron match. For a one-time task on a specific date, pin day-of-month and month in the cron expression.",
+      "Omit or true for a repeating schedule. Set false for a one-time task: it fires once at the next cron match. For a one-time task on a specific date, pin day-of-month and month in the cron expression and leave day-of-week as * — when both day fields are restricted, cron fires on either match, so the task would fire prematurely.",
   }),
   continueSession: Schema.optional(Schema.Boolean).annotate({
     description:

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -31,14 +31,32 @@ const Prompt = Schema.NonEmptyString.check(Schema.isMaxLength(Automation.MAX_PRO
 // continueSession off). Interval/sub-minute cadence stays a UI/SDK power-user
 // feature and is intentionally off the AI surface.
 export const AutomateParameters = Schema.Struct({
-  title: Title,
-  prompt: Prompt,
-  cron: CronExpression,
-  recurring: Schema.optional(Schema.Boolean),
-  continueSession: Schema.optional(Schema.Boolean),
-  timezone: Schema.optional(Timezone),
-  model: Schema.optional(Schema.NonEmptyString),
-  variant: Schema.optional(Schema.NonEmptyString),
+  title: Title.annotate({ description: "Short name shown in the Automations panel." }),
+  prompt: Prompt.annotate({
+    description:
+      "The instruction PawWork runs at the scheduled time. Include the action, recipient, data source, and any context needed then.",
+  }),
+  cron: CronExpression.annotate({
+    description:
+      '5-field cron expression, evaluated in the automation\'s timezone. Examples: "0 15 * * *" = 15:00 daily; "0 11 * * 1-5" = 11:00 on weekdays; "0 15 24 12 *" = 15:00 on Dec 24.',
+  }),
+  recurring: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Omit or true for a repeating schedule. Set false for a one-time task: it fires once at the next cron match. For a one-time task on a specific date, pin day-of-month and month in the cron expression.",
+  }),
+  continueSession: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Set true only when the user explicitly wants this same conversation to continue on the schedule: every run is appended to this chat and sees prior runs, and deleting this conversation deletes the automation. Otherwise omit it; each run starts its own fresh background session.",
+  }),
+  timezone: Schema.optional(Timezone).annotate({
+    description: 'IANA timezone, e.g. "Asia/Shanghai". Defaults to the host timezone.',
+  }),
+  model: Schema.optional(Schema.NonEmptyString).annotate({
+    description: 'Optional "providerID/modelID" override. Defaults to this session\'s model.',
+  }),
+  variant: Schema.optional(Schema.NonEmptyString).annotate({
+    description: "Optional reasoning-effort variant for the chosen model. Usually omit.",
+  }),
 })
 
 export function formatAutomateValidationError(error: unknown) {
@@ -91,8 +109,13 @@ export function createAutomateDefinition(
   automation: Automation.Interface,
 ): Tool.DefWithoutID<typeof AutomateParameters, { automationDefinition: Automation.Definition }> {
   return {
-    description:
-      "Create an Automation that re-runs a prompt on a schedule. Provide a title, the prompt, and a 5-field cron expression; project, timezone, and model default to the current session. By default each run executes in its own fresh background session. Set continueSession true to instead run it as a loop inside THIS conversation: every run is appended to the current chat and sees the previous ones, so the user follows it here and pauses or deletes it from the Automations panel — and deleting this conversation deletes the automation with it. It repeats until paused or deleted. This only stores the definition; it does not run the prompt now.",
+    // Routing-first description: weak models match the user's own words ("remind
+    // me", "later", "every weekday") against the first sentences, so triggers
+    // lead and behavioral detail lives in the field descriptions above.
+    description: [
+      "Create a PawWork Automation: a scheduled task, reminder, or recurring job that PawWork runs for the user. Use this whenever the user asks to do something later, at a specific time or date, one time, daily, weekly, on weekdays, or on any other schedule — including scheduled messages and reminders. Never set up OS schedulers (at, cron, launchd, schtasks) for these requests.",
+      "Automations appear in PawWork's Automations panel, where the user can pause or delete them, and each run uses this session's project context, model, and credentials. Creating the definition schedules the future run; it does not run the prompt now. After creating one, tell the user when it will fire (the result includes the schedule).",
+    ].join("\n\n"),
     parameters: AutomateParameters,
     formatValidationError: formatAutomateValidationError,
     execute: (params, ctx) =>

--- a/packages/opencode/src/tool/automate.ts
+++ b/packages/opencode/src/tool/automate.ts
@@ -113,7 +113,7 @@ export function createAutomateDefinition(
     // me", "later", "every weekday") against the first sentences, so triggers
     // lead and behavioral detail lives in the field descriptions above.
     description: [
-      "Create a PawWork Automation: a scheduled task, reminder, or recurring job that PawWork runs for the user. Use this whenever the user asks to do something later, at a specific time or date, one time, daily, weekly, on weekdays, or on any other schedule — including scheduled messages and reminders. Never set up OS schedulers (at, cron, launchd, schtasks) for these requests.",
+      "Create a PawWork Automation: a scheduled task, reminder, or recurring job that PawWork runs for the user. Use this whenever the user asks to do something later, at a specific time or date, one time, daily, weekly, on weekdays, or on any other schedule — including scheduled messages and reminders. Never set up OS schedulers (at, cron, launchd, schtasks) for these requests unless the user explicitly asks for an OS-level scheduler outside PawWork.",
       "Automations appear in PawWork's Automations panel, where the user can pause or delete them, and each run uses this session's project context, model, and credentials. Creating the definition schedules the future run; it does not run the prompt now. After creating one, tell the user when it will fire (the result includes the schedule).",
     ].join("\n\n"),
     parameters: AutomateParameters,

--- a/packages/opencode/src/tool/shell.txt
+++ b/packages/opencode/src/tool/shell.txt
@@ -37,6 +37,7 @@ Usage notes:
     - Edit files: Use Edit (NOT sed/awk)
     - Write files: Use Write (NOT echo >/cat <<EOF)
     - Communication: Output text directly (NOT echo/printf)
+    - Scheduled or delayed tasks: Use the automate tool (NOT at, cron, crontab, launchd, schtasks, or sleep loops)
     - File deletion: Avoid permanent deletion commands (`rm`, `rmdir`, `unlink`, `find -delete`, `del`, `erase`, `rd`, `Remove-Item`). Prefer a reversible system trash command when available: on macOS use `trash`; on Linux prefer `gio trash`, then `trash-put`. Check availability first: in POSIX shells use `command -v`, and in PowerShell use `Get-Command`. If no reversible command is available, ask the user before deleting.
   - When issuing multiple commands:
     - If the commands are independent and can run in parallel, make multiple Bash tool calls in a single message. For example, if you need to run "git status" and "git diff", send a single message with two Bash tool calls in parallel.

--- a/packages/opencode/test/automation/cron.test.ts
+++ b/packages/opencode/test/automation/cron.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { isValidCronExpression as cronIsValid, parseCronSchedule } from "../../src/automation/cron"
+import { nextCronFireAfter } from "../../src/automation/derived"
 import { Automation } from "../../src/automation"
 
 describe("automation cron validation — single source of truth", () => {
@@ -30,6 +31,17 @@ describe("automation cron validation — single source of truth", () => {
       expect(Automation.isValidCronExpression(expr)).toBe(expected)
       expect(cronIsValid(expr)).toBe(expected)
     }
+  })
+
+  // Vixie rule the automate tool's recurring description documents: when BOTH
+  // day-of-month and day-of-week are restricted, either match fires. A one-shot
+  // pinned to a date must keep day-of-week as * or it fires prematurely.
+  test("restricted day-of-month and day-of-week match as OR", () => {
+    const from = Date.UTC(2026, 11, 1) // 2026-12-01, a Tuesday
+    const pinnedDate = nextCronFireAfter("0 15 24 12 *", "UTC", from)
+    expect(pinnedDate).toBe(Date.UTC(2026, 11, 24, 15, 0)) // Dec 24, as intended
+    const withWeekday = nextCronFireAfter("0 15 24 12 1", "UTC", from)
+    expect(withWeekday).toBe(Date.UTC(2026, 11, 7, 15, 0)) // first Monday — fires 17 days early
   })
 
   test("valid expressions parse without throwing; invalid ones either throw or fail reachability", () => {

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -58,6 +58,7 @@ describe("session.system", () => {
     expect(prompt).toContain("recurring background context")
     expect(prompt).toContain("nearest relevant AGENTS.md")
     expect(prompt).toContain("ask for confirmation before writing")
+    expect(prompt).toContain("`automate` tool")
     expect(prompt).not.toContain("opencode.ai")
     expect(prompt).not.toContain("anomalyco/opencode")
     expect(prompt).not.toContain("Get help with using opencode")

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -7,6 +7,7 @@ import { Provider } from "../../src/provider/provider"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { NotFoundError } from "../../src/storage/db"
+import { toJsonSchema } from "../../src/util/effect-zod"
 import { tmpdir } from "../fixture/fixture"
 import { fakeAutomationProvider } from "../fake/provider"
 
@@ -32,6 +33,31 @@ afterEach(async () => {
 })
 
 describe("automate tool", () => {
+  // Routing contract: weak models pick tools by name, first description sentence,
+  // and field descriptions. These strings are what keep "schedule a task" requests
+  // from drifting into bash at/cron/launchd — do not weaken them without rerunning
+  // the weak-model scheduling scenarios.
+  test("description and schema carry the scheduling routing contract", () => {
+    const tool = createAutomateDefinition(fakeProviderInterface, automation)
+    expect(tool.description).toContain("reminder")
+    expect(tool.description).toContain("one time")
+    expect(tool.description).toContain("Never set up OS schedulers")
+    expect(tool.description).toContain("Automations panel")
+
+    // Field descriptions must survive the real LLM-facing schema conversion
+    // (toJsonSchema is the exact path session/prompt.ts serves to providers).
+    const schema = toJsonSchema(AutomateParameters) as {
+      properties: Record<string, { description?: string }>
+    }
+    expect(schema.properties.cron.description).toContain("5-field")
+    expect(schema.properties.cron.description).toContain("on weekdays")
+    expect(schema.properties.recurring.description).toContain("one-time")
+    expect(schema.properties.continueSession.description).toContain("deleting this conversation deletes the automation")
+    for (const field of ["title", "prompt", "cron", "recurring", "continueSession", "timezone", "model", "variant"]) {
+      expect(schema.properties[field].description).toBeTruthy()
+    }
+  })
+
   test("decode rejects a missing required field and shows the flat shape", () => {
     const decode = Schema.decodeUnknownSync(AutomateParameters)
     let error: unknown

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -42,6 +42,9 @@ describe("automate tool", () => {
     expect(tool.description).toContain("reminder")
     expect(tool.description).toContain("one time")
     expect(tool.description).toContain("Never set up OS schedulers")
+    // The exception must stay aligned with pawwork.txt's scheduling section:
+    // an explicit user request for a system-level scheduler is legitimate work.
+    expect(tool.description).toContain("unless the user explicitly asks for an OS-level scheduler")
     expect(tool.description).toContain("Automations panel")
 
     // Field descriptions must survive the real LLM-facing schema conversion

--- a/packages/opencode/test/tool/automate.test.ts
+++ b/packages/opencode/test/tool/automate.test.ts
@@ -55,6 +55,7 @@ describe("automate tool", () => {
     expect(schema.properties.cron.description).toContain("5-field")
     expect(schema.properties.cron.description).toContain("on weekdays")
     expect(schema.properties.recurring.description).toContain("one-time")
+    expect(schema.properties.recurring.description).toContain("leave day-of-week as *")
     expect(schema.properties.continueSession.description).toContain("deleting this conversation deletes the automation")
     for (const field of ["title", "prompt", "cron", "recurring", "continueSession", "timezone", "model", "variant"]) {
       expect(schema.properties[field].description).toBeTruthy()

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -87,6 +87,21 @@ describe("tool.registry", () => {
     expect(opencodeWorkspaceLockfileSection).not.toContain('"trash": ["trash@')
   })
 
+  // Scheduling requests must route to the automate tool, never to OS schedulers.
+  // Two resident prompt surfaces carry that routing: the bash redirect list
+  // (the entry point models drift into) and the system prompt (the only layer
+  // that also covers writing scheduler files via write/edit).
+  test("keeps scheduling routing contract across prompt surfaces", async () => {
+    const shellDescription = await Bun.file(new URL("../../src/tool/shell.txt", import.meta.url)).text()
+    expect(shellDescription).toContain("Scheduled or delayed tasks: Use the automate tool")
+
+    const systemPrompt = await Bun.file(new URL("../../src/session/prompt/pawwork.txt", import.meta.url)).text()
+    expect(systemPrompt).toContain("# Scheduling, reminders, and recurring work")
+    expect(systemPrompt).toContain("`automate` tool")
+    expect(systemPrompt).toContain("launchd")
+    expect(systemPrompt).toContain("by writing files")
+  })
+
   test("loads tools from .opencode/tool (singular)", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
## Summary

Weak models repeatedly answered "set up a scheduled task" by installing OS-level schedulers through bash (`at` scripts, launchd plists) instead of calling the `automate` tool. Three real-world failures were observed; the worst case left the user with an `at` job that never fires (macOS disables `atrun` by default) while believing the reminder was scheduled.

This PR makes scheduling-intent routing resident on all three model-facing surfaces and pins each one with contract tests:

- **`automate` description**: leads with user-language triggers (reminder, one time, at a specific time or date, daily, on weekdays), covers one-time and recurring tasks alike, and forbids OS schedulers. Behavioral detail moves to new field-level schema descriptions on all 8 parameters — including a specific-date cron example so a "tomorrow 3pm" one-shot cannot silently fire today, and the `continueSession` delete-coupling semantic that the previous draft of this copy would have lost.
- **`pawwork.txt` system prompt**: new `# Scheduling, reminders, and recurring work` section. The prohibition is deliberately tool-agnostic ("neither by running commands nor by writing files") because one observed failure wrote a LaunchAgents plist via the write tool, which a bash-only prohibition cannot catch.
- **`shell.txt`**: one scheduling entry in the existing dedicated-tools redirect list, same style as its neighbors.
- **Contract tests**: pin the routing strings on all three surfaces (mirroring the existing trash-removal contract test) and assert the field descriptions survive `toJsonSchema`, the exact schema path `session/prompt.ts` serves to providers.

No runtime behavior changes; `execute()` is untouched.

## Why

Root cause (two independent analyses converged): the product semantics of `automate` could not win against weak models' strong training prior of `bash + at/cron/launchd`. The tool was registered and visible, but the system prompt never mentioned it, the bash redirect list had no scheduling entry, and the description led with "re-runs a prompt on a schedule" — which reads as recurring-only and shares no vocabulary with how users actually phrase these requests. A deferred-tool approach was considered and rejected (PR #1237 was reworked to defer lsp only): scheduling is a high-stakes user intent and must stay on the shortest path. Hard interception of OS-scheduler commands at the permission layer was deliberately deferred — it is a blocklist against an open set; it gets reconsidered narrowly only if these copy changes prove insufficient in practice.

## Related Issue

None — direct maintainer-requested fix from observed weak-model sessions; root-cause analysis and design discussion happened in the working session rather than an issue.

## Human Review Status

Pending

## Review Focus

- The three routing texts: are the trigger words and prohibitions right, and is the tone consistent with the surrounding prompt style?
- Field descriptions vs `execute()` semantics (recurring/continueSession/timezone/model defaults) — they were cross-checked line by line, but a second reader is valuable here.
- Whether the contract tests pin the right strings (tight enough to catch silent regressions, loose enough to allow future rewording).

## Risk Notes

- Model-facing copy only; no runtime behavior, schema shape, permissions, or dependency changes. The schema gains `description` annotations (additive; verified to survive the provider conversion path by the new test).
- Residual risk: copy-based routing is probabilistic. The follow-up gate is rerunning the three observed weak-model scenarios (plus a "tomorrow 3pm" one-shot) before declaring this sufficient; permission-layer interception remains the documented fallback.
- Skipped conditional checklist items: visible UI/screenshot check (model-facing prompt text, no rendered UI surface); macOS/Windows platform check (no platform/packaging surface touched); docs/release-notes/deps callout (none touched).

## How To Verify

```text
Focused tests: bun test --timeout 30000 test/tool/automate.test.ts test/tool/registry.test.ts test/session/system.test.ts test/tool/tool-info.test.ts test/automation/cron.test.ts
Result: 78 pass, 0 fail, 280 expect() calls (the 3 new contract tests were red before the copy changes, green after; includes the review follow-ups — OS-scheduler exception pin and the cron OR-semantics regression test)

Typecheck: bun run typecheck
Result: tsgo --noEmit successful across all 8 packages

Whitespace: git diff --check
Result: clean
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

