### PR TITLE
fix(opencode): reuse source git data for initial snapshots

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -38,6 +38,7 @@ export namespace Snapshot {
   const core = ["-c", "core.longpaths=true", "-c", "core.symlinks=true"]
   const cfg = ["-c", "core.autocrlf=false", ...core]
   const quote = [...cfg, "-c", "core.quotepath=false"]
+  const gitPath = (item: string) => item.replaceAll("\\", "/")
   interface GitResult {
     readonly code: ChildProcessSpawner.ExitCode
     readonly text: string
@@ -209,6 +210,54 @@ export namespace Snapshot {
             yield* fs.writeFileString(target, text ? `${text}\n` : "").pipe(Effect.orDie)
           })
 
+          const seed = Effect.fnUntraced(
+            function* () {
+              if (state.vcs !== "git") return
+
+              const commonDir = yield* git(["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+                cwd: state.worktree,
+              })
+              const common = commonDir.text.trim()
+              if (commonDir.code !== 0 || !common || !(yield* exists(common))) return
+
+              const sourceObjects = path.join(common, "objects")
+              if (!(yield* exists(sourceObjects))) return
+
+              const sourceInfo = path.join(sourceObjects, "info")
+              const chained = (yield* read(path.join(sourceInfo, "alternates")))
+                .split(/\r?\n/)
+                .map((line) => line.trim())
+                .filter(Boolean)
+                .map((line) => (path.isAbsolute(line) ? line : path.resolve(sourceInfo, line)))
+
+              const alternates: string[] = []
+              for (const candidate of [sourceObjects, ...chained]) {
+                if (alternates.includes(candidate)) continue
+                if (yield* exists(candidate)) alternates.push(candidate)
+              }
+              if (!alternates.length) return
+
+              yield* fs.ensureDir(path.join(state.gitdir, "objects", "info")).pipe(Effect.orDie)
+              yield* fs
+                .writeFileString(
+                  path.join(state.gitdir, "objects", "info", "alternates"),
+                  `${alternates.map(gitPath).join("\n")}\n`,
+                )
+                .pipe(Effect.orDie)
+
+              const index = yield* git(["rev-parse", "--path-format=absolute", "--git-path", "index"], {
+                cwd: state.worktree,
+              })
+              const sourceIndex = index.text.trim()
+              if (index.code !== 0 || !sourceIndex || !(yield* exists(sourceIndex))) return
+              yield* fs.copyFile(sourceIndex, path.join(state.gitdir, "index")).pipe(Effect.catch(() => Effect.void))
+            },
+            Effect.catchCause((cause) => {
+              log.warn("failed to seed snapshot source git data", { cause: Cause.pretty(cause) })
+              return Effect.void
+            }),
+          )
+
           const add = Effect.fnUntraced(function* () {
             yield* sync()
             const [diff, other] = yield* Effect.all(
@@ -306,6 +355,11 @@ export namespace Snapshot {
                   yield* git(["--git-dir", state.gitdir, "config", "core.longpaths", "true"])
                   yield* git(["--git-dir", state.gitdir, "config", "core.symlinks", "true"])
                   yield* git(["--git-dir", state.gitdir, "config", "core.fsmonitor", "false"])
+                  yield* git(["--git-dir", state.gitdir, "config", "feature.manyFiles", "true"])
+                  yield* git(["--git-dir", state.gitdir, "config", "index.version", "4"])
+                  yield* git(["--git-dir", state.gitdir, "config", "index.threads", "true"])
+                  yield* git(["--git-dir", state.gitdir, "config", "core.untrackedCache", "true"])
+                  yield* seed()
                   log.info("initialized")
                 }
                 yield* add()

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -39,6 +39,7 @@ export namespace Snapshot {
   const cfg = ["-c", "core.autocrlf=false", ...core]
   const quote = [...cfg, "-c", "core.quotepath=false"]
   const gitPath = (item: string) => item.replaceAll("\\", "/")
+  const resolveGitPath = (cwd: string, item: string) => (path.isAbsolute(item) ? item : path.resolve(cwd, item))
   interface GitResult {
     readonly code: ChildProcessSpawner.ExitCode
     readonly text: string
@@ -214,11 +215,13 @@ export namespace Snapshot {
             function* () {
               if (state.vcs !== "git") return
 
-              const commonDir = yield* git(["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+              const commonDir = yield* git(["rev-parse", "--git-common-dir"], {
                 cwd: state.worktree,
               })
-              const common = commonDir.text.trim()
-              if (commonDir.code !== 0 || !common || !(yield* exists(common))) return
+              const commonRaw = commonDir.text.trim()
+              if (commonDir.code !== 0 || !commonRaw) return
+              const common = resolveGitPath(state.worktree, commonRaw)
+              if (!(yield* exists(common))) return
 
               const sourceObjects = path.join(common, "objects")
               if (!(yield* exists(sourceObjects))) return
@@ -245,11 +248,13 @@ export namespace Snapshot {
                 )
                 .pipe(Effect.orDie)
 
-              const index = yield* git(["rev-parse", "--path-format=absolute", "--git-path", "index"], {
+              const index = yield* git(["rev-parse", "--git-path", "index"], {
                 cwd: state.worktree,
               })
-              const sourceIndex = index.text.trim()
-              if (index.code !== 0 || !sourceIndex || !(yield* exists(sourceIndex))) return
+              const sourceIndexRaw = index.text.trim()
+              if (index.code !== 0 || !sourceIndexRaw) return
+              const sourceIndex = resolveGitPath(state.worktree, sourceIndexRaw)
+              if (!(yield* exists(sourceIndex))) return
               const targetIndex = path.join(state.gitdir, "index")
               const copied = yield* fs.copyFile(sourceIndex, targetIndex).pipe(
                 Effect.as(true),

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -228,7 +228,7 @@ export namespace Snapshot {
                 .split(/\r?\n/)
                 .map((line) => line.trim())
                 .filter(Boolean)
-                .map((line) => (path.isAbsolute(line) ? line : path.resolve(sourceInfo, line)))
+                .map((line) => (path.isAbsolute(line) ? line : path.resolve(sourceObjects, line)))
 
               const alternates: string[] = []
               for (const candidate of [sourceObjects, ...chained]) {
@@ -250,7 +250,18 @@ export namespace Snapshot {
               })
               const sourceIndex = index.text.trim()
               if (index.code !== 0 || !sourceIndex || !(yield* exists(sourceIndex))) return
-              yield* fs.copyFile(sourceIndex, path.join(state.gitdir, "index")).pipe(Effect.catch(() => Effect.void))
+              const targetIndex = path.join(state.gitdir, "index")
+              const copied = yield* fs.copyFile(sourceIndex, targetIndex).pipe(
+                Effect.as(true),
+                Effect.catch(() => Effect.succeed(false)),
+              )
+              if (!copied) return
+
+              const status = yield* git(args(["status", "--porcelain"]), { cwd: state.directory })
+              const unmerged = yield* git(args(["ls-files", "-u"]), { cwd: state.directory })
+              if (status.code === 0 && unmerged.code === 0 && !unmerged.text.trim()) return
+
+              yield* remove(targetIndex)
             },
             Effect.catchCause((cause) => {
               log.warn("failed to seed snapshot source git data", { cause: Cause.pretty(cause) })

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -87,6 +87,52 @@ test("initial snapshot in secondary worktree reuses common object database", asy
   }
 })
 
+test("initial snapshot preserves source relative alternates", async () => {
+  await using tmp = await bootstrap()
+  const sourceObjects = await sourceObjectsForGitWorktree(tmp.path)
+  const sharedObjects = `${tmp.path}-shared-objects`
+
+  try {
+    await fs.mkdir(sharedObjects, { recursive: true })
+    await fs.mkdir(path.join(sourceObjects, "info"), { recursive: true })
+    await fs.writeFile(
+      path.join(sourceObjects, "info", "alternates"),
+      `${path.relative(sourceObjects, sharedObjects).replaceAll("\\", "/")}\n`,
+    )
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        expect(await Snapshot.track()).toBeTruthy()
+
+        const alternates = await fs.readFile(path.join(snapshotGitdir(), "objects", "info", "alternates"), "utf8")
+        expect(alternates.split(/\r?\n/).filter(Boolean)).toContain(gitPath(sharedObjects))
+      },
+    })
+  } finally {
+    await $`rm -rf ${sharedObjects}`.quiet()
+  }
+})
+
+test("initial snapshot falls back when source index uses split index", async () => {
+  await using tmp = await bootstrap()
+  await $`git config core.splitIndex true`.cwd(tmp.path).quiet()
+  await $`git update-index --split-index`.cwd(tmp.path).quiet()
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const file = fwd(tmp.path, "split-index-new.txt")
+      await Filesystem.write(file, "split index fallback")
+
+      expect((await Snapshot.patch(before!)).files).toContain(file)
+    },
+  })
+})
+
 test("tracks deleted files correctly", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -17,6 +17,7 @@ const SNAPSHOT_BATCH_BOUNDARY = 100
 const OVER_BATCH_COUNT = SNAPSHOT_BATCH_BOUNDARY + 1
 const MIXED_BATCH_GROUP_COUNT = Math.ceil(OVER_BATCH_COUNT / 4)
 const gitPath = (item: string) => item.replaceAll("\\", "/")
+const resolveGitPath = (cwd: string, item: string) => (path.isAbsolute(item) ? item : path.resolve(cwd, item))
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -46,7 +47,7 @@ function snapshotGitdir() {
 }
 
 async function sourceObjectsForGitWorktree(dir: string) {
-  const common = (await $`git rev-parse --path-format=absolute --git-common-dir`.cwd(dir).text()).trim()
+  const common = resolveGitPath(dir, (await $`git rev-parse --git-common-dir`.cwd(dir).text()).trim())
   return path.join(common, "objects")
 }
 

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -3,8 +3,10 @@ import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
 import { Snapshot } from "../../src/snapshot"
+import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { Filesystem } from "../../src/util/filesystem"
+import { Hash } from "../../src/util/hash"
 import { tmpdir } from "../fixture/fixture"
 
 // Git always outputs /-separated paths internally. Snapshot.patch() joins them
@@ -14,6 +16,7 @@ const fwd = (...parts: string[]) => path.join(...parts).replaceAll("\\", "/")
 const SNAPSHOT_BATCH_BOUNDARY = 100
 const OVER_BATCH_COUNT = SNAPSHOT_BATCH_BOUNDARY + 1
 const MIXED_BATCH_GROUP_COUNT = Math.ceil(OVER_BATCH_COUNT / 4)
+const gitPath = (item: string) => item.replaceAll("\\", "/")
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -37,6 +40,52 @@ async function bootstrap() {
     },
   })
 }
+
+function snapshotGitdir() {
+  return path.join(Global.Path.data, "snapshot", Instance.project.id, Hash.fast(Instance.worktree))
+}
+
+async function sourceObjectsForGitWorktree(dir: string) {
+  const common = (await $`git rev-parse --path-format=absolute --git-common-dir`.cwd(dir).text()).trim()
+  return path.join(common, "objects")
+}
+
+async function expectSnapshotAlternatesInclude(worktree: string) {
+  const alternates = await fs.readFile(path.join(snapshotGitdir(), "objects", "info", "alternates"), "utf8")
+  expect(alternates.split(/\r?\n/).filter(Boolean)).toContain(gitPath(await sourceObjectsForGitWorktree(worktree)))
+}
+
+test("initial snapshot reuses source git object database", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      expect(await Snapshot.track()).toBeTruthy()
+
+      await expectSnapshotAlternatesInclude(tmp.path)
+    },
+  })
+})
+
+test("initial snapshot in secondary worktree reuses common object database", async () => {
+  await using tmp = await bootstrap()
+  const worktreePath = `${tmp.path}-reuse-worktree`
+  await $`git worktree add ${worktreePath} HEAD`.cwd(tmp.path).quiet()
+
+  try {
+    await Instance.provide({
+      directory: worktreePath,
+      fn: async () => {
+        expect(await Snapshot.track()).toBeTruthy()
+
+        await expectSnapshotAlternatesInclude(worktreePath)
+      },
+    })
+  } finally {
+    await $`git worktree remove --force ${worktreePath}`.cwd(tmp.path).quiet().nothrow()
+    await $`rm -rf ${worktreePath}`.quiet()
+  }
+})
 
 test("tracks deleted files correctly", async () => {
   await using tmp = await bootstrap()


### PR DESCRIPTION
## Summary

Port upstream anomalyco/opencode#31798 as a focused snapshot robustness/performance hardening change. Initial snapshot gitdirs now best-effort reuse the source repository object database and source index before falling back to the existing full-add path.

No PawWork issue exists for this narrow upstream port; this came from the Round 6 upstream value audit.

## Why

Large repositories can spend a long time re-hashing already-known tracked files during the first snapshot. PawWork's snapshot repo was initialized independently, with no source `git-common-dir`, alternates, source index seed, or large-repo Git tuning before the first `add()`.

## Related Issue

No PawWork issue. Upstream reference: anomalyco/opencode#31798.

## Human Review Status

Pending

## Review Focus

Please focus on the snapshot initialization boundary: the alternates file, source index validation/fallback, and secondary worktree/common-dir behavior. The intended contract is best-effort performance reuse only; snapshot creation should still work if source seeding is incompatible.

## Risk Notes

Snapshot gitdirs now borrow source repository objects through Git alternates. This matches the upstream trade-off, but an aggressive source-repo history rewrite plus object pruning could theoretically invalidate old borrowed objects. Source index reuse is validated before keeping the copied index; split-index and unmerged-index cases fall back to the previous full-add behavior.

Skipped checklist items: no visible UI or copy changed, so no screenshot/manual UI check applies; no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local-only files changed.

## How To Verify

```text
RED check: new initial snapshot alternates test failed before implementation with missing objects/info/alternates.
Focused snapshot tests: bun test test/snapshot/snapshot.test.ts -> 56 pass, 1 skip.
Typecheck: bun run typecheck in packages/opencode -> pass.
Whitespace: git diff --check origin/dev...HEAD -> pass.
Claude review: initial review found two P2 issues; both were fixed. Final Claude review reported no P0/P1/P2 findings.
Occam fresh-eye review: PASS; no blocking findings, only non-blocking verification/perf-evidence notes.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
