### PR TITLE
fix(lsp): resolve JDTLS Maven parent roots

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -127,16 +127,40 @@ export namespace LSPServer {
   }
 
   function normalizeMavenModulePath(modulePath: string) {
-    return modulePath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "")
+    let normalized = modulePath.replace(/\\/g, "/")
+    if (normalized.startsWith("./")) normalized = normalized.slice(2)
+    if (normalized.endsWith("/")) normalized = normalized.slice(0, -1)
+    return normalized
+  }
+
+  function xmlCommentRanges(content: string) {
+    const ranges: Array<{ start: number; end: number }> = []
+    let start = content.indexOf("<!--")
+    while (start !== -1) {
+      const close = content.indexOf("-->", start + 4)
+      const end = close === -1 ? content.length : close + 3
+      ranges.push({ start, end })
+      if (close === -1) break
+      start = content.indexOf("<!--", end)
+    }
+    return ranges
+  }
+
+  function isInsideRange(position: number, ranges: Array<{ start: number; end: number }>) {
+    return ranges.some((range) => position >= range.start && position < range.end)
   }
 
   function declaresMavenModule(pomContent: string, modulePath: string) {
     const normalizedModulePath = normalizeMavenModulePath(modulePath)
     if (!normalizedModulePath) return false
-    const moduleBlocks = pomContent.match(/<modules>([\s\S]*?)<\/modules>/g) ?? []
-    for (const block of moduleBlocks) {
-      const withoutComments = block.replace(/<!--[\s\S]*?-->/g, "")
-      for (const match of withoutComments.matchAll(/<module>\s*([^<]+?)\s*<\/module>/g)) {
+    const comments = xmlCommentRanges(pomContent)
+    for (const blockMatch of pomContent.matchAll(/<modules>([\s\S]*?)<\/modules>/g)) {
+      const blockStart = blockMatch.index ?? 0
+      if (isInsideRange(blockStart, comments)) continue
+      const blockBody = blockMatch[1]
+      const blockBodyStart = blockStart + blockMatch[0].indexOf(blockBody)
+      for (const match of blockBody.matchAll(/<module>\s*([^<]+?)\s*<\/module>/g)) {
+        if (isInsideRange(blockBodyStart + (match.index ?? 0), comments)) continue
         const declaredModule = normalizeMavenModulePath(match[1].trim())
         if (declaredModule === normalizedModulePath) return true
       }

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -103,6 +103,60 @@ export namespace LSPServer {
     }
   }
 
+  const NearestFile = (includePatterns: string[], excludePatterns?: string[]) => {
+    return async (file: string) => {
+      if (excludePatterns) {
+        const excludedFiles = Filesystem.up({
+          targets: excludePatterns,
+          start: path.dirname(file),
+          stop: Instance.directory,
+        })
+        const excluded = await excludedFiles.next()
+        await excludedFiles.return()
+        if (excluded.value) return undefined
+      }
+      const files = Filesystem.up({
+        targets: includePatterns,
+        start: path.dirname(file),
+        stop: Instance.directory,
+      })
+      const first = await files.next()
+      await files.return()
+      return first.value
+    }
+  }
+
+  function normalizeMavenModulePath(modulePath: string) {
+    return modulePath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "")
+  }
+
+  function declaresMavenModule(pomContent: string, modulePath: string) {
+    const normalizedModulePath = normalizeMavenModulePath(modulePath)
+    if (!normalizedModulePath) return false
+    const moduleBlocks = pomContent.match(/<modules>([\s\S]*?)<\/modules>/g) ?? []
+    for (const block of moduleBlocks) {
+      const withoutComments = block.replace(/<!--[\s\S]*?-->/g, "")
+      for (const match of withoutComments.matchAll(/<module>\s*([^<]+?)\s*<\/module>/g)) {
+        const declaredModule = normalizeMavenModulePath(match[1].trim())
+        if (declaredModule === normalizedModulePath) return true
+      }
+    }
+    return false
+  }
+
+  async function topmostMavenRoot(nearestPom: string) {
+    let root = path.dirname(nearestPom)
+    const pomFiles = await Filesystem.findUp("pom.xml", root, Instance.directory)
+    for (const parentPom of pomFiles.slice(1)) {
+      const parentRoot = path.dirname(parentPom)
+      const modulePath = path.relative(parentRoot, root)
+      const content = await fs.readFile(parentPom, "utf-8").catch(() => undefined)
+      if (!content || !declaresMavenModule(content, modulePath)) break
+      root = parentRoot
+    }
+    return root
+  }
+
   export interface Info {
     id: string
     extensions: string[]
@@ -1135,8 +1189,8 @@ export namespace LSPServer {
       const gradleMarkers = ["gradlew", "gradlew.bat"]
       const exclusionsForMonorepos = gradleMarkers.concat(settingsMarkers)
 
-      const [projectRoot, wrapperRoot, settingsRoot] = await Promise.all([
-        NearestRoot(
+      const [projectMarker, wrapperRoot, settingsRoot] = await Promise.all([
+        NearestFile(
           ["pom.xml", "build.gradle", "build.gradle.kts", ".project", ".classpath"],
           exclusionsForMonorepos,
         )(file),
@@ -1144,9 +1198,12 @@ export namespace LSPServer {
         NearestRoot(settingsMarkers)(file),
       ])
 
-      // If projectRoot is undefined we know we are in a monorepo or no project at all.
+      // If projectMarker is undefined we know we are in a monorepo or no project at all.
       // So can safely fall through to the other roots
-      if (projectRoot) return projectRoot
+      if (projectMarker) {
+        if (path.basename(projectMarker) === "pom.xml") return topmostMavenRoot(projectMarker)
+        return path.dirname(projectMarker)
+      }
       if (wrapperRoot) return wrapperRoot
       if (settingsRoot) return settingsRoot
     },

--- a/packages/opencode/test/lsp/server.test.ts
+++ b/packages/opencode/test/lsp/server.test.ts
@@ -85,6 +85,33 @@ describe("JDTLS root resolution", () => {
     ),
   )
 
+  it.live("ignores Maven modules inside XML comments", () =>
+    provideTmpdirInstance((root) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(
+          path.join(root, "pom.xml"),
+          `
+<project>
+  <!--
+  <modules>
+    <module>samples/tool</module>
+  </modules>
+  -->
+</project>
+`,
+        )
+        fs.mkdirSync(path.join(root, "samples/tool/src/main/java/app"), { recursive: true })
+        fs.writeFileSync(path.join(root, "samples/tool/pom.xml"), "<project />")
+        fs.writeFileSync(path.join(root, "samples/tool/src/main/java/app/App.java"), "")
+
+        const resolved = yield* Effect.promise(() =>
+          LSPServer.JDTLS.root(path.join(root, "samples/tool/src/main/java/app/App.java")),
+        )
+        expect(resolved).toBe(path.join(root, "samples/tool"))
+      }),
+    ),
+  )
+
   it.live("keeps Gradle settings root ahead of Maven subproject markers", () =>
     provideTmpdirInstance((root) =>
       Effect.gen(function* () {

--- a/packages/opencode/test/lsp/server.test.ts
+++ b/packages/opencode/test/lsp/server.test.ts
@@ -42,3 +42,92 @@ describe("Typescript root resolution", () => {
     ),
   )
 })
+
+describe("JDTLS root resolution", () => {
+  it.live("resolves Maven module files to the topmost declared parent pom.xml", () =>
+    provideTmpdirInstance((root) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(
+          path.join(root, "pom.xml"),
+          `
+<project>
+  <modules>
+    <module>modules/core</module>
+  </modules>
+</project>
+`,
+        )
+        fs.mkdirSync(path.join(root, "modules/core/src/main/java/app"), { recursive: true })
+        fs.writeFileSync(path.join(root, "modules/core/pom.xml"), "<project />")
+        fs.writeFileSync(path.join(root, "modules/core/src/main/java/app/App.java"), "")
+
+        const resolved = yield* Effect.promise(() =>
+          LSPServer.JDTLS.root(path.join(root, "modules/core/src/main/java/app/App.java")),
+        )
+        expect(resolved).toBe(root)
+      }),
+    ),
+  )
+
+  it.live("keeps independent nested Maven projects at their nearest pom.xml", () =>
+    provideTmpdirInstance((root) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(path.join(root, "pom.xml"), "<project />")
+        fs.mkdirSync(path.join(root, "samples/tool/src/main/java/app"), { recursive: true })
+        fs.writeFileSync(path.join(root, "samples/tool/pom.xml"), "<project />")
+        fs.writeFileSync(path.join(root, "samples/tool/src/main/java/app/App.java"), "")
+
+        const resolved = yield* Effect.promise(() =>
+          LSPServer.JDTLS.root(path.join(root, "samples/tool/src/main/java/app/App.java")),
+        )
+        expect(resolved).toBe(path.join(root, "samples/tool"))
+      }),
+    ),
+  )
+
+  it.live("keeps Gradle settings root ahead of Maven subproject markers", () =>
+    provideTmpdirInstance((root) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(path.join(root, "settings.gradle"), "include 'app'")
+        fs.mkdirSync(path.join(root, "app/src/main/java/app"), { recursive: true })
+        fs.writeFileSync(path.join(root, "app/pom.xml"), "<project />")
+        fs.writeFileSync(path.join(root, "app/src/main/java/app/App.java"), "")
+
+        const resolved = yield* Effect.promise(() =>
+          LSPServer.JDTLS.root(path.join(root, "app/src/main/java/app/App.java")),
+        )
+        expect(resolved).toBe(root)
+      }),
+    ),
+  )
+
+  it.live("keeps Eclipse project markers ahead of ancestor Maven markers", () =>
+    provideTmpdirInstance((root) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(path.join(root, "pom.xml"), "<project />")
+        fs.mkdirSync(path.join(root, "legacy/src/app"), { recursive: true })
+        fs.writeFileSync(path.join(root, "legacy/.project"), "")
+        fs.writeFileSync(path.join(root, "legacy/src/app/App.java"), "")
+
+        const resolved = yield* Effect.promise(() =>
+          LSPServer.JDTLS.root(path.join(root, "legacy/src/app/App.java")),
+        )
+        expect(resolved).toBe(path.join(root, "legacy"))
+      }),
+    ),
+  )
+
+  it.live("keeps no-marker Java files at the instance root", () =>
+    provideTmpdirInstance((root) =>
+      Effect.gen(function* () {
+        fs.mkdirSync(path.join(root, "src/main/java/app"), { recursive: true })
+        fs.writeFileSync(path.join(root, "src/main/java/app/App.java"), "")
+
+        const resolved = yield* Effect.promise(() =>
+          LSPServer.JDTLS.root(path.join(root, "src/main/java/app/App.java")),
+        )
+        expect(resolved).toBe(root)
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
## Summary

Fixes JDTLS root detection so Java files inside declared Maven modules resolve to the topmost parent `pom.xml` instead of the nearest module `pom.xml`. This ports the relevant behavior from upstream #28761 without touching session, browser, provider, MCP, ACP, automation, or tool registry code.

## Why

In a multi-module Maven project, JDTLS needs the parent workspace root so it can see sibling modules and shared parent configuration. PawWork still selected the nearest `pom.xml`, which scoped JDTLS to the nested module.

## Related Issue

No PawWork issue. Scope comes from the upstream-value Line B handoff for upstream #28761.

## Human Review Status

Pending

## Review Focus

Please focus on the root-selection boundary: Maven should climb only through parents that declare the current module under `<modules>`, while independent nested Maven projects, Gradle settings roots, Eclipse markers, and no-marker Java files keep their prior behavior.

## Risk Notes

Maven root parsing is intentionally narrow and only reads `<modules><module>...</module></modules>` declarations from parent POMs. Path separator handling is normalized for platform differences.

Skipped checklist items: visible UI/copy check is not applicable because this only changes engine LSP root detection; docs/release/dependency/generated-content checks are not applicable because none of those surfaces changed.

## How To Verify

```text
RED: bun --cwd packages/opencode test test/lsp/server.test.ts failed because JDTLS returned the nearest module pom.xml instead of the topmost declared parent; review follow-up RED covered commented-out Maven modules being ignored.
Focused LSP tests: bun --cwd packages/opencode test test/lsp -> 33 passed.
Typecheck: bun run --cwd packages/opencode typecheck -> passed.
Whitespace: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
