### PR TITLE
fix(opencode): recover remote config auth login

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -15,6 +15,7 @@ import type { Hooks } from "@opencode-ai/plugin"
 import { Process } from "../../util/process"
 import { text } from "node:stream/consumers"
 import { Effect } from "effect"
+import { errorMessage } from "@/util/error"
 
 type PluginAuth = NonNullable<Hooks["auth"]>
 
@@ -25,6 +26,53 @@ const put = (key: string, info: Auth.Info) =>
       yield* auth.set(key, info)
     }),
   )
+
+async function readWellKnownAuth(url: string) {
+  const remote = `${url}/.well-known/opencode`
+  const response = await fetch(remote).catch((error) => {
+    throw new Error(`Failed to connect to ${remote}: ${errorMessage(error)}`)
+  })
+  const body = await response.text()
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? ""
+  const isHtml = contentType.includes("html") || /^\s*(?:<!doctype html|<html)\b/i.test(body)
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(`Failed to load auth metadata from ${remote}: the server rejected the request with HTTP ${response.status}.`)
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to load auth metadata from ${remote}: the server returned HTTP ${response.status}.`)
+  }
+  if (isHtml) {
+    throw new Error(`Failed to load auth metadata from ${remote}: the server returned a login page instead of JSON.`)
+  }
+  let data: unknown
+  try {
+    data = JSON.parse(body)
+  } catch {
+    throw new Error(`Failed to load auth metadata from ${remote}: the server returned non-JSON content.`)
+  }
+  const auth = data && typeof data === "object" && "auth" in data ? data.auth : undefined
+  if (
+    !auth ||
+    typeof auth !== "object" ||
+    !("command" in auth) ||
+    !Array.isArray(auth.command) ||
+    auth.command.length === 0 ||
+    !auth.command.every((item) => typeof item === "string") ||
+    !("env" in auth) ||
+    typeof auth.env !== "string"
+  ) {
+    throw new Error(`Failed to load auth metadata from ${remote}: the response did not include a valid auth command.`)
+  }
+  return { auth: { command: auth.command, env: auth.env } }
+}
+
+function normalizeWellKnownUrl(input: string) {
+  const url = input.trim().replace(/\/+$/, "")
+  if (!/^https?:\/\//i.test(url)) {
+    throw new Error("Invalid auth provider URL. The URL must start with http:// or https://.")
+  }
+  return url
+}
 
 async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, methodName?: string): Promise<boolean> {
   let index = 0
@@ -290,41 +338,47 @@ export const ProvidersLoginCommand = cmd({
         type: "string",
       }),
   async handler(args) {
+    if (args.url) {
+      UI.empty()
+      prompts.intro("Add credential")
+      const url = normalizeWellKnownUrl(args.url)
+      const wellknown = await readWellKnownAuth(url)
+      prompts.log.info(`Running \`${wellknown.auth.command.join(" ")}\``)
+      const token = await (async () => {
+        const proc = Process.spawn(wellknown.auth.command, { stdout: "pipe", stderr: "inherit" })
+        if (!proc.stdout) {
+          prompts.log.error("Failed")
+          prompts.outro("Done")
+          return
+        }
+        const [exit, output] = await Promise.all([proc.exited, text(proc.stdout)])
+        if (exit !== 0) {
+          prompts.log.error("Failed")
+          prompts.outro("Done")
+          return
+        }
+        return output.trim()
+      })().catch((error) => {
+        throw new Error(`Failed to run auth command: ${errorMessage(error)}`)
+      })
+      if (token === undefined) return
+      await put(url, {
+        type: "wellknown",
+        key: wellknown.auth.env,
+        token,
+      }).catch((error) => {
+        throw new Error(`Failed to save credential for ${url}: ${errorMessage(error)}`)
+      })
+      prompts.log.success("Logged into " + url)
+      prompts.outro("Done")
+      return
+    }
+
     await Instance.provide({
       directory: process.cwd(),
       async fn() {
         UI.empty()
         prompts.intro("Add credential")
-        if (args.url) {
-          const url = args.url.replace(/\/+$/, "")
-          const wellknown = (await fetch(`${url}/.well-known/opencode`).then((x) => x.json())) as {
-            auth: { command: string[]; env: string }
-          }
-          prompts.log.info(`Running \`${wellknown.auth.command.join(" ")}\``)
-          const proc = Process.spawn(wellknown.auth.command, {
-            stdout: "pipe",
-            stderr: "inherit",
-          })
-          if (!proc.stdout) {
-            prompts.log.error("Failed")
-            prompts.outro("Done")
-            return
-          }
-          const [exit, token] = await Promise.all([proc.exited, text(proc.stdout)])
-          if (exit !== 0) {
-            prompts.log.error("Failed")
-            prompts.outro("Done")
-            return
-          }
-          await put(url, {
-            type: "wellknown",
-            key: wellknown.auth.env,
-            token: token.trim(),
-          })
-          prompts.log.success("Logged into " + url)
-          prompts.outro("Done")
-          return
-        }
         await ModelsDev.refresh(true).catch(() => {})
 
         const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get()))

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -69,6 +69,16 @@ export function FormatError(input: unknown) {
     return (input as ErrorLike).data?.message ?? ""
   }
 
+  // ConfigRemoteAuthError: { url: string, remote: string, message: string }
+  if (hasName(input, "ConfigRemoteAuthError")) {
+    const data = (input as ErrorLike).data
+    return [
+      `Failed to load remote config from ${data?.remote}: ${data?.message}.`,
+      "Authentication may be missing or expired.",
+      `Run \`opencode auth login ${data?.url}\` to re-authenticate.`,
+    ].join("\n")
+  }
+
   // ConfigInvalidError: { path?: string, message?: string, issues?: Array<{ message: string, path: string[] }> }
   if (hasName(input, "ConfigInvalidError")) {
     const data = (input as ErrorLike).data

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -45,6 +45,7 @@ import { ConfigProvider } from "./provider"
 import { ConfigServer } from "./server"
 import { ConfigSkills } from "./skills"
 import { ConfigVariable } from "./variable"
+import { RemoteAuthError } from "./error"
 import { Npm } from "@opencode-ai/core/npm"
 import { Filesystem } from "@/util/filesystem"
 import { Flock } from "@/util/flock"
@@ -77,6 +78,26 @@ function projectConfigFilesForDirectory(dir: string) {
     return Runtime.isPawWork() ? PAWWORK_PROJECT_CONFIG_FILES : OPENCODE_PROJECT_CONFIG_FILES
   }
   return []
+}
+
+async function readRemoteConfigJson(response: Response, input: { url: string; remote: string }) {
+  const body = await response.text()
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? ""
+  const isHtml = contentType.includes("html") || /^\s*(?:<!doctype html|<html)\b/i.test(body)
+  if (isHtml) {
+    throw new RemoteAuthError({
+      ...input,
+      message: "the server returned a login page instead of JSON",
+    })
+  }
+  try {
+    return JSON.parse(body)
+  } catch {
+    throw new RemoteAuthError({
+      ...input,
+      message: "the server returned non-JSON content",
+    })
+  }
 }
 
 function shouldGenerateInDirectory(dir: string) {
@@ -888,13 +909,23 @@ const rawLayer = Layer.effect(
             process.env[value.key] = value.token
             log.debug("fetching remote config", { url: `${url}/.well-known/opencode` })
             const response = yield* Effect.promise(() => fetch(`${url}/.well-known/opencode`))
+            const remote = `${url}/.well-known/opencode`
+            if (response.status === 401 || response.status === 403) {
+              throw new RemoteAuthError({
+                url,
+                remote,
+                message: `the server rejected the request with HTTP ${response.status}`,
+              })
+            }
             if (!response.ok) {
               throw new Error(`failed to fetch remote config from ${url}: ${response.status}`)
             }
-            const wellknown = (yield* Effect.promise(() => response.json())) as { config?: Record<string, unknown> }
+            const wellknown = (yield* Effect.promise(() =>
+              readRemoteConfigJson(response, { url, remote }),
+            )) as { config?: Record<string, unknown> }
             const remoteConfig = wellknown.config ?? {}
             if (!remoteConfig.$schema) remoteConfig.$schema = "https://opencode.ai/config.json"
-            const source = `${url}/.well-known/opencode`
+            const source = remote
             const next = yield* loadConfig(JSON.stringify(remoteConfig), {
               dir: path.dirname(source),
               source,

--- a/packages/opencode/src/config/error.ts
+++ b/packages/opencode/src/config/error.ts
@@ -19,3 +19,12 @@ export const InvalidError = NamedError.create(
     message: z.string().optional(),
   }),
 )
+
+export const RemoteAuthError = NamedError.create(
+  "ConfigRemoteAuthError",
+  z.object({
+    url: z.string(),
+    remote: z.string(),
+    message: z.string(),
+  }),
+)

--- a/packages/opencode/test/cli/error.test.ts
+++ b/packages/opencode/test/cli/error.test.ts
@@ -38,4 +38,19 @@ describe("cli.error", () => {
 
     expect(formatted).toBe("Provider not found: missing")
   })
+
+  test("formats remote config auth recovery errors", () => {
+    const formatted = FormatError({
+      name: "ConfigRemoteAuthError",
+      data: {
+        url: "https://example.com",
+        remote: "https://example.com/.well-known/opencode",
+        message: "the server returned a login page instead of JSON",
+      },
+    })
+
+    expect(formatted).toContain("Failed to load remote config from https://example.com/.well-known/opencode")
+    expect(formatted).toContain("returned a login page instead of JSON")
+    expect(formatted).toContain("opencode auth login https://example.com")
+  })
 })

--- a/packages/opencode/test/cli/providers-login.test.ts
+++ b/packages/opencode/test/cli/providers-login.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
+import { Readable } from "node:stream"
+import { Auth } from "../../src/auth"
+import { ProvidersLoginCommand } from "../../src/cli/cmd/providers"
+import { Instance } from "../../src/project/instance"
+import { Process } from "../../src/util/process"
+
+const originalFetch = globalThis.fetch
+const loginUrl = "https://enterprise-auth.test"
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch
+  mock.restore()
+  await Auth.remove(loginUrl).catch(() => {})
+})
+
+test("url login skips instance bootstrap so stale remote config cannot block re-auth", async () => {
+  const provide = spyOn(Instance, "provide").mockImplementation(() => {
+    throw new Error("stale remote config")
+  })
+  const spawn = spyOn(Process, "spawn").mockReturnValue({
+    stdout: undefined,
+    stderr: undefined,
+    exited: Promise.resolve(1),
+  } as never)
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    expect(urlStr).toBe(`${loginUrl}/.well-known/opencode`)
+    return Promise.resolve(
+      new Response(JSON.stringify({ auth: { command: ["sh", "-c", "printf token"], env: "TEST_TOKEN" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  }) as unknown as typeof fetch
+
+  await ProvidersLoginCommand.handler({ url: loginUrl } as never)
+
+  expect(provide).not.toHaveBeenCalled()
+  expect(spawn).toHaveBeenCalledWith(["sh", "-c", "printf token"], {
+    stdout: "pipe",
+    stderr: "inherit",
+  })
+})
+
+test("url login stores the refreshed well-known credential outside instance bootstrap", async () => {
+  const provide = spyOn(Instance, "provide").mockImplementation(() => {
+    throw new Error("stale remote config")
+  })
+  spyOn(Process, "spawn").mockReturnValue({
+    stdout: Readable.from([" fresh-token\n"]),
+    stderr: undefined,
+    exited: Promise.resolve(0),
+  } as never)
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    expect(urlStr).toBe(`${loginUrl}/.well-known/opencode`)
+    return Promise.resolve(
+      new Response(JSON.stringify({ auth: { command: ["sh", "-c", "printf token"], env: "TEST_TOKEN" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  }) as unknown as typeof fetch
+
+  await ProvidersLoginCommand.handler({ url: `${loginUrl}/` } as never)
+
+  expect(provide).not.toHaveBeenCalled()
+  expect(await Auth.get(loginUrl)).toEqual({
+    type: "wellknown",
+    key: "TEST_TOKEN",
+    token: "fresh-token",
+  })
+})
+
+test("url login rejects non-json auth metadata with a clear error", async () => {
+  const spawn = spyOn(Process, "spawn")
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    expect(urlStr).toBe(`${loginUrl}/.well-known/opencode`)
+    return Promise.resolve(
+      new Response("<!doctype html><html><body>Login required</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    )
+  }) as unknown as typeof fetch
+
+  await expect(ProvidersLoginCommand.handler({ url: loginUrl } as never)).rejects.toThrow(
+    "the server returned a login page instead of JSON",
+  )
+
+  expect(spawn).not.toHaveBeenCalled()
+})
+
+test("url login rejects invalid auth provider urls before fetching metadata", async () => {
+  const spawn = spyOn(Process, "spawn")
+  await expect(ProvidersLoginCommand.handler({ url: "enterprise-auth.test" } as never)).rejects.toThrow(
+    "The URL must start with http:// or https://",
+  )
+  expect(spawn).not.toHaveBeenCalled()
+})
+
+test("url login rejects network errors with a clear metadata error", async () => {
+  const spawn = spyOn(Process, "spawn")
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    expect(urlStr).toBe(`${loginUrl}/.well-known/opencode`)
+    return Promise.reject(new TypeError("fetch failed"))
+  }) as unknown as typeof fetch
+
+  await expect(ProvidersLoginCommand.handler({ url: loginUrl } as never)).rejects.toThrow(
+    `Failed to connect to ${loginUrl}/.well-known/opencode: fetch failed`,
+  )
+  expect(spawn).not.toHaveBeenCalled()
+})
+
+test("url login rejects non-ok auth metadata with a clear error", async () => {
+  const spawn = spyOn(Process, "spawn")
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    expect(urlStr).toBe(`${loginUrl}/.well-known/opencode`)
+    return Promise.resolve(new Response("Server error", { status: 500 }))
+  }) as unknown as typeof fetch
+
+  await expect(ProvidersLoginCommand.handler({ url: loginUrl } as never)).rejects.toThrow("the server returned HTTP 500")
+
+  expect(spawn).not.toHaveBeenCalled()
+})
+
+test("url login rejects invalid auth metadata with a clear error", async () => {
+  const spawn = spyOn(Process, "spawn")
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    expect(urlStr).toBe(`${loginUrl}/.well-known/opencode`)
+    return Promise.resolve(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  }) as unknown as typeof fetch
+
+  await expect(ProvidersLoginCommand.handler({ url: loginUrl } as never)).rejects.toThrow(
+    "the response did not include a valid auth command",
+  )
+
+  expect(spawn).not.toHaveBeenCalled()
+})
+
+test("url login rejects empty auth commands as invalid metadata", async () => {
+  const spawn = spyOn(Process, "spawn")
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    expect(urlStr).toBe(`${loginUrl}/.well-known/opencode`)
+    return Promise.resolve(
+      new Response(JSON.stringify({ auth: { command: [], env: "TEST_TOKEN" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  }) as unknown as typeof fetch
+
+  await expect(ProvidersLoginCommand.handler({ url: loginUrl } as never)).rejects.toThrow(
+    "the response did not include a valid auth command",
+  )
+  expect(spawn).not.toHaveBeenCalled()
+})
+
+test("url login rejects auth command failures with a clear error", async () => {
+  spyOn(Process, "spawn").mockReturnValue({
+    stdout: Readable.from([""]),
+    stderr: undefined,
+    exited: Promise.reject(new Error("spawn missing")),
+  } as never)
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    expect(urlStr).toBe(`${loginUrl}/.well-known/opencode`)
+    return Promise.resolve(
+      new Response(JSON.stringify({ auth: { command: ["missing-auth"], env: "TEST_TOKEN" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+  }) as unknown as typeof fetch
+
+  await expect(ProvidersLoginCommand.handler({ url: loginUrl } as never)).rejects.toThrow(
+    "Failed to run auth command: spawn missing",
+  )
+})

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, mock, afterEach, beforeEach, spyOn } from "bun:test"
-import { Effect, Layer, Option } from "effect"
+import { Cause, Effect, Exit, Layer, Option } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { Config, ConfigManaged, ConfigVariable } from "../../src/config"
 import { ConfigParse } from "../../src/config/parse"
@@ -2611,6 +2611,140 @@ test("wellknown URL with trailing slash is normalized", async () => {
         ),
       { git: true },
     ).pipe(Effect.scoped, Effect.provide(layer), Effect.runPromise)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("wellknown HTML response surfaces remote auth recovery error", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    if (urlStr.includes(".well-known/opencode")) {
+      return Promise.resolve(
+        new Response("<!doctype html><html><body>Login required</body></html>", {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      )
+    }
+    return originalFetch(url)
+  }) as unknown as typeof fetch
+
+  const fakeAuth = Layer.mock(Auth.Service)({
+    all: () =>
+      Effect.succeed({
+        "https://example.com": new Auth.WellKnown({ type: "wellknown", key: "TEST_TOKEN", token: "expired-token" }),
+      }),
+  })
+
+  const layer = Config.layer.pipe(
+    Layer.provide(AppFileSystem.defaultLayer),
+    Layer.provide(fakeAuth),
+    Layer.provide(emptyAccount),
+    Layer.provideMerge(infra),
+  )
+
+  try {
+    const exit = await provideTmpdirInstance(
+      () => Config.Service.use((svc) => svc.get()).pipe(Effect.exit),
+      { git: true },
+    ).pipe(Effect.scoped, Effect.provide(layer), Effect.runPromise)
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    const error = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined
+    expect((error as Error | undefined)?.name).toBe("ConfigRemoteAuthError")
+    const data = (error as { data?: { url?: string; remote?: string; message?: string } } | undefined)?.data
+    expect(data?.url).toBe("https://example.com")
+    expect(data?.remote).toBe("https://example.com/.well-known/opencode")
+    expect(data?.message).toBe("the server returned a login page instead of JSON")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("wellknown non-json response surfaces remote auth recovery error", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    if (urlStr.includes(".well-known/opencode")) {
+      return Promise.resolve(
+        new Response("login required", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      )
+    }
+    return originalFetch(url)
+  }) as unknown as typeof fetch
+
+  const fakeAuth = Layer.mock(Auth.Service)({
+    all: () =>
+      Effect.succeed({
+        "https://example.com": new Auth.WellKnown({ type: "wellknown", key: "TEST_TOKEN", token: "expired-token" }),
+      }),
+  })
+
+  const layer = Config.layer.pipe(
+    Layer.provide(AppFileSystem.defaultLayer),
+    Layer.provide(fakeAuth),
+    Layer.provide(emptyAccount),
+    Layer.provideMerge(infra),
+  )
+
+  try {
+    const exit = await provideTmpdirInstance(
+      () => Config.Service.use((svc) => svc.get()).pipe(Effect.exit),
+      { git: true },
+    ).pipe(Effect.scoped, Effect.provide(layer), Effect.runPromise)
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    const error = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined
+    expect((error as Error | undefined)?.name).toBe("ConfigRemoteAuthError")
+    expect((error as { data?: { message?: string } } | undefined)?.data?.message).toBe(
+      "the server returned non-JSON content",
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("wellknown unauthorized response surfaces remote auth recovery error", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url instanceof Request ? url.url : url instanceof URL ? url.href : url
+    if (urlStr.includes(".well-known/opencode")) {
+      return Promise.resolve(new Response("Unauthorized", { status: 401 }))
+    }
+    return originalFetch(url)
+  }) as unknown as typeof fetch
+
+  const fakeAuth = Layer.mock(Auth.Service)({
+    all: () =>
+      Effect.succeed({
+        "https://example.com": new Auth.WellKnown({ type: "wellknown", key: "TEST_TOKEN", token: "expired-token" }),
+      }),
+  })
+
+  const layer = Config.layer.pipe(
+    Layer.provide(AppFileSystem.defaultLayer),
+    Layer.provide(fakeAuth),
+    Layer.provide(emptyAccount),
+    Layer.provideMerge(infra),
+  )
+
+  try {
+    const exit = await provideTmpdirInstance(
+      () => Config.Service.use((svc) => svc.get()).pipe(Effect.exit),
+      { git: true },
+    ).pipe(Effect.scoped, Effect.provide(layer), Effect.runPromise)
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    const error = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined
+    expect((error as Error | undefined)?.name).toBe("ConfigRemoteAuthError")
+    expect((error as { data?: { message?: string } } | undefined)?.data?.message).toBe(
+      "the server rejected the request with HTTP 401",
+    )
   } finally {
     globalThis.fetch = originalFetch
   }


### PR DESCRIPTION
## Summary

Recover expired enterprise remote config auth without trapping users behind opaque JSON/config failures. This PR ports the narrow upstream #31661 runtime/config recovery idea; there is no local PawWork issue, only the upstream reference.

## Why

If a stored well-known enterprise token expires, PawWork can currently fail while loading remote config before `opencode auth login <url>` gets a chance to refresh credentials. Some auth gateways also return HTML or other non-JSON content with HTTP 200, which currently surfaces as a raw JSON parse/config failure.

## Related Issue

No local issue. Upstream reference: https://github.com/anomalyco/opencode/pull/31661

## Human Review Status

Pending

## Review Focus

Please focus on the remote config failure classification and the URL login recovery path:

- `auth login <url>` should not enter `Instance.provide` before fetching fresh well-known auth metadata.
- Remote config `.well-known/opencode` responses that are 401/403, HTML login pages, or non-JSON should become actionable re-auth errors.
- The URL login metadata fetch should fail clearly for bad metadata without masking successful credential writes.

## Risk Notes

This changes CLI/runtime auth recovery behavior and writes refreshed well-known credentials through the existing Auth service. Tests use the repo test preload sandbox and a `.test` URL, and verify successful credential storage. No package, lockfile, UI, provider queue, session, MCP, installation, or platform packaging behavior is changed.

Skipped conditional checklist items:

- Visible UI/copy manual check: CLI error copy changed, covered by formatter and command tests; no screenshot or recording applies.
- Platform/packaging manual check: no platform packaging, updater, signing, native path, shell, or permissions surface changed beyond the existing auth command spawn path.

## How To Verify

```text
RED checks: new config and providers-login regression tests first failed for SyntaxError/raw Instance bootstrap/formatter gaps before implementation.
Focused config + CLI tests: 119 passed across test/config/config.test.ts, test/cli/error.test.ts, and test/cli/providers-login.test.ts.
Typecheck: packages/opencode `bun run typecheck` passed.
Diff check: `git diff --check origin/dev...HEAD` passed.
Claude review: final terminal read-only review found no P0/P1/P2 findings.
Occam fresh-eye review: final terminal read-only review found no P0/P1/P2 findings; only P3/non-blocking observations.
```

## Screenshots or Recordings

Not a UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

