### PR TITLE
fix(app): smooth session switch timeline recovery

### DIFF
--- a/packages/app/src/pages/session/use-session-refresh-effects.test.ts
+++ b/packages/app/src/pages/session/use-session-refresh-effects.test.ts
@@ -3,6 +3,7 @@ import { runBrowserCheck } from "@/testing/browser-subprocess"
 
 const browserCheck = String.raw`
 import { createRoot, createSignal } from "solid-js"
+import { clearSessionPrefetch, SESSION_PREFETCH_TTL, setSessionPrefetch } from "./src/context/global-sync/session-prefetch.ts"
 import { useSessionRefreshEffects } from "./src/pages/session/use-session-refresh-effects.ts"
 
 const assert = (condition, message) => {
@@ -22,31 +23,61 @@ const installAnimationFrameQueue = () => {
   globalThis.cancelAnimationFrame = (id) => {
     frames.delete(id)
   }
+
+  return {
+    runFrame: () => {
+      const pending = [...frames.entries()]
+      frames.clear()
+      for (const [, callback] of pending) callback(0)
+    },
+  }
 }
 
 const installTimerQueue = () => {
   let nextID = 1
   const timers = new Map()
 
-  window.setTimeout = (callback) => {
+  window.setTimeout = (callback, ms = 0) => {
     const id = nextID++
-    timers.set(id, callback)
+    timers.set(id, { callback, ms })
     return id
   }
 
   window.clearTimeout = (id) => {
     timers.delete(id)
   }
+
+  return {
+    runDue: (maxMs) => {
+      const due = [...timers.entries()].filter(([, timer]) => timer.ms <= maxMs)
+      for (const [id, timer] of due) {
+        if (!timers.delete(id)) continue
+        timer.callback()
+      }
+    },
+    runAll: () => {
+      const pending = [...timers.entries()]
+      timers.clear()
+      for (const [, timer] of pending) timer.callback()
+    },
+  }
 }
 
-const mountRefreshEffects = ({ hasTodoCache, recoveryEpoch = () => 0, validatedRecoveryEpoch = () => 0 }) => {
+const mountRefreshEffects = ({
+  hasMessageCache = () => true,
+  hasTodoCache,
+  recoveryEpoch = () => 0,
+  validatedRecoveryEpoch = () => 0,
+  initialSessionID = "ses_initial",
+}) => {
   const scheduledTodos = []
   const canceledTodos = []
+  const syncedSessions = []
   const syncedTodos = []
 
-  const dispose = createRoot((dispose) => {
+  const root = createRoot((dispose) => {
     const [directory] = createSignal("dir-a")
-    const [sessionID] = createSignal("ses_initial")
+    const [sessionID, setSessionID] = createSignal(initialSessionID)
 
     useSessionRefreshEffects({
       directory,
@@ -54,7 +85,7 @@ const mountRefreshEffects = ({ hasTodoCache, recoveryEpoch = () => 0, validatedR
       timelineSessionID: sessionID,
       statusType: () => "idle",
       blocked: () => false,
-      hasMessageCache: () => true,
+      hasMessageCache,
       hasTodoCache,
       isTodoInvalidated: () => false,
       scheduleTodoHydrate: (directory, sessionID, reason) => {
@@ -65,17 +96,19 @@ const mountRefreshEffects = ({ hasTodoCache, recoveryEpoch = () => 0, validatedR
       },
       recoveryEpoch,
       validatedRecoveryEpoch,
-      syncSession: () => {},
+      syncSession: (sessionID, options) => {
+        syncedSessions.push({ sessionID, options })
+      },
       syncTodo: (sessionID, options) => {
         syncedTodos.push({ sessionID, options })
       },
       emitRendererDiagnostic: () => {},
     })
 
-    return dispose
+    return { dispose, setSessionID }
   })
 
-  return { dispose, scheduledTodos, canceledTodos, syncedTodos }
+  return { dispose: root.dispose, setSessionID: root.setSessionID, scheduledTodos, canceledTodos, syncedSessions, syncedTodos }
 }
 
 {
@@ -99,6 +132,73 @@ const mountRefreshEffects = ({ hasTodoCache, recoveryEpoch = () => 0, validatedR
 
   await Promise.resolve()
   assert(scheduledTodos.length === 0, "initial cached idle todo should not schedule a redundant hydrate")
+  dispose()
+}
+
+{
+  const frames = installAnimationFrameQueue()
+  const timers = installTimerQueue()
+  clearSessionPrefetch("dir-a", ["ses_stale"])
+  setSessionPrefetch({
+    directory: "dir-a",
+    sessionID: "ses_stale",
+    limit: 200,
+    complete: false,
+    at: Date.now() - SESSION_PREFETCH_TTL - 1,
+  })
+  const { dispose, syncedSessions } = mountRefreshEffects({
+    initialSessionID: "ses_stale",
+    hasMessageCache: () => true,
+    hasTodoCache: () => true,
+  })
+
+  await Promise.resolve()
+  assert(syncedSessions.length === 1, "stale cached message session should start with the normal sync only")
+  assert(!syncedSessions[0].options?.force, "initial stale cached message sync should not be forced")
+
+  frames.runFrame()
+  timers.runDue(0)
+  await Promise.resolve()
+  assert(syncedSessions.length === 1, "stale cached message force should not run in the first switch tick")
+
+  timers.runAll()
+  await Promise.resolve()
+  assert(syncedSessions.length === 2, "stale cached message force should eventually run when it remains stale")
+  assert(syncedSessions[1].options?.force === true, "delayed stale cached message sync should be forced")
+  clearSessionPrefetch("dir-a", ["ses_stale"])
+  dispose()
+}
+
+{
+  const frames = installAnimationFrameQueue()
+  const timers = installTimerQueue()
+  clearSessionPrefetch("dir-a", ["ses_freshened"])
+  setSessionPrefetch({
+    directory: "dir-a",
+    sessionID: "ses_freshened",
+    limit: 200,
+    complete: false,
+    at: Date.now() - SESSION_PREFETCH_TTL - 1,
+  })
+  const { dispose, syncedSessions } = mountRefreshEffects({
+    initialSessionID: "ses_freshened",
+    hasMessageCache: () => true,
+    hasTodoCache: () => true,
+  })
+
+  await Promise.resolve()
+  frames.runFrame()
+  setSessionPrefetch({
+    directory: "dir-a",
+    sessionID: "ses_freshened",
+    limit: 200,
+    complete: false,
+    at: Date.now(),
+  })
+  timers.runAll()
+  await Promise.resolve()
+  assert(syncedSessions.length === 1, "freshened cached message session should not force refresh from a captured stale flag")
+  clearSessionPrefetch("dir-a", ["ses_freshened"])
   dispose()
 }
 

--- a/packages/app/src/pages/session/use-session-refresh-effects.test.ts
+++ b/packages/app/src/pages/session/use-session-refresh-effects.test.ts
@@ -10,6 +10,9 @@ const assert = (condition, message) => {
   if (!condition) throw new Error(message)
 }
 
+const now = 1_000_000
+Date.now = () => now
+
 const installAnimationFrameQueue = () => {
   let nextID = 1
   const frames = new Map()
@@ -144,7 +147,7 @@ const mountRefreshEffects = ({
     sessionID: "ses_stale",
     limit: 200,
     complete: false,
-    at: Date.now() - SESSION_PREFETCH_TTL - 1,
+    at: Date.now() - SESSION_PREFETCH_TTL,
   })
   const { dispose, syncedSessions } = mountRefreshEffects({
     initialSessionID: "ses_stale",

--- a/packages/app/src/pages/session/use-session-refresh-effects.test.ts
+++ b/packages/app/src/pages/session/use-session-refresh-effects.test.ts
@@ -160,13 +160,13 @@ const mountRefreshEffects = ({
   assert(!syncedSessions[0].options?.force, "initial stale cached message sync should not be forced")
 
   frames.runFrame()
-  timers.runDue(0)
+  timers.runDue(499)
   await Promise.resolve()
-  assert(syncedSessions.length === 1, "stale cached message force should not run in the first switch tick")
+  assert(syncedSessions.length === 1, "stale cached message force should not run before 500ms")
 
-  timers.runAll()
+  timers.runDue(500)
   await Promise.resolve()
-  assert(syncedSessions.length === 2, "stale cached message force should eventually run when it remains stale")
+  assert(syncedSessions.length === 2, "stale cached message force should run at 500ms when it remains stale")
   assert(syncedSessions[1].options?.force === true, "delayed stale cached message sync should be forced")
   clearSessionPrefetch("dir-a", ["ses_stale"])
   dispose()

--- a/packages/app/src/pages/session/use-session-refresh-effects.ts
+++ b/packages/app/src/pages/session/use-session-refresh-effects.ts
@@ -8,6 +8,14 @@ type TodoSyncOptions = {
   reason?: TodoHydrateReason
 }
 
+const STALE_SESSION_FORCE_REFRESH_DELAY_MS = 500
+
+function isSessionPrefetchStale(directory: string, sessionID: string) {
+  const info = getSessionPrefetch(directory, sessionID)
+  if (!info) return true
+  return Date.now() - info.at > SESSION_PREFETCH_TTL
+}
+
 export function useSessionRefreshEffects(input: {
   directory: () => string
   routeSessionID: () => string | undefined
@@ -129,7 +137,7 @@ export function useSessionRefreshEffects(input: {
   }
 
   createEffect(
-    on([input.directory, input.routeSessionID] as const, ([, id]) => {
+    on([input.directory, input.routeSessionID] as const, ([directory, id]) => {
       if (refreshFrame !== undefined) cancelAnimationFrame(refreshFrame)
       if (refreshTimer !== undefined) window.clearTimeout(refreshTimer)
       refreshFrame = undefined
@@ -137,26 +145,23 @@ export function useSessionRefreshEffects(input: {
       if (!id) return
 
       const cached = untrack(() => input.hasMessageCache(id))
-      const stale = !cached
-        ? false
-        : (() => {
-            const info = getSessionPrefetch(input.directory(), id)
-            if (!info) return true
-            return Date.now() - info.at > SESSION_PREFETCH_TTL
-          })()
       untrack(() => {
         syncSessionWithDiagnostics(id, undefined, cached)
       })
+
+      if (!cached || !isSessionPrefetchStale(directory, id)) return
 
       refreshFrame = requestAnimationFrame(() => {
         refreshFrame = undefined
         refreshTimer = window.setTimeout(() => {
           refreshTimer = undefined
-          if (input.routeSessionID() !== id) return
+          if (input.directory() !== directory || input.routeSessionID() !== id) return
           untrack(() => {
-            if (stale) syncSessionWithDiagnostics(id, { force: true }, cached)
+            const currentCached = input.hasMessageCache(id)
+            if (!currentCached || !isSessionPrefetchStale(directory, id)) return
+            syncSessionWithDiagnostics(id, { force: true }, currentCached)
           })
-        }, 0)
+        }, STALE_SESSION_FORCE_REFRESH_DELAY_MS)
       })
     }),
   )

--- a/packages/app/src/pages/session/use-session-refresh-effects.ts
+++ b/packages/app/src/pages/session/use-session-refresh-effects.ts
@@ -13,7 +13,7 @@ const STALE_SESSION_FORCE_REFRESH_DELAY_MS = 500
 function isSessionPrefetchStale(directory: string, sessionID: string) {
   const info = getSessionPrefetch(directory, sessionID)
   if (!info) return true
-  return Date.now() - info.at > SESSION_PREFETCH_TTL
+  return Date.now() - info.at >= SESSION_PREFETCH_TTL
 }
 
 export function useSessionRefreshEffects(input: {

--- a/packages/app/src/pages/session/use-session-timeline-interaction.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from "bun:test"
 import { runBrowserCheck } from "@/testing/browser-subprocess"
 
 const browserCheck = String.raw`
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
 import { MemoryRouter, Route } from "@solidjs/router"
 import { createRoot } from "solid-js"
 import { createSessionTimelineInteraction } from "./src/pages/session/use-session-timeline-interaction.ts"
