### PR TITLE
fix(session): finalize interrupted assistant scaffolds

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2538,7 +2538,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
           const assistant = yield* currentTurnTarget(input.sessionID)
           if (assistant.info.role === "assistant") {
-            const error = assistant.info.error
+            const shouldFinalize = !assistant.info.time.completed
+            const error =
+              assistant.info.error ??
+              (shouldFinalize
+                ? MessageV2.fromError(new DOMException("Aborted", "AbortError"), {
+                    providerID: assistant.info.providerID,
+                    aborted: true,
+                  })
+                : undefined)
             const errorMessage =
               error && "data" in error && error.data && typeof error.data === "object" && "message" in error.data
                 ? String(error.data.message)
@@ -2546,6 +2554,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             const recordedAt = meta?.recordedAt ?? Date.now()
             yield* sessions.updateMessage({
               ...assistant.info,
+              ...(shouldFinalize
+                ? {
+                    error,
+                    time: {
+                      ...assistant.info.time,
+                      completed: recordedAt,
+                    },
+                  }
+                : {}),
               diagnostics: {
                 ...(assistant.info.diagnostics ?? {}),
                 abort: {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1699,6 +1699,117 @@ it.live(
 )
 
 it.live(
+  "cancel after assistant scaffold save finalizes before processor handle",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Processor creation cancel" })
+        const currentUser = yield* user(chat.id, "hello")
+
+        const started = defer<void>()
+        const mutableSessions = sessions as Mutable<typeof sessions>
+        const originalUpdateMessage = sessions.updateMessage
+        let blockedAssistantScaffold = false
+        mutableSessions.updateMessage = (info) => {
+          if (!blockedAssistantScaffold && info.role === "assistant" && info.parentID === currentUser.id) {
+            blockedAssistantScaffold = true
+            return Effect.gen(function* () {
+              const saved = yield* originalUpdateMessage(info)
+              started.resolve()
+              yield* Effect.never
+              return saved
+            })
+          }
+          return originalUpdateMessage(info)
+        }
+        yield* Effect.addFinalizer(() => Effect.sync(() => void (mutableSessions.updateMessage = originalUpdateMessage)))
+
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        const startedExit = yield* Effect.promise(() => started.promise).pipe(Effect.timeout("1 second"), Effect.exit)
+        expect(Exit.isSuccess(startedExit)).toBe(true)
+        const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout("1 second"), Effect.exit)
+        expect(Exit.isSuccess(cancelExit)).toBe(true)
+        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout("1 second"))
+        expect(Exit.isSuccess(exit)).toBe(true)
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const assistant = messages.find(
+          (message) => message.info.role === "assistant" && message.info.parentID === currentUser.id,
+        )
+        expect(assistant?.info.role).toBe("assistant")
+        if (!assistant || assistant.info.role !== "assistant") return
+        expect(assistant.parts).toHaveLength(0)
+        expect(assistant.info.error?.name).toBe("MessageAbortedError")
+        expect(assistant.info.time.completed).toBeNumber()
+        expect(assistant.info.diagnostics?.abort).toMatchObject({
+          source: "session.prompt.cancel",
+          reason: "cancel",
+          propagation_point: "session.prompt.loop.onInterrupt",
+          error_name: "MessageAbortedError",
+        })
+      }),
+      { git: true, config: providerCfg },
+    ),
+  10_000,
+)
+
+it.live(
+  "cancel after processor handle creation finalizes before process starts",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const plugin = yield* Plugin.Service
+        const chat = yield* sessions.create({ title: "Pre-process cancel" })
+        const currentUser = yield* user(chat.id, "hello")
+
+        const started = defer<void>()
+        const mutablePlugin = plugin as Mutable<typeof plugin>
+        const originalTrigger = plugin.trigger
+        mutablePlugin.trigger = ((name: Parameters<typeof plugin.trigger>[0], input: unknown, output: unknown) => {
+          if (name === "experimental.chat.messages.transform") {
+            return Effect.gen(function* () {
+              started.resolve()
+              return yield* Effect.never
+            })
+          }
+          return originalTrigger(name as never, input as never, output as never)
+        }) as typeof plugin.trigger
+        yield* Effect.addFinalizer(() => Effect.sync(() => void (mutablePlugin.trigger = originalTrigger)))
+
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        const startedExit = yield* Effect.promise(() => started.promise).pipe(Effect.timeout("1 second"), Effect.exit)
+        expect(Exit.isSuccess(startedExit)).toBe(true)
+        const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout("1 second"), Effect.exit)
+        expect(Exit.isSuccess(cancelExit)).toBe(true)
+        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout("1 second"))
+        expect(Exit.isSuccess(exit)).toBe(true)
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const assistant = messages.find(
+          (message) => message.info.role === "assistant" && message.info.parentID === currentUser.id,
+        )
+        expect(assistant?.info.role).toBe("assistant")
+        if (!assistant || assistant.info.role !== "assistant") return
+        expect(assistant.parts).toHaveLength(0)
+        expect(assistant.info.error?.name).toBe("MessageAbortedError")
+        expect(assistant.info.time.completed).toBeNumber()
+        expect(assistant.info.diagnostics?.abort).toMatchObject({
+          source: "session.prompt.cancel",
+          reason: "cancel",
+          propagation_point: "session.prompt.loop.onInterrupt",
+          error_name: "MessageAbortedError",
+        })
+      }),
+      { git: true, config: providerCfg },
+    ),
+  10_000,
+)
+
+it.live(
   "cancel interrupts the running loop",
   () =>
     provideTmpdirServer(


### PR DESCRIPTION
## Summary

Fixes the upstream #27254 session interrupt window by finalizing an assistant scaffold when a run is canceled after the scaffold is persisted but before the processor has fully taken over.

No local PawWork issue is linked; this ports upstream anomalyco/opencode#27254 only.

## Why

`SessionPrompt.run` persists the assistant message before processor processing starts. If cancellation lands after that scaffold exists but before processor cleanup owns the turn, the session can retain an empty assistant with no error and no completion timestamp. That stale scaffold can poison later session history.

## Related Issue

Upstream: https://github.com/anomalyco/opencode/pull/27254

## Human Review Status

Pending

## Review Focus

Please focus on the cancel timing around `SessionPrompt.loop`: the fallback should finalize only the current unfinished assistant scaffold and should not import #1252 tool-drain behavior or broaden provider/tool handling.

## Risk Notes

Skipped conditional checklist items:

- Visible UI/manual screenshot: not applicable; no UI or copy changed.
- Platform/packaging check: not applicable; no platform, packaging, updater, signing, path, shell, or permissions surface changed.
- Docs/release/dependency/permission/generated-content check: not applicable; no docs, release notes, dependencies, permissions, credentials, generated files, or local-only files changed.

Residual behavior risk: canceled assistants still follow existing semantics and do not set `finish`; this PR only ensures aborted scaffolds carry `MessageAbortedError` and `time.completed`.

## How To Verify

```text
RED proof: new regression first failed because the canceled scaffold had no MessageAbortedError.
Focused regression: bun test --timeout 30000 ./test/session/prompt-effect.test.ts -t "cancel after assistant scaffold save finalizes before processor handle|cancel after processor handle creation finalizes before process starts" -> 2 passed.
Prompt interruption suite: bun test --timeout 30000 ./test/session/prompt-effect.test.ts -> 65 passed.
Processor abort slice: bun test --timeout 30000 ./test/session/processor-effect.test.ts -t "abort|interrupt" -> 6 passed.
Typecheck: bun run typecheck in packages/opencode -> passed.
Whitespace: git diff --check origin/dev...HEAD -> passed.
Claude review: PASS after final diff.
Independent Occam fresh-eye review: PASS, no P0/P1/P2 findings after addressing the pre-process cancellation window.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
