### PR TITLE
refactor(tool): name write execute effect

### DIFF
--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -38,7 +38,10 @@ export const WriteTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
-      execute: (params: { content: string; filePath: string }, ctx: Tool.Context) =>
+      execute: Effect.fn("WriteTool.execute")((
+        params: Schema.Schema.Type<typeof Parameters>,
+        ctx: Tool.Context,
+      ) =>
         Effect.gen(function* () {
           const rawFilepath = path.isAbsolute(params.filePath)
             ? params.filePath
@@ -125,6 +128,7 @@ export const WriteTool = Tool.define(
             output,
           }
         }).pipe(Effect.orDie),
+      ),
     }
   }),
 )


### PR DESCRIPTION
## Summary

Name the write tool execute Effect with `Effect.fn("WriteTool.execute")` while keeping the write implementation unchanged.

## Why

This is the next flat #936 tool migration slice after apply_patch, bash, and edit. The write tool already executes through Effect; this PR removes the anonymous execute boundary so traces and the tool migration shape match the nearby Effect-native tools.

## Related Issue

Part of #936.

## Human Review Status

Pending

## Review Focus

Please confirm the change stays limited to the execute wrapper and does not alter write permissions, formatting, diagnostics, Bus/FileWatcher events, or TurnChange recording.

## Risk Notes

Behavior risk is expected to be low because the write algorithm and `.pipe(Effect.orDie)` behavior are unchanged. macOS and Windows impact considered: the filesystem and permission behavior remains on the same code path.

Skipped checklist items:

- Visible UI/copy check: not applicable, no UI or copy changed.
- Docs/release/dependencies/credentials/deletion/generated/local-file checklist: not applicable, none of those surfaces changed.

## How To Verify

```text
Baseline focused test: bun test test/tool/write.test.ts -> 15 pass, 0 fail
Post-change focused test: bun test test/tool/write.test.ts -> 15 pass, 0 fail
Typecheck: bun run typecheck -> tsgo --noEmit passed
Diff check: git diff --check -> passed with no whitespace errors
Fresh-eye reviewer: no P0-P3 findings; recommended keeping this minimal slice
Claude read-only review: no P0-P3 findings; optional cross-file simplification intentionally left out of scope
```

## Screenshots or Recordings

Not applicable, no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal implementation of the write tool with improved type safety and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->