### PR TITLE
feat(app): edit automations inline and add full list row actions

### DIFF
--- a/packages/app/e2e/automations/automations-panel.spec.ts
+++ b/packages/app/e2e/automations/automations-panel.spec.ts
@@ -571,6 +571,55 @@ test("automations panel: detail edits title, prompt, schedule and model inline",
     .toBe(key)
 })
 
+test("automations panel: detail moves an automation to another open project", async ({ page, project, backend }) => {
+  test.setTimeout(120_000)
+
+  const other = await createTestProject({ serverUrl: backend.url })
+  try {
+    await project.open({ extra: [other] })
+
+    const otherSDK = backend.sdk(other)
+    const otherProjectID = (await otherSDK.project.current()).data!.id
+    await otherSDK.project.update({ projectID: otherProjectID, name: "Move Target Project" })
+
+    const projectID = (await project.sdk.project.current()).data!.id
+    const created = (
+      await project.sdk.automation.create(
+        recurring(projectID, "Migrating digest", "Summarize for the new home.", "0 9 * * *"),
+      )
+    ).data!
+
+    const surface = await openAutomations(page)
+    const rows = surface.locator('[data-action="automation-row"]')
+    await rows.filter({ hasText: "Migrating digest" }).first().click()
+    const detail = surface.locator('[data-component="automation-detail"]')
+    await expect(detail).toBeVisible()
+
+    // The Project row is a picker when another project is open. Moving is a
+    // create-in-target + delete-from-source pair: the automation appears in
+    // the target project's list, vanishes from the source, and the detail
+    // stays open on the recreated definition (new id, same fields).
+    await detail.locator('[data-action="automation-edit-project"]').click()
+    await page.locator(`[data-project="${otherProjectID}"]`).click()
+
+    await expect
+      .poll(async () =>
+        ((await otherSDK.automation.list()).data?.items ?? []).filter((item) => item.title === "Migrating digest")
+          .length,
+      )
+      .toBe(1)
+    await expect
+      .poll(async () =>
+        ((await project.sdk.automation.list()).data?.items ?? []).filter((item) => item.id === created.id).length,
+      )
+      .toBe(0)
+    await expect(detail.locator('[data-action="automation-edit-title"]')).toHaveValue("Migrating digest")
+    await expect(detail.getByText("Move Target Project")).toBeVisible()
+  } finally {
+    await cleanupTestProject(other, { serverUrl: backend.url })
+  }
+})
+
 test("automations panel: list rows expose run, pause and delete on hover", async ({ page, project }) => {
   test.setTimeout(120_000)
 

--- a/packages/app/e2e/automations/automations-panel.spec.ts
+++ b/packages/app/e2e/automations/automations-panel.spec.ts
@@ -84,7 +84,7 @@ test("@smoke automations panel: list, detail, pause, delete", async ({ page, pro
   await rows.first().click()
   const detail = surface.locator('[data-component="automation-detail"]')
   await expect(detail).toBeVisible()
-  await expect(detail.getByRole("heading", { name: "Daily standup digest" })).toBeVisible()
+  await expect(detail.locator('[data-action="automation-edit-title"]')).toHaveValue("Daily standup digest")
 
   // Pause flips the icon-only action's aria-label to Resume and the status row to Paused.
   await detail.locator('[data-action="automation-toggle-active"]').click()
@@ -130,7 +130,7 @@ test("automations panel: create manually adds an automation", async ({ page, pro
   // Lands on the new automation's detail; it also shows up in the list.
   const detail = surface.locator('[data-component="automation-detail"]')
   await expect(detail).toBeVisible()
-  await expect(detail.getByRole("heading", { name: "Release notes draft" })).toBeVisible()
+  await expect(detail.locator('[data-action="automation-edit-title"]')).toHaveValue("Release notes draft")
 
   await detail.locator('[data-action="automation-detail-back"]').click()
   await expect(surface.locator('[data-action="automation-row"]')).toHaveCount(1)
@@ -177,7 +177,7 @@ test("automations panel: lists automations from every open project", async ({ pa
 
     await row.click()
     const detail = surface.locator('[data-component="automation-detail"]')
-    await expect(detail.getByRole("heading", { name: "Cross-project digest" })).toBeVisible()
+    await expect(detail.locator('[data-action="automation-edit-title"]')).toHaveValue("Cross-project digest")
     await expect(detail.getByText(otherProjectName)).toBeVisible()
     await expect(detail.getByText("Paused")).toBeVisible()
     await expect.poll(() => runListRequests).toBe(1)
@@ -399,7 +399,7 @@ test("automations panel: the automate tool card jumps into the panel", async ({ 
   await expect(surface).toBeVisible()
   const detail = surface.locator('[data-component="automation-detail"]')
   await expect(detail).toBeVisible()
-  await expect(detail.getByRole("heading", { name: "Nightly digest" })).toBeVisible()
+  await expect(detail.locator('[data-action="automation-edit-title"]')).toHaveValue("Nightly digest")
 })
 
 test("automations panel: a second tool card jump opens its own automation", async ({ page, project, assistant }) => {
@@ -415,7 +415,7 @@ test("automations panel: a second tool card jump opens its own automation", asyn
   await cardA.locator('[data-component="automate-tool-action"]').click()
   const surface = page.locator('[data-component="automations-page"]')
   const detail = surface.locator('[data-component="automation-detail"]')
-  await expect(detail.getByRole("heading", { name: "Alpha digest" })).toBeVisible()
+  await expect(detail.locator('[data-action="automation-edit-title"]')).toHaveValue("Alpha digest")
 
   // Close the panel (the surface takes over main, so the chat — and the next
   // tool card — is only reachable once it's closed), then jump from a second
@@ -430,7 +430,7 @@ test("automations panel: a second tool card jump opens its own automation", asyn
   const cardB = page.locator('[data-component="automate-tool-card"]').filter({ hasText: "Bravo digest" })
   await expect(cardB).toBeVisible()
   await cardB.locator('[data-component="automate-tool-action"]').click()
-  await expect(detail.getByRole("heading", { name: "Bravo digest" })).toBeVisible()
+  await expect(detail.locator('[data-action="automation-edit-title"]')).toHaveValue("Bravo digest")
 })
 
 test("automations panel: a pending one-shot shows its next run time", async ({ page, project }) => {
@@ -497,6 +497,119 @@ test("automations panel: a manual run before fireAt keeps the one-shot's next ru
   await expect(detail.getByText("Last run")).toBeVisible()
   // The early run's triggeredAt is before fireAt, so the next run still stands.
   await expect(detail.getByText("Next run")).toBeVisible()
+})
+
+test("automations panel: detail edits title, prompt, schedule and model inline", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  const surface = await openAutomations(page)
+
+  const projectID = (await project.sdk.project.current()).data!.id
+  const created = (
+    await project.sdk.automation.create(
+      recurring(projectID, "Daily digest", "Summarize the day's changes.", "0 9 * * *"),
+    )
+  ).data!
+
+  const rows = surface.locator('[data-action="automation-row"]')
+  await expect(rows).toHaveCount(1)
+  await rows.first().click()
+  const detail = surface.locator('[data-component="automation-detail"]')
+  await expect(detail).toBeVisible()
+
+  const automation = async () =>
+    (await project.sdk.automation.list()).data!.items.find((item) => item.id === created.id)!
+
+  // Title: type and blur commits; Escape while editing only blurs, it must not
+  // unwind back to the list.
+  const title = detail.locator('[data-action="automation-edit-title"]')
+  await title.fill("Daily digest v2")
+  await page.keyboard.press("Escape")
+  await expect(detail).toBeVisible()
+  await expect(title).toHaveValue("Daily digest")
+  await title.fill("Daily digest v2")
+  await page.keyboard.press("Enter")
+  await expect.poll(async () => (await automation()).title).toBe("Daily digest v2")
+
+  // Prompt: blur commits.
+  const prompt = detail.locator('[data-action="automation-edit-prompt"]')
+  await prompt.fill("Summarize the day's changes and open PRs.")
+  await prompt.blur()
+  await expect.poll(async () => (await automation()).prompt).toBe("Summarize the day's changes and open PRs.")
+
+  // Schedule: the Repeats row opens the schedule popover. A recurring
+  // automation must not offer the one-shot frequency, and picking Weekdays
+  // rewrites the cron in place.
+  await detail.locator('[data-action="automation-edit-schedule"]').click()
+  const popover = page.locator('[data-component="popover-content"]')
+  await expect(popover).toBeVisible()
+  await expect(popover.locator('[data-frequency="once"]')).toHaveCount(0)
+  await popover.locator('[data-frequency="weekdays"]').click()
+  await expect
+    .poll(async () => {
+      const definition = await automation()
+      return definition.kind === "recurring" && definition.rhythm.kind === "cron" ? definition.rhythm.expression : ""
+    })
+    .toBe("0 9 * * 1-5")
+  await page.keyboard.press("Escape")
+  await expect(detail).toBeVisible()
+
+  // Model: the Model row opens the shared picker; choosing an entry patches the
+  // definition to that model.
+  await detail.locator('[data-action="automation-edit-model"]').click()
+  const picker = page.locator("[data-picker-content]")
+  await expect(picker).toBeVisible()
+  const target = picker.locator('[data-slot="list-item"][data-key]').last()
+  const key = (await target.getAttribute("data-key"))!
+  await target.click({ force: true })
+  await expect
+    .poll(async () => {
+      const definition = await automation()
+      return `${definition.model.providerID}:${definition.model.modelID}`
+    })
+    .toBe(key)
+})
+
+test("automations panel: list rows expose run, pause and delete on hover", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  const surface = await openAutomations(page)
+
+  const projectID = (await project.sdk.project.current()).data!.id
+  const created = (
+    await project.sdk.automation.create(
+      recurring(projectID, "Hourly check", "Check the build.", "0 * * * *"),
+    )
+  ).data!
+
+  const rows = surface.locator('[data-action="automation-row"]')
+  await expect(rows).toHaveCount(1)
+  await rows.first().hover()
+
+  // Run now fires a run without leaving the list.
+  await surface.locator(`[data-action="automation-run-now"][data-automation-id="${created.id}"]`).click()
+  await expect
+    .poll(async () => ((await project.sdk.automation.runs({ automationID: created.id })).data?.items ?? []).length)
+    .toBeGreaterThan(0)
+
+  // Pause flips the toggle to Resume in place.
+  const toggle = surface.locator(`[data-action="automation-toggle-active"][data-automation-id="${created.id}"]`)
+  await toggle.click()
+  await expect(toggle).toHaveAttribute("aria-label", "Resume")
+  await expect
+    .poll(async () => (await project.sdk.automation.list()).data!.items.find((item) => item.id === created.id)?.paused)
+    .toBe(true)
+
+  // Delete confirms through the shared dialog and empties the list.
+  await rows.first().hover()
+  await surface.locator(`[data-action="automation-delete"][data-automation-id="${created.id}"]`).click()
+  const dialog = page.locator('[data-component="dialog"]')
+  await expect(dialog).toBeVisible()
+  await dialog.locator('[data-action="automation-delete-confirm"]').click()
+  await expect(rows).toHaveCount(0)
+  await expect(surface.locator('[data-component="automations-empty"]')).toBeVisible()
 })
 
 test("automations panel: escape unwinds detail then closes the surface", async ({ page, project }) => {

--- a/packages/app/e2e/automations/automations-panel.spec.ts
+++ b/packages/app/e2e/automations/automations-panel.spec.ts
@@ -620,6 +620,121 @@ test("automations panel: detail moves an automation to another open project", as
   }
 })
 
+test("automations panel: a rhythm the picker cannot express is read-only", async ({ page, project }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  const surface = await openAutomations(page)
+
+  // Hourly cron is real (SDK/automate tool) but outside the picker's four
+  // frequencies. Offering the editor would pre-select a frequency the
+  // definition does not have and silently rewrite the cron on any knob change,
+  // so the Repeats row must render as plain text with no trigger at all.
+  const projectID = (await project.sdk.project.current()).data!.id
+  await project.sdk.automation.create(
+    recurring(projectID, "Hourly build watch", "Check CI and flag a red main build.", "0 * * * *"),
+  )
+
+  const rows = surface.locator('[data-action="automation-row"]')
+  await expect(rows).toHaveCount(1)
+  await rows.first().click()
+
+  const detail = surface.locator('[data-component="automation-detail"]')
+  await expect(detail).toBeVisible()
+  await expect(detail.getByText("Hourly")).toBeVisible()
+  await expect(detail.locator('[data-action="automation-edit-schedule"]')).toHaveCount(0)
+})
+
+test("automations panel: a paused automation arrives paused after a move", async ({ page, project, backend }) => {
+  test.setTimeout(120_000)
+
+  const other = await createTestProject({ serverUrl: backend.url })
+  try {
+    await project.open({ extra: [other] })
+    const otherSDK = backend.sdk(other)
+    const otherProjectID = (await otherSDK.project.current()).data!.id
+
+    const projectID = (await project.sdk.project.current()).data!.id
+    const created = (
+      await project.sdk.automation.create(
+        recurring(projectID, "Silenced digest", "Stay quiet until resumed.", "0 9 * * *"),
+      )
+    ).data!
+    await project.sdk.automation.pause({ automationID: created.id })
+
+    const surface = await openAutomations(page)
+    await surface.locator('[data-action="automation-row"]').filter({ hasText: "Silenced digest" }).first().click()
+    const detail = surface.locator('[data-component="automation-detail"]')
+    await expect(detail).toBeVisible()
+
+    await detail.locator('[data-action="automation-edit-project"]').click()
+    await page.locator(`[data-project="${otherProjectID}"]`).click()
+
+    // The recreated copy must keep the silence the user set, not wake up live.
+    await expect
+      .poll(async () => {
+        const moved = ((await otherSDK.automation.list()).data?.items ?? []).find(
+          (item) => item.title === "Silenced digest",
+        )
+        return moved ? moved.paused : "missing"
+      })
+      .toBe(true)
+    await expect
+      .poll(async () => ((await project.sdk.automation.list()).data?.items ?? []).length)
+      .toBe(0)
+  } finally {
+    await cleanupTestProject(other, { serverUrl: backend.url })
+  }
+})
+
+test("automations panel: a failed pause during a move rolls back and keeps the source", async ({
+  page,
+  project,
+  backend,
+}) => {
+  test.setTimeout(120_000)
+
+  const other = await createTestProject({ serverUrl: backend.url })
+  try {
+    await project.open({ extra: [other] })
+    const otherSDK = backend.sdk(other)
+    const otherProjectID = (await otherSDK.project.current()).data!.id
+
+    const projectID = (await project.sdk.project.current()).data!.id
+    const created = (
+      await project.sdk.automation.create(
+        recurring(projectID, "Silenced digest", "Stay quiet until resumed.", "0 9 * * *"),
+      )
+    ).data!
+    await project.sdk.automation.pause({ automationID: created.id })
+
+    const surface = await openAutomations(page)
+    await surface.locator('[data-action="automation-row"]').filter({ hasText: "Silenced digest" }).first().click()
+    const detail = surface.locator('[data-component="automation-detail"]')
+    await expect(detail).toBeVisible()
+
+    // Re-applying the pause on the target fails. The move must fail as a whole:
+    // the fresh copy is deleted, the paused source is untouched, and the user
+    // is told — never a silenced automation suddenly live in another project.
+    await page.route("**/automation/*/pause*", (route) => route.fulfill({ status: 500, body: "{}" }))
+    await detail.locator('[data-action="automation-edit-project"]').click()
+    await page.locator(`[data-project="${otherProjectID}"]`).click()
+
+    await expect(page.locator('[data-component="toast"]')).toBeVisible()
+    await expect
+      .poll(async () => ((await otherSDK.automation.list()).data?.items ?? []).length)
+      .toBe(0)
+    await expect
+      .poll(async () => {
+        const source = ((await project.sdk.automation.list()).data?.items ?? []).find((item) => item.id === created.id)
+        return source ? source.paused : "gone"
+      })
+      .toBe(true)
+  } finally {
+    await cleanupTestProject(other, { serverUrl: backend.url })
+  }
+})
+
 test("automations panel: list rows expose run, pause and delete on hover", async ({ page, project }) => {
   test.setTimeout(120_000)
 
@@ -635,6 +750,12 @@ test("automations panel: list rows expose run, pause and delete on hover", async
 
   const rows = surface.locator('[data-action="automation-row"]')
   await expect(rows).toHaveCount(1)
+
+  // Keyboard path: focusing the row alone must already reveal the actions —
+  // a keyboard user should not face a blank slot where the summary just hid.
+  await rows.first().focus()
+  await expect(surface.locator('[data-component="automation-row-actions"]')).toHaveCSS("opacity", "1")
+
   await rows.first().hover()
 
   // Run now fires a run without leaving the list.

--- a/packages/app/e2e/snap/automations-surface.snap.ts
+++ b/packages/app/e2e/snap/automations-surface.snap.ts
@@ -82,6 +82,23 @@ test("automations-surface", async ({ page, project, assistant }) => {
   const detail = await openDetail("Daily standup digest")
   const detailContinue = await openDetail("Inbox triage loop")
 
+  // Inline edit affordances on the detail page: the Repeats row opens the
+  // schedule popover, the Model row opens the shared picker.
+  await surface.locator('[data-action="automation-row"]', { hasText: "Daily standup digest" }).first().click()
+  const detailPane = surface.locator('[data-component="automation-detail"]')
+  await detailPane.waitFor({ state: "visible", timeout: 30_000 })
+  await detailPane.locator('[data-action="automation-edit-schedule"]').click()
+  await page.locator('[data-action="automation-frequency"]').waitFor({ state: "visible", timeout: 10_000 })
+  await page.waitForTimeout(300) // let the popover's fade-in settle before the shot
+  const detailSchedule = await page.screenshot()
+  await page.keyboard.press("Escape")
+  await detailPane.locator('[data-action="automation-edit-model"]').click()
+  await page.locator("[data-picker-content]").waitFor({ state: "visible", timeout: 10_000 })
+  const detailModel = await page.screenshot()
+  await page.keyboard.press("Escape")
+  await surface.locator('[data-action="automation-detail-back"]').click()
+  await rows.first().waitFor({ state: "visible", timeout: 10_000 })
+
   // Split entry: open the New automation menu, screenshot it, then Create
   // manually, fill the card, and expand the schedule popover.
   await surface.locator('[data-action="automation-create-open"]').click()
@@ -106,6 +123,8 @@ test("automations-surface", async ({ page, project, assistant }) => {
     { name: "list-hover", buf: listHover },
     { name: "detail", buf: detail },
     { name: "detail-continue", buf: detailContinue },
+    { name: "detail-schedule", buf: detailSchedule },
+    { name: "detail-model", buf: detailModel },
     { name: "create-menu", buf: createMenu },
     { name: "create-card", buf: createCard },
     { name: "schedule", buf: schedulePopover },

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -1,5 +1,6 @@
 import type {
   AutomationCreateInput,
+  AutomationUpdateInput,
   Config,
   OpencodeClient,
   Path,
@@ -432,6 +433,18 @@ function createGlobalSync() {
     }
   }
 
+  async function updateAutomation(directory: string, automationID: string, patch: AutomationUpdateInput) {
+    children.pin(directory)
+    try {
+      const [store, setStore] = children.peek(directory, { bootstrap: false })
+      const res = await sdkFor(directory).automation.update({ automationID, automationUpdateInput: patch })
+      if (res.data) applyAutomationDefinition(store, setStore, res.data)
+      return res.data
+    } finally {
+      children.unpin(directory)
+    }
+  }
+
   async function bootstrapInstance(directory: string) {
     if (!directory) return
     const pending = booting.get(directory)
@@ -694,6 +707,7 @@ function createGlobalSync() {
     project: projectApi,
     automation: {
       create: createAutomation,
+      update: updateAutomation,
       loadRuns: loadAutomationRuns,
       pause: pauseAutomation,
       resume: resumeAutomation,

--- a/packages/app/src/pages/automations/automation-detail-editors.tsx
+++ b/packages/app/src/pages/automations/automation-detail-editors.tsx
@@ -62,7 +62,9 @@ export function EditableText(props: {
       return
     }
     const ok = await props.onCommit(next)
-    if (!ok && element) {
+    // Roll back only if the control still shows the failed submission — the
+    // user may have refocused and retyped while the request was in flight.
+    if (!ok && element && element.value === next) {
       element.value = props.value
       autoresize()
     }
@@ -165,20 +167,17 @@ export function ProjectEditorRow(props: {
 // in a popover. Every knob change commits immediately — each intermediate state
 // is itself a valid schedule. The kind is fixed by the server (no
 // oneshot<->recurring conversion), so the frequency switch only offers what the
-// kind supports, and an arbitrary cron (hourly etc.) keeps its rhythm until the
-// user explicitly picks one of the four picker frequencies.
+// kind supports. A rhythm the picker cannot express (hourly, interval,
+// arbitrary cron) renders read-only instead: the segmented switch would have
+// to pre-select a frequency the definition does not have, and any knob change
+// would silently rewrite the rhythm to it.
 export function ScheduleEditorRow(props: {
   automation: Accessor<AutomationDefinition>
   t: Translate
   onPatch: CommitPatch
 }): JSX.Element {
-  const draftFromDefinition = (): ScheduleDraft => {
-    const definition = props.automation()
-    return (
-      scheduleDraftFromDefinition(definition) ??
-      (definition.kind === "oneshot" ? { ...DEFAULT_SCHEDULE, frequency: "once" } : DEFAULT_SCHEDULE)
-    )
-  }
+  const draftFromDefinition = (): ScheduleDraft => scheduleDraftFromDefinition(props.automation()) ?? DEFAULT_SCHEDULE
+  const editable = createMemo(() => scheduleDraftFromDefinition(props.automation()) !== undefined)
   const [draft, setDraft] = createSignal<ScheduleDraft>(draftFromDefinition())
   createEffect(() => setDraft(draftFromDefinition()))
 
@@ -199,7 +198,15 @@ export function ScheduleEditorRow(props: {
 
   return (
     <EditorRow label={props.t("automations.detail.repeats")}>
-      <Popover
+      <Show
+        when={editable()}
+        fallback={
+          <span class="min-w-0 truncate text-right text-body text-fg-base">
+            {formatScheduleSummary(props.automation(), props.t)}
+          </span>
+        }
+      >
+        <Popover
         modal
         placement="bottom-end"
         class="w-max max-w-[440px]"
@@ -219,13 +226,14 @@ export function ScheduleEditorRow(props: {
           </>
         }
       >
-        <AutomationScheduleControls
-          value={draft()}
-          onChange={(next) => void change(next)}
-          t={props.t}
-          frequencies={frequencies()}
-        />
-      </Popover>
+          <AutomationScheduleControls
+            value={draft()}
+            onChange={(next) => void change(next)}
+            t={props.t}
+            frequencies={frequencies()}
+          />
+        </Popover>
+      </Show>
     </EditorRow>
   )
 }
@@ -251,7 +259,7 @@ export function ModelEditorRow(props: {
     set: (item) => {
       if (!item) return
       models.setVisibility(item, true)
-      void props.onPatch({ model: item, variant: null })
+      void props.onPatch({ model: { providerID: item.providerID, modelID: item.modelID }, variant: null })
     },
     variant: {
       list: () => Object.keys(current()?.variants ?? {}),

--- a/packages/app/src/pages/automations/automation-detail-editors.tsx
+++ b/packages/app/src/pages/automations/automation-detail-editors.tsx
@@ -164,10 +164,15 @@ export function ScheduleEditorRow(props: {
             type: "button",
             "data-action": "automation-edit-schedule",
             "aria-label": props.t("automations.detail.repeats"),
-            class: ROW_VALUE_CLASS,
+            class: `flex min-w-0 items-center gap-1.5 ${ROW_VALUE_CLASS}`,
           } as never
         }
-        trigger={<span>{formatScheduleSummary(props.automation(), props.t)}</span>}
+        trigger={
+          <>
+            <span class="min-w-0 truncate">{formatScheduleSummary(props.automation(), props.t)}</span>
+            <Icon name="chevron-down" class="size-3 shrink-0 text-icon-weak" />
+          </>
+        }
       >
         <AutomationScheduleControls
           value={draft()}

--- a/packages/app/src/pages/automations/automation-detail-editors.tsx
+++ b/packages/app/src/pages/automations/automation-detail-editors.tsx
@@ -1,0 +1,236 @@
+import { createEffect, createSignal, Show, type Accessor, type JSX } from "solid-js"
+import type { AutomationDefinition, AutomationUpdateInput } from "@opencode-ai/sdk/v2/client"
+import { Icon } from "@opencode-ai/ui/icon"
+import { Popover } from "@opencode-ai/ui/popover"
+import { ProviderIcon } from "@opencode-ai/ui/provider-icon"
+import { ModelSelectorPopover, type ModelPickerState } from "@/components/prompt-input/model-picker"
+import { useScopedModels } from "@/context/models"
+import type { useLanguage } from "@/context/language"
+import { AutomationScheduleControls } from "./automation-schedule-controls"
+import {
+  buildScheduleInput,
+  cronForSchedule,
+  scheduleDraftFromDefinition,
+  DEFAULT_SCHEDULE,
+  type ScheduleDraft,
+  type ScheduleFrequency,
+} from "./automation-schedule-form"
+import { formatScheduleSummary } from "./automation-schedule"
+
+type Translate = ReturnType<typeof useLanguage>["t"]
+
+// Each edit commits its own one-field patch (resolved true on success); there
+// is no edit mode and no save button. Failure rolls the control back to the
+// definition, which the store still holds unchanged.
+export type CommitPatch = (patch: AutomationUpdateInput) => Promise<boolean>
+
+// The detail title / instructions rendered as a transparent always-editable
+// control: blur commits when changed and non-empty, Escape or an empty value
+// reverts. The DOM input owns the text while focused so an SSE refresh never
+// stomps a half-typed edit.
+export function EditableText(props: {
+  value: string
+  onCommit: (next: string) => Promise<boolean>
+  multiline?: boolean
+  class: string
+  ariaLabel: string
+  action: string
+}): JSX.Element {
+  let element: HTMLInputElement | HTMLTextAreaElement | undefined
+
+  const autoresize = () => {
+    if (!props.multiline || !element) return
+    element.style.height = "auto"
+    element.style.height = `${element.scrollHeight}px`
+  }
+
+  createEffect(() => {
+    const value = props.value
+    if (!element || document.activeElement === element) return
+    element.value = value
+    autoresize()
+  })
+
+  const commit = async () => {
+    if (!element) return
+    const next = element.value.trim()
+    if (!next || next === props.value) {
+      element.value = props.value
+      autoresize()
+      return
+    }
+    const ok = await props.onCommit(next)
+    if (!ok && element) {
+      element.value = props.value
+      autoresize()
+    }
+  }
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      if (element) element.value = props.value
+      autoresize()
+      element?.blur()
+      return
+    }
+    if (event.key === "Enter" && !props.multiline) element?.blur()
+  }
+
+  const shared = {
+    "aria-label": props.ariaLabel,
+    "data-action": props.action,
+    class: `${props.class} bg-transparent focus:outline-none`,
+    onBlur: () => void commit(),
+    onKeyDown,
+  }
+
+  return (
+    <Show
+      when={props.multiline}
+      fallback={<input type="text" ref={(el) => (element = el)} value={props.value} {...shared} />}
+    >
+      <textarea
+        ref={(el) => {
+          element = el
+          queueMicrotask(autoresize)
+        }}
+        value={props.value}
+        rows={1}
+        onInput={autoresize}
+        {...shared}
+        class={`${props.class} resize-none bg-transparent focus:outline-none`}
+      />
+    </Show>
+  )
+}
+
+const ROW_VALUE_CLASS =
+  "min-w-0 truncate text-right text-body text-fg-base hover:text-fg-strong hover:underline focus-visible:text-fg-strong focus-visible:underline focus:outline-none cursor-default"
+
+function EditorRow(props: { label: string; children: JSX.Element }): JSX.Element {
+  return (
+    <div class="flex items-baseline justify-between gap-3">
+      <span class="shrink-0 text-caption text-fg-weak">{props.label}</span>
+      {props.children}
+    </div>
+  )
+}
+
+// The "Repeats" row: the summary text opens the create card's schedule controls
+// in a popover. Every knob change commits immediately — each intermediate state
+// is itself a valid schedule. The kind is fixed by the server (no
+// oneshot<->recurring conversion), so the frequency switch only offers what the
+// kind supports, and an arbitrary cron (hourly etc.) keeps its rhythm until the
+// user explicitly picks one of the four picker frequencies.
+export function ScheduleEditorRow(props: {
+  automation: Accessor<AutomationDefinition>
+  t: Translate
+  onPatch: CommitPatch
+}): JSX.Element {
+  const draftFromDefinition = (): ScheduleDraft => {
+    const definition = props.automation()
+    return (
+      scheduleDraftFromDefinition(definition) ??
+      (definition.kind === "oneshot" ? { ...DEFAULT_SCHEDULE, frequency: "once" } : DEFAULT_SCHEDULE)
+    )
+  }
+  const [draft, setDraft] = createSignal<ScheduleDraft>(draftFromDefinition())
+  createEffect(() => setDraft(draftFromDefinition()))
+
+  const frequencies = (): ScheduleFrequency[] =>
+    props.automation().kind === "oneshot" ? ["once"] : ["daily", "weekdays", "weekly"]
+
+  const change = async (next: ScheduleDraft) => {
+    setDraft(next)
+    const definition = props.automation()
+    const scheduled = buildScheduleInput(next, definition.timezone, Date.now())
+    const ok = await props.onPatch(
+      scheduled.kind === "oneshot"
+        ? { fireAt: scheduled.fireAt }
+        : { rhythm: { kind: "cron", expression: cronForSchedule(next) } },
+    )
+    if (!ok) setDraft(draftFromDefinition())
+  }
+
+  return (
+    <EditorRow label={props.t("automations.detail.repeats")}>
+      <Popover
+        modal
+        placement="bottom-end"
+        class="w-max max-w-[440px]"
+        triggerAs="button"
+        triggerProps={
+          {
+            type: "button",
+            "data-action": "automation-edit-schedule",
+            "aria-label": props.t("automations.detail.repeats"),
+            class: ROW_VALUE_CLASS,
+          } as never
+        }
+        trigger={<span>{formatScheduleSummary(props.automation(), props.t)}</span>}
+      >
+        <AutomationScheduleControls
+          value={draft()}
+          onChange={(next) => void change(next)}
+          t={props.t}
+          frequencies={frequencies()}
+        />
+      </Popover>
+    </EditorRow>
+  )
+}
+
+// The "Model" row reuses the composer's model picker. Picking a model clears
+// the variant (thinking levels are model-specific); picking a thinking level
+// patches the variant alone.
+export function ModelEditorRow(props: {
+  directory: Accessor<string>
+  automation: Accessor<AutomationDefinition>
+  t: Translate
+  onPatch: CommitPatch
+}): JSX.Element {
+  const models = useScopedModels(props.directory)
+  const current = () => {
+    const model = props.automation().model
+    return models.find({ providerID: model.providerID, modelID: model.modelID })
+  }
+  const state: ModelPickerState = {
+    list: models.list,
+    current,
+    visible: (item) => models.visible(item),
+    set: (item) => {
+      if (!item) return
+      models.setVisibility(item, true)
+      void props.onPatch({ model: item, variant: null })
+    },
+    variant: {
+      list: () => Object.keys(current()?.variants ?? {}),
+      current: () => props.automation().variant,
+      set: (value) => void props.onPatch({ variant: value ?? null }),
+    },
+  }
+
+  return (
+    <EditorRow label={props.t("automations.detail.model")}>
+      <ModelSelectorPopover
+        modal
+        model={state}
+        triggerProps={{
+          "data-action": "automation-edit-model",
+          "aria-label": props.t("automations.detail.model"),
+          class: `flex min-w-0 items-center gap-1.5 ${ROW_VALUE_CLASS}`,
+        }}
+      >
+        <Show when={current()} fallback={<span class="min-w-0 truncate">{props.automation().model.modelID}</span>}>
+          {(selected) => (
+            <>
+              <ProviderIcon id={selected().provider.id} class="size-3.5 shrink-0 text-icon-weak" />
+              <span class="min-w-0 truncate">{selected().name}</span>
+            </>
+          )}
+        </Show>
+        <Icon name="chevron-down" class="size-3 shrink-0 text-icon-weak" />
+      </ModelSelectorPopover>
+    </EditorRow>
+  )
+}

--- a/packages/app/src/pages/automations/automation-detail-editors.tsx
+++ b/packages/app/src/pages/automations/automation-detail-editors.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, Show, type Accessor, type JSX } from "solid-js"
+import { createEffect, createMemo, createSignal, Show, type Accessor, type JSX } from "solid-js"
 import type { AutomationDefinition, AutomationUpdateInput } from "@opencode-ai/sdk/v2/client"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Popover } from "@opencode-ai/ui/popover"
@@ -6,6 +6,8 @@ import { ProviderIcon } from "@opencode-ai/ui/provider-icon"
 import { ModelSelectorPopover, type ModelPickerState } from "@/components/prompt-input/model-picker"
 import { useScopedModels } from "@/context/models"
 import type { useLanguage } from "@/context/language"
+import { useLayout } from "@/context/layout"
+import { AutomationFolderPicker, type AutomationProject } from "./automation-folder-picker"
 import { AutomationScheduleControls } from "./automation-schedule-controls"
 import {
   buildScheduleInput,
@@ -113,6 +115,49 @@ function EditorRow(props: { label: string; children: JSX.Element }): JSX.Element
       <span class="shrink-0 text-caption text-fg-weak">{props.label}</span>
       {props.children}
     </div>
+  )
+}
+
+// The "Project" row: there is no server-side move (each project is its own
+// instance and update rejects a foreign projectID), so "move" is the create
+// card's folder picker driving a create-in-target + delete-from-source pair
+// (see moveToProject in automation-detail). A continue automation stays
+// read-only — it loops inside a conversation that only exists in its source
+// project — as does everything else when no other project is open.
+export function ProjectEditorRow(props: {
+  directory: Accessor<string>
+  automation: Accessor<AutomationDefinition>
+  projectName: Accessor<string>
+  t: Translate
+  onMove: (project: AutomationProject) => void
+}): JSX.Element {
+  const layout = useLayout()
+  const projects = createMemo<AutomationProject[]>(() =>
+    layout.projects
+      .list()
+      .filter((project) => project.id && project.id !== "global" && project.worktree)
+      .map((project) => ({ id: project.id!, worktree: project.worktree, name: project.name })),
+  )
+  const movable = createMemo(
+    () =>
+      props.automation().context === "fresh" &&
+      projects().some((project) => project.id !== props.automation().where.projectID),
+  )
+  return (
+    <EditorRow label={props.t("automations.detail.project")}>
+      <Show
+        when={movable()}
+        fallback={<span class="min-w-0 truncate text-right text-body text-fg-base">{props.projectName()}</span>}
+      >
+        <AutomationFolderPicker
+          variant="row"
+          action="automation-edit-project"
+          projects={projects()}
+          current={props.directory()}
+          onSelect={(project) => props.onMove(project)}
+        />
+      </Show>
+    </EditorRow>
   )
 }
 

--- a/packages/app/src/pages/automations/automation-detail.tsx
+++ b/packages/app/src/pages/automations/automation-detail.tsx
@@ -239,8 +239,11 @@ export function AutomationDetail(props: {
           : { kind: "recurring", ...common, rhythm: previous.rhythm, stop: previous.stop }
       const created = await globalSync.automation.create(project.worktree, input)
       if (!created) return
-      if (previous.paused) await globalSync.automation.pause(project.worktree, created.id).catch(() => {})
+      // A paused source must arrive paused: if the target pause fails, the
+      // move fails — roll the copy back rather than leave an automation the
+      // user silenced suddenly live in another project.
       try {
+        if (previous.paused) await globalSync.automation.pause(project.worktree, created.id)
         await globalSync.automation.delete(props.directory(), previous.id)
       } catch (error) {
         await globalSync.automation.delete(project.worktree, created.id).catch(() => {})

--- a/packages/app/src/pages/automations/automation-detail.tsx
+++ b/packages/app/src/pages/automations/automation-detail.tsx
@@ -1,5 +1,10 @@
 import { createEffect, createMemo, createSignal, For, Show, type Accessor, type JSX } from "solid-js"
-import type { AutomationDefinition, AutomationRun, AutomationUpdateInput } from "@opencode-ai/sdk/v2/client"
+import type {
+  AutomationCreateInput,
+  AutomationDefinition,
+  AutomationRun,
+  AutomationUpdateInput,
+} from "@opencode-ai/sdk/v2/client"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Button } from "@opencode-ai/ui/button"
 import { showToast } from "@opencode-ai/ui/toast"
@@ -10,7 +15,8 @@ import { formatServerError } from "@/utils/server-errors"
 import { getRelativeTime } from "@/utils/time"
 import { DialogDeleteAutomation } from "@/components/dialog-delete-automation"
 import { formatTimestamp } from "./automation-schedule"
-import { EditableText, ModelEditorRow, ScheduleEditorRow } from "./automation-detail-editors"
+import { EditableText, ModelEditorRow, ProjectEditorRow, ScheduleEditorRow } from "./automation-detail-editors"
+import type { AutomationProject } from "./automation-folder-picker"
 import { RunStatusIcon, runStatusLabelKey } from "./automation-run-status"
 
 const INITIAL_RUN_COUNT = 5
@@ -104,6 +110,7 @@ export function AutomationDetail(props: {
   projectName: Accessor<string>
   onBack: () => void
   onOpenRun: (sessionID: string) => void
+  onMoved: (definition: AutomationDefinition) => void
 }): JSX.Element {
   const globalSync = useGlobalSync()
   const language = useLanguage()
@@ -206,6 +213,47 @@ export function AutomationDetail(props: {
     }
   }
 
+  // There is no cross-project move on the server (per-project instances;
+  // update rejects a foreign projectID), so "move" recreates the definition in
+  // the target project, then deletes the source. Create-first so a failure
+  // loses nothing; if the source delete fails (e.g. a run in flight), the
+  // fresh copy is rolled back instead of leaving a duplicate. The id changes
+  // and the run list starts empty — past runs' sessions survive regardless.
+  const moveToProject = async (project: AutomationProject) => {
+    const previous = props.automation()
+    if (busy() || project.id === previous.where.projectID) return
+    setBusy(true)
+    try {
+      const common = {
+        title: previous.title,
+        prompt: previous.prompt,
+        context: "fresh" as const,
+        where: { projectID: project.id, ...(previous.where.worktree ? { worktree: previous.where.worktree } : {}) },
+        timezone: previous.timezone,
+        model: { providerID: previous.model.providerID, modelID: previous.model.modelID },
+        ...(previous.variant ? { variant: previous.variant } : {}),
+      }
+      const input: AutomationCreateInput =
+        previous.kind === "oneshot"
+          ? { kind: "oneshot", ...common, fireAt: previous.fireAt }
+          : { kind: "recurring", ...common, rhythm: previous.rhythm, stop: previous.stop }
+      const created = await globalSync.automation.create(project.worktree, input)
+      if (!created) return
+      if (previous.paused) await globalSync.automation.pause(project.worktree, created.id).catch(() => {})
+      try {
+        await globalSync.automation.delete(props.directory(), previous.id)
+      } catch (error) {
+        await globalSync.automation.delete(project.worktree, created.id).catch(() => {})
+        throw error
+      }
+      props.onMoved(created)
+    } catch (error) {
+      notifyFailure(error)
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const confirmDelete = () => {
     const automation = props.automation()
     dialog.show(() => (
@@ -299,7 +347,13 @@ export function AutomationDetail(props: {
           </DetailGroup>
 
           <DetailGroup heading={t("automations.detail.detailsHeading")}>
-            <InfoRow label={t("automations.detail.project")} value={props.projectName()} />
+            <ProjectEditorRow
+              directory={props.directory}
+              automation={props.automation}
+              projectName={props.projectName}
+              t={t}
+              onMove={(project) => void moveToProject(project)}
+            />
             <ScheduleEditorRow automation={props.automation} t={t} onPatch={commitPatch} />
             <Show
               when={props.automation().context === "continue" && props.automation().sourceSessionID}

--- a/packages/app/src/pages/automations/automation-detail.tsx
+++ b/packages/app/src/pages/automations/automation-detail.tsx
@@ -1,5 +1,5 @@
 import { createEffect, createMemo, createSignal, For, Show, type Accessor, type JSX } from "solid-js"
-import type { AutomationDefinition, AutomationRun } from "@opencode-ai/sdk/v2/client"
+import type { AutomationDefinition, AutomationRun, AutomationUpdateInput } from "@opencode-ai/sdk/v2/client"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Button } from "@opencode-ai/ui/button"
 import { showToast } from "@opencode-ai/ui/toast"
@@ -9,7 +9,8 @@ import { useLanguage } from "@/context/language"
 import { formatServerError } from "@/utils/server-errors"
 import { getRelativeTime } from "@/utils/time"
 import { DialogDeleteAutomation } from "@/components/dialog-delete-automation"
-import { formatScheduleSummary, formatTimestamp } from "./automation-schedule"
+import { formatTimestamp } from "./automation-schedule"
+import { EditableText, ModelEditorRow, ScheduleEditorRow } from "./automation-detail-editors"
 import { RunStatusIcon, runStatusLabelKey } from "./automation-run-status"
 
 const INITIAL_RUN_COUNT = 5
@@ -167,6 +168,18 @@ export function AutomationDetail(props: {
     })
   }
 
+  // One-field patches from the inline editors. The store applies the response
+  // immediately, so a false return tells the editor to roll its control back.
+  const commitPatch = async (patch: AutomationUpdateInput) => {
+    try {
+      await globalSync.automation.update(props.directory(), props.automation().id, patch)
+      return true
+    } catch (error) {
+      notifyFailure(error)
+      return false
+    }
+  }
+
   const runNow = async () => {
     if (busy()) return
     setBusy(true)
@@ -226,7 +239,13 @@ export function AutomationDetail(props: {
       </nav>
 
       <header class="flex items-start justify-between gap-4">
-        <h1 class="min-w-0 truncate text-h2 text-fg-strong">{props.automation().title}</h1>
+        <EditableText
+          value={props.automation().title}
+          onCommit={(next) => commitPatch({ title: next })}
+          class="min-w-0 flex-1 truncate text-h2 text-fg-strong"
+          ariaLabel={t("automations.create.titlePlaceholder")}
+          action="automation-edit-title"
+        />
         <div class="flex shrink-0 items-center gap-2">
           <Button
             variant="ghost"
@@ -255,7 +274,14 @@ export function AutomationDetail(props: {
           <h2 class="text-caption font-emphasis uppercase tracking-wide text-fg-weak">
             {t("automations.detail.instructions")}
           </h2>
-          <p class="whitespace-pre-wrap text-body text-fg-base">{props.automation().prompt}</p>
+          <EditableText
+            multiline
+            value={props.automation().prompt}
+            onCommit={(next) => commitPatch({ prompt: next })}
+            class="w-full text-body text-fg-base"
+            ariaLabel={t("automations.detail.instructions")}
+            action="automation-edit-prompt"
+          />
         </section>
 
         <aside class="flex flex-col gap-5">
@@ -274,7 +300,7 @@ export function AutomationDetail(props: {
 
           <DetailGroup heading={t("automations.detail.detailsHeading")}>
             <InfoRow label={t("automations.detail.project")} value={props.projectName()} />
-            <InfoRow label={t("automations.detail.repeats")} value={formatScheduleSummary(props.automation(), t)} />
+            <ScheduleEditorRow automation={props.automation} t={t} onPatch={commitPatch} />
             <Show
               when={props.automation().context === "continue" && props.automation().sourceSessionID}
               fallback={<InfoRow label={t("automations.detail.session")} value={sessionLabel()} />}
@@ -293,7 +319,7 @@ export function AutomationDetail(props: {
                 </div>
               )}
             </Show>
-            <InfoRow label={t("automations.detail.model")} value={props.automation().model.modelID} />
+            <ModelEditorRow directory={props.directory} automation={props.automation} t={t} onPatch={commitPatch} />
             <Show when={reasoningLabel()}>
               {(value) => <InfoRow label={t("automations.detail.reasoning")} value={value()} />}
             </Show>

--- a/packages/app/src/pages/automations/automation-folder-picker.tsx
+++ b/packages/app/src/pages/automations/automation-folder-picker.tsx
@@ -1,4 +1,4 @@
-import { For, type JSX } from "solid-js"
+import { For, Show, type JSX } from "solid-js"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Popover } from "@opencode-ai/ui/popover"
 import { getFilename } from "@opencode-ai/util/path"
@@ -16,38 +16,46 @@ const projectLabel = (project: AutomationProject) => project.name || getFilename
 // WorkspaceChip (folder icon + name + popover of open projects). Unlike the
 // chip it writes the card's local directory/projectID state instead of
 // navigating the route, so the automation can be filed against any open project.
+// The "row" variant restyles the trigger as a detail-sidebar value (no border,
+// no folder icon) for the detail page's Project editor row.
 export function AutomationFolderPicker(props: {
   projects: AutomationProject[]
   current: string
   onSelect: (project: AutomationProject) => void
+  variant?: "knob" | "row"
+  action?: string
 }): JSX.Element {
   const isActive = (project: AutomationProject) => workspaceKey(project.worktree) === workspaceKey(props.current)
   const label = () => {
     const match = props.projects.find(isActive)
     return match ? projectLabel(match) : getFilename(props.current)
   }
+  const row = () => props.variant === "row"
 
   return (
     <Popover
       modal
-      placement="bottom-start"
+      placement={row() ? "bottom-end" : "bottom-start"}
       class="min-w-56 max-w-xs"
       triggerAs="button"
       triggerProps={
         {
           type: "button",
-          "data-action": "automation-folder",
+          "data-action": props.action ?? "automation-folder",
           "data-picker-trigger": "",
           "aria-haspopup": "menu",
-          class:
-            "inline-flex h-[30px] min-w-0 items-center gap-1.5 rounded-lg border border-border-weak px-2.5 text-body text-fg-base hover:bg-row-hover-overlay focus:outline-none cursor-default",
+          class: row()
+            ? "flex min-w-0 items-center gap-1.5 truncate text-right text-body text-fg-base hover:text-fg-strong focus-visible:text-fg-strong focus:outline-none cursor-default"
+            : "inline-flex h-[30px] min-w-0 items-center gap-1.5 rounded-lg border border-border-weak px-2.5 text-body text-fg-base hover:bg-row-hover-overlay focus:outline-none cursor-default",
         } as never
       }
       trigger={
         <>
-          <Icon name="folder" class="shrink-0 text-icon-weak" />
+          <Show when={!row()}>
+            <Icon name="folder" class="shrink-0 text-icon-weak" />
+          </Show>
           <span class="min-w-0 truncate">{label()}</span>
-          <Icon name="chevron-down" class="shrink-0 text-icon-weak" />
+          <Icon name="chevron-down" class={row() ? "size-3 shrink-0 text-icon-weak" : "shrink-0 text-icon-weak"} />
         </>
       }
     >

--- a/packages/app/src/pages/automations/automation-folder-picker.tsx
+++ b/packages/app/src/pages/automations/automation-folder-picker.tsx
@@ -42,10 +42,13 @@ export function AutomationFolderPicker(props: {
         {
           type: "button",
           "data-action": props.action ?? "automation-folder",
-          "data-picker-trigger": "",
+          // data-picker-trigger carries picker.css's pill hover; the row
+          // variant instead matches the detail sidebar's underline hover so
+          // all editable rows read the same.
+          ...(row() ? {} : { "data-picker-trigger": "" }),
           "aria-haspopup": "menu",
           class: row()
-            ? "flex min-w-0 items-center gap-1.5 truncate text-right text-body text-fg-base hover:text-fg-strong focus-visible:text-fg-strong focus:outline-none cursor-default"
+            ? "flex min-w-0 items-center gap-1.5 truncate text-right text-body text-fg-base hover:text-fg-strong hover:underline focus-visible:text-fg-strong focus-visible:underline focus:outline-none cursor-default"
             : "inline-flex h-[30px] min-w-0 items-center gap-1.5 rounded-lg border border-border-weak px-2.5 text-body text-fg-base hover:bg-row-hover-overlay focus:outline-none cursor-default",
         } as never
       }

--- a/packages/app/src/pages/automations/automation-list.tsx
+++ b/packages/app/src/pages/automations/automation-list.tsx
@@ -50,7 +50,10 @@ export function AutomationList(props: {
               {/* Same three actions as the detail header, surfaced on hover in
                   place of the schedule summary. Siblings of the row button, so
                   clicking one never opens the row. */}
-              <div class="absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/automation:opacity-100">
+              <div
+                data-component="automation-row-actions"
+                class="absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/automation:opacity-100 group-focus-within/automation:opacity-100"
+              >
                 <Button
                   variant="ghost"
                   icon="trash"

--- a/packages/app/src/pages/automations/automation-list.tsx
+++ b/packages/app/src/pages/automations/automation-list.tsx
@@ -1,5 +1,6 @@
 import { For, type Accessor, type JSX } from "solid-js"
 import type { AutomationDefinition } from "@opencode-ai/sdk/v2/client"
+import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { useLanguage } from "@/context/language"
 import { formatScheduleSummary } from "./automation-schedule"
@@ -13,6 +14,8 @@ export function AutomationList(props: {
   items: Accessor<AutomationListItem[]>
   onSelect: (id: string) => void
   onToggleActive: (automation: AutomationDefinition) => void
+  onRunNow: (automation: AutomationDefinition) => void
+  onDelete: (automation: AutomationDefinition) => void
 }): JSX.Element {
   const language = useLanguage()
   return (
@@ -44,18 +47,37 @@ export function AutomationList(props: {
                   {formatScheduleSummary(automation, language.t)}
                 </span>
               </button>
-              <button
-                type="button"
-                data-action="automation-toggle-active"
-                data-automation-id={automation.id}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  props.onToggleActive(automation)
-                }}
-                class="absolute right-2.5 top-1/2 -translate-y-1/2 rounded px-1.5 py-0.5 text-caption text-fg-weak opacity-0 transition-colors hover:bg-row-hover-overlay hover:text-fg-strong focus-visible:opacity-100 focus:outline-none group-hover/automation:opacity-100"
-              >
-                {automation.paused ? language.t("automations.action.resume") : language.t("automations.action.pause")}
-              </button>
+              {/* Same three actions as the detail header, surfaced on hover in
+                  place of the schedule summary. Siblings of the row button, so
+                  clicking one never opens the row. */}
+              <div class="absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/automation:opacity-100">
+                <Button
+                  variant="ghost"
+                  icon="trash"
+                  data-action="automation-delete"
+                  data-automation-id={automation.id}
+                  aria-label={language.t("automations.action.delete")}
+                  onClick={() => props.onDelete(automation)}
+                />
+                <Button
+                  variant="ghost"
+                  icon={automation.paused ? "play" : "pause"}
+                  data-action="automation-toggle-active"
+                  data-automation-id={automation.id}
+                  aria-label={
+                    automation.paused ? language.t("automations.action.resume") : language.t("automations.action.pause")
+                  }
+                  onClick={() => props.onToggleActive(automation)}
+                />
+                <Button
+                  variant="ghost"
+                  icon="play"
+                  data-action="automation-run-now"
+                  data-automation-id={automation.id}
+                  aria-label={language.t("automations.action.runNow")}
+                  onClick={() => props.onRunNow(automation)}
+                />
+              </div>
             </li>
           )
         }}

--- a/packages/app/src/pages/automations/automation-schedule-controls.tsx
+++ b/packages/app/src/pages/automations/automation-schedule-controls.tsx
@@ -1,7 +1,13 @@
 import { For, Show, type JSX } from "solid-js"
 import { Popover } from "@opencode-ai/ui/popover"
 import type { useLanguage } from "@/context/language"
-import { frequencyLabel, scheduleTimeLabel, SCHEDULE_FREQUENCIES, type ScheduleDraft } from "./automation-schedule-form"
+import {
+  frequencyLabel,
+  scheduleTimeLabel,
+  SCHEDULE_FREQUENCIES,
+  type ScheduleDraft,
+  type ScheduleFrequency,
+} from "./automation-schedule-form"
 
 type Translate = ReturnType<typeof useLanguage>["t"]
 
@@ -58,6 +64,10 @@ export function AutomationScheduleControls(props: {
   value: ScheduleDraft
   onChange: (next: ScheduleDraft) => void
   t: Translate
+  // The edit popover narrows the choices: a recurring automation cannot become
+  // a one-shot (or vice versa) through update, so it only offers the
+  // frequencies its kind supports. The create card omits this and gets all four.
+  frequencies?: ScheduleFrequency[]
 }): JSX.Element {
   return (
     <div data-component="automation-schedule" class="flex flex-wrap items-center gap-x-3 gap-y-2">
@@ -66,7 +76,7 @@ export function AutomationScheduleControls(props: {
         role="radiogroup"
         class="inline-flex h-[30px] items-center gap-0.5 rounded-lg border border-border-weak p-0.5"
       >
-        <For each={SCHEDULE_FREQUENCIES}>
+        <For each={props.frequencies ?? SCHEDULE_FREQUENCIES}>
           {(freq) => (
             <button
               type="button"

--- a/packages/app/src/pages/automations/automation-schedule-form.test.ts
+++ b/packages/app/src/pages/automations/automation-schedule-form.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import type { AutomationDefinition, AutomationRhythm } from "@opencode-ai/sdk/v2/client"
+import { scheduleDraftFromDefinition } from "./automation-schedule-form"
+
+const recurring = (rhythm: AutomationRhythm): AutomationDefinition =>
+  ({ kind: "recurring", rhythm }) as AutomationDefinition
+
+const oneshot = (fireAt: number, timezone: string): AutomationDefinition =>
+  ({ kind: "oneshot", fireAt, timezone }) as AutomationDefinition
+
+describe("scheduleDraftFromDefinition", () => {
+  test("daily cron round-trips", () => {
+    expect(scheduleDraftFromDefinition(recurring({ kind: "cron", expression: "5 9 * * *" }))).toEqual({
+      frequency: "daily",
+      hour: 9,
+      minute: 5,
+      weekday: 1,
+    })
+  })
+
+  test("weekdays cron round-trips", () => {
+    expect(scheduleDraftFromDefinition(recurring({ kind: "cron", expression: "0 18 * * 1-5" }))).toEqual({
+      frequency: "weekdays",
+      hour: 18,
+      minute: 0,
+      weekday: 1,
+    })
+  })
+
+  test("weekly cron keeps the weekday", () => {
+    expect(scheduleDraftFromDefinition(recurring({ kind: "cron", expression: "30 8 * * 0" }))).toEqual({
+      frequency: "weekly",
+      hour: 8,
+      minute: 30,
+      weekday: 0,
+    })
+  })
+
+  test("oneshot maps fireAt to local time in the definition timezone", () => {
+    // 2026-06-12T09:00 in Asia/Shanghai = 2026-06-12T01:00 UTC.
+    const fireAt = Date.UTC(2026, 5, 12, 1, 0)
+    expect(scheduleDraftFromDefinition(oneshot(fireAt, "Asia/Shanghai"))).toEqual({
+      frequency: "once",
+      hour: 9,
+      minute: 0,
+      weekday: 1,
+    })
+  })
+
+  test("arbitrary cron does not map", () => {
+    expect(scheduleDraftFromDefinition(recurring({ kind: "cron", expression: "0 * * * *" }))).toBeUndefined()
+    expect(scheduleDraftFromDefinition(recurring({ kind: "cron", expression: "*/15 * * * *" }))).toBeUndefined()
+    expect(scheduleDraftFromDefinition(recurring({ kind: "cron", expression: "0 9 1 * *" }))).toBeUndefined()
+    expect(scheduleDraftFromDefinition(recurring({ kind: "cron", expression: "99 9 * * *" }))).toBeUndefined()
+  })
+
+  test("interval rhythm does not map", () => {
+    expect(scheduleDraftFromDefinition(recurring({ kind: "interval", everyMs: 3600000 }))).toBeUndefined()
+  })
+})

--- a/packages/app/src/pages/automations/automation-schedule-form.ts
+++ b/packages/app/src/pages/automations/automation-schedule-form.ts
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon"
+import type { AutomationDefinition } from "@opencode-ai/sdk/v2/client"
 
 // Input side of the schedule picker (draft -> AutomationCreateInput). The read
 // side (definition -> human label) lives in automation-schedule.ts and still
@@ -69,6 +70,27 @@ export function buildScheduleInput(
     return { kind: "oneshot", fireAt: nextDailyFireAt(draft.hour, draft.minute, timezone, now) }
   }
   return { kind: "recurring", rhythm: { kind: "cron", expression: cronForSchedule(draft) } }
+}
+
+// Inverse of buildScheduleInput, for prefilling the schedule editor from an
+// existing definition. Only the four picker frequencies round-trip; an
+// arbitrary cron created via the SDK or automate tool (hourly, day-of-month…)
+// returns undefined and the editor must keep the original rhythm untouched.
+export function scheduleDraftFromDefinition(definition: AutomationDefinition): ScheduleDraft | undefined {
+  if (definition.kind === "oneshot") {
+    const at = DateTime.fromMillis(definition.fireAt, { zone: definition.timezone })
+    if (!at.isValid) return undefined
+    return { frequency: "once", hour: at.hour, minute: at.minute, weekday: DEFAULT_SCHEDULE.weekday }
+  }
+  if (definition.rhythm.kind !== "cron") return undefined
+  const match = definition.rhythm.expression.match(/^(\d{1,2}) (\d{1,2}) \* \* (\*|1-5|[0-6])$/)
+  if (!match) return undefined
+  const minute = Number(match[1])
+  const hour = Number(match[2])
+  if (minute > 59 || hour > 23) return undefined
+  if (match[3] === "*") return { frequency: "daily", hour, minute, weekday: DEFAULT_SCHEDULE.weekday }
+  if (match[3] === "1-5") return { frequency: "weekdays", hour, minute, weekday: DEFAULT_SCHEDULE.weekday }
+  return { frequency: "weekly", hour, minute, weekday: Number(match[3]) }
 }
 
 // Short label for the Schedule knob / popover trigger, reusing the same i18n

--- a/packages/app/src/pages/automations/automations-surface.tsx
+++ b/packages/app/src/pages/automations/automations-surface.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
 import { displayName, workspaceKey } from "@/pages/layout/helpers"
 import { formatServerError } from "@/utils/server-errors"
+import { DialogDeleteAutomation } from "@/components/dialog-delete-automation"
 import { AutomationList } from "./automation-list"
 import { AutomationDetail } from "./automation-detail"
 import { AutomationCreateDialog } from "./automation-create-dialog"
@@ -92,9 +93,12 @@ export function AutomationsSurface(props: {
   onMount(() => {
     const onEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return
+      // Inline editors on the detail page own Escape (revert + blur); only an
+      // Escape outside an editable control navigates.
+      if (event.target instanceof Element && event.target.closest("input, textarea")) return
       if (
         document.querySelector(
-          '[data-component="dialog-overlay"], [data-component="select-content"], [data-component="dropdown-menu-content"], [data-component="context-menu-content"]',
+          '[data-component="dialog-overlay"], [data-component="select-content"], [data-component="dropdown-menu-content"], [data-component="context-menu-content"], [data-component="popover-content"], [data-picker-content]',
         )
       )
         return
@@ -153,6 +157,14 @@ export function AutomationsSurface(props: {
     return itemForAutomation(id)
   })
 
+  const notifyFailure = (error: unknown) => {
+    showToast({
+      variant: "error",
+      title: language.t("automations.toast.actionFailed.title"),
+      description: formatServerError(error, language.t),
+    })
+  }
+
   const toggleActive = async (automation: AutomationDefinition) => {
     const item = itemForAutomation(automation.id)
     if (!item) return
@@ -160,12 +172,36 @@ export function AutomationsSurface(props: {
       if (automation.paused) await globalSync.automation.resume(item.directory, automation.id)
       else await globalSync.automation.pause(item.directory, automation.id)
     } catch (error) {
-      showToast({
-        variant: "error",
-        title: language.t("automations.toast.actionFailed.title"),
-        description: formatServerError(error, language.t),
-      })
+      notifyFailure(error)
     }
+  }
+
+  const runNow = async (automation: AutomationDefinition) => {
+    const item = itemForAutomation(automation.id)
+    if (!item) return
+    try {
+      await globalSync.automation.runNow(item.directory, automation.id)
+    } catch (error) {
+      notifyFailure(error)
+    }
+  }
+
+  const confirmDelete = (automation: AutomationDefinition) => {
+    const item = itemForAutomation(automation.id)
+    if (!item) return
+    dialog.show(() => (
+      <DialogDeleteAutomation
+        title={automation.title}
+        onConfirm={async () => {
+          try {
+            await globalSync.automation.delete(item.directory, automation.id)
+          } catch (error) {
+            notifyFailure(error)
+            throw error
+          }
+        }}
+      />
+    ))
   }
 
   // On a first-class page the create actions must not silently no-op: with no
@@ -245,7 +281,13 @@ export function AutomationsSurface(props: {
                 when={automationItems().length > 0}
                 fallback={<AutomationsEmpty onUseTemplate={openCreate} disabled={!canCreateManually()} />}
               >
-                <AutomationList items={automationItems} onSelect={setSelectedID} onToggleActive={toggleActive} />
+                <AutomationList
+                  items={automationItems}
+                  onSelect={setSelectedID}
+                  onToggleActive={toggleActive}
+                  onRunNow={runNow}
+                  onDelete={confirmDelete}
+                />
               </Show>
             </div>
           }

--- a/packages/app/src/pages/automations/automations-surface.tsx
+++ b/packages/app/src/pages/automations/automations-surface.tsx
@@ -299,6 +299,7 @@ export function AutomationsSurface(props: {
               projectName={() => item().projectName}
               onBack={() => setSelectedID(undefined)}
               onOpenRun={props.onOpenRun}
+              onMoved={(definition) => setSelectedID(definition.id)}
             />
           )}
         </Show>


### PR DESCRIPTION
## Summary

The Automations panel was read-only after creation: detail fields (title, prompt, schedule, model) were static text, and list rows only offered a pause toggle — even though the server has long shipped a full `PUT /automation/:id` update route. This PR makes the panel editable in place and gives list rows the same three actions as the detail header.

Related: complements #1249 (conversation-side `automate_manage`), which explicitly scopes panel UI out; #1249's v1 design defers `edit` to "a panel action" — this is that panel action. No dependency between the two: both wrap the same existing Automation service.

## Changes

**Detail page — inline editing, one field per patch, no edit mode**
- Title and instructions are transparent always-editable inputs: blur commits, Escape or an empty value reverts.
- The Repeats row opens the create card's schedule controls (`AutomationScheduleControls`) in a popover. The kind is fixed by the server (no oneshot↔recurring conversion), so the frequency switch only offers what the kind supports; an arbitrary cron (hourly, day-of-month…) keeps its rhythm until the user explicitly picks a picker frequency.
- The Model row reuses the composer's `ModelSelectorPopover`. Switching models clears the variant; picking a thinking level patches the variant alone.
- The Project row moves the automation to another open project. There is no server-side move (per-project instances; update rejects a foreign projectID) and none is needed — moving only has to affect future runs: the row reuses the create card's folder picker (new "row" trigger variant) and performs create-in-target + delete-from-source. Create-first so a failure loses nothing; if the source delete fails the fresh copy is rolled back. The id changes, the run list starts empty, past runs' sessions survive, paused state is re-applied. A continue automation stays read-only (bound to a conversation in its source project), as does everything when no other project is open.

**List rows** — delete (shared confirm dialog), pause/resume, and run-now ghost icon buttons fade in on hover where the schedule summary fades out, replacing the lone text-styled pause button.

**Plumbing** — `globalSync.automation.update` wrapper (revision-gated apply, same pattern as pause/delete); `scheduleDraftFromDefinition` inverse mapping with unit tests; the surface's capture-phase Escape handler now yields to open popovers/pickers and focused inputs so Escape closes the top layer instead of unwinding the detail view.

No new i18n keys — all labels reuse existing `automations.*` strings. The create dialog is untouched.

## Verification

- `bun test src/pages/automations` — 15 pass (new `automation-schedule-form.test.ts` covers cron↔draft round-trips and non-mapping crons)
- `bun run typecheck` (packages/app) and `eslint` on touched files — clean
- E2E `e2e/automations/automations-panel.spec.ts` — 15 pass locally, including three new user-path tests: cross-project move (definition lands in the target SDK, vanishes from the source, detail stays open on the recreated automation), detail inline edit (title/prompt/schedule/model committed through the real UI, asserted via SDK polls; recurring popover offers no "Once") and list row hover actions (run now / pause / delete through the confirm dialog)
- Visual check: `bun run snap automations-surface` with two new shots (`detail-schedule`, `detail-model`); reviewed the grid — list-hover shows the three ghost icons, the schedule popover renders Daily | Weekdays | Weekly + time token, the model picker opens anchored to the Model row

## Residual risk

- Per-knob schedule commits mean switching frequency then time issues two small PUTs; each intermediate state is a valid schedule and the store applies the authoritative response, so no torn state.
- Real-window (Electron) walk of the new popovers not done in this PR; the same popover stack is already exercised inside the create dialog in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline editing for automation title, prompt, schedule, model, and project (move between projects) in the detail view.
  * Hover-visible row actions: Run Now, Pause/Resume, and Delete; Run Now and pause state preserved when moving.
  * Updated schedule editor to show/read unsupported rhythms and improved model picker; restyled folder trigger variant.

* **Tests**
  * New e2e coverage validating inline edits, project moves (including rollback cases), row actions, and updated UI snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
