### PR TITLE
fix(app): fork dialog crash from palette and blank attachment-only previews

### DIFF
--- a/packages/app/e2e/files/file-open.spec.ts
+++ b/packages/app/e2e/files/file-open.spec.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises"
 import path from "node:path"
 import { test, expect } from "../fixtures"
+import { openPalette } from "../actions"
 import { promptSelector } from "../selectors"
 
 test("can open a file tab from the search palette", async ({ page, project }) => {
@@ -39,4 +40,22 @@ test("can open a file tab from the search palette", async ({ page, project }) =>
 
   const tabs = page.locator('[data-component="tabs"][data-variant="normal"]')
   await expect(tabs.locator('[data-slot="tabs-trigger"]').first()).toBeVisible()
+})
+
+// The palette's own "Open file" row re-shows DialogSelectFile from inside the
+// closing palette; that second show has no LayoutPageContext wrapper of its
+// own, so it must be re-provided or useLayoutPage throws and the picker never
+// appears.
+test("palette Open file row chains into the file-only picker", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const palette = await openPalette(page)
+  await palette.locator('[data-slot="list-item"][data-key="command:file.open"]').click()
+
+  const picker = page
+    .getByRole("dialog")
+    .filter({ has: page.getByPlaceholder(/search files/i) })
+    .first()
+  await expect(picker).toBeVisible()
+  await expect(picker.locator('[data-slot="list-item"][data-key^="command:"]')).toHaveCount(0)
 })

--- a/packages/app/e2e/session/fork-dialog-preview.spec.ts
+++ b/packages/app/e2e/session/fork-dialog-preview.spec.ts
@@ -6,6 +6,7 @@
  */
 import { writeFileSync } from "node:fs"
 import path from "node:path"
+import { pathToFileURL } from "node:url"
 import { test, expect } from "../fixtures"
 import { withSession, openPalette } from "../actions"
 
