### PR TITLE
fix(tool): route website tasks to opencli adapters before the browser

### DIFF
--- a/packages/opencode/src/session/prompt/pawwork.txt
+++ b/packages/opencode/src/session/prompt/pawwork.txt
@@ -59,11 +59,11 @@ Never install OS-level schedulers for these requests with any tool: no `at`, `cr
 
 When a task operates a specific website — checking an account, searching a site, booking, ordering, posting, or pulling structured data from it — first activate the `opencli` tool group via `tool_info` and run `opencli_search` for that site or action. PawWork bundles purpose-built site adapters; when one matches, run it with `opencli_run` instead of driving the page by hand, since a scripted adapter is faster and more reliable than clicking through the UI.
 
-Fall back to the `browser` tool group via `tool_info` when no adapter matches, or when an adapter is blocked, errors, or returns something unusable — do not retry the same adapter more than once. The `browser` tools drive PawWork's embedded browser: the user's visible tab, sharing their login state, with every step on screen where they can watch and intervene. Use them for general browsing, visual checks, and any site without an adapter.
+Fall back to the `browser` tool group via `tool_info` when no adapter matches, or when an adapter is unavailable, errors, or returns unusable output — do not retry the same adapter more than once. The `browser` tools drive PawWork's embedded browser: the user's visible tab, sharing their login state, with every step on screen where they can watch and intervene. Use them for general browsing, visual checks, and any site without an adapter.
 
-If the user denies an OpenCLI or browser permission, stop and tell them — do not switch to another tool to carry out the same action they just declined.
+A user denying an OpenCLI or browser permission is not an adapter failure to route around: stop and tell them, and do not switch to another tool to carry out the same action they just declined.
 
-Use `webfetch` only for a one-shot read-only fetch of a single page's content. Never simulate a browser session with `curl` or `wget` (logins, cookies, form posts), and never declare a web task impossible without trying these tools first.
+Use `webfetch` only for a one-shot read-only fetch of a single page's content. Never simulate a browser session with `curl` or `wget` (logins, cookies, form posts), and never declare a web task impossible without trying the `opencli` or `browser` tool groups first.
 
 # Bundled capabilities
 

--- a/packages/opencode/src/session/prompt/pawwork.txt
+++ b/packages/opencode/src/session/prompt/pawwork.txt
@@ -57,9 +57,13 @@ Never install OS-level schedulers for these requests with any tool: no `at`, `cr
 
 # Browsing and operating websites
 
-When a task needs to browse, read, or operate a website — opening a page, logging in, filling a form, clicking through a flow, or visually checking a result — activate the `browser` tool group via `tool_info` and drive PawWork's embedded browser. It is the user's visible browser tab: it shares their login state, and every step stays on screen where they can watch and intervene.
+When a task operates a specific website — checking an account, searching a site, booking, ordering, posting, or pulling structured data from it — first activate the `opencli` tool group via `tool_info` and run `opencli_search` for that site or action. PawWork bundles purpose-built site adapters; when one matches, run it with `opencli_run` instead of driving the page by hand, since a scripted adapter is faster and more reliable than clicking through the UI.
 
-Use `webfetch` only for a one-shot read-only fetch of a page's content. Never simulate a browser session with `curl` or `wget` (logins, cookies, form posts), and never declare a web task impossible without trying the browser tools first.
+Fall back to the `browser` tool group via `tool_info` when no adapter matches, or when an adapter is blocked, errors, or returns something unusable — do not retry the same adapter more than once. The `browser` tools drive PawWork's embedded browser: the user's visible tab, sharing their login state, with every step on screen where they can watch and intervene. Use them for general browsing, visual checks, and any site without an adapter.
+
+If the user denies an OpenCLI or browser permission, stop and tell them — do not switch to another tool to carry out the same action they just declined.
+
+Use `webfetch` only for a one-shot read-only fetch of a single page's content. Never simulate a browser session with `curl` or `wget` (logins, cookies, form posts), and never declare a web task impossible without trying these tools first.
 
 # Bundled capabilities
 

--- a/packages/opencode/src/tool/shell.txt
+++ b/packages/opencode/src/tool/shell.txt
@@ -38,7 +38,7 @@ Usage notes:
     - Write files: Use Write (NOT echo >/cat <<EOF)
     - Communication: Output text directly (NOT echo/printf)
     - Scheduled or delayed tasks: Use the automate tool (NOT at, cron, crontab, launchd, schtasks, or sleep loops)
