### PR TITLE
fix(session): avoid shell cancel race

### DIFF
--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -183,7 +183,7 @@ export const layer = Layer.effect(
     const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID, meta?: InterruptMeta) {
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(sessionID)
-      if (!existing || !existing.busy) {
+      if (!existing) {
         yield* status.set(sessionID, { type: "idle" })
         return
       }

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -68,7 +68,7 @@ describe("SessionRunState", () => {
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
             make.mockRestore()
-            yield* Deferred.succeed(releaseRunner, undefined).pipe(Effect.ignore)
+            yield* Deferred.succeed(releaseRunner, undefined)
           }),
         )
 

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { Hono } from "hono"
 import { GlobalBus } from "../../src/bus/global"
 import { Config } from "../../src/config"
+import { Runner, type InterruptMeta, type Runner as RunnerInstance } from "../../src/effect/runner"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { registerDisposer } from "../../src/effect/instance-registry"
@@ -30,6 +31,66 @@ describe("SessionRunState", () => {
       const idle = yield* Effect.promise(() => whenAllRunsIdle([directory])).pipe(Effect.timeout("100 millis"), Effect.exit)
       expect(Exit.isSuccess(idle)).toBe(true)
     })
+
+  it.live("delivers cancel to an existing shell runner before it reports busy", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const run = yield* SessionRunState.Service
+        const sessionID = SessionID.make("ses_shell_cancel_startup_race")
+        const runnerEntered = yield* Deferred.make<void>()
+        const releaseRunner = yield* Deferred.make<void>()
+        let cancelMeta: InterruptMeta | undefined
+
+        const make = spyOn(Runner, "make").mockImplementation(() => {
+          const fake = {
+            get state() {
+              return { _tag: "Idle" } as const
+            },
+            get busy() {
+              return false
+            },
+            ensureRunning: () => Effect.die(new Error("unexpected ensureRunning")),
+            startShell: () =>
+              Deferred.succeed(runnerEntered, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseRunner)),
+                Effect.as({} as never),
+              ),
+            cancel: Effect.sync(() => {
+              cancelMeta = undefined
+            }),
+            cancelWith: (meta?: InterruptMeta) =>
+              Effect.sync(() => {
+                cancelMeta = meta
+              }),
+          } satisfies RunnerInstance<never>
+          return fake as never
+        })
+        yield* Effect.addFinalizer(() =>
+          Effect.gen(function* () {
+            make.mockRestore()
+            yield* Deferred.succeed(releaseRunner, undefined).pipe(Effect.ignore)
+          }),
+        )
+
+        const shellFiber = yield* run
+          .startShell(
+            sessionID,
+            () => Effect.sync(() => ({}) as never),
+            Effect.sync(() => ({}) as never),
+          )
+          .pipe(Effect.forkChild)
+
+        yield* Deferred.await(runnerEntered)
+        yield* run.cancel(sessionID, { source: "test", reason: "shell_startup_cancel" })
+        yield* Deferred.succeed(releaseRunner, undefined)
+
+        expect(Exit.isSuccess(yield* Fiber.await(shellFiber))).toBe(true)
+        expect(cancelMeta).toMatchObject({
+          source: "test",
+          reason: "shell_startup_cancel",
+        })
+      }),
+    ))
 
   test("keeps overlapping lifecycle actions isolated per directory", async () => {
     const directory = "/tmp/pawwork-lifecycle-overlap"


### PR DESCRIPTION
## Summary

Fixes the session shell cancel race from upstream #30641 by continuing to route cancel requests through an existing runner even when the runner has not reported `busy` yet.

## Why

`SessionRunState.cancel` previously returned early when a runner existed but `runner.busy` was still false. During shell startup, that can drop a cancel request after the runner is registered but before the shell transition reports busy. The runner owns the serialized transition, so cancel must be delivered to the runner whenever one exists.

## Related Issue

No local issue; this ports the runtime correctness fix from upstream `anomalyco/opencode#30641` under the Round 4 upstream-value Line B contract.

## Human Review Status

Pending

## Review Focus

Please focus on the cancel boundary in `SessionRunState.cancel` and the regression test that forces an existing runner to report `busy === false` while still expecting cancel metadata to be delivered.

## Risk Notes

The behavior change is intentionally narrow: sessions without a runner still move to idle and return. Existing runners now receive cancel metadata even if they are between idle and shell startup.

Skipped checklist items:
- Manual visible UI check: no visible UI or copy changed.
- Docs/release/dependency/permission/generated/local-file surface check: none of those surfaces changed.

## How To Verify

```text
RED: bun --cwd packages/opencode test test/session/run-state.test.ts failed before the production change because cancelMeta stayed undefined for an existing busy=false runner.
Focused tests: bun --cwd packages/opencode test test/session/run-state.test.ts -> 23 pass, 0 fail.
Related tests: bun --cwd packages/opencode test test/session/run-state.test.ts test/effect/runner.test.ts -> 53 pass, 0 fail.
Typecheck: bun run --cwd packages/opencode typecheck -> tsgo --noEmit passed.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session cancellation to correctly handle cases where a runner is present but not actively busy, ensuring proper status management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->