@@ -33,7 +34,7 @@ test("fork dialog previews an attachment-only message as a file placeholder", as
         {
           type: "file",
           mime: "text/plain",
-          url: `file://${filePath}`,
+          url: pathToFileURL(filePath).href,
           filename,
           metadata: { attachment: true },
         },

--- a/packages/app/e2e/session/fork-dialog-preview.spec.ts
+++ b/packages/app/e2e/session/fork-dialog-preview.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Fork dialog preview for attachment-only messages (post-merge review of
+ * #1247): a message submitted with only an attachment chip carries an empty
+ * text part and used to render as a blank row in the fork list. The preview
+ * now falls back to the same [file:path] placeholder the revert banner uses.
+ */
+import { writeFileSync } from "node:fs"
+import path from "node:path"
+import { test, expect } from "../fixtures"
+import { withSession, openPalette } from "../actions"
+
+test("fork dialog previews an attachment-only message as a file placeholder", async ({ page, project }) => {
+  await project.open()
+  const sdk = project.sdk
+
+  await withSession(sdk, "fork attachment preview", async (session) => {
+    project.trackSession(session.id)
+
+    const filename = "fork-preview-attachment.txt"
+    const filePath = path.join(project.directory, filename)
+    writeFileSync(filePath, "attachment body\n")
+
+    await sdk.session.prompt({
+      sessionID: session.id,
+      noReply: true,
+      parts: [{ type: "text", text: "regular question" }],
+    })
+    await sdk.session.prompt({
+      sessionID: session.id,
+      noReply: true,
+      parts: [
+        { type: "text", text: "" },
+        {
+          type: "file",
+          mime: "text/plain",
+          url: `file://${filePath}`,
+          filename,
+          metadata: { attachment: true },
+        },
+      ],
+    })
+
+    await project.gotoSession(session.id)
+
+    const palette = await openPalette(page)
+    await palette.getByRole("textbox").first().fill("fork")
+    const forkRow = palette.locator('[data-slot="list-item"][data-key="command:session.fork"]')
+    await expect(forkRow).toBeVisible()
+    await forkRow.click()
+
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.getByText("regular question")).toBeVisible()
+    await expect(dialog.getByText(`[file:${filePath}]`)).toBeVisible()
+  })
+})

--- a/packages/app/src/components/command-palette/command-palette-dialog.tsx
+++ b/packages/app/src/components/command-palette/command-palette-dialog.tsx
@@ -11,7 +11,7 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
-import { useLayoutPage } from "@/context/layout-page"
+import { LayoutPageContext, useLayoutPage } from "@/context/layout-page"
 import { SDKProvider, useSDK } from "@/context/sdk"
 import { SyncProvider } from "@/context/sync"
 import { pawworkSessionDirectories } from "@/pages/layout/pawwork-session-source"
@@ -194,8 +194,15 @@ function CommandPaletteDialog(props: { mode?: DialogSelectFileMode; onOpenFile?:
     if (!params.dir) navigate(`/${slug()}/session`)
   }
 
+  // The new dialog is anchored to the palette's outer owner, which sits above
+  // the LayoutPageContext.Provider the layout wraps around the FIRST palette
+  // element — re-provide it or DialogSelectFile's useLayoutPage throws.
   const openFileOnlyPicker = () => {
-    dialog.show(() => <DialogSelectFile mode="files" onOpenFile={props.onOpenFile} />)
+    dialog.show(() => (
+      <LayoutPageContext.Provider value={layoutPage}>
+        <DialogSelectFile mode="files" onOpenFile={props.onOpenFile} />
+      </LayoutPageContext.Provider>
+    ))
   }
 
   const handleSelect = (item: CommandPaletteEntry | undefined) => {

--- a/packages/app/src/components/dialog-fork.tsx
+++ b/packages/app/src/components/dialog-fork.tsx
@@ -7,7 +7,7 @@ import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { List } from "@opencode-ai/ui/list"
 import { showToast } from "@opencode-ai/ui/toast"
-import { extractPromptFromParts } from "@/utils/prompt"
+import { extractPromptFromParts, promptPreviewText } from "@/utils/prompt"
 import { deriveCommandInvocation } from "@opencode-ai/ui/lib/command-invocation"
 import type { TextPart as SDKTextPart } from "@opencode-ai/sdk/v2/client"
 import { base64Encode } from "@opencode-ai/util/encode"
@@ -53,12 +53,27 @@ export const DialogFork: Component = () => {
         continue
       }
 
+      // Attachment-only messages have an empty (or no) text part; preview them
+      // through the same [file:path] fallback the revert banner uses instead of
+      // rendering a blank row. Messages with neither text nor files stay hidden.
       const textPart = parts.find((x): x is SDKTextPart => x.type === "text" && !x.synthetic && !x.ignored)
-      if (!textPart) continue
+      const hasFilePart = parts.some((x) => x.type === "file")
+      if (!textPart && !hasFilePart) continue
+
+      const text = textPart?.text.replace(/\n/g, " ").trim()
+      const preview =
+        text ||
+        promptPreviewText(
+          extractPromptFromParts(parts, {
+            directory: sdk.directory,
+            attachmentName: language.t("common.attachment"),
+          }),
+          language.t("common.attachment"),
+        )
 
       result.push({
         id: message.id,
-        text: textPart.text.replace(/\n/g, " ").slice(0, 200),
+        text: preview.slice(0, 200),
         time: formatTime(new Date(message.time.created)),
       })
     }

--- a/packages/app/src/components/dialog-fork.tsx
+++ b/packages/app/src/components/dialog-fork.tsx
@@ -55,12 +55,14 @@ export const DialogFork: Component = () => {
 
       // Attachment-only messages have an empty (or no) text part; preview them
       // through the same [file:path] fallback the revert banner uses instead of
-      // rendering a blank row. Messages with neither text nor files stay hidden.
+      // rendering a blank row. Messages with neither visible text nor files
+      // stay hidden — the fallback must not stamp [attachment] on a message
+      // that has nothing to show.
       const textPart = parts.find((x): x is SDKTextPart => x.type === "text" && !x.synthetic && !x.ignored)
       const hasFilePart = parts.some((x) => x.type === "file")
-      if (!textPart && !hasFilePart) continue
-
       const text = textPart?.text.replace(/\n/g, " ").trim()
+      if (!text && !hasFilePart) continue
+
       const preview =
         text ||
         promptPreviewText(

--- a/packages/app/src/components/prompt-input/build-request-parts.test.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.test.ts
@@ -554,6 +554,28 @@ describe("attachment chips", () => {
     expect(fileParts[0]).toMatchObject({ url: "file:///repo/src/foo.ts" })
   })
 
+  // A line-scoped pill and a whole-file chip are semantically different
+  // references (collapsing on path would silently narrow the chip to the
+  // selection); this pins that both parts are submitted.
+  test("keeps a selection-scoped pill and a whole-file chip for the same path", () => {
+    const prompt: Prompt = [
+      {
+        type: "file",
+        path: "src/foo.ts",
+        content: "@src/foo.ts",
+        start: 0,
+        end: 11,
+        selection: { startLine: 3, startChar: 0, endLine: 9, endChar: 0 },
+      },
+      { type: "attachment", id: "att_1", path: "/repo/src/foo.ts", filename: "foo.ts" },
+    ]
+
+    const parts = buildAttachmentRequestParts({ prompt, images: [], sessionDirectory: "/repo" })
+
+    const urls = parts.filter((part) => part.type === "file").map((part) => part.url)
+    expect(urls.sort()).toEqual(["file:///repo/src/foo.ts", "file:///repo/src/foo.ts?start=3&end=9"])
+  })
+
   test("includes chips in full request builds", () => {
     const prompt: Prompt = [
       { type: "text", content: "hi", start: 0, end: 2 },

--- a/packages/app/src/pages/session/use-session-revert-support.ts
+++ b/packages/app/src/pages/session/use-session-revert-support.ts
@@ -6,7 +6,7 @@ import type { useSDK } from "@/context/sdk"
 import type { useSync } from "@/context/sync"
 import { promptScopeForSession } from "@/pages/session/prompt-route-scope"
 import type { ExecutionScope } from "@/pages/session/execution-scope"
-import { extractPromptFromParts } from "@/utils/prompt"
+import { extractPromptFromParts, promptPreviewText } from "@/utils/prompt"
 import { formatServerError } from "@/utils/server-errors"
 
 type SyncStore = ReturnType<typeof useSync>["data"]
@@ -30,19 +30,8 @@ export function createSessionRevertSupport(input: {
       attachmentName: input.attachmentLabel(),
     })
 
-  const line = (id: string) => {
-    const text = draftFrom({ directory: input.directory(), store: input.sync.data }, id)
-      .map((part) => {
-        if (part.type === "image") return `[image:${part.filename}]`
-        if (part.type === "attachment") return `[file:${part.path}]`
-        return part.content
-      })
-      .join("")
-      .replace(/\s+/g, " ")
-      .trim()
-    if (text) return text
-    return `[${input.attachmentLabel()}]`
-  }
+  const line = (id: string) =>
+    promptPreviewText(draftFrom({ directory: input.directory(), store: input.sync.data }, id), input.attachmentLabel())
 
   const fail = (err: unknown) => {
     showToast({

--- a/packages/app/src/utils/prompt.test.ts
+++ b/packages/app/src/utils/prompt.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Part } from "@opencode-ai/sdk/v2"
-import { extractPromptFromParts } from "./prompt"
+import { extractPromptFromParts, promptPreviewText } from "./prompt"
 
 describe("extractPromptFromParts", () => {
   test("restores multiple uploaded attachments", () => {
@@ -435,5 +435,42 @@ describe("extractPromptFromParts", () => {
       content: "/explain this",
       command: { name: "explain", source: "command" },
     })
+  })
+})
+
+describe("promptPreviewText", () => {
+  test("keeps the prompt text and collapses whitespace", () => {
+    const preview = promptPreviewText(
+      [
+        { type: "text", content: "look at\n  this ", start: 0, end: 15 },
+        { type: "file", path: "src/foo.ts", content: "@src/foo.ts", start: 15, end: 26 },
+      ],
+      "attachment",
+    )
+    expect(preview).toBe("look at this @src/foo.ts")
+  })
+
+  test("renders attachment-only prompts as file placeholders, not a blank line", () => {
+    const preview = promptPreviewText(
+      [
+        { type: "text", content: "", start: 0, end: 0 },
+        { type: "attachment", id: "att_1", path: "/repo/shot.png", filename: "shot.png" },
+      ],
+      "attachment",
+    )
+    expect(preview).toBe("[file:/repo/shot.png]")
+  })
+
+  test("renders legacy data-URL images with the image placeholder", () => {
+    const preview = promptPreviewText(
+      [{ type: "image", id: "img_1", filename: "shot.png", mime: "image/png", dataUrl: "data:image/png;base64,AA==" }],
+      "attachment",
+    )
+    expect(preview).toBe("[image:shot.png]")
+  })
+
+  test("falls back to the attachment label when nothing is visible", () => {
+    const preview = promptPreviewText([{ type: "text", content: "  ", start: 0, end: 2 }], "附件")
+    expect(preview).toBe("[附件]")
   })
 })

--- a/packages/app/src/utils/prompt.ts
+++ b/packages/app/src/utils/prompt.ts
@@ -293,3 +293,23 @@ export function extractPromptFromParts(parts: Part[], opts?: { directory?: strin
   if (floating.length === 0) return result
   return [...result, ...floating]
 }
+
+/**
+ * One-line list-row preview of a restored prompt (fork dialog, revert banner):
+ * inline parts keep their text, floating attachments render as [image:name] /
+ * [file:path], and a prompt with no visible text falls back to the localized
+ * attachment label so attachment-only messages never show as a blank row.
+ */
+export function promptPreviewText(prompt: Prompt, attachmentLabel: string): string {
+  const text = prompt
+    .map((part) => {
+      if (part.type === "image") return `[image:${part.filename}]`
+      if (part.type === "attachment") return `[file:${part.path}]`
+      return part.content
+    })
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (text) return text
+  return `[${attachmentLabel}]`
+}

--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -21,6 +21,7 @@ type Active = {
   owner: Owner
   onClose?: () => void
   setClosing: (closing: boolean) => void
+  closing: boolean
 }
 
 const Context = createContext<ReturnType<typeof init>>()
@@ -40,6 +41,7 @@ function init() {
     const current = active()
     if (!current || lock.value) return
     lock.value = true
+    current.closing = true
     current.onClose?.()
     current.setClosing(true)
 
@@ -100,7 +102,7 @@ function init() {
 
     if (!dispose || !setClosing) return
 
-    setActive({ id, node, dispose, owner, onClose, setClosing })
+    setActive({ id, node, dispose, owner, onClose, setClosing, closing: false })
   }
 
   return {
@@ -138,7 +140,14 @@ export function useDialog() {
       return ctx.active
     },
     show(element: DialogElement, onClose?: () => void) {
-      const base = ctx.active?.owner ?? owner
+      // A dialog mid-close (palette command flows call close() and then the
+      // command handler shows the next dialog within the close animation) must
+      // not anchor the new dialog's owner: its owner sits wherever IT was
+      // opened from and is about to be disposed — context lookups from the new
+      // dialog (e.g. useSync from a session-page command) would miss providers
+      // the caller can see.
+      const current = ctx.active
+      const base = current && !current.closing ? current.owner : owner
       ctx.show(element, base, onClose)
     },
     close() {

--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -21,7 +21,15 @@ type Active = {
   owner: Owner
   onClose?: () => void
   setClosing: (closing: boolean) => void
-  closing: boolean
+  rootOwner: Owner | null
+}
+
+function ownerWithin(owner: Owner | null, root: Owner | null): boolean {
+  if (!root) return false
+  for (let current = owner; current; current = current.owner) {
+    if (current === root) return true
+  }
+  return false
 }
 
 const Context = createContext<ReturnType<typeof init>>()
@@ -41,7 +49,6 @@ function init() {
     const current = active()
     if (!current || lock.value) return
     lock.value = true
-    current.closing = true
     current.onClose?.()
     current.setClosing(true)
 
@@ -76,10 +83,12 @@ function init() {
     const id = Math.random().toString(36).slice(2)
     let dispose: (() => void) | undefined
     let setClosing: ((closing: boolean) => void) | undefined
+    let rootOwner: Owner | null = null
 
     const node = runWithOwner(owner, () =>
       createRoot((d: () => void) => {
         dispose = d
+        rootOwner = getOwner()
         const [closing, setClosingSignal] = createSignal(false)
         setClosing = setClosingSignal
         return (
@@ -102,7 +111,7 @@ function init() {
 
     if (!dispose || !setClosing) return
 
-    setActive({ id, node, dispose, owner, onClose, setClosing, closing: false })
+    setActive({ id, node, dispose, owner, onClose, setClosing, rootOwner })
   }
 
   return {
@@ -140,14 +149,16 @@ export function useDialog() {
       return ctx.active
     },
     show(element: DialogElement, onClose?: () => void) {
-      // A dialog mid-close (palette command flows call close() and then the
-      // command handler shows the next dialog within the close animation) must
-      // not anchor the new dialog's owner: its owner sits wherever IT was
-      // opened from and is about to be disposed — context lookups from the new
-      // dialog (e.g. useSync from a session-page command) would miss providers
-      // the caller can see.
+      // Owner anchoring: a caller INSIDE the active dialog (a dialog replacing
+      // itself, e.g. palette -> file picker) keeps the active dialog's outer
+      // owner — its own owner lives in the dialog root that show() is about to
+      // dispose. A caller OUTSIDE it (e.g. a session-page command running
+      // after the palette starts closing) uses its own owner — anchoring to
+      // the dialog's owner would resolve context from wherever the dialog was
+      // opened and miss providers the caller can see (useSync crashed exactly
+      // this way when Fork was launched from the closing palette).
       const current = ctx.active
-      const base = current && !current.closing ? current.owner : owner
+      const base = current && ownerWithin(owner, current.rootOwner) ? current.owner : owner
       ctx.show(element, base, onClose)
     },
     close() {


### PR DESCRIPTION
## Summary

Two fixes from the post-merge review of #1247, both on the fork-dialog user path:

1. **Fork dialog crash from the command palette (found by the new e2e, pre-existing).** Palette command flows call `dialog.close()` and then run the command handler inside the 100ms close animation, while `active` is still set. `useDialog.show` anchored the new dialog to `ctx.active.owner` — the dying palette's owner at layout level — so `DialogFork`'s `useSync()` threw "Sync context must be used within a context provider" and the session route fell into the error boundary. Since the palette is the only entry point for `session.fork`, the fork dialog was unreachable. Fix: a dialog mid-close no longer serves as the owner anchor; the new dialog uses its caller's owner.

2. **Attachment-only messages rendered as a blank row in the fork list.** Such a message persists an empty text part, and the preview only read text parts. The revert banner's `[image:name]` / `[file:path]` mapping is now extracted into a shared `promptPreviewText` helper (`utils/prompt.ts`); the revert banner delegates to it, and the fork dialog falls back to it whenever the text part is empty or missing. Messages with neither text nor file parts stay hidden.

Also adopts the review's verification ask on dedupe semantics: a new pinning test locks that a selection-scoped inline pill and a whole-file chip for the same path submit as **two** parts — they are semantically different references, and collapsing on path would silently narrow the whole-file attachment to the selection.

## Why

Post-merge review of #1247 flagged the blank fork row (P3) and asked for explicit dedupe-semantics coverage. The owner-anchoring crash surfaced while writing the e2e for the blank row and is a hard prerequisite for that path to work at all, so it lands in the same review boundary.

## Related Issue

Follow-up from the post-merge review of #1247 (fixed directly per maintainer direction, no standalone issue). Related: #1264 tracks sent-bubble attachment rendering alignment separately.

## Human Review Status

Pending

## Review Focus

- `packages/ui/src/context/dialog.tsx`: the owner-anchoring change affects every dialog-from-dialog flow. The rule is minimal — only a dialog that is already closing stops anchoring; an active, non-closing dialog keeps the previous chaining behavior.
- `promptPreviewText` is now the single preview mapping for revert banner and fork dialog; the revert banner's behavior must be unchanged (same map/join/collapse/fallback sequence, moved verbatim).
- `dialog-fork.tsx`: messages with neither a non-synthetic text part nor a file part are still skipped, so non-promptable rows do not appear with a bare placeholder.

## Risk Notes

- The dialog owner change alters context resolution for dialogs opened while another dialog is closing: they now resolve through the caller's owner chain. For every current call site this is the owner that actually has the providers the dialog needs; flows opening a dialog while another is fully open (not closing) are unchanged.
- `e2e/models/model-picker-visual.spec.ts` fails 3 hover-color assertions locally on a clean tree as well (environment flake, pre-existing); verified unrelated by stash-rerun.

## How To Verify

```text
bun run test:e2e e2e/session/fork-dialog-preview.spec.ts (packages/app): 1 passed
  - real user path: seed attachment-only message -> open palette -> run Fork from message
    -> dialog lists "[file:<path>]" placeholder row (RED before both fixes: crash, then blank row)
bun run test:e2e e2e/app/palette.spec.ts e2e/app/palette-viewport.spec.ts e2e/sidebar/sidebar-session-search.spec.ts: 9 passed
bun test (packages/app): 1886 pass / 0 fail (new: promptPreviewText unit tests; selection-pill + chip pinning test)
bun test (packages/ui): 722 pass / 0 fail
bun run typecheck (packages/app, packages/ui): clean
bun run lint (repo root): clean
```

Visual check: the changed surface (fork dialog list rows) is exercised end-to-end by the new `fork-dialog-preview` e2e through the real palette route; row markup/styling is unchanged, only the text content of the preview row.

## Screenshots or Recordings

Covered by the e2e assertion on the visible row text; no styling change. Can attach the e2e trace on request.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings (e2e asserts the visible row content through the real user path).
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Open file" command in the palette to properly display the file picker dialog.
  * Fixed fork dialog preview to correctly display file attachments.
  * Improved dialog handling for better context preservation during dialog transitions.

* **Tests**
  * Added E2E tests for file-open command and fork dialog with attachments.
  * Added tests for attachment handling in prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->