### PR TITLE
refactor(workspace): add Effect service seam

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -226,7 +226,7 @@ Still open:
 
 - [x] `SessionTodo` — `session/todo.ts`
 - [x] `SyncEvent` — `sync/index.ts`
-- [ ] `Workspace` — `control-plane/workspace.ts`
+- [x] `Workspace` — `control-plane/workspace.ts`
 
 ## Tool interface → Effect
 
@@ -376,6 +376,7 @@ Decision table for the design:
 - `Question` — migrated 2026-04-11. Callers in `server/routes/question.ts` and test converted; facade removed.
 - `Truncate` — migrated 2026-04-11. Caller in `tool/tool.ts` and test converted; facade removed.
 - `SyncEvent` — migrated 2026-06-14. Added `SyncEvent.Service` / `defaultLayer`, wired it into `AppRuntime`, and introduced typed `SyncEventError` failures for the Effect service path. Existing synchronous facade functions remain as the compatibility boundary for legacy callers.
+- `Workspace` — migrated 2026-06-14. Added `Workspace.Service` / `defaultLayer`, wired it into `AppRuntime`, introduced typed `WorkspaceError` failures for the Effect service path, and moved workspace routing record/sync/adaptor resolution onto the injected service. Existing async facade functions remain as the compatibility boundary for legacy route/tests callers.
 
 ## Route handler effectification
 

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -1,6 +1,6 @@
 import z from "zod"
 import { setTimeout as sleep } from "node:timers/promises"
-import { Effect } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 import { fn } from "@/util/fn"
 import { Database, eq } from "@/storage/db"
 import { Project } from "@/project/project"
@@ -13,10 +13,9 @@ import { ProjectID } from "@/project/schema"
 import { Instance } from "@/project/instance"
 import { Plugin } from "@/plugin"
 import { Auth } from "@/auth"
-import { AppRuntime } from "@/effect/app-runtime"
 import { WorkspaceTable } from "./workspace.sql"
 import { getAdaptor, getBuiltinAdaptor, ownerKey } from "./adaptors"
-import { WorkspaceInfo } from "./types"
+import { type Adaptor, WorkspaceInfo } from "./types"
 import { WorkspaceID } from "./schema"
 import { parseSSE } from "./sse"
 
@@ -25,7 +24,7 @@ export namespace Workspace {
     ref: "Workspace",
   })
   export type Info = z.infer<typeof Info>
-  type StoredInfo = Info & {
+  export type StoredInfo = Info & {
     owner: string | null
   }
 
@@ -84,6 +83,83 @@ export namespace Workspace {
     projectID: ProjectID.zod,
     extra: Info.shape.extra,
   })
