### PR TITLE
fix(session): respect directory filter with workspaces

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -1243,10 +1243,8 @@ export function* list(input?: {
   if (input?.workspaceID) {
     conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
   }
-  if (!Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
-    if (input?.directory) {
-      conditions.push(eq(SessionTable.directory, input.directory))
-    }
+  if (input?.directory) {
+    conditions.push(eq(SessionTable.directory, input.directory))
   }
   if (input?.roots) {
     conditions.push(isNull(SessionTable.parent_id))

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { Effect } from "effect"
+import fs from "fs/promises"
+import path from "path"
 import { Instance } from "../../src/project/instance"
 import { Session as SessionNs } from "../../src/session"
 import type { SessionID } from "../../src/session/schema"
@@ -50,6 +53,37 @@ describe("session.list", () => {
         expect(ids).not.toContain(second.id)
       },
     })
+  })
+
+  test("filters by directory with experimental workspaces enabled", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const subdir = path.join(tmp.path, "packages", "app")
+    await fs.mkdir(subdir, { recursive: true })
+
+    const experimental = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
+    // @ts-expect-error - Flag is readonly at type level but mutable at runtime for test toggling
+    Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = true
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const root = await svc.create({ title: "root-session" })
+          const nested = await Instance.provide({
+            directory: subdir,
+            fn: async () => svc.create({ title: "nested-session" }),
+          })
+
+          const sessions = [...svc.list({ directory: tmp.path })]
+          const ids = sessions.map((s) => s.id)
+
+          expect(ids).toContain(root.id)
+          expect(ids).not.toContain(nested.id)
+        },
+      })
+    } finally {
+      // @ts-expect-error - Flag is readonly at type level but mutable at runtime for test toggling
+      Flag.OPENCODE_EXPERIMENTAL_WORKSPACES = experimental
+    }
   })
 
   test("filters root sessions", async () => {


### PR DESCRIPTION
## Summary

Port upstream anomalyco/opencode#30804: directory-scoped session listing now applies the requested directory filter even when experimental workspaces are enabled. No local issue; this is a narrow upstream correctness port.

## Why

`Session.list({ directory })` previously skipped the directory predicate whenever `OPENCODE_EXPERIMENTAL_WORKSPACES` was enabled. That could widen a directory-scoped listing to other sessions in the same project, so workspace-enabled callers could see sessions outside the requested directory.

## Related Issue

No local issue. Upstream source: https://github.com/anomalyco/opencode/pull/30804

## Human Review Status

Pending

## Review Focus

Please focus on whether `Session.list({ directory })` should always preserve the explicit directory boundary, and whether the regression test proves same-project sessions from a nested directory no longer leak into the root directory listing under the experimental workspace flag.

## Risk Notes

Behavior intentionally narrows workspace-mode listing when a caller supplies `directory`; calls without `directory` are unchanged. Skipped conditional checklist items: no visible UI or copy changed; no platform, packaging, updater, signing, path, shell, or permissions surface changed; no docs, release notes, dependencies, credentials, deletion behavior, generated content, or local file changes are involved.

## How To Verify

```text
RED proof: bun test test/server/session-list.test.ts -t "filters by directory with experimental workspaces enabled" failed before the fix because the nested same-project session was returned.
Focused test: bun test test/server/session-list.test.ts -> 8 pass, 0 fail.
Adjacent route/listing test: bun test test/server/global-session-list.test.ts -> 15 pass, 0 fail.
Typecheck: bun run typecheck in packages/opencode -> tsgo --noEmit passed.
Diff check: git diff --check -> passed.
Claude review: no P0-P3 findings.
Independent fresh-eye review: no P1/P2 issues.
Rebase note: rebased onto latest origin/dev after #1241 landed, then reran the focused tests, typecheck, and diff check above.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
