### PR TITLE
fix(permission): persist "always allow" grants so they survive a restart

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -173,6 +173,21 @@ export namespace Permission {
     return evalRule(permission, pattern, ...rulesets)
   }
 
+  // Union two rulesets, dropping exact duplicates, existing entries first. Used
+  // to merge the persisted permission row with an instance's in-memory grants
+  // so neither side is lost and the row does not grow unboundedly.
+  function mergeRulesets(existing: Ruleset, incoming: Ruleset): Ruleset {
+    const key = (rule: Ruleset[number]) => JSON.stringify([rule.permission, rule.pattern, rule.action])
+    const seen = new Set(existing.map(key))
+    const merged = [...existing]
+    for (const rule of incoming) {
+      if (seen.has(key(rule))) continue
+      seen.add(key(rule))
+      merged.push(rule)
+    }
+    return merged
+  }
+
   export class Service extends Context.Service<Service, Interface>()("@opencode/Permission") {}
 
   export const layer = Layer.effect(
@@ -327,17 +342,26 @@ export namespace Permission {
         // Persist the grant so "always allow" survives an instance reload / app
         // restart. The approved list is loaded from this row at startup but was
         // never written back, so before this every restart dropped all "always"
-        // grants and re-asked. Write the full cumulative set under the project's
-        // primary key (upsert).
+        // grants and re-asked.
+        //
+        // Re-read and merge inside one synchronous use() callback rather than
+        // writing `approved` whole: several instances can share this project row
+        // (project id is the shared git-common-dir, so different worktrees or
+        // subdirectories of one repo resolve to the same row) while each keeps
+        // its own `approved` loaded at startup. Writing whole would clobber
+        // grants another instance persisted after we loaded; unioning the
+        // current row keeps every instance's grants. One process + a synchronous
+        // callback (no await between read and write) makes this atomic.
         if (existing.info.always.length > 0) {
           const now = Date.now()
-          Database.use((db) =>
-            db
-              .insert(PermissionTable)
-              .values({ project_id: projectID, data: approved, time_created: now, time_updated: now })
-              .onConflictDoUpdate({ target: PermissionTable.project_id, set: { data: approved, time_updated: now } })
-              .run(),
-          )
+          Database.use((db) => {
+            const current = db.select().from(PermissionTable).where(eq(PermissionTable.project_id, projectID)).get()
+            const data = mergeRulesets(current?.data ?? [], approved)
+            db.insert(PermissionTable)
+              .values({ project_id: projectID, data, time_created: now, time_updated: now })
+              .onConflictDoUpdate({ target: PermissionTable.project_id, set: { data, time_updated: now } })
+              .run()
+          })
         }
 
         for (const [id, item] of pending.entries()) {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -139,6 +139,9 @@ export namespace Permission {
   interface State {
     pending: Map<PermissionID, PendingEntry>
     approved: Ruleset
+    // Project this state belongs to, captured at load so reply() can persist
+    // newly approved "always" grants back to PermissionTable.
+    projectID: ProjectID
     // Tombstone of recently-resolved request IDs. A reply can cascade-resolve
     // sibling pending requests, so a client's own follow-up reply to one of
     // those would otherwise miss `pending` and look unknown. Remembering the ID
@@ -184,6 +187,7 @@ export namespace Permission {
           const state = {
             pending: new Map<PermissionID, PendingEntry>(),
             approved: row?.data ?? [],
+            projectID: ctx.project.id,
             resolved: new Set<PermissionID>(),
           }
 
@@ -271,7 +275,7 @@ export namespace Permission {
       })
 
       const reply = Effect.fn("Permission.reply")(function* (input: z.infer<typeof ReplyInput>) {
-        const { approved, pending, resolved } = yield* InstanceState.get(state)
+        const { approved, pending, resolved, projectID } = yield* InstanceState.get(state)
         const existing = pending.get(input.requestID)
         if (!existing) {
           // Already handled (most often as a cascade sibling of an earlier
@@ -318,6 +322,22 @@ export namespace Permission {
             pattern,
             action: "allow",
           })
+        }
+
+        // Persist the grant so "always allow" survives an instance reload / app
+        // restart. The approved list is loaded from this row at startup but was
+        // never written back, so before this every restart dropped all "always"
+        // grants and re-asked. Write the full cumulative set under the project's
+        // primary key (upsert).
+        if (existing.info.always.length > 0) {
+          const now = Date.now()
+          Database.use((db) =>
+            db
+              .insert(PermissionTable)
+              .values({ project_id: projectID, data: approved, time_created: now, time_updated: now })
+              .onConflictDoUpdate({ target: PermissionTable.project_id, set: { data: approved, time_updated: now } })
+              .run(),
+          )
         }
 
         for (const [id, item] of pending.entries()) {

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -657,6 +657,52 @@ test("ask - an 'always' approval relaxes asks but never a configured deny", asyn
   })
 })
 
+test("reply - an 'always' grant survives an instance reload", async () => {
+  await using tmp = await tmpdir({ git: true })
+  const ruleset = [{ permission: "browser", pattern: "*", action: "ask" as const }]
+
+  // First lifecycle: approve "always" for an origin.
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const askPromise = Permission.ask({
+        sessionID: SessionID.make("session_persist"),
+        permission: "browser",
+        patterns: ["https://ok.example/home"],
+        metadata: {},
+        always: ["https://ok.example/*"],
+        ruleset,
+      })
+      const [pending] = await waitForPending(1)
+      await Permission.reply({ requestID: pending.id, reply: "always" })
+      await askPromise
+    },
+  })
+
+  // Simulate an app restart: drop all in-memory instance state, then reload the
+  // same project directory (its on-disk DB persists).
+  await Instance.disposeAll()
+
+  // Second lifecycle: the persisted grant auto-allows the same origin with no
+  // further ask. Before the fix this re-asked, because the approval was only
+  // ever held in memory and never written back to PermissionTable.
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const result = await Permission.ask({
+        sessionID: SessionID.make("session_persist_reload"),
+        permission: "browser",
+        patterns: ["https://ok.example/other"],
+        metadata: {},
+        always: ["https://ok.example/*"],
+        ruleset,
+      })
+      expect(result).toBeUndefined()
+      expect(await Permission.list()).toEqual([])
+    },
+  })
+})
+
 const bashDeleteCases = [
   { command: "rm file.txt", rule: "rm *" },
   { command: "rm -rf folder", rule: "rm -rf *" },

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, test, expect } from "bun:test"
+import fs from "node:fs/promises"
 import os from "os"