-    - Browsing or operating websites: Use the browser tools, activated via tool_info (NOT curl or wget for pages, logins, or form submissions)
+    - Browsing or operating websites: For a specific site, check opencli_search for a bundled adapter first, then fall back to the browser tools — both activated via tool_info (NOT curl or wget for pages, logins, or form submissions)
     - File deletion: Avoid permanent deletion commands (`rm`, `rmdir`, `unlink`, `find -delete`, `del`, `erase`, `rd`, `Remove-Item`). Prefer a reversible system trash command when available: on macOS use `trash`; on Linux prefer `gio trash`, then `trash-put`. Check availability first: in POSIX shells use `command -v`, and in PowerShell use `Get-Command`. If no reversible command is available, ask the user before deleting.
   - When issuing multiple commands:
     - If the commands are independent and can run in parallel, make multiple Bash tool calls in a single message. For example, if you need to run "git status" and "git diff", send a single message with two Bash tool calls in parallel.

--- a/packages/opencode/src/tool/shell.txt
+++ b/packages/opencode/src/tool/shell.txt
@@ -38,7 +38,7 @@ Usage notes:
     - Write files: Use Write (NOT echo >/cat <<EOF)
     - Communication: Output text directly (NOT echo/printf)
     - Scheduled or delayed tasks: Use the automate tool (NOT at, cron, crontab, launchd, schtasks, or sleep loops)
-    - Browsing or operating websites: For a specific site, check opencli_search for a bundled adapter first, then fall back to the browser tools — both activated via tool_info (NOT curl or wget for pages, logins, or form submissions)
+    - Browsing or operating websites: To act on a specific site (sign in, search, book, post, pull data), check opencli_search for an adapter first, then fall back to the browser tools; a one-shot page read can use webfetch — all activated via tool_info (NOT curl or wget for pages, logins, or form submissions)
     - File deletion: Avoid permanent deletion commands (`rm`, `rmdir`, `unlink`, `find -delete`, `del`, `erase`, `rd`, `Remove-Item`). Prefer a reversible system trash command when available: on macOS use `trash`; on Linux prefer `gio trash`, then `trash-put`. Check availability first: in POSIX shells use `command -v`, and in PowerShell use `Get-Command`. If no reversible command is available, ask the user before deleting.
   - When issuing multiple commands:
     - If the commands are independent and can run in parallel, make multiple Bash tool calls in a single message. For example, if you need to run "git status" and "git diff", send a single message with two Bash tool calls in parallel.

