### PR TITLE
refactor(tool): name webfetch execute effect

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -28,7 +28,10 @@ export const WebFetchTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
-      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+      execute: Effect.fn("WebFetchTool.execute")((
+        params: Schema.Schema.Type<typeof Parameters>,
+        ctx: Tool.Context,
+      ) =>
         Effect.gen(function* () {
           if (!params.url.startsWith("http://") && !params.url.startsWith("https://")) {
             throw new Error("URL must start with http:// or https://")
@@ -153,6 +156,7 @@ export const WebFetchTool = Tool.define(
               return { output: content, title, metadata: {} }
           }
         }).pipe(Effect.orDie),
+      ),
     }
   }),
 )


### PR DESCRIPTION
## Summary

Names the `webfetch` tool execute Effect boundary with `Effect.fn("WebFetchTool.execute")`.

## Why

This continues the #936 non-UI backend Effect migration slices by aligning `webfetch.ts` with the already-merged tool execute tracing pattern used by grep, write, and edit. The tool behavior stays unchanged.

## Related Issue

Part of #936.

## Human Review Status

Pending

## Review Focus

Please verify that the `Effect.fn("WebFetchTool.execute")` wrapper preserves the existing webfetch validation, permission, header, fallback, size-limit, output, and error semantics.

## Risk Notes

No behavior change intended. The diff only names the execute trace boundary. Skipped conditional checklist items: no visible UI or copy changed; no platform, packaging, updater, signing, path, shell, or permission surface changed; no docs, release notes, dependencies, credentials, deletion behavior, generated content, or local file changes were introduced.

## How To Verify

```text
Baseline focused test: bun test test/tool/webfetch.test.ts — 7 pass on origin/dev before the change
Focused test: bun test test/tool/webfetch.test.ts — 7 pass after the change
Typecheck: bun run typecheck — passed in packages/opencode
Diff check: git diff --check — passed
Fresh-eye review: no findings; recommended proceed
Claude read-only review: no findings; confirmed the change is the simplest safe pattern
```

## Screenshots or Recordings

Not applicable: no visible UI or copy changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal implementation of the web fetch tool to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->