+import path from "node:path"
 import { Bus } from "../../src/bus"
 import { Permission } from "../../src/permission"
 import { fromDeniedRule, isPermanentDeleteRule, permanentDeleteSuggestions } from "../../src/permission/diagnostic"
@@ -699,6 +701,88 @@ test("reply - an 'always' grant survives an instance reload", async () => {
       })
       expect(result).toBeUndefined()
       expect(await Permission.list()).toEqual([])
+    },
+  })
+})
+
+test("reply - sibling instances of one project merge their 'always' grants instead of clobbering", async () => {
+  // Two directories under one git repo resolve to the SAME project id (project
+  // id is the shared git-common-dir) but to DIFFERENT instances (instance state
+  // is keyed by directory), so each holds its own in-memory `approved`. This is
+  // the multi-worktree / multi-sandbox case where a whole-row write loses grants.
+  await using repo = await tmpdir({ git: true })
+  const dirA = path.join(repo.path, "a")
+  const dirB = path.join(repo.path, "b")
+  await fs.mkdir(dirA, { recursive: true })
+  await fs.mkdir(dirB, { recursive: true })
+  const ruleset = [{ permission: "bash", pattern: "*", action: "ask" as const }]
+
+  // Load instance B's permission state while the project row is still empty, so
+  // its in-memory `approved` is stale ([]) when it later writes. list() loads it.
+  await Instance.provide({ directory: dirB, fn: () => Permission.list() })
+
+  // Instance A grants "always" for `ls` and persists it to the shared row.
+  await Instance.provide({
+    directory: dirA,
+    fn: async () => {
+      const ask = Permission.ask({
+        sessionID: SessionID.make("session_merge_a"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: ["ls"],
+        ruleset,
+      })
+      const [pending] = await waitForPending(1)
+      await Permission.reply({ requestID: pending.id, reply: "always" })
+      await ask
+    },
+  })
+
+  // Instance B still holds the stale empty `approved`; it grants "always" for
+  // `pwd`. A whole-row write would replace the row with only B's grant, dropping
+  // A's `ls`. Merging the current row keeps both.
+  await Instance.provide({
+    directory: dirB,
+    fn: async () => {
+      const ask = Permission.ask({
+        sessionID: SessionID.make("session_merge_b"),
+        permission: "bash",
+        patterns: ["pwd"],
+        metadata: {},
+        always: ["pwd"],
+        ruleset,
+      })
+      const [pending] = await waitForPending(1)
+      await Permission.reply({ requestID: pending.id, reply: "always" })
+      await ask
+    },
+  })
+
+  // Restart: drop in-memory state, reload the project, confirm BOTH grants
+  // survived — a fresh instance auto-allows ls and pwd with no further ask.
+  await Instance.disposeAll()
+  await Instance.provide({
+    directory: dirA,
+    fn: async () => {
+      const ls = await Permission.ask({
+        sessionID: SessionID.make("session_merge_reload_ls"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: ["ls"],
+        ruleset,
+      })
+      expect(ls).toBeUndefined()
+      const pwd = await Permission.ask({
+        sessionID: SessionID.make("session_merge_reload_pwd"),
+        permission: "bash",
+        patterns: ["pwd"],
+        metadata: {},
+        always: ["pwd"],
+        ruleset,
+      })
+      expect(pwd).toBeUndefined()
     },
   })
 })


### PR DESCRIPTION
## Summary

On an "always allow" reply, the granted rules were pushed into the in-memory `approved` list but never written back to `PermissionTable`. Capture the project id in the permission `State` at load, and on an "always" reply upsert the full cumulative `approved` ruleset under the project's primary key so the grant persists.

## Why

The `approved` list is loaded from the project's `PermissionTable` row at instance startup (`permission/index.ts:186`), but nothing ever wrote it back — `approved.push(...)` only mutated memory. So every app restart (or instance reload) dropped all "always allow" grants and the next action re-asked. This affected **every** tool that supports "always" (edit, bash, browser, …), and was the real reason "always" felt like it never stuck.

## Related Issue

None — found while investigating the embedded-browser permission prompts (context: PR #1330).

## Human Review Status

Pending

## Review Focus

- The upsert in `reply()`: it writes the whole cumulative `approved` array under `project_id` (the table's primary key) via `onConflictDoUpdate`. Confirm that's the right shape and that writing inside the `reply` effect (synchronous `Database.use`, current instance's DB) is correct.
- That the write is gated to `existing.info.always.length > 0`, so plain "once" replies and empty-`always` browser asks don't write.

## Risk Notes

Behavior change limited to permission persistence: "always allow" now survives restarts as intended. No schema/migration change — `PermissionTable` already exists and is already read at startup; this only starts writing the column that was already being read. No platform/UI surface touched.

Skipped conditional checklist items: visible-UI item (no UI or copy changed); platform item (no Electron/packaging/updater/signing/paths surface — server-side permission persistence).

## How To Verify

```text
opencode typecheck (tsgo --noEmit): clean
bun test test/permission/: 113 pass / 0 fail (includes new reload test)
new test "reply - an 'always' grant survives an instance reload":
  approve always -> Instance.disposeAll() -> reload same dir -> ask again resolves with no prompt
  confirmed it FAILS (re-asks, ask pends -> times out) with the persistence write reverted
```

## Screenshots or Recordings

None — no visible UI or copy changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permissions marked as "always allow" now correctly persist and remain in effect after application restarts, instead of being lost on reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->