### PR TITLE
refactor(tool): name edit execute effect

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -69,7 +69,10 @@ export const EditTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
-      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+      execute: Effect.fn("EditTool.execute")((
+        params: Schema.Schema.Type<typeof Parameters>,
+        ctx: Tool.Context,
+      ) =>
         Effect.gen(function* () {
           if (!params.filePath) {
             throw new Error("filePath is required")
@@ -265,7 +268,7 @@ export const EditTool = Tool.define(
             title: relativeFilePath,
             output,
           }
-        }),
+        })),
     }
   }),
 )


### PR DESCRIPTION
## Summary

Wrap the edit tool execute callback with `Effect.fn("EditTool.execute")` so the remaining high-value edit tool slice has a named Effect execution boundary without moving the implementation body.

## Why

This continues #936's non-UI tool Effect migration after the apply_patch and bash slices. The edit tool already initializes through `Tool.define(...)`; this slice keeps the existing execute behavior intact while naming the Effect boundary for tracing and consistency.

## Related Issue

Closes part of https://github.com/Astro-Han/pawwork/issues/936.

## Human Review Status

Pending

## Review Focus

Please check that the inline `Effect.fn("EditTool.execute")` wrapper keeps the original execute callback shape and avoids unrelated edit algorithm changes.

## Risk Notes

No behavior change intended. The edit algorithm, BOM handling, formatting, LSP diagnostics, FileWatcher/Bus events, permission metadata, and TurnChange recording are unchanged.

Skipped conditional checklist items:

- Manual visible UI/copy check: not applicable; this is a non-UI backend tool refactor.
- Docs/release/dependencies/etc.: not applicable; no docs, release notes, dependencies, credentials, generated content, or local file behavior changed.

macOS/Windows impact was considered: the path-handling body is unchanged, so no platform-specific behavior is intended to move in this slice.

## How To Verify

```text
Baseline focused test: bun test test/tool/edit.test.ts --timeout 30000 (packages/opencode) — 36 passed before the refactor.
Focused test: bun test test/tool/edit.test.ts --timeout 30000 (packages/opencode) — 36 passed after the final inline Effect.fn wrapper.
Typecheck: bun run typecheck (packages/opencode) — passed.
Diff check: git diff --check — passed with no output.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.