### PR TITLE
fix(harness): stabilize automation route scheduler test

### DIFF
--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -50,16 +50,6 @@ async function json(app: Hono, input: string, init?: RequestInit) {
   return response.json()
 }
 
-async function waitForRunCount(automationID: string, count: number) {
-  const deadline = Date.now() + 2_000
-  while (Date.now() < deadline) {
-    const items = Automation.runs({ automationID, limit: 100 }).items
-    if (items.length >= count) return items
-    await Bun.sleep(5)
-  }
-  throw new Error(`Timed out waiting for automation run count: ${count}`)
-}
-
 async function waitForRunState(automationID: string, state: Automation.Run["state"]) {
   const deadline = Date.now() + 2_000
   while (Date.now() < deadline) {
@@ -476,17 +466,39 @@ describe("automation routes", () => {
     })
   })
 
-  test("create lazily starts the scheduler before publishing definition updates", async () => {
+  test("create settles the scheduler before publishing definition updates", async () => {
     await withAutomationApp(async ({ app, projectID }) => {
-      const created = await json(app, "/automation", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(oneshotInput(projectID, { fireAt: Date.now() + 20 })),
+      const publication = deferred<boolean>()
+      let publishedID: string | undefined
+      let settled = false
+      const unsubscribe = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {
+        publishedID = event.properties.id
+        publication.resolve(settled)
+      })
+      AutomationScheduler.install({
+        stop: () => undefined,
+        stopOwnedRuns: () => undefined,
+        settleOwner: async () => {
+          settled = true
+        },
+        reschedule: () => undefined,
+        cancel: () => undefined,
+        computeNextFireAt: () => null,
       })
 
-      const runs = await waitForRunCount(created.id, 1)
+      try {
+        const created = await json(app, "/automation", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(oneshotInput(projectID)),
+        })
+        const wasSettledBeforePublish = await publication.promise
 
-      expect(runs[0]?.automationID).toBe(created.id)
+        expect(publishedID).toBe(created.id)
+        expect(wasSettledBeforePublish).toBe(true)
+      } finally {
+        unsubscribe()
+      }
     })
   })
 

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -468,18 +468,20 @@ describe("automation routes", () => {
 
   test("create settles the scheduler before publishing definition updates", async () => {
     await withAutomationApp(async ({ app, projectID }) => {
-      const publication = deferred<boolean>()
+      const settleStarted = deferred<void>()
+      const releaseSettle = deferred<void>()
+      const publication = deferred<string>()
       let publishedID: string | undefined
-      let settled = false
       const unsubscribe = Bus.subscribe(Automation.Event.DefinitionUpdated, (event) => {
         publishedID = event.properties.id
-        publication.resolve(settled)
+        publication.resolve(event.properties.id)
       })
       AutomationScheduler.install({
         stop: () => undefined,
         stopOwnedRuns: () => undefined,
         settleOwner: async () => {
-          settled = true
+          settleStarted.resolve()
+          await releaseSettle.promise
         },
         reschedule: () => undefined,
         cancel: () => undefined,
@@ -487,16 +489,23 @@ describe("automation routes", () => {
       })
 
       try {
-        const created = await json(app, "/automation", {
+        const create = json(app, "/automation", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify(oneshotInput(projectID)),
         })
-        const wasSettledBeforePublish = await publication.promise
+        await settleStarted.promise
+        await Bun.sleep(1)
 
+        expect(publishedID).toBeUndefined()
+
+        releaseSettle.resolve()
+        const created = await create
+        const emittedID = await publication.promise
         expect(publishedID).toBe(created.id)
-        expect(wasSettledBeforePublish).toBe(true)
+        expect(emittedID).toBe(created.id)
       } finally {
+        releaseSettle.resolve()
         unsubscribe()
       }
     })


### PR DESCRIPTION
## Summary

Stabilizes the automation route scheduler-order test that is blocking Line B PR #1251's Windows advisory run.

This PR has no linked issue because it is a narrow CI unblocker for the out-of-scope `unit-windows-opencode-server-tools` failure observed on PR #1251.

## Why

The previous test used a real one-shot automation with `fireAt: Date.now() + 20` and waited for a run to appear. On slow Windows CI timing, the route and scheduler could cross that 20 ms window, so the scheduler recorded the one-shot as missed instead of creating the run, making the test fail even though the route ordering contract was the target.

The replacement keeps the same contract but removes wall-clock timing from the assertion: it installs a fake scheduler, observes the `DefinitionUpdated` event, and verifies the create route settles the scheduler before publishing that event for the created definition.

## Related Issue

No linked issue. This is a scoped CI unblocker for PR #1251.

## Human Review Status

Pending

## Review Focus

Please check that the new test still covers the intended route contract: `POST /automation` must settle the scheduler owner before publishing `DefinitionUpdated` for the new definition.

## Risk Notes

No production behavior changes. The only risk is test coverage drift, mitigated by asserting the specific scheduler-settle-before-publish ordering rather than relying on a real timer side effect.

Skipped checklist items:

- Visible UI or copy check: no visible UI or copy changed.
- Docs/release/dependency/permission checklist: none of those surfaces changed.

## How To Verify

```text
Diff check: git diff --check passed
Focused route test: bun test --timeout 30000 test/server/automation-routes.test.ts -t "create settles the scheduler before publishing definition updates" passed (1 pass)
Automation routes suite: bun test --timeout 30000 test/server/automation-routes.test.ts passed (46 pass)
Automation route/scheduler slice: bun test --timeout 30000 test/server/automation-routes.test.ts test/server/automation-scheduler.test.ts test/automation passed (95 pass)
Opencode typecheck: bun run typecheck passed
Local server-tools shard equivalent: bun test --timeout 30000 test/server test/snapshot test/tool test/mcp test/question test/effect test/agent test/git/ test/storage test/provider test/pty test/share/ test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/format test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth test/automation passed (1906 pass, 2 skip)
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
