### PR TITLE
refactor(server): route session stragglers through effect services

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -387,6 +387,7 @@ Decision table for the design:
 - MCP route handlers — migrated 2026-06-15. The current `server/instance/mcp.ts` operation handlers now run MCP service calls through `AppRuntime.runPromise(Effect.gen(...))` and `MCP.Service`, with route tests covering disabled local server add and non-OAuth auth 400 behavior. This does not change MCP service behavior, OAuth providers, or config schema.
 - Workspace route handlers — migrated 2026-06-15. The current `server/instance/workspace.ts` create/list/status/remove handlers now run through `AppRuntime.runPromise(Effect.gen(...))` and `Workspace.Service`, with route tests covering the public create/list/status/remove HTTP behavior, current-project status filtering, and legacy worktree bad-request error mapping.
 - Server routing/runtime helpers — migrated 2026-06-15. `server/proxy.ts` and `server/fence.ts` now read workspace connection status through `AppRuntime` and `Workspace.Service`, while `server/instance/workspace-routing.ts` resolves session-bound workspace ownership through the injected `Session.Service`. This keeps Hono routing behavior unchanged and leaves the service facades as legacy compatibility boundaries.
+- Session route facade stragglers — migrated 2026-06-15. The current `server/instance/session.ts` owner now routes the listed GET `/session`, share/unshare session fetches, summarize post-loop message check, and deprecated session permission response through `AppRuntime.runPromise(Effect.gen(...))` with `Session.Service` / `Permission.Service`. This only clears those route-owner stragglers; it does not claim full `server/routes/session.ts` migration and does not touch session processor, prompt, or run-state internals.
 
 ## Route handler effectification
 
@@ -418,7 +419,7 @@ When migrating, always use `{ concurrency: "unbounded" }` with `Effect.all` — 
 
 Route files to convert (each handler that calls facades should be wrapped):
 
-- [ ] `server/routes/session.ts` — heaviest; uses Session, SessionPrompt, SessionRevert, SessionCompaction, SessionShare, SessionSummary, SessionRunState, Agent, Permission, Bus
+- [ ] `server/routes/session.ts` — heaviest; current owner is `server/instance/session.ts`. The 2026-06-15 straggler pass cleared GET `/session`, share/unshare `Session.get`, summarize `Session.messages`, and deprecated permission response `Permission.reply`; heavier SessionPrompt/SessionRevert/SessionShare/etc. route work remains out of scope.
 - [ ] `server/routes/global.ts` — uses Config, Project, Provider, Vcs, Snapshot, Agent
 - [x] `server/instance/provider.ts` — migrated 2026-06-15. Provider auth route bodies now yield `ProviderAuth.Service` inside `AppRuntime.runPromise(Effect.gen(...))`; the old `server/routes/provider.ts` checklist path is stale in the current tree.
 - [ ] `server/routes/question.ts` — stale checklist path. The current tree has no `server/instance/question.ts` route; do not claim completion without a live route owner.

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -116,17 +116,19 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const query = c.req.valid("query")
-        const sessions: Session.Info[] = []
-        for await (const session of Session.list({
-          directory: query.directory,
-          roots: query.roots,
-          start: query.start,
-          search: query.search,
-          limit: query.limit,
-          sort: query.sort,
-        })) {
-          sessions.push(session)
-        }
+        const sessions = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const session = yield* Session.Service
+            return yield* session.list({
+              directory: query.directory,
+              roots: query.roots,
+              start: query.start,
+              search: query.search,
+              limit: query.limit,
+              sort: query.sort,
+            })
+          }),
+        )
         return c.json(sessions)
       },
     )
@@ -650,7 +652,12 @@ export const SessionRoutes = lazy(() =>
           return c.json({ error: "cloud_share_disabled" }, 410)
         }
         const share = await SessionShare.share(sessionID)
-        const session = await Session.get(sessionID)
+        const session = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.get(sessionID)
+          }),
+        )
         return c.json({
           ...session,
           share,
@@ -1040,7 +1047,12 @@ export const SessionRoutes = lazy(() =>
           return c.json({ error: "cloud_share_disabled" }, 410)
         }
         await SessionShare.unshare(sessionID)
-        const session = await Session.get(sessionID)
+        const session = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.get(sessionID)
+          }),
+        )
         return c.json({
           ...session,
           share: undefined,
@@ -1114,7 +1126,12 @@ export const SessionRoutes = lazy(() =>
         // resolve `true` for a session that visibly failed. Surface the
         // error so SDK callers can branch on it. User-initiated aborts are
         // not failures from the route's perspective.
-        const finalMsgs = await Session.messages({ sessionID })
+        const finalMsgs = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            return yield* sessions.messages({ sessionID })
+          }),
+        )
         for (let i = finalMsgs.length - 1; i >= 0; i--) {
           const info = finalMsgs[i].info
           if (info.role !== "assistant" || info.mode !== "compaction") continue
@@ -1659,10 +1676,15 @@ export const SessionRoutes = lazy(() =>
         const params = c.req.valid("param")
         // Await so an unknown permission surfaces this route's documented 404
         // instead of being swallowed by a fire-and-forget rejection.
-        await Permission.reply({
-          requestID: params.permissionID,
-          reply: c.req.valid("json").response,
-        })
+        await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const permission = yield* Permission.Service
+            yield* permission.reply({
+              requestID: params.permissionID,
+              reply: c.req.valid("json").response,
+            })
+          }),
+        )
         return c.json(true)
       },
     ),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -80,6 +80,15 @@ type GlobalListRow = SessionRow & {
   lastUserMessageAt?: number | null
 }
 type ProjectFallback = { worktree?: string | null; vcs?: string | null }
