### PR TITLE
fix(session): honor disabled auto compaction on overflow

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1225,6 +1225,15 @@ export const layer: Layer.Layer<
           error.data = { ...error.data, message: options.interruptionMessage }
         }
         if (MessageV2.ContextOverflowError.isInstance(error)) {
+          if (!ctx.assistantMessage.summary && (yield* config.get()).compaction?.auto === false) {
+            ctx.assistantMessage.error = error
+            yield* bus.publish(Session.Event.Error, {
+              sessionID: ctx.assistantMessage.sessionID,
+              error: ctx.assistantMessage.error,
+            })
+            yield* status.set(ctx.sessionID, { type: "idle" })
+            return
+          }
           ctx.needsCompaction = true
           yield* bus.publish(Session.Event.Error, { sessionID: ctx.sessionID, error })
           return

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1207,14 +1207,14 @@ describe("session.compaction.process", () => {
     })
   })
 
-  test("marks summary message as errored on compact result", async () => {
+  test("marks summary message as errored on compact result when auto compaction is disabled", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
         const session = await svc.create({})
         const msg = await user(session.id, "hello")
-        const rt = runtime("compact", Plugin.defaultLayer, wide())
+        const rt = runtime("compact", Plugin.defaultLayer, wide(), cfg({ auto: false }))
         try {
           const msgs = await svc.messages({ sessionID: session.id })
           const result = await rt.runPromise(

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -116,6 +116,15 @@ function providerCfg(url: string) {
   }
 }
 
+function providerCfgWithDisabledAutoCompaction(url: string) {
+  return {
+    ...providerCfg(url),
+    compaction: {
+      auto: false,
+    },
+  }
+}
+
 function copilotResponsesProviderCfg(url: string) {
   return {
     provider: {
@@ -2293,6 +2302,49 @@ it.live("session.processor effect tests compact on structured context overflow",
         expect(handle.message.error).toBeUndefined()
       }),
     { git: true, config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests stop structured context overflow when auto compaction is disabled", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.error(400, { type: "error", error: { code: "context_length_exceeded" } })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "no auto compact json")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({ safeRecoveryDelay: FAST_SAFE_RECOVERY_DELAY,
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "no auto compact json" }],
+          tools: {},
+        })
+
+        expect(value).toBe("stop")
+        expect(yield* llm.calls).toBe(1)
+        expect(handle.message.error?.name).toBe("ContextOverflowError")
+      }),
+    { git: true, config: (url) => providerCfgWithDisabledAutoCompaction(url) },
   ),
 )
 


### PR DESCRIPTION
## Summary

Provider-side context overflow now respects `compaction.auto: false` instead of forcing the session into automatic compaction.

## Why

Upstream #30749 identified a gap where token-threshold overflow checks respected disabled auto-compaction, but structured provider `ContextOverflowError` still set `needsCompaction` and silently compacted. This preserves the no-auto-compaction behavior for that provider overflow path.

## Related Issue

No local issue. Imported from upstream `anomalyco/opencode#30749` as the Line B runtime-correctness boundary.

## Human Review Status

Pending

## Review Focus

Please focus on the `ContextOverflowError` branch in `SessionProcessor.halt`: when `compaction.auto === false`, it should stop with the provider overflow error and not set `needsCompaction`.

## Risk Notes

Open PR #1252 also touches `packages/opencode/src/session/processor.ts`; this collision was owner-accepted for this PR and #1252 is expected to rebase later. This PR intentionally does not absorb #927/tool-drain/recovery behavior.

Skipped conditional checks:
- Visible UI/copy: not applicable, no visible UI or copy changed.
- Platform/packaging: not applicable, no platform, packaging, updater, signing, path, shell, or permission surface changed.
- Docs/release/dependencies/permissions/generated/local files: not applicable, none changed.

## How To Verify

```text
RED: bun --cwd packages/opencode test test/session/processor-effect.test.ts -t "stops structured context overflow when auto compaction is disabled" failed because the processor returned "compact".
Focused regression: bun --cwd packages/opencode test test/session/processor-effect.test.ts -t "stop structured context overflow when auto compaction is disabled" -> 1 pass.
Default behavior guard: bun --cwd packages/opencode test test/session/processor-effect.test.ts -t "compact on structured context overflow" -> 1 pass.
Related processor suite: bun --cwd packages/opencode test test/session/processor-effect.test.ts -> 36 pass.
Related compaction guard: bun --cwd packages/opencode test test/session/compaction.test.ts -t "returns false when compaction.auto is disabled" -> 1 pass.
Typecheck: bun run --cwd packages/opencode typecheck -> pass.
Diff check: git diff --check -> pass.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
