### PR TITLE
refactor(sync): expose SyncEvent as an Effect service

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -225,7 +225,7 @@ Fully migrated (single namespace, InstanceState where needed, flattened facade):
 Still open:
 
 - [x] `SessionTodo` — `session/todo.ts`
-- [ ] `SyncEvent` — `sync/index.ts`
+- [x] `SyncEvent` — `sync/index.ts`
 - [ ] `Workspace` — `control-plane/workspace.ts`
 
 ## Tool interface → Effect
@@ -375,6 +375,7 @@ Decision table for the design:
 - `FileWatcher` — migrated 2026-04-11. Callers in `project/bootstrap.ts` and test converted; facade removed.
 - `Question` — migrated 2026-04-11. Callers in `server/routes/question.ts` and test converted; facade removed.
 - `Truncate` — migrated 2026-04-11. Caller in `tool/tool.ts` and test converted; facade removed.
+- `SyncEvent` — migrated 2026-06-14. Added `SyncEvent.Service` / `defaultLayer`, wired it into `AppRuntime`, and introduced typed `SyncEventError` failures for the Effect service path. Existing synchronous facade functions remain as the compatibility boundary for legacy callers.
 
 ## Route handler effectification
 

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -49,6 +49,7 @@ import { ShareNext } from "@/share/share-next"
 import { SessionShare } from "@/share/session"
 import { ShareRuntime } from "@/share/runtime"
 import { Automation } from "@/automation"
+import { SyncEvent } from "@/sync"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { InstanceLayer } from "@/project/instance-layer"
 
@@ -101,6 +102,7 @@ export const AppLayer = Layer.mergeAll(
   SessionShare.defaultLayer,
   ShareRuntime.cloudShareGateDefaultLayer,
   Automation.defaultLayer,
+  SyncEvent.defaultLayer,
 ).pipe(Layer.provideMerge(InstanceLayer.layer))
 
 const rt = ManagedRuntime.make(AppLayer, { memoMap })

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -1,6 +1,7 @@
 import z from "zod"
 import type { ZodObject } from "zod"
 import { EventEmitter } from "events"
