### PR TITLE
fix(provider): preserve anthropic tool-call block order

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -263,31 +263,6 @@ function normalizeMessages(
       return msg
     })
   }
-  if (["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
-    // Anthropic rejects assistant turns where tool_use blocks are followed by non-tool
-    // content, e.g. [tool_use, tool_use, text], with:
-    // `tool_use` ids were found without `tool_result` blocks immediately after...
-    //
-    // Reorder that invalid shape into [text] + [tool_use, tool_use]. Consecutive
-    // assistant messages are later merged by the provider/SDK, so preserving the
-    // original [tool_use...] then [text] order still produces the invalid payload.
-    //
-    // The root cause appears to be somewhere upstream where the stream is originally
-    // processed. We were unable to locate an exact narrower reproduction elsewhere,
-    // so we keep this transform in place for the time being.
-    msgs = msgs.flatMap((msg) => {
-      if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [msg]
-
-      const parts = msg.content
-      const first = parts.findIndex((part) => part.type === "tool-call")
-      if (first === -1) return [msg]
-      if (!parts.slice(first).some((part) => part.type !== "tool-call")) return [msg]
-      return [
-        { ...msg, content: parts.filter((part) => part.type !== "tool-call") },
-        { ...msg, content: parts.filter((part) => part.type === "tool-call") },
-      ]
-    })
-  }
   if (
     model.providerID === "mistral" ||
     model.api.id.toLowerCase().includes("mistral") ||

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2171,7 +2171,20 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     expect(result[1].content).toHaveLength(1)
   })
 
-  test("splits anthropic assistant messages when text trails tool calls", () => {
+  test("preserves anthropic assistant messages when thinking and text trail tool calls", () => {
+    const opusModel = {
+      ...anthropicModel,
+      id: "anthropic/claude-opus-4-7",
+      api: {
+        id: "claude-opus-4-7-20260101",
+        url: "https://api.anthropic.com",
+        npm: "@ai-sdk/anthropic",
+      },
+      capabilities: {
+        ...anthropicModel.capabilities,
+        reasoning: true,
+      },
+    }
     const msgs = [
       {
         role: "user",
@@ -2182,6 +2195,11 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
         content: [
           { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
           { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+          {
+            type: "reasoning",
+            text: "The tool calls have completed.",
+            providerOptions: { anthropic: { signature: "sig_1" } },
+          },
           { type: "text", text: "I checked your home directory and looked for PDF files." },
         ],
       },
@@ -2199,18 +2217,20 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
+    const result = ProviderTransform.message(msgs, opusModel, {}) as any[]
 
-    expect(result).toHaveLength(4)
+    expect(result).toHaveLength(3)
     expect(result[1]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "I checked your home directory and looked for PDF files." }],
-    })
-    expect(result[2]).toMatchObject({
       role: "assistant",
       content: [
         { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
         { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+        {
+          type: "reasoning",
+          text: "The tool calls have completed.",
+          providerOptions: { anthropic: { signature: "sig_1" } },
+        },
+        { type: "text", text: "I checked your home directory and looked for PDF files." },
       ],
     })
   })
@@ -2237,7 +2257,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     ])
   })
 
