### PR TITLE
test(opencode): relax prompt cancel race timeout

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -79,6 +79,8 @@ function defer<T>() {
   return { promise, resolve }
 }
 
+const cancelRaceCheckpointTimeout = "5 seconds"
+
 type Mutable<T> = { -readonly [K in keyof T]: T[K] }
 
 function withSh<A, E, R>(fx: () => Effect.Effect<A, E, R>) {
@@ -1801,11 +1803,14 @@ it.live(
         yield* Effect.addFinalizer(() => Effect.sync(() => void (mutableSessions.updateMessage = originalUpdateMessage)))
 
         const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
-        const startedExit = yield* Effect.promise(() => started.promise).pipe(Effect.timeout("1 second"), Effect.exit)
+        const startedExit = yield* Effect.promise(() => started.promise).pipe(
+          Effect.timeout(cancelRaceCheckpointTimeout),
+          Effect.exit,
+        )
         expect(Exit.isSuccess(startedExit)).toBe(true)
-        const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout("1 second"), Effect.exit)
+        const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout(cancelRaceCheckpointTimeout), Effect.exit)
         expect(Exit.isSuccess(cancelExit)).toBe(true)
-        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout("1 second"))
+        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout(cancelRaceCheckpointTimeout))
         expect(Exit.isSuccess(exit)).toBe(true)
 
         const messages = yield* sessions.messages({ sessionID: chat.id })
@@ -1855,11 +1860,14 @@ it.live(
         yield* Effect.addFinalizer(() => Effect.sync(() => void (mutablePlugin.trigger = originalTrigger)))
 
         const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
-        const startedExit = yield* Effect.promise(() => started.promise).pipe(Effect.timeout("1 second"), Effect.exit)
+        const startedExit = yield* Effect.promise(() => started.promise).pipe(
+          Effect.timeout(cancelRaceCheckpointTimeout),
+          Effect.exit,
+        )
         expect(Exit.isSuccess(startedExit)).toBe(true)
-        const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout("1 second"), Effect.exit)
+        const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout(cancelRaceCheckpointTimeout), Effect.exit)
         expect(Exit.isSuccess(cancelExit)).toBe(true)
-        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout("1 second"))
+        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout(cancelRaceCheckpointTimeout))
         expect(Exit.isSuccess(exit)).toBe(true)
 
         const messages = yield* sessions.messages({ sessionID: chat.id })


### PR DESCRIPTION
## Summary

Relax the timeout guard used by the prompt cancel race regression tests.

There is no related issue; this is a small Windows advisory flake fix discovered while checking PR #1274.

## Why

Windows advisory has intermittently failed in `unit-windows-opencode-session` because `cancel after processor handle creation finalizes before process starts` only waited one second for the prompt loop to reach `experimental.chat.messages.transform`. Recent Windows runs show the same test can validly take around 1.6-2.0 seconds, and `dev` has already seen the same failure outside PR #1274.

The test contract is that cancellation finalizes the assistant once the race checkpoint is reached, not that Windows must reach that checkpoint within one second.

## Related Issue

No issue. Follow-up from Windows advisory diagnosis on PR #1274.

## Human Review Status

Pending

## Review Focus

Please check that this stays test-only and preserves the race checkpoint: the tests still wait for the real `started` signal before canceling; only the guard timeout changed.

## Risk Notes

Low. This only touches test code. It does not change session runtime behavior.

Skipped conditional checklist items:
- Visible UI/manual check: not applicable; no UI or copy changes.
- Platform/packaging check: this touches Windows advisory test reliability only, not runtime platform behavior.
- Docs/release/dependency/etc.: not applicable.

## How To Verify

```text
Focused prompt cancel regressions: bun test --timeout 30000 test/session/prompt-effect.test.ts -t "cancel after assistant scaffold save finalizes before processor handle|cancel after processor handle creation finalizes before process starts" -> 2 passed
Prompt effect suite: bun test --timeout 30000 test/session/prompt-effect.test.ts -> 67 passed
Opencode typecheck: bun run typecheck -> passed
Whitespace: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