+type ListInput = {
+  directory?: string
+  workspaceID?: WorkspaceID
+  roots?: boolean
+  start?: number
+  search?: string
+  limit?: number
+  sort?: SessionListSort
+}
 
 function legacyExecutionContext(row: SessionRow, project: ProjectFallback | undefined) {
   const ownerDirectoryRaw = project?.vcs === "git" ? (project.worktree ?? row.directory) : row.directory
@@ -514,6 +523,7 @@ export interface Interface {
   }) => Effect.Effect<Info>
   readonly fork: (input: { sessionID: SessionID; messageID?: MessageID }) => Effect.Effect<Info>
   readonly touch: (sessionID: SessionID) => Effect.Effect<void>
+  readonly list: (input?: ListInput) => Effect.Effect<Info[]>
   readonly get: (id: SessionID) => Effect.Effect<Info>
   readonly setTitle: (input: { sessionID: SessionID; title: string }) => Effect.Effect<void>
   readonly setArchived: (input: { sessionID: SessionID; time?: number }) => Effect.Effect<void>
@@ -679,6 +689,11 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
           )
         : undefined
       return fromRow(row, project)
+    })
+
+    const list = Effect.fn("Session.list")(function* (input?: ListInput) {
+      const ctx = yield* InstanceState.context
+      return yield* Effect.sync(() => listForProject(ctx.project, input))
     })
 
     const children = Effect.fn("Session.children")(function* (parentID: SessionID) {
@@ -1143,6 +1158,7 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       getPart,
       updatePartDelta,
       findMessage,
+      list,
     })
   }),
 )
@@ -1233,16 +1249,7 @@ const activitySelect = {
   lastUserMessageAt: lastUserMessageAtExpr,
 }
 
-export function* list(input?: {
-  directory?: string
-  workspaceID?: WorkspaceID
-  roots?: boolean
-  start?: number
-  search?: string
-  limit?: number
-  sort?: SessionListSort
-}) {
-  const project = Instance.project
+function listForProject(project: { id: ProjectID }, input?: ListInput) {
   const conditions = [eq(SessionTable.project_id, project.id)]
 
   if (input?.workspaceID) {
@@ -1286,9 +1293,11 @@ export function* list(input?: {
     )
     for (const item of items) projects.set(item.id, item)
   }
-  for (const row of rows) {
-    yield fromRow(row, projects.get(row.project_id))
-  }
+  return rows.map((row) => fromRow(row, projects.get(row.project_id)))
+}
+
+export function* list(input?: ListInput) {
+  yield* listForProject(Instance.project, input)
 }
 
 export function* listGlobal(input?: {

--- a/packages/opencode/test/server/permission-routes.test.ts
+++ b/packages/opencode/test/server/permission-routes.test.ts
@@ -7,6 +7,7 @@ import { PermissionID } from "../../src/permission/schema"
 import { Instance } from "../../src/project/instance"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { PermissionRoutes } from "../../src/server/instance/permission"
+import { SessionRoutes } from "../../src/server/instance/session"
 import { SessionID } from "../../src/session/schema"
 import { tmpdir } from "../fixture/fixture"
 
@@ -17,6 +18,12 @@ afterEach(async () => {
 describe("permission routes", () => {
   function app() {
     const instance = new Hono().route("/permission", PermissionRoutes())
+    instance.onError(ErrorMiddleware)
+    return instance
+  }
+
+  function sessionApp() {
+    const instance = new Hono().route("/session", SessionRoutes())
     instance.onError(ErrorMiddleware)
     return instance
   }
@@ -70,6 +77,51 @@ describe("permission routes", () => {
         })
 
         expect(response.status).toBe(404)
+      },
+    })
+  })
+
+  test("replies through the deprecated session permission route", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const sessionID = SessionID.descending()
+        const requestID = PermissionID.ascending()
+        const pending = await AppRuntime.runPromise(Deferred.make<void>())
+        const asked = AppRuntime.runPromise(
+          Permission.Service.use((permission) =>
+            permission.ask({
+              id: requestID,
+              sessionID,
+              permission: "bash",
+              patterns: ["echo ok"],
+              metadata: {},
+              always: ["echo ok"],
+              ruleset: [{ permission: "bash", pattern: "echo ok", action: "ask" }],
+              onPending: () => Deferred.succeed(pending, undefined),
+            }),
+          ),
+        )
+
+        await AppRuntime.runPromise(Deferred.await(pending))
+
+        try {
+          const response = await sessionApp().request(`/session/${sessionID}/permissions/${requestID}`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ response: "once" }),
+          })
+
+          expect(response.status).toBe(200)
+          expect(await response.json()).toBe(true)
+          await expect(asked).resolves.toBeUndefined()
+        } finally {
+          await AppRuntime.runPromise(
+            Permission.Service.use((permission) => permission.reply({ requestID, reply: "reject" })),
+          ).catch(() => undefined)
+          await asked.catch(() => undefined)
+        }
       },
     })
   })

