### PR TITLE
fix(opencode): parse structured stream error payloads

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -139,6 +139,14 @@ function isRecord(input: unknown): input is Record<string, unknown> {
   return typeof input === "object" && input !== null && !Array.isArray(input)
 }
 
+function isBareProviderError(input: unknown): input is Record<string, unknown> {
+  return isRecord(input) && typeof input.code === "string"
+}
+
+function isStreamErrorBody(input: unknown): input is Record<string, unknown> {
+  return isRecord(input) && (input.type === "error" || isBareProviderError(input))
+}
+
 export type ParsedStreamError =
   | {
       type: "context_overflow"
@@ -159,14 +167,16 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   if (!isRecord(raw)) return
 
   const inner = typeof raw.message === "string" ? json(raw.message) : undefined
+  const cause = isRecord(raw.cause) ? raw.cause : undefined
+  const causeBody = cause ? json(cause.body) : undefined
   // OpenAI stream errors can arrive wrapped in an Error-like object. Use the
   // inner provider payload so responseBody matches the payload users need.
-  const body = isRecord(inner) && inner.type === "error" ? inner : raw
+  const body = isStreamErrorBody(inner) ? inner : isStreamErrorBody(causeBody) ? causeBody : raw
 
   const responseBody = JSON.stringify(body)
-  if (body.type !== "error") return
+  const error = body.type === "error" && isRecord(body.error) ? body.error : isBareProviderError(body) ? body : undefined
+  if (!error) return
 
-  const error = isRecord(body.error) ? body.error : undefined
   const code = typeof error?.code === "string" ? error.code : undefined
   switch (error?.code) {
     case "context_length_exceeded":

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1751,6 +1751,63 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("classifies bare response.failed stream error payloads", () => {
+    const body = {
+      code: "server_error",
+      message: "The provider failed while streaming the response.",
+    }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: body.message,
+        isRetryable: true,
+        responseBody: JSON.stringify(body),
+        providerID,
+        providerFailure: { kind: "server_overload", code: "server_error" },
+      },
+    })
+  })
+
+  test("leaves untyped nested error envelopes as UnknownError", () => {
+    const body = {
+      error: {
+        code: "server_error",
+        message: "The provider failed while streaming the response.",
+      },
+    }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "UnknownError",
+      data: { message: JSON.stringify(body) },
+    })
+  })
+
+  test("classifies stream error payloads from Error cause bodies", () => {
+    const body = {
+      type: "error",
+      error: {
+        code: "server_is_overloaded",
+        message: "The provider is overloaded.",
+      },
+    }
+    const error = new Error("provider stream failed", { cause: { body } })
+    const result = MessageV2.fromError(error, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: body.error.message,
+        isRetryable: true,
+        responseBody: JSON.stringify(body),
+        providerID,
+        providerFailure: { kind: "server_overload", code: "server_is_overloaded" },
+      },
+    })
+  })
+
   test("leaves Error-wrapped payloads with unhandled codes as UnknownError", () => {
     // Guard against the stream parser over-matching: an Error whose JSON message
     // carries a code the parser does not handle must stay Unknown, not become a


### PR DESCRIPTION
## Summary

Parse two structured provider stream failure shapes before `MessageV2.fromError` falls back to `UnknownError`:

- bare Responses `response.failed` error payloads such as `{ code, message }`
- SDK-style `Error.cause.body` payloads that contain the provider stream error body

The parser remains scoped to the existing stream error codes and keeps untyped nested `{ error: ... }` envelopes as `UnknownError`.

## Why

#1105 Slice 1 is about preserving provider stream payloads on the session LLM error path instead of collapsing structured failures into generic string errors. Current `dev` already handled JSON-in-`Error.message` payloads, but bare `response.failed` bodies and payloads stored under `cause.body` still reached `UnknownError` with only generic text.

## Related Issue

Part of #1105.

## Human Review Status

Pending

## Review Focus

Please focus on `ProviderError.parseStreamError` body selection and the narrowness of the accepted shapes. The intended accepted shapes are typed stream envelopes, bare provider error payloads with known codes, and `Error.cause.body`; untyped nested `{ error: ... }` objects should remain unknown.

## Risk Notes

Runtime behavior changes for provider stream errors on both macOS and Windows, but no OS-specific paths, packaging, updater, signing, persistence schema, UI, dependencies, docs, release notes, credentials, generated files, or permissions changed.

Skipped conditional checklist items: screenshots/recordings are not applicable because there are no visible UI or copy changes; docs/release/dependencies are not applicable because none of those surfaces changed.

## How To Verify

```text
Install: bun install --frozen-lockfile -> completed in the isolated worktree
RED: bare response.failed payload test failed as UnknownError before the parser change
RED: Error.cause.body payload test failed as UnknownError before the parser change
RED: untyped nested error envelope test failed after the first implementation, proving the Claude P2 over-match claim
Focused fromError tests: bun --cwd packages/opencode test test/session/message-v2.test.ts --test-name-pattern "fromError" -> 21 pass, 0 fail
Retry tests: bun --cwd packages/opencode test src/session/retry.test.ts test/session/retry.test.ts -> 58 pass, 0 fail
LLM stream tests: bun --cwd packages/opencode test test/session/llm.test.ts -> 21 pass, 0 fail
Typecheck: (cd packages/opencode && bun run typecheck) -> tsgo --noEmit passed
Diff check: git diff --check -> passed
Claude review: final diff reviewed, no P1/P2 findings
Codex fresh-eye review: final diff reviewed, no P1/P2 findings
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override if wrong, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.