### PR TITLE
fix(opencode): apply MCP catalog timeouts

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -767,25 +767,38 @@ export namespace MCP {
 
       function collectFromConnected<T extends { name: string }>(
         s: State,
-        listFn: (c: Client) => Promise<T[]>,
+        listFn: (client: Client, timeout?: number) => Promise<T[]>,
         label: string,
       ) {
-        return Effect.forEach(
-          Object.entries(s.clients).filter(([name]) => s.status[name]?.status === "connected"),
-          ([clientName, client]) =>
-            fetchFromClient(clientName, client, listFn, label).pipe(Effect.map((items) => Object.entries(items ?? {}))),
-          { concurrency: "unbounded" },
-        ).pipe(Effect.map((results) => Object.fromEntries<T & { client: string }>(results.flat())))
+        return Effect.gen(function* () {
+          const cfg = yield* cfgSvc.get()
+          const config = cfg.mcp ?? {}
+          const defaultTimeout = cfg.experimental?.mcp_timeout
+
+          return yield* Effect.forEach(
+            Object.entries(s.clients).filter(([name]) => s.status[name]?.status === "connected"),
+            ([clientName, client]) => {
+              const mcpConfig = s.config[clientName] ?? config[clientName]
+              const entry = mcpConfig && isMcpConfigured(mcpConfig) ? mcpConfig : undefined
+              const timeout = entry?.timeout ?? defaultTimeout
+
+              return fetchFromClient(clientName, client, (c) => listFn(c, timeout), label).pipe(
+                Effect.map((items) => Object.entries(items ?? {})),
+              )
+            },
+            { concurrency: "unbounded" },
+          ).pipe(Effect.map((results) => Object.fromEntries<T & { client: string }>(results.flat())))
+        })
       }
 
       const prompts = Effect.fn("MCP.prompts")(function* () {
         const s = yield* InstanceState.get(state)
         return yield* collectFromConnected(
           s,
-          (client) =>
+          (client, timeout) =>
             hasCapability(client, "prompts")
               ? paginate(
-                  (cursor) => client.listPrompts(cursor === undefined ? undefined : { cursor }),
+                  (cursor) => client.listPrompts(cursor === undefined ? undefined : { cursor }, { timeout }),
                   (result) => result.prompts,
                 )
               : Promise.resolve([]),
@@ -797,10 +810,10 @@ export namespace MCP {
         const s = yield* InstanceState.get(state)
         return yield* collectFromConnected(
           s,
-          (client) =>
+          (client, timeout) =>
             hasCapability(client, "resources")
               ? paginate(
-                  (cursor) => client.listResources(cursor === undefined ? undefined : { cursor }),
+                  (cursor) => client.listResources(cursor === undefined ? undefined : { cursor }, { timeout }),
                   (result) => result.resources,
                 )
               : Promise.resolve([]),

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -9,6 +9,8 @@ interface MockClientState {
   listToolsCalls: number
   listPromptsCalls: number
   listResourcesCalls: number
+  listPromptsTimeouts: Array<number | undefined>
+  listResourcesTimeouts: Array<number | undefined>
   getPromptTimeouts: Array<number | undefined>
   readResourceTimeouts: Array<number | undefined>
   requestCalls: number
@@ -57,6 +59,8 @@ function getOrCreateClientState(name?: string): MockClientState {
       listToolsCalls: 0,
       listPromptsCalls: 0,
       listResourcesCalls: 0,
+      listPromptsTimeouts: [],
+      listResourcesTimeouts: [],
       getPromptTimeouts: [],
       readResourceTimeouts: [],
       requestCalls: 0,
@@ -188,8 +192,9 @@ mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       throw new Error(`unsupported request: ${request.method}`)
     }
 
-    async listPrompts(params?: { cursor?: string }) {
+    async listPrompts(params?: { cursor?: string }, options?: { timeout?: number }) {
       if (this._state) this._state.listPromptsCalls++
+      this._state?.listPromptsTimeouts.push(options?.timeout)
       if (this._state?.listPromptsShouldFail) {
         throw new Error("listPrompts failed")
       }
@@ -198,8 +203,9 @@ mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return { prompts: this._state?.prompts ?? [] }
     }
 
-    async listResources(params?: { cursor?: string }) {
+    async listResources(params?: { cursor?: string }, options?: { timeout?: number }) {
       if (this._state) this._state.listResourcesCalls++
+      this._state?.listResourcesTimeouts.push(options?.timeout)
       if (this._state?.listResourcesShouldFail) {
         throw new Error("listResources failed")
       }
@@ -514,6 +520,55 @@ test(
 
       expect(fallbackState.getPromptTimeouts).toEqual([5000])
       expect(fallbackState.readResourceTimeouts).toEqual([5000])
+    },
+    { experimental: { mcp_timeout: 5000 } },
+  ),
+)
+
+test(
+  "catalog list requests use per-server timeout",
+  withInstance(
+    {},
+    async () => {
+      lastCreatedClientName = "catalog-timeout-server"
+      const timeoutState = getOrCreateClientState("catalog-timeout-server")
+      timeoutState.prompts = [{ name: "prompt" }]
+      timeoutState.resources = [{ name: "resource", uri: "test://resource" }]
+
+      await MCP.add("catalog-timeout-server", {
+        type: "local",
+        command: ["echo", "test"],
+        timeout: 2500,
+      })
+      await MCP.prompts()
+      await MCP.resources()
+
+      expect(timeoutState.listPromptsTimeouts).toEqual([2500])
+      expect(timeoutState.listResourcesTimeouts).toEqual([2500])
+    },
+    { experimental: { mcp_timeout: 5000 } },
+  ),
+)
+
+test(
+  "catalog list requests use experimental fallback timeout",
+  withInstance(
+    {},
+    async () => {
+      lastCreatedClientName = "catalog-fallback-server"
+      const timeoutState = getOrCreateClientState("catalog-fallback-server")
+      timeoutState.prompts = [{ name: "prompt" }]
+      timeoutState.resources = [{ name: "resource", uri: "test://resource" }]
+
+      await MCP.add("catalog-fallback-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+      await MCP.prompts()
+      await MCP.resources()
+
+      expect(timeoutState.listPromptsTimeouts).toEqual([5000])
+      expect(timeoutState.listResourcesTimeouts).toEqual([5000])
     },
     { experimental: { mcp_timeout: 5000 } },
   ),


### PR DESCRIPTION
## Summary

Apply configured MCP request timeouts to prompt and resource catalog listing requests.

This is a narrow upstream #31618 port. There is no PawWork issue because this came from the Round 6 upstream correctness audit.

## Why

MCP tool listing already used the configured timeout wrapper, and `getPrompt` / `readResource` already passed request timeout options. Prompt and resource catalog listing still called `listPrompts` and `listResources` without request timeout options, leaving one catalog hang path on slow or stuck MCP servers.

## Related Issue

Upstream: https://github.com/anomalyco/opencode/pull/31618

## Human Review Status

Pending

## Review Focus

Please focus on the timeout precedence in `collectFromConnected` and whether `listPrompts` / `listResources` now match the existing per-server timeout and `experimental.mcp_timeout` behavior without changing tool listing behavior.

## Risk Notes

Configured MCP timeouts now also bound prompt/resource catalog listing. A very slow catalog server that previously relied on the SDK default request timeout may now time out according to its PawWork MCP timeout configuration, which matches the upstream fix and existing prompt/resource read behavior.

Conditional checklist skips: no visible UI or copy changed; no platform, packaging, updater, signing, path, shell, or permissions surface was touched; no docs, release notes, dependencies, credentials, deletion behavior, generated content, or local file surface was touched.

## How To Verify

```text
RED: bun test test/mcp/lifecycle.test.ts -t "catalog list requests use per-server timeout" failed before implementation with listPromptsTimeouts [undefined] instead of [2500].
Focused catalog tests: bun test test/mcp/lifecycle.test.ts -t "catalog list requests use" -> 2 passed.
Lifecycle regression: bun test test/mcp/lifecycle.test.ts -> 30 passed.
MCP suite: bun test test/mcp/*.test.ts -> 50 passed.
Typecheck: bun run typecheck in packages/opencode -> tsgo --noEmit passed.
Diff check: git diff --check origin/dev...HEAD -> no whitespace errors.
Claude review: no P0/P1/P2 findings after one P2 test-priority gap was fixed.
Occam fresh-eye review: PASS, no P0/P1/P2 findings.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