@@ -130,7 +131,7 @@ assert(viewport.scrollTop === 0, "system scroll drift should not synchronously w
 frames.runFrame()
 assert(viewport.scrollTop === 600, "system scroll drift should reconcile on the next frame")
 root.dispose()
-process.exit(0)
+GlobalRegistrator.unregister()
 `
 
 describe("createSessionTimelineInteraction", () => {

--- a/packages/app/src/pages/session/use-session-timeline-interaction.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.test.ts
@@ -1,0 +1,140 @@
+import { describe, test } from "bun:test"
+import { runBrowserCheck } from "@/testing/browser-subprocess"
+
+const browserCheck = String.raw`
+import { MemoryRouter, Route } from "@solidjs/router"
+import { createRoot } from "solid-js"
+import { createSessionTimelineInteraction } from "./src/pages/session/use-session-timeline-interaction.ts"
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message)
+}
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    disconnect() {}
+  }
+}
+
+const installAnimationFrameQueue = () => {
+  let nextID = 1
+  const frames = new Map()
+
+  globalThis.requestAnimationFrame = (callback) => {
+    const id = nextID++
+    frames.set(id, callback)
+    return id
+  }
+
+  globalThis.cancelAnimationFrame = (id) => {
+    frames.delete(id)
+  }
+
+  return {
+    runFrame: () => {
+      const pending = [...frames.entries()]
+      frames.clear()
+      for (const [, callback] of pending) callback(0)
+    },
+  }
+}
+
+const installTimerQueue = () => {
+  let nextID = 1
+  const timers = new Map()
+
+  globalThis.setTimeout = (callback, ms = 0) => {
+    const id = nextID++
+    timers.set(id, { callback, ms })
+    return id
+  }
+  globalThis.clearTimeout = (id) => {
+    timers.delete(id)
+  }
+  window.setTimeout = globalThis.setTimeout
+  window.clearTimeout = globalThis.clearTimeout
+}
+
+const makeViewport = ({ scrollTop, clientHeight, scrollHeight }) => {
+  const viewport = document.createElement("div")
+  let top = scrollTop
+  Object.defineProperties(viewport, {
+    clientHeight: { value: clientHeight, configurable: true },
+    scrollHeight: { value: scrollHeight, configurable: true },
+    scrollTop: { configurable: true, get: () => top, set: (value) => { top = value } },
+  })
+  viewport.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 720,
+    bottom: clientHeight,
+    width: 720,
+    height: clientHeight,
+    toJSON: () => ({}),
+  })
+  viewport.scrollTo = ({ top }) => {
+    viewport.scrollTop = top
+  }
+  return viewport
+}
+
+const frames = installAnimationFrameQueue()
+installTimerQueue()
+const viewport = makeViewport({ scrollTop: 0, clientHeight: 400, scrollHeight: 1000 })
+let interaction
+const root = createRoot((dispose) => {
+  MemoryRouter({
+    children: Route({
+      path: "*",
+      component: () => {
+        interaction = createSessionTimelineInteraction({
+          routeSessionID: () => "ses_a",
+          sessionKey: () => "dir-a:ses_a",
+          sessionID: () => "ses_a",
+          messagesReady: () => true,
+          loadedMessages: () => 1,
+          visibleUserMessages: () => [{ id: "msg_1" }],
+          historyMore: () => false,
+          historyLoading: () => false,
+          loadMore: async () => {},
+          consumePendingMessage: () => undefined,
+        })
+        interaction.setScrollRef(viewport)
+        return null
+      },
+    }),
+  })
+  return { dispose }
+})
+
+assert(interaction, "timeline interaction should mount under the memory router")
+interaction.onTimelineScrollObservation({
+  type: "scroll_sample",
+  userInitiated: false,
+  safePosition: { kind: "latest" },
+  metrics: {
+    scrollTop: 0,
+    scrollHeight: 1000,
+    clientHeight: 400,
+    distanceFromTop: 0,
+    distanceFromBottom: 600,
+    nearTop: true,
+    nearBottom: false,
+  },
+})
+
+assert(viewport.scrollTop === 0, "system scroll drift should not synchronously write scrollTop")
+frames.runFrame()
+assert(viewport.scrollTop === 600, "system scroll drift should reconcile on the next frame")
+root.dispose()
+process.exit(0)
+`
+
+describe("createSessionTimelineInteraction", () => {
+  test("coalesces system scroll drift instead of writing scrollTop synchronously", () => {
+    runBrowserCheck(browserCheck)
+  })
+})

--- a/packages/app/src/pages/session/use-session-timeline-interaction.ts
+++ b/packages/app/src/pages/session/use-session-timeline-interaction.ts
@@ -323,7 +323,7 @@ export function createSessionTimelineInteraction(input: {
       !next.metrics.nearBottom &&
       result.mode === "following_latest"
     ) {
-      reconciler.restoreNow("scroll-drift", next.safePosition)
+      reconciler.markDirty("scroll-drift")
     }
     return result
   }


### PR DESCRIPTION
## Summary

Reduce session-switch jank by coalescing system scroll-drift recovery onto the existing timeline reconciler frame queue, and by moving stale cached message force-refresh out of the first switch tick.

No public issue. This came from a local problem report and screen recording that showed normal session switches followed by renderer jank.

## Why

The captured diagnostics showed normal `session.identity.transition` events followed by repeated `scroll-drift` reconciliation and one stale cached `message_force_start` inside the switch window. The route switch itself was expected; the risky work was happening immediately after the switch.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please focus on whether the scroll-drift path should always use the coalesced reconciler frame, and whether the 500ms stale force-refresh delay is the right balance between avoiding switch-frame work and keeping cached messages fresh.

## Risk Notes

The stale cached message force refresh is delayed by 500ms only when cached message data exists and the prefetch metadata is stale. Cached content still renders immediately, and the force refresh still runs if the same session is current and stale at execution time.

`restoreNow` remains available for explicit immediate restore cases; this PR removes the production scroll-drift escape hatch that synchronously flushed from the scroll observation path.

Skipped conditional checklist items: no platform, packaging, updater, signing, path, shell, permission, docs, release note, dependency, credential, deletion, generated content, or local-file behavior surfaces were touched.

## How To Verify

```text
Original report replay: confirmed captured window had 9 normal session transitions, 3 scroll-drift reconciles, 1 stale message_force_start, and 3 janky perf samples.
Focused session tests: 12 passed for use-session-timeline-interaction, use-session-refresh-effects, and timeline-scroll-reconciler.
App unit tests: 1928 passed with bun run test:unit in packages/app.
App typecheck: passed with bun run typecheck in packages/app.
Workspace typecheck: 8 successful tasks with bun run typecheck at repo root.
Lint: passed with bun run lint at repo root.
Visual smoke: bun run snap session-opening-skeleton passed; generated grid was reviewed locally and was not blank or misaligned.
Diff hygiene: git diff --check passed.
```

## Screenshots or Recordings

No visual styling or copy changed. Ran the existing `session-opening-skeleton` snap as a session-surface smoke check and reviewed the generated grid locally.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced session synchronization for stale prefetched data with intelligent refresh scheduling to ensure timely updates.
  * Improved scroll drift handling in timeline views for smoother and more responsive scrolling behavior.
  * Refined session cache validation and deferred refresh mechanisms for better data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->