+  export type CreateInput = z.infer<typeof CreateInput>
+
+  const WorkspaceErrorReason = Schema.Union([
+    Schema.Literal("create"),
+    Schema.Literal("list"),
+    Schema.Literal("record"),
+    Schema.Literal("get"),
+    Schema.Literal("sync"),
+    Schema.Literal("remove"),
+    Schema.Literal("adaptor"),
+    Schema.Literal("status"),
+  ])
+
+  export class WorkspaceError extends Schema.TaggedErrorClass<WorkspaceError>()("WorkspaceError", {
+    reason: WorkspaceErrorReason,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  }) {}
+
+  export interface Interface {
+    readonly create: (input: CreateInput) => Effect.Effect<Info, WorkspaceError>
+    readonly list: (project: Project.Info) => Effect.Effect<Info[], WorkspaceError>
+    readonly record: (id: WorkspaceID) => Effect.Effect<StoredInfo | undefined, WorkspaceError>
+    readonly get: (id: WorkspaceID) => Effect.Effect<Info | undefined, WorkspaceError>
+    readonly ensureSync: (space: StoredInfo | undefined, hint?: string | null) => Effect.Effect<void, WorkspaceError>
+    readonly remove: (id: WorkspaceID) => Effect.Effect<Info | undefined, WorkspaceError>
+    readonly resolveAdaptor: (
+      input: Pick<StoredInfo, "projectID" | "type" | "owner"> & { hint?: string | null },
+    ) => Effect.Effect<Adaptor, WorkspaceError>
+    readonly status: () => Effect.Effect<ConnectionStatus[], WorkspaceError>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/Workspace") {}
+
+  const workspaceFailure =
+    (reason: WorkspaceError["reason"], message: string) =>
+    (cause: unknown) => {
+      if (cause instanceof WorkspaceError) return cause
+      const causeMessage =
+        cause instanceof Error ? cause.message : typeof cause === "string" && cause.length > 0 ? cause : undefined
+      return new WorkspaceError({
+        reason,
+        message: causeMessage ? `${message}: ${causeMessage}` : message,
+        cause,
+      })
+    }
+
+  const effect = <A>(reason: WorkspaceError["reason"], message: string, run: () => A) =>
+    Effect.try({
+      try: run,
+      catch: workspaceFailure(reason, message),
+    })
+
+  const promise = <A>(reason: WorkspaceError["reason"], message: string, run: () => Promise<A>) =>
+    Effect.tryPromise({
+      try: run,
+      catch: workspaceFailure(reason, message),
+    })
+
+  export const layer = Layer.succeed(
+    Service,
+    Service.of({
+      create: (input) => promise("create", "Failed to create workspace", () => Workspace.create(input)),
+      list: (project) => effect("list", "Failed to list workspaces", () => Workspace.list(project)),
+      record: (id) => promise("record", `Failed to read workspace: ${id}`, () => Workspace.record(id)),
+      get: (id) => promise("get", `Failed to get workspace: ${id}`, () => Workspace.get(id)),
+      ensureSync: (space, hint) =>
+        effect("sync", space ? `Failed to start workspace sync: ${space.id}` : "Failed to start workspace sync", () =>
+          Workspace.ensureSync(space, hint),
+        ),
+      remove: (id) => promise("remove", `Failed to remove workspace: ${id}`, () => Workspace.remove(id)),
+      resolveAdaptor: (input) =>
+        promise("adaptor", `Failed to resolve workspace adaptor: ${input.type}`, () => Workspace.resolveAdaptor(input)),
+      status: () => effect("status", "Failed to read workspace status", () => Workspace.status()),
+    }),
+  )
+  export const defaultLayer = layer
 
   async function bootstrapAdaptor(
     input: Pick<StoredInfo, "projectID" | "type" | "owner"> & { hint?: string | null },
@@ -209,16 +285,11 @@ export namespace Workspace {
     const scopedAuth =
       requestedProviders.length === 0
         ? undefined
-        : await AppRuntime.runPromise(
-            Auth.Service.use((auth) =>
-              Effect.gen(function* () {
-                const all = yield* auth.all()
-                return Object.fromEntries(
-                  requestedProviders
-                    .map((provider) => [provider, all[provider]] as const)
-                    .filter(([, value]) => value !== undefined),
-                )
-              }),
+        : await Auth.all().then((all) =>
+            Object.fromEntries(
+              requestedProviders
+                .map((provider) => [provider, all[provider]] as const)
+                .filter(([, value]) => value !== undefined),
             ),
           )
 

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -50,6 +50,7 @@ import { SessionShare } from "@/share/session"
 import { ShareRuntime } from "@/share/runtime"
 import { Automation } from "@/automation"
 import { SyncEvent } from "@/sync"
+import { Workspace } from "@/control-plane/workspace"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { InstanceLayer } from "@/project/instance-layer"
 
@@ -103,6 +104,7 @@ export const AppLayer = Layer.mergeAll(
   ShareRuntime.cloudShareGateDefaultLayer,
   Automation.defaultLayer,
   SyncEvent.defaultLayer,
+  Workspace.defaultLayer,
 ).pipe(Layer.provideMerge(InstanceLayer.layer))
 
 const rt = ManagedRuntime.make(AppLayer, { memoMap })

--- a/packages/opencode/src/server/instance/workspace-routing.ts
+++ b/packages/opencode/src/server/instance/workspace-routing.ts
@@ -99,7 +99,7 @@ export function resolveWorkspaceRoute(input: {
   ensureConfig: boolean
   isPawWork: boolean
   isWebSocketUpgrade?: boolean
-}): Effect.Effect<WorkspaceRouteResolution, WorkspaceRoutingError> {
+}): Effect.Effect<WorkspaceRouteResolution, WorkspaceRoutingError, Workspace.Service> {
   return Effect.gen(function* () {
     const sessionWorkspaceID = yield* Effect.tryPromise({
       try: () => getSessionWorkspace(input.pathname),
@@ -124,10 +124,10 @@ export function resolveWorkspaceRoute(input: {
       try: () => WorkspaceID.make(workspaceID),
       catch: workspaceRoutingFailure("workspace-id", `Invalid workspace id: ${workspaceID}`),
     })
-    const workspace = yield* Effect.tryPromise({
-      try: () => Workspace.record(id),
-      catch: workspaceRoutingFailure("workspace-record", `Failed to read workspace: ${id}`),
-    })
+    const workspaceService = yield* Workspace.Service
+    const workspace = yield* workspaceService
+      .record(id)
+      .pipe(Effect.mapError(workspaceRoutingFailure("workspace-record", `Failed to read workspace: ${id}`)))
 
     if (!workspace) {
       const decision = classifyWorkspaceRoute({
@@ -141,19 +141,16 @@ export function resolveWorkspaceRoute(input: {
       return { action: "missing-workspace-error", workspaceID: id }
     }
 
-    yield* Effect.try({
-      try: () => Workspace.ensureSync(workspace, input.directory),
-      catch: workspaceRoutingFailure("workspace-sync", `Failed to start workspace sync: ${id}`),
-    })
+    yield* workspaceService
+      .ensureSync(workspace, input.directory)
+      .pipe(Effect.mapError(workspaceRoutingFailure("workspace-sync", `Failed to start workspace sync: ${id}`)))
 
-    const adaptor = yield* Effect.tryPromise({
-      try: () =>
-        Workspace.resolveAdaptor({
-          ...workspace,
-          hint: input.directory,
-        }),
-      catch: workspaceRoutingFailure("workspace-adaptor", `Failed to resolve workspace adaptor: ${id}`),
-    })
+    const adaptor = yield* workspaceService
+      .resolveAdaptor({
+        ...workspace,
+        hint: input.directory,
+      })
+      .pipe(Effect.mapError(workspaceRoutingFailure("workspace-adaptor", `Failed to resolve workspace adaptor: ${id}`)))
     const target = yield* Effect.tryPromise({
       try: async () => {
         const next = await adaptor.target(workspace)

--- a/packages/opencode/test/server/workspace-routing-decision.test.ts
+++ b/packages/opencode/test/server/workspace-routing-decision.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
+import { Workspace } from "../../src/control-plane/workspace"
+import { WorkspaceID } from "../../src/control-plane/schema"
+import { ProjectID } from "../../src/project/schema"
 import {
   classifyWorkspaceRoute,
   resolveWorkspaceRoute,
@@ -107,7 +110,7 @@ describe("workspace routing decisions", () => {
         workspaceID: undefined,
         ensureConfig: true,
         isPawWork: false,
-      }),
+      }).pipe(Effect.provide(Workspace.defaultLayer)),
     )
 
     expect(decision).toEqual({
@@ -115,5 +118,74 @@ describe("workspace routing decisions", () => {
       directory,
       createLegacyConfig: true,
     })
+  })
+
+  test("resolves workspace routes through the injected Workspace service", async () => {
+    const id = WorkspaceID.make("ws_effect_router")
+    const requestDirectory = "/tmp/pawwork-effect-request"
+    const targetDirectory = "/tmp/pawwork-effect-target"
+    const calls: string[] = []
+
+    const decision = await Effect.runPromise(
+      resolveWorkspaceRoute({
+        method: "GET",
+        pathname: "/path",
+        directory: requestDirectory,
+        workspaceID: id,
+        ensureConfig: false,
+        isPawWork: true,
+      }).pipe(
+        Effect.provideService(
+          Workspace.Service,
+          Workspace.Service.of({
+            create: () => Effect.die("unexpected create"),
+            list: () => Effect.die("unexpected list"),
+            record: (workspaceID) =>
+              Effect.sync(() => {
+                calls.push(`record:${workspaceID}`)
+                return {
+                  id: workspaceID,
+                  type: "test",
+                  branch: null,
+                  name: null,
+                  directory: null,
+                  owner: null,
+                  extra: null,
+                  projectID: ProjectID.global,
+                }
+              }),
+            get: () => Effect.die("unexpected get"),
+            ensureSync: (space, hint) =>
+              Effect.sync(() => {
+                if (!space) throw new Error("expected workspace")
+                calls.push(`ensureSync:${space.id}:${hint}`)
+              }),
+            remove: () => Effect.die("unexpected remove"),
+            resolveAdaptor: (space) =>
+              Effect.sync(() => {
+                calls.push(`resolveAdaptor:${id}:${space.type}`)
+                return {
+                  configure: (input) => input,
+                  create: async () => {},
+                  remove: async () => {},
+                  target: () => ({ type: "local" as const, directory: targetDirectory }),
+                }
+              }),
+            status: () => Effect.succeed([]),
+          }),
+        ),
+      ),
+    )
+
+    expect(decision).toEqual({
+      action: "provide-local-context",
+      directory: targetDirectory,
+      workspaceID: id,
+    })
+    expect(calls).toEqual([
+      `record:${id}`,
+      `ensureSync:${id}:${requestDirectory}`,
+      `resolveAdaptor:${id}:test`,
+    ])
   })
 })


### PR DESCRIPTION
## Summary

Adds a `Workspace.Service` / `defaultLayer` seam for the remaining #936 Workspace service checklist item, wires it into `AppRuntime`, and moves workspace routing's workspace record/sync/adaptor lookup through the injected service.

## Why

#936's current Effect migration checklist has `Workspace` as the remaining backend service item after `SyncEvent` merged in #1282. This keeps Hono and the public route/API shape unchanged while moving the next review-sized Workspace routing dependency onto the Effect service chain with typed `WorkspaceError` failures.

## Related Issue

Refs #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether `Workspace.Service` is the right minimal seam for this slice, and whether `resolveWorkspaceRoute` still preserves existing PawWork workspace behavior while using the injected service.

## Risk Notes

No public API, SDK, OpenAPI, UI, dependency, release, or raw proxy/WebSocket behavior is intentionally changed. Existing async Workspace facades remain as the compatibility boundary for legacy route and test callers. The route inventory command generated an ignored local report under `docs/`, not a committed file.

Skipped conditional checklist items:

- Visible UI/manual screenshot check: not applicable, no visible UI or copy changed.
- Platform/packaging manual check: not applicable, no platform, packaging, updater, signing, shell, or permissions surface changed.

## How To Verify

```text
RED: bun --cwd packages/opencode test test/server/workspace-routing-decision.test.ts failed before implementation because Workspace.Service did not exist.
Focused tests: bun --cwd packages/opencode test test/server/workspace-routing-decision.test.ts test/server/workspace-router.test.ts test/plugin/workspace-adaptor.test.ts test/server/middleware.test.ts test/server/route-inventory-harness.test.ts -> 55 pass, 0 fail.
Typecheck: bun run --cwd packages/opencode typecheck -> ok.
Route inventory: bun run --cwd packages/opencode route:inventory -> completed and wrote the ignored local report docs/research/2026-06-13-route-inventory.md.
Diff check: git diff --check -> no whitespace errors.
```

## Screenshots or Recordings

Not applicable, no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