--- a/packages/opencode/test/server/session-runtime-routes.test.ts
+++ b/packages/opencode/test/server/session-runtime-routes.test.ts
@@ -37,14 +37,10 @@ describe("session runtime routes", () => {
       fn: async () => {
         const session = await svc.create({})
 
-        const shared = { ...session, share: { url: "https://share.example/s/demo" } }
-        const unshared = { ...session, share: undefined }
+        const share = { url: "https://share.example/s/demo" }
 
-        const shareSpy = spyOn(SessionShare, "share").mockResolvedValue({ url: shared.share!.url } as any)
+        const shareSpy = spyOn(SessionShare, "share").mockResolvedValue(share as any)
         const unshareSpy = spyOn(SessionShare, "unshare").mockResolvedValue(undefined as any)
-        const getSpy = spyOn(SessionNs, "get")
-        getSpy.mockResolvedValueOnce(shared as any)
-        getSpy.mockResolvedValueOnce(unshared as any)
 
         const commandSpy = spyOn(SessionPrompt, "command").mockResolvedValue({
           info: { id: "msg_command", sessionID: session.id, role: "assistant" },
@@ -58,7 +54,7 @@ describe("session runtime routes", () => {
 
         const shareRes = await app.request(`/session/${session.id}/share`, { method: "POST" })
         expect(shareRes.status).toBe(200)
-        expect((await shareRes.json()).share.url).toBe(shared.share!.url)
+        expect((await shareRes.json()).share.url).toBe(share.url)
         expect(shareSpy).toHaveBeenCalledWith(session.id)
 
         const unshareRes = await app.request(`/session/${session.id}/share`, { method: "DELETE" })


### PR DESCRIPTION
## Summary

Routes the listed session owner facade stragglers through the shared Effect runtime boundary:

- Adds `Session.Service.list` while preserving the legacy `Session.list` generator facade for existing callers.
- Moves GET `/session`, share/unshare session fetches, summarize post-loop message reads, and the deprecated session permission response route onto `AppRuntime` + `Session.Service` / `Permission.Service`.
- Records the partial session route straggler cleanup without claiming full session route migration.

## Why

This is part of the non-UI backend Effect migration lane. The current session route owner still had a few raw facade calls in otherwise Effect-aware route code; this PR clears those specific stragglers without expanding into session processor, prompt, or run-state internals.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the new `Session.Service.list` boundary preserves the legacy list query behavior and whether the route handlers still return the same HTTP responses while using the shared runtime.

## Risk Notes

Low risk backend migration. Permission surface touched only for the deprecated session permission response route; behavior is covered by a focused route test and the reply schema is unchanged. Migration docs were updated only to record this partial straggler cleanup. No UI/copy, platform/packaging, dependency, credential, generated-content, or deletion behavior was changed.

## How To Verify

```text
Baseline focused routes: 20 passed before implementation.
Focused server routes: bun test test/server/session-core-routes.test.ts test/server/session-runtime-routes.test.ts test/server/session-messages.test.ts test/server/permission-routes.test.ts -> 21 passed.
Session list compatibility: bun test test/server/session-list.test.ts -> 8 passed.
Typecheck: bun run typecheck -> tsgo --noEmit passed.
Diff check: git diff --check -> passed.
Route facade inventory: rg -n "Session\.(list|get|messages)\(|Permission\.reply\(" packages/opencode/src/server/instance/session.ts -> no matches.
Fresh-eye review: no blocking findings.
Claude read-only review: no P0/P1 findings; optional P3 notes did not require code changes.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Session route handlers refactored to use standardized effect-based execution for enhanced reliability and consistency across session operations.
  * Session service extended with improved list functionality for better session management.
  * Test coverage updated to verify session permission and sharing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->