### PR TITLE
refactor(tool): name glob execute effect

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -24,7 +24,10 @@ export const GlobTool = Tool.define(
     return {
       description: DESCRIPTION,
       parameters: Parameters,
-      execute: (params: { pattern: string; path?: string }, ctx: Tool.Context) =>
+      execute: Effect.fn("GlobTool.execute")((
+        params: Schema.Schema.Type<typeof Parameters>,
+        ctx: Tool.Context,
+      ) =>
         Effect.gen(function* () {
           const ins = yield* InstanceState.context
           yield* ctx.ask({
@@ -93,6 +96,7 @@ export const GlobTool = Tool.define(
             output: output.join("\n"),
           }
         }).pipe(Effect.orDie),
+      ),
     }
   }),
 )


### PR DESCRIPTION
## Summary

Names the glob tool's execute effect with `Effect.fn("GlobTool.execute")` and derives its execute parameter type from the existing `Parameters` schema.

## Why

This is the next flat #936 tool migration slice. It aligns `glob` with the already-migrated tool execute trace pattern while preserving the existing Hono/tool compatibility boundary and all runtime behavior.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

Please verify that this remains a trace/type-only migration for `glob` and does not change permission prompts, path resolution, external-directory handling, ripgrep limits, sorting, output, metadata, errors, or abort behavior.

## Risk Notes

Low risk: the function body is unchanged and the wrapper matches the surrounding migrated tool pattern.

Skipped conditional checklist items:

- Visible UI/copy check: not applicable; no UI or user-facing copy changed.
- Docs/release/dependencies/generated/local-file surfaces: not applicable; none changed.

## How To Verify

```text
Baseline glob test: bun --cwd packages/opencode test test/tool/glob.test.ts -> 5 pass, 0 fail before the code change
Focused glob test: bun --cwd packages/opencode test test/tool/glob.test.ts -> 5 pass, 0 fail after the code change
Package typecheck: bun --cwd packages/opencode typecheck -> tsgo --noEmit completed successfully
Diff check: git diff --check -> no whitespace errors
Fresh-eye review: independent reviewer reported no P0-P3 findings and recommended continuing
Claude read-only review: reported no findings and said the change can be merged
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the Glob tool's execute method to use an improved wrapper function pattern. This change enhances code consistency and maintainability while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