--- a/packages/opencode/src/tool/tool-info.ts
+++ b/packages/opencode/src/tool/tool-info.ts
@@ -134,9 +134,9 @@ const DEFERRED: DeferredEntry[] = [
 // group's tool_info output instead.
 const GROUP_CARDS: Record<string, string> = {
   browser:
-    "Drive the user-visible embedded browser: navigate, snapshot (numbered element refs), click, type, wait, screenshot, extract page content as markdown. Activates as one set — use for any task that needs to browse, read, or operate a website.",
+    "Drive the user-visible embedded browser: navigate, snapshot (numbered element refs), click, type, wait, screenshot, extract page content as markdown. Activates as one set — use for general browsing, visual checks, and any site without a bundled adapter; for a specific site, check the opencli group first.",
   opencli:
-    "Find and use bundled OpenCLI site adapters for website-specific workflows. Start with opencli_search, then run the selected command with opencli_run.",
+    "Find and use bundled OpenCLI site adapters for a specific site or site-specific workflow — prefer these over the browser tools when one matches. Start with opencli_search, then run the selected command with opencli_run.",
 }
 
 const BY_ID: Record<string, DeferredEntry> = Object.fromEntries(DEFERRED.map((d) => [d.id, d]))

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -59,6 +59,7 @@ describe("session.system", () => {
     expect(prompt).toContain("nearest relevant AGENTS.md")
     expect(prompt).toContain("ask for confirmation before writing")
     expect(prompt).toContain("`automate` tool")
+    expect(prompt).toContain("`opencli` tool group via `tool_info`")
     expect(prompt).not.toContain("opencode.ai")
     expect(prompt).not.toContain("anomalyco/opencode")
     expect(prompt).not.toContain("Get help with using opencode")

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -128,6 +128,9 @@ describe("tool.registry", () => {
     expect(shellDescription).toContain("check opencli_search for a bundled adapter first")
     expect(shellDescription).toContain("fall back to the browser tools")
 
+    // The redirect must not drift back to a browser-first rule.
+    expect(shellDescription).not.toContain("Use the browser tools, activated via tool_info")
+
     const systemPrompt = await Bun.file(new URL("../../src/session/prompt/pawwork.txt", import.meta.url)).text()
     expect(systemPrompt).toContain("# Browsing and operating websites")
     expect(systemPrompt).toContain("`opencli` tool group via `tool_info`")
@@ -138,6 +141,16 @@ describe("tool.registry", () => {
     expect(systemPrompt).toContain("do not switch to another tool to carry out the same action they just declined")
     expect(systemPrompt).toContain("Never simulate a browser session with `curl` or `wget`")
     expect(systemPrompt).toContain("never declare a web task impossible")
+    // Adapter-first ordering: opencli_search is reached before the browser fallback.
+    expect(systemPrompt.indexOf("opencli_search")).toBeLessThan(systemPrompt.indexOf("Fall back to the `browser`"))
+
+    // The tool_info group cards are resident surfaces too: the browser card must
+    // not re-route every website task back to the browser, or it would undo the
+    // adapter-first routing the prompt and shell redirect establish.
+    const toolInfoSource = await Bun.file(new URL("../../src/tool/tool-info.ts", import.meta.url)).text()
+    expect(toolInfoSource).not.toContain("use for any task that needs to browse, read, or operate a website")
+    expect(toolInfoSource).toContain("for a specific site, check the opencli group first")
+    expect(toolInfoSource).toContain("prefer these over the browser tools when one matches")
   })
 
   test("loads tools from .opencode/tool (singular)", async () => {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -125,11 +125,16 @@ describe("tool.registry", () => {
   // redirect list catches the entry point models drift into.
   test("keeps browsing routing contract across prompt surfaces", async () => {
     const shellDescription = await Bun.file(new URL("../../src/tool/shell.txt", import.meta.url)).text()
-    expect(shellDescription).toContain("check opencli_search for a bundled adapter first")
-    expect(shellDescription).toContain("fall back to the browser tools")
+    // The redirect triggers on acting on a site, not on merely visiting one, so it
+    // stays in step with the system prompt's action-intent routing and doesn't push
+    // opencli_search ahead of a one-shot read.
+    expect(shellDescription).toContain("To act on a specific site (sign in, search, book, post, pull data)")
+    expect(shellDescription).toContain("check opencli_search for an adapter first")
+    expect(shellDescription).toContain("a one-shot page read can use webfetch")
 
-    // The redirect must not drift back to a browser-first rule.
+    // The redirect must not drift back to a browser-first rule or a visit-based trigger.
     expect(shellDescription).not.toContain("Use the browser tools, activated via tool_info")
+    expect(shellDescription).not.toContain("For a specific site, check opencli_search")
 
     const systemPrompt = await Bun.file(new URL("../../src/session/prompt/pawwork.txt", import.meta.url)).text()
     expect(systemPrompt).toContain("# Browsing and operating websites")
@@ -138,9 +143,15 @@ describe("tool.registry", () => {
     expect(systemPrompt).toContain("opencli_run")
     expect(systemPrompt).toContain("`browser` tool group via `tool_info`")
     expect(systemPrompt).toContain("do not retry the same adapter more than once")
+    // Permission denial is held distinct from an adapter failure so the stop is not
+    // read as just another fall-back-to-browser case.
+    expect(systemPrompt).toContain("is not an adapter failure to route around")
     expect(systemPrompt).toContain("do not switch to another tool to carry out the same action they just declined")
     expect(systemPrompt).toContain("Never simulate a browser session with `curl` or `wget`")
     expect(systemPrompt).toContain("never declare a web task impossible")
+    // The "try first" pointer names the actual tools, not an ambiguous "these tools".
+    expect(systemPrompt).toContain("trying the `opencli` or `browser` tool groups first")
+    expect(systemPrompt).not.toContain("trying these tools first")
     // Adapter-first ordering: opencli_search is reached before the browser fallback.
     expect(systemPrompt.indexOf("opencli_search")).toBeLessThan(systemPrompt.indexOf("Fall back to the `browser`"))
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -116,18 +116,26 @@ describe("tool.registry", () => {
     expect(systemPrompt).toContain("by writing files")
   })
 
-  // Web tasks must route to the embedded browser tools, never to curl/wget
-  // sessions or a premature "can't access the web". The tools are deferred
-  // (one tool_info card), so the resident surfaces carry the routing: the
-  // system prompt names the trigger intents and the bash redirect list
-  // catches the entry point models drift into.
+  // Web tasks route adapter-first: a specific site checks opencli_search for a
+  // bundled adapter before falling back to the embedded browser tools, never to
+  // curl/wget sessions or a premature "can't access the web". Both tool groups
+  // are deferred (one tool_info card each), so the resident surfaces carry the
+  // routing — the system prompt names the trigger intents, the adapter→browser
+  // fallback order, the one-retry cap, and the permission-denial stop; the bash
+  // redirect list catches the entry point models drift into.
   test("keeps browsing routing contract across prompt surfaces", async () => {
     const shellDescription = await Bun.file(new URL("../../src/tool/shell.txt", import.meta.url)).text()
-    expect(shellDescription).toContain("Browsing or operating websites: Use the browser tools, activated via tool_info")
+    expect(shellDescription).toContain("check opencli_search for a bundled adapter first")
+    expect(shellDescription).toContain("fall back to the browser tools")
 
     const systemPrompt = await Bun.file(new URL("../../src/session/prompt/pawwork.txt", import.meta.url)).text()
     expect(systemPrompt).toContain("# Browsing and operating websites")
+    expect(systemPrompt).toContain("`opencli` tool group via `tool_info`")
+    expect(systemPrompt).toContain("opencli_search")
+    expect(systemPrompt).toContain("opencli_run")
     expect(systemPrompt).toContain("`browser` tool group via `tool_info`")
+    expect(systemPrompt).toContain("do not retry the same adapter more than once")
+    expect(systemPrompt).toContain("do not switch to another tool to carry out the same action they just declined")
     expect(systemPrompt).toContain("Never simulate a browser session with `curl` or `wget`")
     expect(systemPrompt).toContain("never declare a web task impossible")
   })


### PR DESCRIPTION
## Summary

Add resident-prompt routing so the agent reaches for the bundled OpenCLI site adapters before manually driving the embedded browser. Adapter-first for specific-site tasks, with an explicit fallback to the browser group.

- `pawwork.txt` "# Browsing and operating websites": adapter-first routing keyed on **action intents** (check account, search, book, order, post, pull structured data), not site names (the manifest is dynamic — 162 sites / 1050 commands). Explicit fallback to the `browser` group on no match or adapter error, **capped at one retry**. A **permission-denial stop** so a declined OpenCLI/browser permission is never worked around with another tool. `webfetch` and the curl/wget guard kept.
- `shell.txt` redirect: check `opencli_search` for a bundled adapter first, then fall back to the browser tools.
- Contract tests pin the new ordering, fallback, one-retry cap, and permission-denial stop across both resident surfaces; system-prompt anchor added.

Copy + contract tests only. No `execute()` / runtime change.

## Why

The OpenCLI adapters shipped in #(521b01ef72) as **deferred** tools — exposed only as a one-line `opencli` card inside `tool_info` — so the agent almost never discovered them. Worse, the resident prompt actively routed every website task to the competing `browser` group (the browsing section and the shell redirect both pointed only at the browser tools). So "check my 12306 account" → read browsing section → activate browser → hand-drive the page → never find the `12306/me` adapter.

Same failure class as the earlier automate misroute (`ae981f021e`): a capable tool losing to a more familiar default because nothing in the resident prompt routes to it. That fix added a pawwork.txt routing section + shell.txt redirect + contract tests; this mirrors it for opencli.

This direction and final shape were pressure-tested by an independent fresh-eye review and a Codex consult — both converged on: prompt-only is the right altitude (don't un-defer the tools), key on action intents not site names, two tiers not three, and pin the rule with contract tests.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

- The new copy in `pawwork.txt` — is the adapter→browser fallback order and the permission-denial stop unambiguous to a weak model?
- That the two failure branches stay distinct: adapter error → browser; user permission denial → stop (do not reroute).

## Risk Notes

Resident system-prompt behavior change: the agent will now spend one `opencli_search` turn on specific-site tasks before falling back to the browser. Mitigated by keying on action intents so pure one-page reads still go to `webfetch`. No runtime, permission, or packaging surface touched. UI checklist item left unticked: no visible UI or copy-in-app changed (this is the agent system prompt, not user-facing copy).

## How To Verify

```text
bun test test/tool/registry.test.ts test/session/system.test.ts test/tool/shell-prompt.test.ts test/tool/opencli-tools.test.ts — 73 pass, 0 fail (280 expects)
bun run typecheck (packages/opencode) — clean (tsgo --noEmit)
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — `bug`.
- [x] **Routing labels** — `harness` (prompts + tool descriptions).
- [x] **Priority label** — `P2`.
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

## Follow-up (out of scope)

**Navigate-time discovery** — when the browser navigates to a domain that has a bundled adapter, surface the matching adapter from the browser tool result so the model is pulled back even if it ignored the resident routing. Prompt routing is best-effort (the model can ignore it); a navigate-time hook is the structural backstop. Deferred here because it touches the tool execution path and needs its own tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Website interaction guidance now prioritizes site-specific OpenCLI adapters first, then falls back to browser tools; includes explicit ordering and exposure guidance, a one-retry cap, a stop rule when permissions are denied, and a one-shot read-only webfetch recommendation.
* **Tests**
  * Expanded tests to validate adapter-first routing, tool-exposure ordering, the one-retry cap, and the permission stop rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->