### PR TITLE
fix(permission): default opencli web tools to allow, matching browser and edits

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -83,8 +83,12 @@ export namespace Agent {
           const defaults = Permission.fromConfig({
             "*": "allow",
             doom_loop: "ask",
-            opencli_read: "ask",
-            opencli_write: "ask",
+            // Web automation (browser_* tools and the opencli adapters) inherits
+            // the "*": "allow" baseline by design: the embedded browser is local
+            // and fully visible to the user, which is the safety net (browser
+            // design §9). It stays consistent with file editing, which is also
+            // default-allow. Tighten per target with permission rules if ever
+            // needed — the gate is default-open, not absent.
             question: "deny",
             plan_enter: "deny",
             plan_exit: "deny",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -84,11 +84,14 @@ export namespace Agent {
             "*": "allow",
             doom_loop: "ask",
             // Web automation (browser_* tools and the opencli adapters) inherits
-            // the "*": "allow" baseline by design: the embedded browser is local
-            // and fully visible to the user, which is the safety net (browser
-            // design §9). It stays consistent with file editing, which is also
-            // default-allow. Tighten per target with permission rules if ever
-            // needed — the gate is default-open, not absent.
+            // the "*": "allow" baseline by design. Browser-backed actions are safe
+            // because the embedded browser is local and fully visible to the user
+            // (browser design §9). Non-browser adapters reach here read-only only —
+            // non-browser write adapters are hidden and rejected before running —
+            // so they are no riskier than webfetch, which is also default-allow.
+            // Either way this stays consistent with default-allow file editing.
+            // Tighten per target with permission rules if ever needed — the gate is
+            // default-open, not absent.
             question: "deny",
             plan_enter: "deny",
             plan_exit: "deny",

--- a/packages/opencode/test/permission/pawwork-defaults.test.ts
+++ b/packages/opencode/test/permission/pawwork-defaults.test.ts
@@ -35,12 +35,14 @@ test("build agent uses PawWork permission defaults", async () => {
       expect(Permission.evaluate("bash", "rd folder", build!.permission).action).toBe("deny")
       expect(Permission.evaluate("bash", "sudo rm -rf /", build!.permission).action).toBe("ask")
       expect(Permission.evaluate("doom_loop", "*", build!.permission).action).toBe("ask")
-      // Deliberate design ruling (browser design doc §9): every browser action
-      // defaults to allow — the embedded browser is local and fully visible,
-      // which is the safety net; permission.browser rules tighten per URL.
+      // Deliberate design ruling (browser design doc §9): web automation defaults
+      // to allow — the embedded browser is local and fully visible, which is the
+      // safety net; permission.browser rules tighten per URL. The opencli adapters
+      // inherit the same baseline so web access stays consistent with browser_*
+      // and with default-allow file editing.
       expect(Permission.evaluate("browser", "https://example.com/page", build!.permission).action).toBe("allow")
-      expect(Permission.evaluate("opencli_read", "chatgpt-app/read", build!.permission).action).toBe("ask")
-      expect(Permission.evaluate("opencli_write", "spotify/play", build!.permission).action).toBe("ask")
+      expect(Permission.evaluate("opencli_read", "chatgpt-app/read", build!.permission).action).toBe("allow")
+      expect(Permission.evaluate("opencli_write", "spotify/play", build!.permission).action).toBe("allow")
       expect(Permission.evaluate("question", "*", build!.permission).action).toBe("allow")
       expect(Permission.evaluate("plan_enter", "*", build!.permission).action).toBe("allow")
       expect(Permission.evaluate("plan_exit", "*", build!.permission).action).toBe("deny")


### PR DESCRIPTION
## Summary

Drop the `opencli_read` / `opencli_write` "ask" permission defaults so the OpenCLI web adapters inherit the `"*": "allow"` baseline. Web automation now behaves the same as the `browser_*` tools and as file editing — all default-allow, no per-action prompt.

## Why

The OpenCLI adapters were the lone web tools defaulting to `ask`, so every adapter call prompted the user — on every action, and again after each restart (the "always" grant is held only in memory and never written back to the DB). Meanwhile the `browser_*` tools already default to allow by a deliberate, documented design ruling (browser design §9: the embedded browser is local and fully visible to the user, which is the safety net), and file edits default to allow too. This change removes that one inconsistency.

The permission *mechanism* is unchanged: a user can still tighten any target via `permission.opencli_read` / `permission.opencli_write` / `permission.browser` rules (the gate is default-open, not absent), and the per-URL deny / redirect / page-move re-judge safety for the browser tools is left fully intact.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

- The single behavior change: `permission.opencli_read` / `permission.opencli_write` now resolve to `allow` by default instead of `ask`. Confirm that policy is intended — web automation default-open, gated only by the visible embedded browser + stop button, configurable per target.
- That no other code path relied on those keys defaulting to `ask` (only `pawwork-defaults.test.ts` asserted it; updated here).

## Risk Notes

Permissions/behavior change. OpenCLI web adapters — including write-access adapters that can act on third-party sites with the user's logged-in session — no longer prompt before running. The safety surface is now the visible embedded browser and the stop button, consistent with `browser_*`. A user can re-gate via `permission.opencli_read` / `permission.opencli_write` / `permission.browser` rules. No persistence, schema, migration, or platform surface was touched; this is agent-side permission policy in `packages/opencode`.

Skipped conditional checklist items: visible-UI item (no UI or copy changed — agent-side default only); platform item (no Electron / packaging / updater / signing / paths / OS-permission surface touched).

## How To Verify

```text
opencode typecheck (tsgo --noEmit): clean
bun test test/permission/ test/permission-agent.test.ts: 169 pass / 0 fail
bun test opencli-tools + browser-tools + registry + pawwork-defaults: 80 pass / 0 fail
pawwork-defaults.test.ts: opencli_read / opencli_write now assert action "allow"
```

## Screenshots or Recordings

None — no visible UI or copy changed (agent-side permission default only).

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
