### PR TITLE
refactor(tool): keep bash initialization effectful

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -658,8 +658,7 @@ export const ShellTool = Tool.define(
       }
     })
 
-    return () =>
-      Effect.gen(function* () {
+    return Effect.fn("ShellTool.init")(function* () {
         const directory = (yield* InstanceState.context).directory
         const shell = Shell.acceptable()
         const name = Shell.name(shell)

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -659,95 +659,95 @@ export const ShellTool = Tool.define(
     })
 
     return Effect.fn("ShellTool.init")(function* () {
-        const directory = (yield* InstanceState.context).directory
-        const shell = Shell.acceptable()
-        const name = Shell.name(shell)
-        log.info("shell tool using shell", { shell })
+      const directory = (yield* InstanceState.context).directory
+      const shell = Shell.acceptable()
+      const name = Shell.name(shell)
+      log.info("shell tool using shell", { shell })
 
-        const limits: Limits = { maxLines: Truncate.MAX_LINES, maxBytes: Truncate.MAX_BYTES }
-        const description = renderDescription({
-          name,
-          platform: process.platform,
-          directory,
-          tmp: Global.Path.tmp,
-          limits,
-          defaultTimeout: DEFAULT_TIMEOUT,
-        })
-
-        const deps: ArtifactDeps = {
-          resolveExecutionPath,
-          assertExternalDirectory: assertExternalDirectoryEffect,
-          readTrackedState,
-          discoverOfficeOutputs,
-          officeCliTargets,
-          nonOfficeCliCommandText,
-          isLikelyWriteCommand,
-          recordWrite: (input) => turnChange.recordWrite(input),
-          recordUncaptured: (input) => turnChange.recordUncaptured(input),
-        }
-
-        return {
-          description,
-          parameters: Parameters,
-          execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
-            Effect.gen(function* () {
-              const instance = yield* InstanceState.context
-              const directory = instance.directory
-              const cwd = params.workdir ? yield* resolveExecutionPath(params.workdir, directory, shell) : directory
-              const permissionCwdTarget = params.workdir
-                ? yield* resolvePermissionTarget(params.workdir, directory, shell)
-                : directory
-              if (params.timeout !== undefined && params.timeout <= 0) {
-                throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
-              }
-              const timeout = params.timeout ?? DEFAULT_TIMEOUT
-              const ps = PS.has(name)
-              yield* Effect.scoped(
-                Effect.gen(function* () {
-                  const tree = yield* Effect.acquireRelease(parse(params.command, ps), (tree: Tree) =>
-                    Effect.sync(() => tree.delete()),
-                  )
-                  const scan = yield* collect(tree.rootNode, cwd, ps, shell, instance)
-                  const permissionCwd = resolveExternalPathForPermission(permissionCwdTarget, directory)
-                  if (!Instance.containsPath(permissionCwd, instance)) scan.dirs.add(permissionCwd)
-                  yield* ask(ctx, scan, params)
-                }),
-              )
-
-              // shellEnv() must run AFTER the orchestrator's before-snapshots.
-              // A `shell.env` plugin can create or modify files (config, sockets,
-              // bundled-tool drops) as a side effect; running it before the
-              // before-state read would fold that mutation into "before" and the
-              // subsequent change would never surface as a turn-change record.
-              return yield* orchestrateArtifacts(
-                {
-                  ctx,
-                  cwd,
-                  directory,
-                  shell,
-                  command: params.command,
-                  expectedOutputs: params.expected_outputs ?? [],
-                },
-                () =>
-                  Effect.gen(function* () {
-                    const env = yield* shellEnv(ctx, cwd)
-                    return yield* run(
-                      {
-                        shell,
-                        name,
-                        command: params.command,
-                        cwd,
-                        env,
-                        timeout,
-                        description: params.description,
-                      },
-                      ctx,
-                    )
-                  }),
-                deps,
-              )
-            }),
-        }
+      const limits: Limits = { maxLines: Truncate.MAX_LINES, maxBytes: Truncate.MAX_BYTES }
+      const description = renderDescription({
+        name,
+        platform: process.platform,
+        directory,
+        tmp: Global.Path.tmp,
+        limits,
+        defaultTimeout: DEFAULT_TIMEOUT,
       })
+
+      const deps: ArtifactDeps = {
+        resolveExecutionPath,
+        assertExternalDirectory: assertExternalDirectoryEffect,
+        readTrackedState,
+        discoverOfficeOutputs,
+        officeCliTargets,
+        nonOfficeCliCommandText,
+        isLikelyWriteCommand,
+        recordWrite: (input) => turnChange.recordWrite(input),
+        recordUncaptured: (input) => turnChange.recordUncaptured(input),
+      }
+
+      return {
+        description,
+        parameters: Parameters,
+        execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+          Effect.gen(function* () {
+            const instance = yield* InstanceState.context
+            const directory = instance.directory
+            const cwd = params.workdir ? yield* resolveExecutionPath(params.workdir, directory, shell) : directory
+            const permissionCwdTarget = params.workdir
+              ? yield* resolvePermissionTarget(params.workdir, directory, shell)
+              : directory
+            if (params.timeout !== undefined && params.timeout <= 0) {
+              throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
+            }
+            const timeout = params.timeout ?? DEFAULT_TIMEOUT
+            const ps = PS.has(name)
+            yield* Effect.scoped(
+              Effect.gen(function* () {
+                const tree = yield* Effect.acquireRelease(parse(params.command, ps), (tree: Tree) =>
+                  Effect.sync(() => tree.delete()),
+                )
+                const scan = yield* collect(tree.rootNode, cwd, ps, shell, instance)
+                const permissionCwd = resolveExternalPathForPermission(permissionCwdTarget, directory)
+                if (!Instance.containsPath(permissionCwd, instance)) scan.dirs.add(permissionCwd)
+                yield* ask(ctx, scan, params)
+              }),
+            )
+
+            // shellEnv() must run AFTER the orchestrator's before-snapshots.
+            // A `shell.env` plugin can create or modify files (config, sockets,
+            // bundled-tool drops) as a side effect; running it before the
+            // before-state read would fold that mutation into "before" and the
+            // subsequent change would never surface as a turn-change record.
+            return yield* orchestrateArtifacts(
+              {
+                ctx,
+                cwd,
+                directory,
+                shell,
+                command: params.command,
+                expectedOutputs: params.expected_outputs ?? [],
+              },
+              () =>
+                Effect.gen(function* () {
+                  const env = yield* shellEnv(ctx, cwd)
+                  return yield* run(
+                    {
+                      shell,
+                      name,
+                      command: params.command,
+                      cwd,
+                      env,
+                      timeout,
+                      description: params.description,
+                    },
+                    ctx,
+                  )
+                }),
+              deps,
+            )
+          }),
+      }
+    })
   }),
 )

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -38,13 +38,13 @@ const testLayer = Layer.mergeAll(
 const runtime = ManagedRuntime.make(testLayer)
 const it = testEffect(testLayer)
 
-const initBashEffect = Effect.fn("ShellToolTest.initBash")(function* () {
+const initBashEffect = Effect.gen(function* () {
   const info = yield* ShellTool
   return yield* info.init()
 })
 
 function initBash() {
-  return runtime.runPromise(initBashEffect())
+  return runtime.runPromise(initBashEffect)
 }
 
 const ctx = {
@@ -186,7 +186,7 @@ describe("tool.bash", () => {
   it.live("initializes through Effect", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
-        const tool = yield* initBashEffect()
+        const tool = yield* initBashEffect
         expect(tool.description).toContain("Executes one command in the selected shell")
         expect(tool.parameters).toBeDefined()
       }),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -11,7 +11,7 @@ import { Shell } from "../../src/shell/shell"
 import { ShellTool } from "../../src/tool/shell"
 import { Instance } from "../../src/project/instance"
 import { Filesystem } from "../../src/util/filesystem"
-import { tmpdir } from "../fixture/fixture"
+import { provideTmpdirInstance, tmpdir } from "../fixture/fixture"
 import type { Permission } from "../../src/permission"
 import { Agent } from "../../src/agent/agent"
 import { Truncate } from "../../src/tool/truncate"
@@ -25,20 +25,26 @@ import { Session as SessionNs } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { resetDatabase } from "../fixture/db"
+import { testEffect } from "../lib/effect"
 
-const runtime = ManagedRuntime.make(
-  Layer.mergeAll(
-    CrossSpawnSpawner.defaultLayer,
-    AppFileSystem.defaultLayer,
-    Plugin.defaultLayer,
-    Truncate.defaultLayer,
-    Agent.defaultLayer,
-    TurnChange.defaultLayer,
-  ),
+const testLayer = Layer.mergeAll(
+  CrossSpawnSpawner.defaultLayer,
+  AppFileSystem.defaultLayer,
+  Plugin.defaultLayer,
+  Truncate.defaultLayer,
+  Agent.defaultLayer,
+  TurnChange.defaultLayer,
 )
+const runtime = ManagedRuntime.make(testLayer)
+const it = testEffect(testLayer)
+
+const initBashEffect = Effect.fn("ShellToolTest.initBash")(function* () {
+  const info = yield* ShellTool
+  return yield* info.init()
+})
 
 function initBash() {
-  return runtime.runPromise(ShellTool.pipe(Effect.flatMap((info) => info.init())))
+  return runtime.runPromise(initBashEffect())
 }
 
 const ctx = {
@@ -177,6 +183,16 @@ const mustTruncate = (result: {
 }
 
 describe("tool.bash", () => {
+  it.live("initializes through Effect", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const tool = yield* initBashEffect()
+        expect(tool.description).toContain("Executes one command in the selected shell")
+        expect(tool.parameters).toBeDefined()
+      }),
+    ),
+  )
+
   each(
     "basic",
     async () => {


### PR DESCRIPTION
## Summary

- Keeps the bash tool init path as a named Effect function instead of an anonymous init callback.
- Adds an Effect-native initialization guardrail for the bash tool using the real instance test helper.

## Why

This is the next flat non-UI slice for #936's tool migration lane. The current bash implementation lives in `packages/opencode/src/tool/shell.ts` while preserving the public `bash` tool id, so this slice tightens that real init boundary without touching session processor, UI, Hono, or adjacent tool migrations.

## Related Issue

Closes part of #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether the bash tool init boundary stays Effect-native without changing shell execution, permission scanning, output capture, or registry behavior.

## Risk Notes

No user-facing behavior is intended to change. The bash tool is platform-relevant because it shells out on macOS and Windows, so the direct shell tests and package typecheck were run locally.

Labels confirmed: `task`, `harness`, and `P2`. The visible UI checklist item is left unticked because this PR has no visible UI or copy changes.

## How To Verify

```text
Focused RED: bun test ./test/tool/shell.test.ts -t "initializes through Effect" failed first on the missing Effect-native helper, then passed after the helper/init change.
Focused test after Claude follow-up: bun test ./test/tool/shell.test.ts -t "initializes through Effect" -> 1 passed, 0 failed.
Focused tests: bun test ./test/tool/shell.test.ts -> 55 passed, 0 failed.
Registry guardrail: bun test ./test/tool/registry.test.ts -> 35 passed, 0 failed.
Typecheck: bun run typecheck -> tsgo --noEmit passed.
Route inventory: bun run route:inventory -> completed and wrote the local ignored inventory file.
Diff check: git diff --check -> no whitespace errors.
Fresh-eye reviewer: no blocking findings; recommended merge.
Claude read-only review: accepted concrete indentation/helper simplification feedback; re-ran verification after applying it.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved ShellTool initialization logic for better consistency and maintainability.

* **Tests**
  * Expanded test coverage for bash tool initialization to ensure proper setup and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
