### PR TITLE
test(opencode): harden session export cleanup

### DIFF
--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
+import { setTimeout as sleep } from "timers/promises"
 import { Instance } from "../../src/project/instance"
 import { Session as SessionNs } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -19,19 +20,67 @@ import { RunLifecycle } from "../../src/session/run-lifecycle"
 const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
 
+type RemoveDirectory = (dir: string, options: Parameters<typeof fs.rm>[1]) => Promise<void>
+
+function isRetryableDirectoryRemovalError(error: unknown) {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+  return code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY"
+}
+
+async function removeDirectoryWithBusyRetry(
+  dir: string,
+  input: {
+    attempts?: number
+    delayMs?: number
+    remove?: RemoveDirectory
+    wait?: (ms: number) => Promise<void>
+  } = {},
+) {
+  const attempts = input.attempts ?? (process.platform === "win32" ? 50 : 6)
+  const delayMs = input.delayMs ?? 100
+  const remove = input.remove ?? fs.rm
+  const wait = input.wait ?? sleep
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      await remove(dir, { recursive: true, force: true })
+      return
+    } catch (error) {
+      if (attempt === attempts || !isRetryableDirectoryRemovalError(error)) throw error
+      await wait(delayMs)
+    }
+  }
+}
+
 async function removeLoadedSessionProjectDirectory(dir: string) {
-  await Instance.disposeDirectory(dir)
-  await fs.rm(dir, {
-    recursive: true,
-    force: true,
-    maxRetries: process.platform === "win32" ? 30 : 5,
-    retryDelay: 100,
-  })
+  await Instance.disposeDirectory(dir, { mode: "force" })
+  await removeDirectoryWithBusyRetry(dir)
 }
 
 describe("Export.session", () => {
   test("getRuntimeNamespace returns 'pawwork' or 'opencode'", () => {
     expect(["pawwork", "opencode"]).toContain(getRuntimeNamespace())
+  })
+
+  test("removeDirectoryWithBusyRetry retries transient busy directory removal", async () => {
+    let attempts = 0
+
+    await removeDirectoryWithBusyRetry("busy-dir", {
+      attempts: 3,
+      delayMs: 0,
+      remove: async (_dir, options) => {
+        attempts++
+        expect(options).toEqual({ recursive: true, force: true })
+        if (attempts < 3) {
+          const error = new Error("busy") as NodeJS.ErrnoException
+          error.code = "EBUSY"
+          throw error
+        }
+      },
+      wait: async () => {},
+    })
+
+    expect(attempts).toBe(3)
   })
 
   test("exports a single root session with empty messages and stub runtime_context", async () => {

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -24,7 +24,7 @@ type RemoveDirectory = (dir: string, options: Parameters<typeof fs.rm>[1]) => Pr
 
 function isRetryableDirectoryRemovalError(error: unknown) {
   const code = (error as NodeJS.ErrnoException | undefined)?.code
-  return code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY"
+  return code === "EBUSY" || code === "EACCES" || code === "EPERM" || code === "ENOTEMPTY"
 }
 
 async function removeDirectoryWithBusyRetry(
@@ -63,24 +63,28 @@ describe("Export.session", () => {
   })
 
   test("removeDirectoryWithBusyRetry retries transient busy directory removal", async () => {
-    let attempts = 0
+    const retryableCodes = ["EBUSY", "EACCES", "EPERM", "ENOTEMPTY"]
 
-    await removeDirectoryWithBusyRetry("busy-dir", {
-      attempts: 3,
-      delayMs: 0,
-      remove: async (_dir, options) => {
-        attempts++
-        expect(options).toEqual({ recursive: true, force: true })
-        if (attempts < 3) {
-          const error = new Error("busy") as NodeJS.ErrnoException
-          error.code = "EBUSY"
-          throw error
-        }
-      },
-      wait: async () => {},
-    })
+    for (const code of retryableCodes) {
+      let attempts = 0
 
-    expect(attempts).toBe(3)
+      await removeDirectoryWithBusyRetry("busy-dir", {
+        attempts: 3,
+        delayMs: 0,
+        remove: async (_dir, options) => {
+          attempts++
+          expect(options).toEqual({ recursive: true, force: true })
+          if (attempts < 3) {
+            const error = new Error("busy") as NodeJS.ErrnoException
+            error.code = code
+            throw error
+          }
+        },
+        wait: async () => {},
+      })
+
+      expect(attempts).toBe(3)
+    }
   })
 
   test("exports a single root session with empty messages and stub runtime_context", async () => {

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -87,6 +87,50 @@ describe("Export.session", () => {
     }
   })
 
+  test("removeDirectoryWithBusyRetry does not retry non-transient removal errors", async () => {
+    let attempts = 0
+    const expected = new Error("invalid") as NodeJS.ErrnoException
+    expected.code = "EINVAL"
+
+    try {
+      await removeDirectoryWithBusyRetry("invalid-dir", {
+        attempts: 3,
+        delayMs: 0,
+        remove: async () => {
+          attempts++
+          throw expected
+        },
+        wait: async () => {},
+      })
+      throw new Error("expected removal to fail")
+    } catch (error) {
+      expect(error).toBe(expected)
+      expect(attempts).toBe(1)
+    }
+  })
+
+  test("removeDirectoryWithBusyRetry throws after transient removal retries are exhausted", async () => {
+    let attempts = 0
+    const expected = new Error("busy") as NodeJS.ErrnoException
+    expected.code = "EBUSY"
+
+    try {
+      await removeDirectoryWithBusyRetry("busy-dir", {
+        attempts: 3,
+        delayMs: 0,
+        remove: async () => {
+          attempts++
+          throw expected
+        },
+        wait: async () => {},
+      })
+      throw new Error("expected removal to fail")
+    } catch (error) {
+      expect(error).toBe(expected)
+      expect(attempts).toBe(3)
+    }
+  })
+
   test("exports a single root session with empty messages and stub runtime_context", async () => {
     await Instance.provide({
       directory: projectRoot,


### PR DESCRIPTION
## Summary

Hardens the session export test helper that removes a loaded temp project directory to simulate a missing original instruction directory. This PR is a narrow test-harness fix for the Windows advisory blocker on #1245.

## Why

#1245 is blocked by `windows-advisory / unit-windows-opencode-session`, where `packages/opencode/test/session/export.test.ts` fails before the export assertion runs. Windows reports `EBUSY` when the test helper calls `fs.rm(...)` on the temp git project directory after `Instance.disposeDirectory(...)`.

## Related Issue

No standalone issue. Unblocks #1245.

## Human Review Status

Pending

## Review Focus

Please focus on whether the helper remains test-only, retries only transient Windows-style directory removal errors, and does not change session export behavior.

## Risk Notes

No product behavior changes. The only meaningful risk is test duration if Windows holds a temp directory for longer than the explicit retry budget. No visible UI or copy changed. Platform impact is intentionally limited to Windows temp-directory cleanup in tests.

## How To Verify

```text
Focused export tests: bun --cwd packages/opencode test test/session/export.test.ts -> 45 pass, 0 fail
Opencode typecheck: bun run --cwd packages/opencode typecheck -> pass
Windows job equivalent on macOS: bun test --timeout 30000 test/session test/plugin test/permission test/util test/skill test/index-runtime-namespace.test.ts test/permission-agent.test.ts test/permission-cleanup.test.ts -> 1324 pass, 4 skip, 1 todo, 0 fail
Diff check: git diff --check -> pass
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
