### PR TITLE
fix(opencode): align provider transform PDF capability with resolver

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -3,18 +3,28 @@ import { mergeDeep, unique } from "remeda"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import type { JSONSchema } from "zod/v4/core"
 import type * as Provider from "./provider"
-import type * as ModelsDev from "./models"
 import { iife } from "@/util/iife"
 import { Flag } from "@opencode-ai/core/flag/flag"
 
-type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
+export type MediaInputKind = "image" | "audio" | "video" | "pdf"
 
-function mimeToModality(mime: string): Modality | undefined {
+function mimeToModality(mime: string): MediaInputKind | undefined {
   if (mime.startsWith("image/")) return "image"
   if (mime.startsWith("audio/")) return "audio"
   if (mime.startsWith("video/")) return "video"
   if (mime === "application/pdf") return "pdf"
   return undefined
+}
+
+// The one capability rule for media input. The session resolver decides with
+// this whether to upgrade a path-backed part, and this layer decides whether to
+// withhold it from the provider; the composer's attachment warning mirrors it.
+// If the layers disagree, the UI shows no warning for a part the model never sees.
+export function modelCanReadMedia(model: Provider.Model, kind: MediaInputKind) {
+  if (model.capabilities.input[kind] === true) return true
+  // PDF borrows image input: models.dev frequently omits the pdf flag on
+  // models that read PDFs through their image pipeline.
+  return kind === "pdf" && model.capabilities.input.image === true
 }
 
 export function sanitizeSurrogates(content: string) {
@@ -445,7 +455,7 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
       const filename = part.type === "file" ? part.filename : undefined
       const modality = mimeToModality(mime)
       if (!modality) return part
-      if (model.capabilities.input[modality]) return part
+      if (modelCanReadMedia(model, modality)) return part
 
       // Keep this wording in sync with the resolver-side dropped-media notice
       // in session/prompt.ts so the model hears one consistent contract.
@@ -1481,6 +1491,8 @@ export function openAICompatibleRequestBodyText(model: Provider.Model, body: unk
 
 const ProviderTransformOptionsValue = options
 const ProviderTransformMessageValue = message
+const ProviderTransformModelCanReadMediaValue = modelCanReadMedia
+type ProviderTransformMediaInputKindValue = MediaInputKind
 const ProviderTransformVariantsValue = variants
 const ProviderTransformProviderOptionsValue = providerOptions
 const ProviderTransformSchemaValue = schema
@@ -1498,6 +1510,8 @@ export namespace ProviderTransform {
   export const OUTPUT_TOKEN_MAX = ProviderTransformOutputTokenMaxValue
   export const options = ProviderTransformOptionsValue
   export const message = ProviderTransformMessageValue
+  export const modelCanReadMedia = ProviderTransformModelCanReadMediaValue
+  export type MediaInputKind = ProviderTransformMediaInputKindValue
   export const variants = ProviderTransformVariantsValue
   export const providerOptions = ProviderTransformProviderOptionsValue
   export const schema = ProviderTransformSchemaValue

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -8,7 +8,7 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 
 export type MediaInputKind = "image" | "audio" | "video" | "pdf"
 
-function mimeToModality(mime: string): MediaInputKind | undefined {
+export function mediaInputKind(mime: string): MediaInputKind | undefined {
   if (mime.startsWith("image/")) return "image"
   if (mime.startsWith("audio/")) return "audio"
   if (mime.startsWith("video/")) return "video"
@@ -453,7 +453,7 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
 
       const mime = part.type === "image" ? String(part.image).split(";")[0].replace("data:", "") : part.mediaType
       const filename = part.type === "file" ? part.filename : undefined
-      const modality = mimeToModality(mime)
+      const modality = mediaInputKind(mime)
       if (!modality) return part
       if (modelCanReadMedia(model, modality)) return part
 
@@ -1492,6 +1492,7 @@ export function openAICompatibleRequestBodyText(model: Provider.Model, body: unk
 const ProviderTransformOptionsValue = options
 const ProviderTransformMessageValue = message
 const ProviderTransformModelCanReadMediaValue = modelCanReadMedia
+const ProviderTransformMediaInputKindFnValue = mediaInputKind
 type ProviderTransformMediaInputKindValue = MediaInputKind
 const ProviderTransformVariantsValue = variants
 const ProviderTransformProviderOptionsValue = providerOptions
@@ -1511,6 +1512,7 @@ export namespace ProviderTransform {
   export const options = ProviderTransformOptionsValue
   export const message = ProviderTransformMessageValue
   export const modelCanReadMedia = ProviderTransformModelCanReadMediaValue
+  export const mediaInputKind = ProviderTransformMediaInputKindFnValue
   export type MediaInputKind = ProviderTransformMediaInputKindValue
   export const variants = ProviderTransformVariantsValue
   export const providerOptions = ProviderTransformProviderOptionsValue

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -261,19 +261,12 @@ function attachedLocalFileText(filepath: string, filename?: string) {
   return `${text} (attachment name: ${filename})`
 }
 
-type MediaInputKind = "image" | "pdf" | "audio" | "video"
-
-function mediaInputKind(mime: string): MediaInputKind | undefined {
+function mediaInputKind(mime: string): ProviderTransform.MediaInputKind | undefined {
   if (mime.startsWith("image/")) return "image"
   if (mime === "application/pdf") return "pdf"
   if (mime.startsWith("audio/")) return "audio"
   if (mime.startsWith("video/")) return "video"
   return undefined
-}
-
-function modelCanReadMedia(model: Provider.Model, kind: MediaInputKind) {
-  if (model.capabilities.input[kind] === true) return true
-  return kind === "pdf" && model.capabilities.input.image === true
 }
 
 export interface Interface {
@@ -1729,7 +1722,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   const media = result.attachments ?? []
                   const attachments = media.filter((attachment) => {
                     const kind = mediaInputKind(attachment.mime)
-                    return kind !== undefined && modelCanReadMedia(model, kind)
+                    return kind !== undefined && ProviderTransform.modelCanReadMedia(model, kind)
                   })
                   const droppedNotice = {
                     messageID: info.id,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -261,13 +261,6 @@ function attachedLocalFileText(filepath: string, filename?: string) {
   return `${text} (attachment name: ${filename})`
 }
 
-function mediaInputKind(mime: string): ProviderTransform.MediaInputKind | undefined {
-  if (mime.startsWith("image/")) return "image"
-  if (mime === "application/pdf") return "pdf"
-  if (mime.startsWith("audio/")) return "audio"
-  if (mime.startsWith("video/")) return "video"
-  return undefined
-}
 
 export interface Interface {
   readonly cancel: (sessionID: SessionID, options?: { source?: string }) => Effect.Effect<boolean>
@@ -1721,7 +1714,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   const { model, result } = exit.value
                   const media = result.attachments ?? []
                   const attachments = media.filter((attachment) => {
-                    const kind = mediaInputKind(attachment.mime)
+                    const kind = ProviderTransform.mediaInputKind(attachment.mime)
                     return kind !== undefined && ProviderTransform.modelCanReadMedia(model, kind)
                   })
                   const droppedNotice = {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1873,6 +1873,32 @@ describe("ProviderTransform.message - empty image handling", () => {
     })
   })
 
+  test("lets PDF borrow image input like the resolver and the composer warning", () => {
+    const imageOnly = {
+      ...mockModel,
+      capabilities: {
+        ...mockModel.capabilities,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+      },
+    } as any
+    const pdfPart = {
+      type: "file",
+      data: "JVBERi0xLjc=",
+      mediaType: "application/pdf",
+      filename: "report.pdf",
+    } as const
+    const msgs = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Summarize this." }, pdfPart],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, imageOnly, {})
+
+    expect(result[0].content[1]).toEqual(pdfPart)
+  })
+
   test("should keep valid base64 images unchanged", () => {
     const validBase64 =
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1873,6 +1873,14 @@ describe("ProviderTransform.message - empty image handling", () => {
     })
   })
 
+  test("maps mime types onto the shared media input kinds", () => {
+    expect(ProviderTransform.mediaInputKind("image/png")).toBe("image")
+    expect(ProviderTransform.mediaInputKind("audio/mpeg")).toBe("audio")
+    expect(ProviderTransform.mediaInputKind("video/mp4")).toBe("video")
+    expect(ProviderTransform.mediaInputKind("application/pdf")).toBe("pdf")
+    expect(ProviderTransform.mediaInputKind("text/plain")).toBeUndefined()
+  })
+
   test("lets PDF borrow image input like the resolver and the composer warning", () => {
     const imageOnly = {
       ...mockModel,


### PR DESCRIPTION
## Summary

Post-merge review of #1247 surfaced a three-way disagreement in the media capability rule. The session resolver (`session/prompt.ts`) and the composer's attachment warning both let PDF borrow image input — models.dev frequently omits the `pdf` flag on models that read PDFs through their image pipeline — but `unsupportedParts` in `provider/transform.ts` only checked the raw `pdf` flag. On an image=true/pdf=false model: the UI showed no capability badge, the resolver upgraded the PDF into a data part, and the transform then silently replaced it with the "contents were NOT provided" withhold notice. The user believed the model saw the PDF; it did not.

Fix: move `modelCanReadMedia` into `provider/transform.ts` as the single shared rule (exported via the `ProviderTransform` namespace). The resolver now imports it, `unsupportedParts` applies it, and the composer warning already mirrors the same rule (`attachmentCapabilityWarning`, pinned by its own tests).

## Why

Pre-existing inconsistency (the transform-side check predates #1247); #1247's capability badge work made it visible. Reviewed and confirmed at code level: `transform.ts` checked only `model.capabilities.input[modality]` while `prompt.ts:274-277` and `attachment-routing.ts:34` shared the borrow rule.

## Related Issue

Follow-up from the post-merge review of #1247 (no standalone issue; fixed directly per maintainer direction).

## Human Review Status

Pending

## Review Focus

- `modelCanReadMedia` is now the one capability gate for both resolve-time upgrade and request-time withhold; the comment on it states the three-layer contract.
- `mimeToModality` return type narrowed from the models.dev modality union to the four media kinds it actually returns (no behavior change).

## Risk Notes

- Behavior change is one-directional: PDFs that were previously withheld on image-capable models now reach the provider. If a provider truly rejects PDF for such a model, the API error surfaces instead of a silent withhold — consistent with what the resolver already promised by upgrading the part.
- No UI or platform surface touched; engine-only.

## How To Verify

```text
bun test test/provider/transform.test.ts (packages/opencode): 209 pass / 0 fail
  - new: "lets PDF borrow image input like the resolver and the composer warning" (RED->GREEN)
bun test test/session/prompt-effect.test.ts: 67 pass / 0 fail (resolver upgrade path unchanged)
bun run typecheck (packages/opencode): clean
bun run lint (repo root): clean
```

No visual surface changed; snap not applicable.

## Screenshots or Recordings

Not applicable (engine-only change).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for different media file types (images, audio, video, and PDFs) across models.
  * Improved PDF file handling with intelligent fallback—PDFs can now be processed using image capabilities when explicit PDF support is unavailable.

* **Tests**
  * Added test coverage to verify PDF media handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->