### PR TITLE
chore(release): bump desktop version to v2026.6.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.6.5",
+      "version": "2026.6.6",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.6.5",
+  "version": "2026.6.6",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the PawWork desktop release metadata from `2026.6.5` to `2026.6.6` so the production release workflow can build the next stable desktop version. The release tag will be `v2026.6.6`.

Scope:
- `packages/desktop-electron/package.json` version `2026.6.5` -> `2026.6.6`
- `bun.lock` workspace package version `2026.6.5` -> `2026.6.6`

There is no linked issue because this is the release-prep version bump for the current `dev` tip.

## Why

Version bumps are a manual prerequisite to the `build.yml` release dispatch. This PR only moves the pinned desktop version and matching workspace lock metadata; no product code, workflow behavior, dependency version, or generated release asset changes are included.

## Related Issue

None. Release-prep version bump only.

## Human Review Status

Pending

## Review Focus

Confirm the version is advanced to `2026.6.6` in both release metadata sources and that no dependency or product-code drift is included.

## Risk Notes

- No product code or release workflow behavior changed.
- Production artifacts, R2 mirror, and packaged startup smoke are verified after the release workflow publishes `v2026.6.6`.
- The visible UI / copy checklist item is not applicable because this PR changes only release metadata.

## How To Verify

```text
bun install --frozen-lockfile: dependencies installed and lockfile accepted before the bump.
bun install --lockfile-only: updated only the workspace package version in bun.lock.
bun run typecheck:release (from packages/desktop-electron): passed.
bun test scripts/verify-release.test.ts scripts/release-metadata-contract.test.ts scripts/publish-when-complete.test.ts scripts/mirror-release-to-r2.test.ts scripts/release-workflow-contract.test.ts (from packages/desktop-electron): 77 pass, 0 fail.
release version metadata check: package.json and bun.lock both report 2026.6.6.
git diff --check: no whitespace errors.
```

## Screenshots or Recordings

Not applicable. No visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.