### PR TITLE
fix(app): unify Windows titlebar chrome and continue sidebar divider

### DIFF
--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -120,15 +120,40 @@
      see issue tracked alongside PR #880 follow-up. The toggle's own
      absolute `right-2` (or `right-0` on Windows) provides the inset from
      the viewport edge in both open and closed states. */
-  [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"] {
-    padding-inline-start: 8px;
+  /* Chrome-surface continuity: the titlebar's left segment (over the sidebar
+     width) carries the sidebar color, then a 1px --border-weaker band, then it
+     falls through to the thread bg — so both the color seam AND the divider
+     line continue the sidebar/content divide drawn below by the sidebar
+     <aside>'s `border-r border-border-weaker` (layout-shell-frame). The
+     titlebar is its own row above that flex body, so without this the divider
+     visibly stops at the session-title row. macOS and Windows share this; only
+     macOS adds the traffic-light inset. Windows sits under its own native title
+     bar, and this keeps our toolbar in the same warm-neutral chrome family
+     instead of a flat white slab disconnected from both.
+     The line band is [sidebar-width - 1px, sidebar-width], landing on the
+     aside's border-box right edge (border-box + 1px border-r), so the titlebar
+     line is colinear with the body divider and — being --border-weaker (alpha)
+     over the transparent right segment — composites to the same shade as the
+     body border over the content bg. Drawing it in the gradient (vs a separate
+     ::after) needs no element and collapses cleanly: at --sidebar-width 0px all
+     stops clamp to 0 and the whole band is transparent. */
+  [data-component="titlebar-shell"][data-shell="desktop"]:is(
+      [data-shell-os="macos"],
+      [data-shell-os="windows"]
+    ) {
     background: linear-gradient(
       to right,
       var(--sidebar) 0,
-      var(--sidebar) var(--sidebar-width, 0px),
+      var(--sidebar) calc(var(--sidebar-width, 0px) - 1px),
+      var(--border-weaker) calc(var(--sidebar-width, 0px) - 1px),
+      var(--border-weaker) var(--sidebar-width, 0px),
       transparent var(--sidebar-width, 0px),
       transparent 100%
     );
+  }
+
+  [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"] {
+    padding-inline-start: 8px;
   }
 
   [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"] [data-shell-slot="left-portal"] {
@@ -139,17 +164,17 @@
     pointer-events: auto;
   }
 
-  [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"]
+  [data-component="titlebar-shell"][data-shell="desktop"]:is([data-shell-os="macos"], [data-shell-os="windows"])
     :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"] {
     border-radius: 10px;
   }
 
-  [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"]
+  [data-component="titlebar-shell"][data-shell="desktop"]:is([data-shell-os="macos"], [data-shell-os="windows"])
     :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"]:hover:not(:disabled) {
     background-color: var(--surface-sunken);
   }
 
-  [data-component="titlebar-shell"][data-shell="desktop"][data-shell-os="macos"]
+  [data-component="titlebar-shell"][data-shell="desktop"]:is([data-shell-os="macos"], [data-shell-os="windows"])
     :is([data-component="button"], [data-component="icon-button"]).titlebar-icon[data-variant="ghost"]:is(
       [data-action="pawwork-sidebar-toggle"],
       [aria-controls="right-panel"]


### PR DESCRIPTION
<!-- Checklist policy: the Checklist section below is policy. Do not edit, add, or remove items. Tick boxes only by replacing [ ] with [x]. -->

## Summary

Two CSS-only changes in `packages/app/src/index.css`, both about the desktop titlebar chrome:

1. **Unify the Windows titlebar chrome with macOS** via `:is([data-shell-os="macos"], [data-shell-os="windows"])` — the titlebar background gradient (left segment carries `--sidebar`, right falls through to the thread background) and the ghost icon-button radius / hover / expanded-transparent treatment now apply to Windows too. The traffic-light inset (`padding-inline-start: 8px`) stays macOS-only.
2. **Continue the sidebar↔content divider through the titlebar** — bake a 1px `--border-weaker` band into the titlebar gradient at the `[sidebar-width - 1px, sidebar-width]` boundary so it continues the body divider (drawn as `border-r border-border-weaker` on the sidebar `<aside>`) pixel-for-pixel. No extra element; a collapsed sidebar (`--sidebar-width: 0px`) clamps every gradient stop to 0 so the band vanishes.

`linux` is unaffected. There is no tracked issue; this came from direct design feedback on how Windows renders.

## Why

On Windows the in-app toolbar rendered as a flat white slab, disconnected from both the native Windows title bar above it and the warm-grey sidebar below. The sidebar↔content divider that runs down the body also stopped at the session-title ("New session") row instead of continuing up through the titlebar.

## Related Issue

None — see Summary.

## Human Review Status

Pending

## Review Focus

- The 1px alignment math: the gradient seam and the `--border-weaker` band both pivot on `sidebar-width - 1px`, landing on the body sidebar `<aside>`'s border-box right edge so the titlebar line is colinear with, and composites to the same shade as, the body `border-r border-border-weaker`.
- A collapsed sidebar (`--sidebar-width: 0px`) clamps the gradient stops to 0, so the band disappears with no extra element or gating.
- macOS only shares the existing rules; the seam was confirmed pixel-identical, so it should look unchanged in practice.

## Risk Notes

- Pure CSS, scoped to the `[data-shell-os="macos"|"windows"]` titlebar branch; `linux` and all non-titlebar surfaces are untouched.
- The real Windows native title bar can only be confirmed on a Windows machine — the Mac-side render covers our app branch only.
- Skipped checklist item: the third **(conditional)** item (docs / release notes / dependencies / permissions / credentials / deletion / generated / local files) is left unticked because none of those surfaces was touched — CSS only.

## How To Verify

```text
Rendered windows + macos shell branches on Mac via __PAWWORK_SHELL_OS override (Chromium snap):
  both show the divider continuous from titlebar top down into the body.
Pixel sample of the seam — titlebar row (y=40) vs body row (y=400), both OSes — identical:
  grey (248,246,243) -> divider (235,235,235) -> content (255,255,255).
Collapsed sidebar: --sidebar-width=0 -> gradient stops clamp to 0, band not visible.
shell-frame-contract test: 10 pass / 0 fail.
bun run typecheck: clean.
```

## Screenshots or Recordings

Rendered before/after comparisons were produced — a full Windows/macOS 4-panel and a 4x-zoomed seam strip — showing the divider absent in the titlebar before and continuous after. They live in the git-ignored `docs/design/preview/screenshots/` (`divider-before-after.png`, `seam-zoom.png`) and cannot be inlined from the CLI; drag them into the PR if an embedded image is required. The pixel table in How To Verify is the substantive proof that the titlebar and body seams match exactly.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored desktop titlebar styling to deliver consistent visual appearance across macOS and Windows platforms.
  * Enhanced sidebar-continuity gradient with refined border styling details for improved visual cohesion.
  * Expanded icon styling enhancements to both macOS and Windows, featuring updated hover effects and improved visual appearance for title bar controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->