### PR TITLE
refactor(tool): name grep execute effect

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -29,7 +29,10 @@ export const GrepTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
-      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+      execute: Effect.fn("GrepTool.execute")((
+        params: Schema.Schema.Type<typeof Parameters>,
+        ctx: Tool.Context,
+      ) =>
         Effect.gen(function* () {
           const empty = {
             title: params.pattern,
@@ -163,6 +166,7 @@ export const GrepTool = Tool.define(
             output: output.join("\n"),
           }
         }).pipe(Effect.orDie),
+      ),
     }
   }),
 )


### PR DESCRIPTION
## Summary

Wrap the grep tool `execute` body in a named `Effect.fn("GrepTool.execute")` while preserving the existing `Effect.gen(...).pipe(Effect.orDie)` execution body.

## Why

This continues #936's tool Effect migration by making grep match the recently merged Effect-native execute pattern used by adjacent tools. The slice is intentionally limited to tracing/Effect shape only.

## Related Issue

Closes part of #936.

## Human Review Status

Pending

## Review Focus

Please verify that this is only the execute-wrapper migration and that grep's search semantics, permissions, output formatting, and error behavior remain unchanged.

## Risk Notes

No intended behavior, API, permission, output, dependency, generated-file, UI, docs, release, or platform changes. Conditional checklist items left unticked only where the surface is not touched: visible UI/copy, platform/packaging, docs/release/dependencies/credentials/deletion/generated/local file changes.

## How To Verify

```text
Baseline: bun --cwd packages/opencode test test/tool/grep.test.ts — 10 passed before the refactor
Focused tests: bun --cwd packages/opencode test test/tool/grep.test.ts — 10 passed after the refactor
Typecheck: bun run typecheck from packages/opencode — tsgo --noEmit passed
Whitespace: git diff --check — passed
```

## Screenshots or Recordings

Not applicable. This change has no visible UI surface.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