-  test("splits vertex anthropic assistant messages when text trails tool calls", () => {
+  test("preserves vertex anthropic assistant messages when text trails tool calls", () => {
     const model = {
       ...anthropicModel,
       providerID: "google-vertex-anthropic",
@@ -2261,16 +2281,13 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
 
     const result = ProviderTransform.message(msgs, model, {}) as any[]
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "I checked your home directory and looked for PDF files." }],
-    })
-    expect(result[1]).toMatchObject({
       role: "assistant",
       content: [
         { type: "tool-call", toolCallId: "toolu_1", toolName: "read", input: { filePath: "/root" } },
         { type: "tool-call", toolCallId: "toolu_2", toolName: "glob", input: { pattern: "**/*.pdf" } },
+        { type: "text", text: "I checked your home directory and looked for PDF files." },
       ],
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1541,7 +1541,7 @@ describe("session.llm.stream", () => {
     })
   })
 
-  test("sends anthropic tool_use blocks with tool_result immediately after them", async () => {
+  test("preserves Anthropic assistant tool_use order when text trails tool calls", async () => {
     const server = state.server
     if (!server) {
       throw new Error("Server not initialized")
@@ -1761,10 +1761,6 @@ describe("session.llm.stream", () => {
             role: "assistant",
             content: [
               {
-                type: "text",
-                text: "I checked your home directory and looked for PDF files.",
-              },
-              {
                 type: "tool_use",
                 id: "toolu_01N8mDEzG8DSTs7UPHFtmgCT",
                 name: "read",
@@ -1775,6 +1771,10 @@ describe("session.llm.stream", () => {
                 id: "toolu_01APxrADs7VozN8uWzw9WwHr",
                 name: "glob",
                 input: { pattern: "**/*.pdf", path: "/root" },
+              },
+              {
+                type: "text",
+                text: "I checked your home directory and looked for PDF files.",
                 cache_control: {
                   type: "ephemeral",
                 },


### PR DESCRIPTION
## Summary

Port upstream `anomalyco/opencode#30483` by removing the stale Anthropic / Vertex Anthropic assistant tool-call reorder from provider message transforms. No PawWork issue was opened for this narrow upstream provider-safety port.

## Why

The old transform split assistant messages when tool calls were followed by text or reasoning content. Upstream removed this reorder while closing a provider-error bug, and PawWork still had both the stale transform and tests asserting the old split behavior.

The final diff also updates the existing Anthropic wire-payload fixture so the session-layer request contract matches the new preserved-order behavior.

## Related Issue

No PawWork issue. Related upstream PR: https://github.com/anomalyco/opencode/pull/30483

## Human Review Status

Pending

## Review Focus

Please focus on whether removing the Anthropic / Vertex Anthropic split is correctly scoped to `ProviderTransform.message`, and whether the replacement fixtures cover trailing text and thinking/reasoning content without re-opening provider policy work.

## Risk Notes

The main residual risk is that this is transform/session-level verification only. I did not run a live Anthropic or Vertex Anthropic API call.

Conditional checklist items left unticked:

- Visible UI/copy check: no UI or copy changed.
- macOS/Windows platform check: no platform, packaging, updater, signing, path, shell, or permissions surface changed.
- Docs/release/dependency/permission/generated/local-file check: none of those surfaces changed.

## How To Verify

```text
RED: bun test test/provider/transform.test.ts --timeout 30000 --test-name-pattern "preserves anthropic assistant messages when thinking and text trail tool calls|preserves vertex anthropic assistant messages when text trails tool calls" failed before the production change with the old split behavior (Anthropic length 4 vs expected 3, Vertex length 2 vs expected 1).
RED from Occam review: bun test test/session/llm.test.ts --timeout 30000 --test-name-pattern "sends anthropic tool_use blocks with tool_result immediately after them" failed because the existing session wire-payload fixture still expected the old reordered payload.
Focused transform regression: same provider transform command passed after the transform change, 2 passed.
Focused session regression: bun test test/session/llm.test.ts --timeout 30000 --test-name-pattern "preserves Anthropic assistant tool_use order when text trails tool calls", 1 passed.
Provider transform suite: bun test test/provider/transform.test.ts --timeout 30000, 207 passed.
Session LLM suite: bun test test/session/llm.test.ts --timeout 30000, 21 passed.
Typecheck: bun run typecheck in packages/opencode, passed.
Whitespace: git diff --check, passed with no output.
Claude final review: no P1/P2 findings; residual gap is no live provider API call.
Occam fresh-eye rerun: no P0/P1/P2 findings; only non-blocking/P3 coverage gap for other Anthropic-compatible providers.
```

## Screenshots or Recordings

Not applicable, no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
