### PR TITLE
fix(provider): support Vertex REP endpoints

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -118,6 +118,13 @@ export function stripOpenAIResponseInputIDs(body: unknown) {
   return JSON.stringify(parsed)
 }
 
+function googleVertexAnthropicBaseURL(project: string | undefined, location: string | undefined) {
+  if (!project) return
+  if (location !== "eu" && location !== "us") return
+  // Continental multi-regions require Regional Endpoint Platform domains.
+  return `https://aiplatform.${location}.rep.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
+}
+
 type BundledSDK = {
   languageModel(modelId: string): LanguageModelV3
   chatModel?(modelId: string): LanguageModelV3
@@ -459,7 +466,11 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
     "google-vertex": Effect.fnUntraced(function* (provider: Info) {
       const env = yield* dep.env()
       const project =
-        provider.options?.project ?? env["GOOGLE_CLOUD_PROJECT"] ?? env["GCP_PROJECT"] ?? env["GCLOUD_PROJECT"]
+        provider.options?.project ??
+        env["GOOGLE_VERTEX_PROJECT"] ??
+        env["GOOGLE_CLOUD_PROJECT"] ??
+        env["GCP_PROJECT"] ??
+        env["GCLOUD_PROJECT"]
 
       const location = String(
         provider.options?.location ??
@@ -502,10 +513,20 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         },
       }
     }),
-    "google-vertex-anthropic": Effect.fnUntraced(function* () {
+    "google-vertex-anthropic": Effect.fnUntraced(function* (provider: Info) {
       const env = yield* dep.env()
-      const project = env["GOOGLE_CLOUD_PROJECT"] ?? env["GCP_PROJECT"] ?? env["GCLOUD_PROJECT"]
-      const location = env["GOOGLE_CLOUD_LOCATION"] ?? env["VERTEX_LOCATION"] ?? "global"
+      const project =
+        provider.options?.project ??
+        env["GOOGLE_VERTEX_PROJECT"] ??
+        env["GOOGLE_CLOUD_PROJECT"] ??
+        env["GCP_PROJECT"] ??
+        env["GCLOUD_PROJECT"]
+      const location =
+        provider.options?.location ??
+        env["GOOGLE_VERTEX_LOCATION"] ??
+        env["GOOGLE_CLOUD_LOCATION"] ??
+        env["VERTEX_LOCATION"] ??
+        "global"
       const autoload = Boolean(project)
       if (!autoload) return { autoload: false }
       return {
@@ -1498,6 +1519,14 @@ const layer: Layer.Layer<
         })
         const provider = s.providers[model.providerID]
         const options = { ...provider.options }
+
+        if (model.api.npm === "@ai-sdk/google-vertex/anthropic" && !options.baseURL && !model.api.url) {
+          const baseURL = googleVertexAnthropicBaseURL(
+            typeof options.project === "string" ? options.project : undefined,
+            typeof options.location === "string" ? options.location : undefined,
+          )
+          if (baseURL) options.baseURL = baseURL
+        }
 
         if (model.providerID === "google-vertex" && !model.api.npm.includes("@ai-sdk/openai-compatible")) {
           delete options.fetch

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -26,6 +26,17 @@ import {
 
 const env = makeRuntime(Env.Service, Env.defaultLayer)
 const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
+const unset = (k: string) => env.runSync((svc) => svc.remove(k))
+
+function clearVertexEnv() {
+  unset("GOOGLE_VERTEX_PROJECT")
+  unset("GOOGLE_VERTEX_LOCATION")
+  unset("GOOGLE_CLOUD_PROJECT")
+  unset("GCP_PROJECT")
+  unset("GCLOUD_PROJECT")
+  unset("GOOGLE_CLOUD_LOCATION")
+  unset("VERTEX_LOCATION")
+}
 
 async function run<A, E>(fn: (provider: Provider.Interface) => Effect.Effect<A, E, never>) {
   return AppRuntime.runPromise(
@@ -84,6 +95,31 @@ async function restoreAuthSnapshot(snapshot: string | undefined) {
   } catch (e) {
     if (!(typeof e === "object" && e !== null && "code" in e && e.code === "ENOENT")) throw e
   }
+}
+
+function languageBaseURL(language: unknown) {
+  return (language as { config: { baseURL: string } }).config.baseURL
+}
+
+async function writeVertexAnthropicConfig(dir: string) {
+  await Bun.write(
+    path.join(dir, "opencode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      provider: {
+        "google-vertex": {
+          models: {
+            "claude-test": {
+              name: "Claude Test",
+              provider: {
+                npm: "@ai-sdk/google-vertex/anthropic",
+              },
+            },
+          },
+        },
+      },
+    }),
+  )
 }
 
 test("OpenCode Zen and OpenCode Go providers remain discoverable in PawWork runtime mode", async () => {
@@ -2804,6 +2840,291 @@ test("Google Vertex: supports OpenAI compatible models", async () => {
 
       expect(model).toBeDefined()
       expect(model.api.npm).toBe("@ai-sdk/openai-compatible")
+    },
+  })
+})
+
+test("Google Vertex: uses REP endpoint for Claude continental multi-regions", async () => {
+  await using tmp = await tmpdir({
+    init: writeVertexAnthropicConfig,
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+      set("GOOGLE_CLOUD_PROJECT", "test-project")
+      set("VERTEX_LOCATION", "eu")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex"), ModelID.make("claude-test"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe(
+        "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models",
+      )
+    },
+  })
+})
+
+test("Google Vertex: uses REP endpoint with Vertex SDK env names", async () => {
+  await using tmp = await tmpdir({
+    init: writeVertexAnthropicConfig,
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+      set("GOOGLE_VERTEX_PROJECT", "test-project")
+      set("GOOGLE_VERTEX_LOCATION", "eu")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex"), ModelID.make("claude-test"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe(
+        "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models",
+      )
+    },
+  })
+})
+
+test("Google Vertex: keeps explicit Claude API URL", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex": {
+              options: {
+                project: "test-project",
+                location: "eu",
+              },
+              models: {
+                "claude-proxy": {
+                  name: "Claude Proxy",
+                  provider: {
+                    npm: "@ai-sdk/google-vertex/anthropic",
+                    api: "https://proxy.example/v1",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex"), ModelID.make("claude-proxy"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe("https://proxy.example/v1")
+    },
+  })
+})
+
+test("Google Vertex Anthropic: uses REP endpoint for continental multi-regions", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+      set("GOOGLE_CLOUD_PROJECT", "test-project")
+      set("VERTEX_LOCATION", "us")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex-anthropic"), ModelID.make("claude-sonnet-4-6@default"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe(
+        "https://aiplatform.us.rep.googleapis.com/v1/projects/test-project/locations/us/publishers/anthropic/models",
+      )
+    },
+  })
+})
+
+test("Google Vertex Anthropic: uses REP endpoint from config options", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: {
+                project: "config-project",
+                location: "eu",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex-anthropic"), ModelID.make("claude-sonnet-4-6@default"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe(
+        "https://aiplatform.eu.rep.googleapis.com/v1/projects/config-project/locations/eu/publishers/anthropic/models",
+      )
+    },
+  })
+})
+
+test("Google Vertex Anthropic: prefers config options over env names", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: {
+                project: "config-project",
+                location: "eu",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+      set("GOOGLE_VERTEX_PROJECT", "env-project")
+      set("GOOGLE_VERTEX_LOCATION", "us")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex-anthropic"), ModelID.make("claude-sonnet-4-6@default"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe(
+        "https://aiplatform.eu.rep.googleapis.com/v1/projects/config-project/locations/eu/publishers/anthropic/models",
+      )
+    },
+  })
+})
+
+test("Google Vertex Anthropic: keeps explicit provider baseURL", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: {
+                project: "config-project",
+                location: "eu",
+                baseURL: "https://proxy.example/vertex",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex-anthropic"), ModelID.make("claude-sonnet-4-6@default"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe("https://proxy.example/vertex")
+    },
+  })
+})
+
+test("Google Vertex Anthropic: keeps explicit Claude API URL", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: {
+                project: "test-project",
+                location: "eu",
+              },
+              models: {
+                "claude-proxy": {
+                  name: "Claude Proxy",
+                  provider: {
+                    api: "https://proxy.example/v1",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex-anthropic"), ModelID.make("claude-proxy"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe("https://proxy.example/v1")
+    },
+  })
+})
+
+test("Google Vertex Anthropic: uses REP endpoint with Vertex SDK env names", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+      set("GOOGLE_VERTEX_PROJECT", "test-project")
+      set("GOOGLE_VERTEX_LOCATION", "eu")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex-anthropic"), ModelID.make("claude-sonnet-4-6@default"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe(
+        "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/anthropic/models",
+      )
+    },
+  })
+})
+
+test("Google Vertex: keeps regional Claude endpoints unchanged", async () => {
+  await using tmp = await tmpdir({
+    init: writeVertexAnthropicConfig,
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      clearVertexEnv()
+      set("GOOGLE_CLOUD_PROJECT", "test-project")
+      set("VERTEX_LOCATION", "europe-west1")
+    },
+    fn: async () => {
+      const model = await getModel(ProviderID.make("google-vertex"), ModelID.make("claude-test"))
+      const language = await getLanguage(model)
+      expect(languageBaseURL(language)).toBe(
+        "https://europe-west1-aiplatform.googleapis.com/v1/projects/test-project/locations/europe-west1/publishers/anthropic/models",
+      )
     },
   })
 })


### PR DESCRIPTION
## Summary

Adds Vertex Anthropic REP endpoint support for continental multi-region locations (`eu` and `us`) without changing unrelated provider behavior.

No PawWork issue exists for this narrow upstream-port PR; this ports upstream anomalyco/opencode#28347 as the related source.

## Why

Vertex Anthropic requests for continental multi-regions need `aiplatform.<location>.rep.googleapis.com`; the default SDK endpoint shape uses `<location>-aiplatform.googleapis.com`, which does not cover those REP locations.

## Related Issue

No PawWork issue. Related upstream PR: https://github.com/anomalyco/opencode/pull/28347

## Human Review Status

Not required: terminal Claude and Occam reviews passed, all checks passed, and branch protection does not require human approval.

## Review Focus

Please focus on whether REP baseURL injection is limited to `@ai-sdk/google-vertex/anthropic`, preserves explicit provider `baseURL` and explicit model `api` proxy URLs, and leaves regional Vertex endpoints unchanged.

## Risk Notes

No visible UI, copy, package, lockfile, generated file, dependency, permissions, credentials, deletion, docs, release-note, packaging, or OS-specific surface was touched.

This adds support for the Vertex SDK environment variable names (`GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION`) ahead of the older Google Cloud aliases. Explicit provider options still take precedence over all environment variables.

The visible UI/copy checklist item is left unticked because this is provider runtime behavior only.
The docs/release/dependencies/permissions/generated/local-files checklist item is left unticked because none of those surfaces changed.

## How To Verify

```text
Focused provider baseURL preservation: passed, 1/1 in provider.test.ts
Vertex focused provider tests: passed, 12/12 in provider.test.ts
Full provider test file: passed, 108/108 in provider.test.ts
Typecheck: passed, packages/opencode tsgo --noEmit
Diff check: passed, no whitespace errors
Claude terminal review: no confirmed P0/P1/P2 findings after final diff; one diff-context concern was checked against source/tests and dismissed, env-priority note documented above
Occam terminal fresh-eye review: no P0/P1/P2 findings after final diff
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
