### PR TITLE
fix(permission): gate opencli group on its own keys, not browser

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -420,6 +420,16 @@ export namespace Permission {
   // Permission keys the opencli group asks at execution (read vs write commands).
   const OPENCLI_KEYS = ["opencli_read", "opencli_write"]
 
+  // True when the key's last-matching rule is a `*` deny — the same last-match
+  // convention the non-opencli path below uses. `disabled()` is only a cosmetic
+  // visibility gate, so it must never hide a usable tool; a false *show* is
+  // harmless (execution still denies). That rules out the tempting
+  // `evaluate(key, "*").action === "deny"` shortcut: querying the literal value
+  // "*" only sees the baseline rule, so `{ "*": deny, "x": allow }` would report
+  // denied and wrongly hide a group that can still run `x`. This check returns
+  // false there, keeping the group visible. Its only imperfection is the inverse
+  // — a redundant `{ "*": deny, "x": deny }` leaves the group cosmetically shown
+  // though fully denied — which execution corrects on first use.
   function isWildcardDeny(permission: string, ruleset: Ruleset): boolean {
     const rule = ruleset.findLast((entry) => Wildcard.match(permission, entry.permission))
     return rule?.pattern === "*" && rule.action === "deny"

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -417,18 +417,33 @@ export namespace Permission {
 
   const EDIT_TOOLS = ["edit", "write", "apply_patch"]
 
+  // Permission keys the opencli group asks at execution (read vs write commands).
+  const OPENCLI_KEYS = ["opencli_read", "opencli_write"]
+
+  function isWildcardDeny(permission: string, ruleset: Ruleset): boolean {
+    const rule = ruleset.findLast((entry) => Wildcard.match(permission, entry.permission))
+    return rule?.pattern === "*" && rule.action === "deny"
+  }
+
   export function disabled(tools: string[], ruleset: Ruleset): Set<string> {
     const result = new Set<string>()
     for (const tool of tools) {
-      // Browser-backed tools all ask the `browser` permission key, so a
-      // configured `permission.browser: deny` disables the whole set (hiding
-      // their deferred cards and repair hints, not just denying the eventual ask).
-      const permission = EDIT_TOOLS.includes(tool)
-        ? "edit"
-        : tool.startsWith("browser_") || tool.startsWith("opencli_")
-          ? "browser"
-          : tool
-      const rule = ruleset.findLast((rule) => Wildcard.match(permission, rule.permission))
+      // The opencli group (opencli_search + opencli_run) gates on its own
+      // opencli_read / opencli_write keys, never on "browser" — browser rules
+      // are URL-scoped, opencli rules are command-name-scoped, so conflating
+      // them let a `browser` rule appear to govern opencli while execution
+      // ignored it. Hide the group only when BOTH read and write are a
+      // configured `*: deny`; with either half allowed an adapter is still
+      // runnable, so the discovery + run tools stay.
+      if (tool.startsWith("opencli_")) {
+        if (OPENCLI_KEYS.every((key) => isWildcardDeny(key, ruleset))) result.add(tool)
+        continue
+      }
+      // Browser tools all ask the `browser` permission key, so a configured
+      // `permission.browser: deny` disables the whole set (hiding their deferred
+      // cards and repair hints, not just denying the eventual ask).
+      const permission = EDIT_TOOLS.includes(tool) ? "edit" : tool.startsWith("browser_") ? "browser" : tool
+      const rule = ruleset.findLast((entry) => Wildcard.match(permission, entry.permission))
       if (!rule) continue
       if (rule.pattern === "*" && rule.action === "deny") result.add(tool)
     }

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -487,9 +487,9 @@ test("disabled - does not disable when partially denied", () => {
   expect(result.has("bash")).toBe(false)
 })
 
-test("disabled - disables every browser-backed tool when the browser key is denied", () => {
+test("disabled - disables every browser_* tool when the browser key is denied", () => {
   const result = Permission.disabled(
-    ["browser_navigate", "browser_click", "browser_extract", "opencli_search", "opencli_run", "bash"],
+    ["browser_navigate", "browser_click", "browser_extract", "bash"],
     [
       { permission: "*", pattern: "*", action: "allow" },
       { permission: "browser", pattern: "*", action: "deny" },
@@ -498,8 +498,6 @@ test("disabled - disables every browser-backed tool when the browser key is deni
   expect(result.has("browser_navigate")).toBe(true)
   expect(result.has("browser_click")).toBe(true)
   expect(result.has("browser_extract")).toBe(true)
-  expect(result.has("opencli_search")).toBe(true)
-  expect(result.has("opencli_run")).toBe(true)
   expect(result.has("bash")).toBe(false)
 })
 
@@ -564,6 +562,42 @@ test("disabled - specific allow overrides wildcard deny", () => {
   expect(result.has("bash")).toBe(false)
   expect(result.has("edit")).toBe(true)
   expect(result.has("read")).toBe(true)
+})
+
+test("disabled - the opencli group is hidden only when both opencli_read and opencli_write are denied", () => {
+  const both = Permission.disabled(
+    ["opencli_run", "opencli_search"],
+    [
+      { permission: "opencli_read", pattern: "*", action: "deny" },
+      { permission: "opencli_write", pattern: "*", action: "deny" },
+    ],
+  )
+  expect(both.has("opencli_run")).toBe(true)
+  expect(both.has("opencli_search")).toBe(true)
+
+  // Only the write half denied: read commands still run, so the group stays.
+  const writeOnly = Permission.disabled(
+    ["opencli_run", "opencli_search"],
+    [{ permission: "opencli_write", pattern: "*", action: "deny" }],
+  )
+  expect(writeOnly.has("opencli_run")).toBe(false)
+  expect(writeOnly.has("opencli_search")).toBe(false)
+})
+
+test("disabled - a browser deny no longer hides opencli tools", () => {
+  const result = Permission.disabled(
+    ["browser_navigate", "opencli_run", "opencli_search"],
+    [{ permission: "browser", pattern: "*", action: "deny" }],
+  )
+  // browser deny still hides browser tools, but opencli is governed by its own keys.
+  expect(result.has("browser_navigate")).toBe(true)
+  expect(result.has("opencli_run")).toBe(false)
+  expect(result.has("opencli_search")).toBe(false)
+})
+
+test("disabled - a global wildcard deny still hides opencli_run", () => {
+  const result = Permission.disabled(["opencli_run"], [{ permission: "*", pattern: "*", action: "deny" }])
+  expect(result.has("opencli_run")).toBe(true)
 })
 
 // ask tests

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -1303,13 +1303,18 @@ describe("tool.registry", () => {
           })
           expect(activated.map((tool) => tool.id)).toContain("opencli_search")
 
-          const browserDenied = [{ permission: "browser", pattern: "*", action: "deny" as const }]
-          const browserDeniedDeferredAvailable = (id: string) => !Permission.disabled([id], browserDenied).has(id)
+          // The opencli group is gated by its own opencli_read / opencli_write keys
+          // (a `browser` deny no longer hides it); both halves denied hides the group.
+          const opencliDenied = [
+            { permission: "opencli_read", pattern: "*", action: "deny" as const },
+            { permission: "opencli_write", pattern: "*", action: "deny" as const },
+          ]
+          const opencliDeniedDeferredAvailable = (id: string) => !Permission.disabled([id], opencliDenied).has(id)
           const deniedDeferred = await ToolRegistry.tools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
-            deferredAvailable: browserDeniedDeferredAvailable,
+            deferredAvailable: opencliDeniedDeferredAvailable,
           })
           expect(deniedDeferred.find((tool) => tool.id === "tool_info")!.description).not.toContain("**opencli**")
 
@@ -1318,7 +1323,7 @@ describe("tool.registry", () => {
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
             activatedTools: new Set(deferredGroupMembers("opencli")),
-            deferredAvailable: browserDeniedDeferredAvailable,
+            deferredAvailable: opencliDeniedDeferredAvailable,
           })
           expect(deniedActivated.map((tool) => tool.id)).not.toContain("opencli_search")
           expect(deniedActivated.map((tool) => tool.id)).not.toContain("opencli_run")


### PR DESCRIPTION
## Summary

`Permission.disabled()` mapped every `opencli_*` tool to the `browser` permission key, so a configured `permission.browser: deny` hid the opencli discovery + run tools from the model. But the opencli adapters never ask `browser` at execution — they ask `opencli_read` / `opencli_write`. Decouple the two so the opencli group is gated by its own keys, and `browser` deny governs only `browser_*` tools.

## Why

The visibility gate (`disabled()`, which hides deferred tool cards / repair hints) and the execution gate (what `ask()` actually checks) used different permission keys for the opencli group:

- **Visibility** treated `opencli_*` as `browser`-keyed (`permission/index.ts`, old `disabled()`).
- **Execution** asks `opencli_read` / `opencli_write` for the command, plus a per-navigation `browser` ask only when an adapter drives the embedded browser (`tool/opencli-run.ts`).

The keys are scoped differently — `browser` rules are URL-scoped, `opencli_read`/`opencli_write` are command-name-scoped — so conflating them let a `browser` rule appear to govern opencli in the tool listing while execution ignored it. This was the pre-existing inconsistency surfaced by Gemini's review of #1330.

Fix: opencli tools are hidden only when **both** `opencli_read` and `opencli_write` are a configured `*: deny` (either half allowed means an adapter is still runnable, so the discovery + run tools stay). `browser` deny still hides `browser_*` as before. A global `*: deny` still hides everything.

## Related Issue

None — found while reviewing PR #1330 (embedded-browser permission prompts). Gemini's bot flagged the opencli/browser key mismatch on that PR; this is the focused fix.

## Human Review Status

Pending

## Review Focus

- The `disabled()` rewrite in `permission/index.ts`: opencli now gates on `OPENCLI_KEYS` (`opencli_read` + `opencli_write`) via `isWildcardDeny`, requiring **both** denied to hide the group. Confirm the both-vs-either choice matches intent (either half allowed ⇒ adapter runnable ⇒ keep visible).
- That `browser` deny still fully hides `browser_*` (unchanged path), and a global `*: deny` still hides opencli.

## Risk Notes

Behavior change limited to tool visibility under a `permission.browser: deny` rule: opencli discovery/run tools are no longer hidden by a browser-only deny (they were already runnable at execution under that config, so this aligns the listing with execution — not a new capability). No schema/migration/UI/platform surface touched.

Deliberate scope deferral: I did **not** promote `opencli_read` / `opencli_write` to first-class keys in the permission config schema. They already work through the config catchall, and adding schema keys would ripple into generated SDK artifacts (`packages/sdk/openapi.json`, `packages/sdk/js/src/v2/gen/types.gen.ts`) requiring regen + commit — out of scope for this focused fix.

Skipped conditional checklist items: visible-UI item (no UI or copy changed); platform item (no Electron/packaging/updater/signing/paths surface — server-side permission-key logic).

## How To Verify

```text
opencode typecheck (tsgo --noEmit): clean
bun test test/permission/ test/tool/registry.test.ts test/tool/browser-tools.test.ts test/tool/opencli-tools.test.ts:
  193 pass / 0 fail
new disabled() cases:
  - opencli group hidden only when BOTH opencli_read + opencli_write denied (write-only ⇒ stays)
  - browser deny no longer hides opencli tools (browser_* still hidden)
  - global *: deny still hides opencli_run
registry tool_info group-hiding test: switched to deny via opencli_read + opencli_write keys; group still hides correctly
```

## Screenshots or Recordings

None — no visible UI or copy changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
