### PR TITLE
refactor(tool): keep apply_patch verification effectful

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -44,6 +44,31 @@ function safeTotalDiff(changes: Array<{ diff: string; sensitive: boolean }>) {
     .join("")
 }
 
+const VERIFICATION_ERROR_PREFIX = "apply_patch verification failed:"
+
+function verificationError(error: unknown) {
+  if (error instanceof Error && error.message.startsWith(VERIFICATION_ERROR_PREFIX)) return error
+  const message = error instanceof Error ? error.message : String(error)
+  return new Error(`${VERIFICATION_ERROR_PREFIX} ${message}`, { cause: error })
+}
+
+const parseHunks = Effect.fn("ApplyPatchTool.parseHunks")(function* (patchText: string) {
+  return yield* Effect.try({
+    try: () => Patch.parsePatch(patchText).hunks,
+    catch: verificationError,
+  })
+})
+
+const deriveNewContents = Effect.fn("ApplyPatchTool.deriveNewContents")(function* (
+  filePath: string,
+  chunks: Patch.UpdateFileChunk[],
+) {
+  return yield* Effect.try({
+    try: () => Patch.deriveNewContentsFromChunks(filePath, chunks),
+    catch: verificationError,
+  })
+})
+
 export const ApplyPatchTool = Tool.define(
   "apply_patch",
   Effect.gen(function* () {
@@ -62,20 +87,14 @@ export const ApplyPatchTool = Tool.define(
       }
 
       // Parse the patch to get hunks
-      let hunks: Patch.Hunk[]
-      try {
-        const parseResult = Patch.parsePatch(params.patchText)
-        hunks = parseResult.hunks
-      } catch (error) {
-        return yield* Effect.fail(new Error(`apply_patch verification failed: ${error}`))
-      }
+      const hunks = yield* parseHunks(params.patchText)
 
       if (hunks.length === 0) {
         const normalized = params.patchText.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim()
         if (normalized === "*** Begin Patch\n*** End Patch") {
           return yield* Effect.fail(new Error("patch rejected: empty patch"))
         }
-        return yield* Effect.fail(new Error("apply_patch verification failed: no hunks found"))
+        return yield* Effect.fail(new Error(`${VERIFICATION_ERROR_PREFIX} no hunks found`))
       }
 
       // Validate file paths and check permissions
@@ -147,7 +166,7 @@ export const ApplyPatchTool = Tool.define(
             const stats = yield* afs.stat(filePath).pipe(Effect.catch(() => Effect.succeed(undefined)))
             if (!stats || stats.type === "Directory") {
               return yield* Effect.fail(
-                new Error(`apply_patch verification failed: Failed to read file to update: ${filePath}`),
+                new Error(`${VERIFICATION_ERROR_PREFIX} Failed to read file to update: ${filePath}`),
               )
             }
 
@@ -157,13 +176,9 @@ export const ApplyPatchTool = Tool.define(
             let bom = source.bom
 
             // Apply the update chunks to get new content
-            try {
-              const fileUpdate = Patch.deriveNewContentsFromChunks(filePath, hunk.chunks)
-              newContent = fileUpdate.content
-              bom = fileUpdate.bom
-            } catch (error) {
-              return yield* Effect.fail(new Error(`apply_patch verification failed: ${error}`))
-            }
+            const fileUpdate = yield* deriveNewContents(filePath, hunk.chunks)
+            newContent = fileUpdate.content
+            bom = fileUpdate.bom
 
             const diff = trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
 
@@ -206,13 +221,7 @@ export const ApplyPatchTool = Tool.define(
 
           case "delete": {
             const source = yield* Bom.readFile(afs, filePath).pipe(
-              Effect.catch((error) =>
-                Effect.fail(
-                  new Error(
-                    `apply_patch verification failed: ${error instanceof Error ? error.message : String(error)}`,
-                  ),
-                ),
-              ),
+              Effect.catch((error) => Effect.fail(verificationError(error))),
             )
             const contentToDelete = source.text
             const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
 import * as fs from "fs/promises"
-import { Effect, ManagedRuntime, Layer } from "effect"
+import { Cause, Effect, ManagedRuntime, Layer } from "effect"
 import { ApplyPatchTool } from "../../src/tool/apply_patch"
 import { Instance } from "../../src/project/instance"
 import { LSP } from "../../src/lsp"
@@ -13,18 +13,19 @@ import { Truncate } from "../../src/tool/truncate"
 import { tmpdir } from "../fixture/fixture"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { TurnChange } from "../../src/session/turn-change"
+import { testEffect } from "../lib/effect"
 
-const runtime = ManagedRuntime.make(
-  Layer.mergeAll(
-    LSP.defaultLayer,
-    AppFileSystem.defaultLayer,
-    Format.defaultLayer,
-    Bus.layer,
-    Truncate.defaultLayer,
-    Agent.defaultLayer,
-    TurnChange.defaultLayer,
-  ),
+const testLayer = Layer.mergeAll(
+  LSP.defaultLayer,
+  AppFileSystem.defaultLayer,
+  Format.defaultLayer,
+  Bus.layer,
+  Truncate.defaultLayer,
+  Agent.defaultLayer,
+  TurnChange.defaultLayer,
 )
+const runtime = ManagedRuntime.make(testLayer)
+const it = testEffect(testLayer)
 
 const baseCtx = {
   sessionID: SessionID.make("ses_test"),
@@ -57,6 +58,13 @@ const execute = async (params: { patchText: string }, ctx: ToolCtx) => {
   return runtime.runPromise(tool.execute(params, ctx))
 }
 
+const executeEffect = (params: { patchText: string }, ctx: ToolCtx) =>
+  Effect.gen(function* () {
+    const info = yield* ApplyPatchTool
+    const tool = yield* info.init()
+    return yield* tool.execute(params, ctx)
+  })
+
 const makeCtx = () => {
   const calls: AskInput[] = []
   const ctx: ToolCtx = {
@@ -71,6 +79,21 @@ const makeCtx = () => {
 }
 
 describe("tool.apply_patch freeform", () => {
+  it.effect("initializes through Effect and preserves the current defectified execute boundary", () =>
+    Effect.gen(function* () {
+      const { ctx } = makeCtx()
+
+      const exit = yield* executeEffect({ patchText: "invalid patch" }, ctx).pipe(Effect.exit)
+      expect(exit._tag).toBe("Failure")
+      if (exit._tag === "Failure") {
+        expect(Cause.hasDies(exit.cause)).toBe(true)
+        const error = Cause.squash(exit.cause)
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toContain("apply_patch verification failed")
+      }
+    }),
+  )
+
   test("requires patchText", async () => {
     const { ctx } = makeCtx()
     await expect(execute({ patchText: "" }, ctx)).rejects.toThrow("patchText is required")
@@ -78,7 +101,12 @@ describe("tool.apply_patch freeform", () => {
 
   test("rejects invalid patch format", async () => {
     const { ctx } = makeCtx()
-    await expect(execute({ patchText: "invalid patch" }, ctx)).rejects.toThrow("apply_patch verification failed")
+    await expect(execute({ patchText: "invalid patch" }, ctx)).rejects.toMatchObject({
+      message: "apply_patch verification failed: Invalid patch format: missing Begin/End markers",
+      cause: expect.objectContaining({
+        message: "Invalid patch format: missing Begin/End markers",
+      }),
+    })
   })
 
   test("rejects empty patch", async () => {


### PR DESCRIPTION
## Summary

Keep `apply_patch` verification inside the Effect tool body by wrapping the remaining throwable patch parser/update derivation calls in traced Effect helpers.

## Why

This is the next flat #936 tool migration slice after the Workspace Effect seam. `apply_patch` already runs on Effect services; this narrows the remaining synchronous throw boundary in verification while preserving the current Hono/tool framework error behavior.

## Related Issue

Closes part of #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether the parser/update derivation boundaries are now the smallest correct Effect wrappers and whether the test guardrail covers Effect-native init/execution without changing existing tool error semantics.

## Risk Notes

No UI, platform, dependency, generated, release, or public API surface changed. Existing non-ExternalResult tool errors still defectify through the tool framework; this PR intentionally does not change that broader policy.

## How To Verify

```text
Focused tool tests: bun --cwd packages/opencode test test/tool/apply_patch.test.ts -> 29 passed
Package typecheck: bun run --cwd packages/opencode typecheck -> passed
Route/tool inventory guardrail: bun run --cwd packages/opencode route:inventory -> passed, generated ignored docs/research/2026-06-13-route-inventory.md
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable: no visible UI or copy changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