+import { Context, Effect, Layer, Schema } from "effect"
 import { Database, eq } from "@/storage/db"
 import { Bus as ProjectBus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
@@ -9,6 +10,22 @@ import { EventID } from "./schema"
 import { Flag } from "@opencode-ai/core/flag/flag"
 
 export namespace SyncEvent {
+  const SyncEventErrorReason = Schema.Union([
+    Schema.Literal("frozen"),
+    Schema.Literal("projectors-unavailable"),
+    Schema.Literal("projector-not-found"),
+    Schema.Literal("unknown-event-type"),
+    Schema.Literal("sequence-mismatch"),
+    Schema.Literal("missing-aggregate"),
+    Schema.Literal("old-event-version"),
+  ])
+
+  export class SyncEventError extends Schema.TaggedErrorClass<SyncEventError>()("SyncEventError", {
+    reason: SyncEventErrorReason,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  }) {}
+
   export type Definition = {
     type: string
     version: number
@@ -30,6 +47,18 @@ export namespace SyncEvent {
   export type SerializedEvent<Def extends Definition = Definition> = Event<Def> & { type: string }
 
   type ProjectorFunc = (db: Database.TxOrDb, data: unknown) => void
+  export interface Interface {
+    readonly run: <Def extends Definition>(
+      def: Def,
+      data: Event<Def>["data"],
+      options?: { publish?: boolean },
+    ) => Effect.Effect<void, SyncEventError>
+    readonly replay: (event: SerializedEvent, options?: { publish?: boolean }) => Effect.Effect<void, SyncEventError>
+    readonly remove: (aggregateID: string) => Effect.Effect<void, SyncEventError>
+    readonly subscribeAll: (handler: (event: { def: Definition; event: Event }) => void) => Effect.Effect<() => void>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/SyncEvent") {}
 
   export const registry = new Map<string, Definition>()
   let projectors: Map<Definition, ProjectorFunc> | undefined
@@ -38,6 +67,30 @@ export namespace SyncEvent {
   let convertEvent: (type: string, event: Event["data"]) => Promise<Record<string, unknown>> | Record<string, unknown>
 
   const Bus = new EventEmitter<{ event: [{ def: Definition; event: Event }] }>()
+
+  const fail = (reason: SyncEventError["reason"], message: string, cause?: unknown) =>
+    new SyncEventError({ reason, message, cause })
+
+  const effect = <A>(fn: () => A): Effect.Effect<A, SyncEventError> =>
+    Effect.suspend(() => {
+      try {
+        return Effect.succeed(fn())
+      } catch (cause) {
+        if (cause instanceof SyncEventError) return Effect.fail(cause)
+        return Effect.die(cause)
+      }
+    })
+
+  export const layer = Layer.succeed(
+    Service,
+    Service.of({
+      run: (def, data, options) => effect(() => run(def, data, options)),
+      replay: (event, options) => effect(() => replay(event, options)),
+      remove: (aggregateID) => effect(() => remove(aggregateID)),
+      subscribeAll: (handler) => Effect.sync(() => subscribeAll(handler)),
+    }),
+  )
+  export const defaultLayer = layer
 
   export function reset() {
     frozen = false
@@ -77,7 +130,7 @@ export namespace SyncEvent {
     BusSchema extends ZodObject = Schema,
   >(input: { type: Type; version: number; aggregate: Agg; schema: Schema; busSchema?: BusSchema }) {
     if (frozen) {
-      throw new Error("Error defining sync event: sync system has been frozen")
+      throw fail("frozen", "Error defining sync event: sync system has been frozen")
     }
 
     const def = {
@@ -104,12 +157,12 @@ export namespace SyncEvent {
 
   function process<Def extends Definition>(def: Def, event: Event<Def>, options: { publish: boolean }) {
     if (projectors == null) {
-      throw new Error("No projectors available. Call `SyncEvent.init` to install projectors")
+      throw fail("projectors-unavailable", "No projectors available. Call `SyncEvent.init` to install projectors")
     }
 
     const projector = projectors.get(def)
     if (!projector) {
-      throw new Error(`Projector not found for event: ${def.type}`)
+      throw fail("projector-not-found", `Projector not found for event: ${def.type}`)
     }
 
     // idempotent: need to ignore any events already logged
@@ -165,10 +218,10 @@ export namespace SyncEvent {
   //   and it validets all the sequence ids
   // * when loading events from db, apply zod validation to ensure shape
 
-  export function replay(event: SerializedEvent, options?: { publish: boolean }) {
+  export function replay(event: SerializedEvent, options?: { publish?: boolean }) {
     const def = registry.get(event.type)
     if (!def) {
-      throw new Error(`Unknown event type: ${event.type}`)
+      throw fail("unknown-event-type", `Unknown event type: ${event.type}`)
     }
 
     const row = Database.use((db) =>
@@ -186,7 +239,10 @@ export namespace SyncEvent {
 
     const expected = latest + 1
     if (event.seq !== expected) {
-      throw new Error(`Sequence mismatch for aggregate "${event.aggregateID}": expected ${expected}, got ${event.seq}`)
+      throw fail(
+        "sequence-mismatch",
+        `Sequence mismatch for aggregate "${event.aggregateID}": expected ${expected}, got ${event.seq}`,
+      )
     }
 
     process(def, event, { publish: !!options?.publish })
@@ -197,11 +253,11 @@ export namespace SyncEvent {
     // This should never happen: we've enforced it via typescript in
     // the definition
     if (agg == null) {
-      throw new Error(`SyncEvent.run: "${def.aggregate}" required but not found: ${JSON.stringify(data)}`)
+      throw fail("missing-aggregate", `SyncEvent.run: "${def.aggregate}" required but not found: ${JSON.stringify(data)}`)
     }
 
     if (def.version !== versions.get(def.type)) {
-      throw new Error(`SyncEvent.run: running old versions of events is not allowed: ${def.type}`)
+      throw fail("old-event-version", `SyncEvent.run: running old versions of events is not allowed: ${def.type}`)
     }
 
     const { publish = true } = options || {}

--- a/packages/opencode/test/sync/index.test.ts
+++ b/packages/opencode/test/sync/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, afterAll } from "bun:test"
+import { Cause, Effect, Exit } from "effect"
 import { tmpdir } from "../fixture/fixture"
 import z from "zod"
 import { Bus } from "../../src/bus"
@@ -133,6 +134,33 @@ describe("SyncEvent", () => {
   })
 
   describe("replay", () => {
+    test(
+      "returns a typed Effect failure for unknown event types",
+      withInstance(async () => {
+        setup()
+
+        const exit = await Effect.runPromiseExit(
+          SyncEvent.Service.use((sync) =>
+            sync.replay({
+              id: "evt_1",
+              type: "unknown.event.1",
+              seq: 0,
+              aggregateID: "x",
+              data: {},
+            }),
+          ).pipe(Effect.provide(SyncEvent.defaultLayer)),
+        )
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isSuccess(exit)) return
+        const failure = Cause.squash(exit.cause)
+        const syncError = failure as SyncEvent.SyncEventError
+        expect(syncError).toBeInstanceOf(SyncEvent.SyncEventError)
+        expect(syncError.reason).toBe("unknown-event-type")
+        expect(syncError.message).toContain("Unknown event type")
+      }),
+    )
+
     test(
       "inserts event from external payload",
       withInstance(() => {

--- a/packages/opencode/test/sync/index.test.ts
+++ b/packages/opencode/test/sync/index.test.ts
@@ -10,8 +10,10 @@ import { EventTable } from "../../src/sync/event.sql"
 import { Identifier } from "../../src/id/id"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { initProjectors } from "../../src/server/projectors"
+import { testEffect } from "../lib/effect"
 
 const original = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
+const syncIt = testEffect(SyncEvent.defaultLayer)
 
 beforeEach(() => {
   Database.close()
@@ -134,12 +136,12 @@ describe("SyncEvent", () => {
   })
 
   describe("replay", () => {
-    test(
+    syncIt.effect(
       "returns a typed Effect failure for unknown event types",
-      withInstance(async () => {
+      Effect.gen(function* () {
         setup()
 
-        const exit = await Effect.runPromiseExit(
+        const exit = yield*
           SyncEvent.Service.use((sync) =>
             sync.replay({
               id: "evt_1",
@@ -148,8 +150,7 @@ describe("SyncEvent", () => {
               aggregateID: "x",
               data: {},
             }),
-          ).pipe(Effect.provide(SyncEvent.defaultLayer)),
-        )
+          ).pipe(Effect.exit)
 
         expect(Exit.isFailure(exit)).toBe(true)
         if (Exit.isSuccess(exit)) return


### PR DESCRIPTION
## Summary

Adds an Effect-native `SyncEvent.Service` / `defaultLayer` for the sync event subsystem and wires it into `AppRuntime`.

Expected SyncEvent failures now have a typed `SyncEventError` on the Effect service path, while the existing synchronous facade remains as the compatibility boundary for legacy callers.

## Why

#936's remaining backend migration checklist still had `SyncEvent` open. This is the smallest non-UI backend slice after the already-merged workspace routing, VCS, PTY, and SSE guardrail work: it gives SyncEvent a real Effect service boundary without changing route, SDK, OpenAPI, SSE, or session behavior.

## Related Issue

Refs #936.

## Human Review Status

Pending

## Review Focus

Please focus on the Effect service boundary: expected SyncEvent failures should enter the typed error channel, unexpected defects should remain defects, and legacy `SyncEvent.run/replay/remove/subscribeAll` behavior should remain compatible.

## Risk Notes

Low behavior risk. The synchronous facade now throws `SyncEventError` instances with the same messages for expected SyncEvent failures; callers that match messages should keep working, but code depending on exact `Error` constructor identity should be reviewed.

Skipped conditional checklist items: screenshots are not applicable because there are no visible UI or copy changes. macOS/Windows platform verification is not applicable because no platform, packaging, updater, signing, path, or shell behavior changed.

## How To Verify

```text
Install: bun install --frozen-lockfile completed in the isolated worktree
RED check: bun --cwd packages/opencode test test/sync/index.test.ts -t "returns a typed Effect failure for unknown event types" first failed because SyncEvent.Service was undefined
Focused sync test: bun --cwd packages/opencode test test/sync/index.test.ts -> 8 pass, 0 fail
Related event/session surface tests: bun --cwd packages/opencode test test/sync/index.test.ts test/server/event-stream-routes.test.ts test/server/global-event-replay.test.ts test/server/global-session-activity-list.test.ts test/server/global-session-list.test.ts -> 45 pass, 0 fail
Opencode typecheck: cd packages/opencode && bun run typecheck -> tsgo --noEmit passed
Diff check: git diff --check -> passed
Route/OpenAPI/SDK inventory: not run; this PR does not touch route, raw stream/WebSocket, OpenAPI, SDK, or app call surfaces
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced typed error handling for SyncEvent operations with specific error reasons (`frozen`, `projector-not-found`, `unknown-event-type`, etc.) for improved error diagnostics.

* **Bug Fixes**
  * Enhanced error handling throughout SyncEvent lifecycle to prevent unhandled exceptions and improve failure recovery.

* **Tests**
  * Added test coverage for typed error scenarios in SyncEvent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->