### PR TITLE
refactor(tool): name websearch execute effect

### DIFF
--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -33,7 +33,10 @@ export const WebSearchTool = Tool.define(
         return DESCRIPTION.replace("{{year}}", new Date().getFullYear().toString())
       },
       parameters: Parameters,
-      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+      execute: Effect.fn("WebSearchTool.execute")((
+        params: Schema.Schema.Type<typeof Parameters>,
+        ctx: Tool.Context,
+      ) =>
         Effect.gen(function* () {
           yield* ctx.ask({
             permission: "websearch",
@@ -77,7 +80,7 @@ export const WebSearchTool = Tool.define(
             title: `Web search: ${params.query}`,
             metadata: {},
           }
-        }),
+        })),
     }
   }),
 )


### PR DESCRIPTION
## Summary

Wrap `WebSearchTool.execute` with `Effect.fn("WebSearchTool.execute")` so the websearch tool has the same named Effect trace boundary as the recently migrated tool slices.

## Why

This is the next flat #936 backend/tool migration slice after `webfetch`: it keeps the existing Hono/tool behavior unchanged while making the websearch execute body Effect-native and traceable.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please verify that this is only a trace-boundary refactor and that permission prompts, credential lookup, Exa request defaults, failure metadata, title/output/error behavior, and tests remain unchanged.

## Risk Notes

No behavior or dependency risk expected; this only names the existing Effect execute boundary.

Skipped conditional checklist items:
- Visible UI/copy check: no visible UI or copy changed.
- Platform/packaging check: no platform, packaging, updater, signing, path, shell, or permissions behavior changed.
- Docs/release/dependencies/generated/local-file surfaces: none touched.

## How To Verify

```text
Baseline focused test before the refactor: bun --cwd packages/opencode test test/tool/websearch.test.ts -> 2 pass, 0 fail
Focused test after the refactor: bun --cwd packages/opencode test test/tool/websearch.test.ts -> 2 pass, 0 fail
Typecheck: bun run typecheck from packages/opencode -> tsgo --noEmit passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
