### PR TITLE
fix(desktop): update OpenCLI third-party notice

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,7 @@ ci:
 platform:
   - changed-files:
       - any-glob-to-any-file:
+          - "THIRD_PARTY_NOTICES.md"
           - "packages/desktop-electron/**"
 
 app:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -17,7 +17,7 @@ PawWork packages the OpenCLI runtime files needed by the desktop app, including 
 
 - Project: https://github.com/jackwener/opencli
 - Package: `@jackwener/opencli`
-- Version: 1.8.3
+- Version: 1.8.4
 - License: Apache License 2.0
 
 The Apache License 2.0 text for OfficeCLI and OpenCLI follows.

--- a/packages/opencode/test/github/pr-triage-workflow.test.ts
+++ b/packages/opencode/test/github/pr-triage-workflow.test.ts
@@ -64,6 +64,10 @@ describe("pr triage workflow", () => {
     expect(labelerLabelsForGlob("packages/sdk/**")).toEqual(["harness"])
   })
 
+  test("routes packaged third-party notices to the platform area", () => {
+    expect(labelerLabelsForGlob("THIRD_PARTY_NOTICES.md")).toEqual(["platform"])
+  })
+
   test("labels workflow PRs with routing while scripts own priority and selected type inference", () => {
     const labels = labelerLabelsForGlob(".github/workflows/**")
 


### PR DESCRIPTION
## Summary
Update the root third-party notices entry for bundled OpenCLI from 1.8.3 to 1.8.4, and teach PR triage to route root third-party notice changes to the platform area.

This is a post-merge follow-up to #1315; there is no separate issue because the dev branch CI failure identified the missing notice update immediately after that merge.

## Why
`unit-desktop` on `dev` failed because `packages/opencode/package.json` now depends on `@jackwener/opencli` 1.8.4 while `THIRD_PARTY_NOTICES.md` still reported 1.8.3.

The follow-up PR itself also exposed that `THIRD_PARTY_NOTICES.md` had no labeler routing rule, so `pr-triage` removed manual routing labels and failed policy. Since the notices file is packaged by the desktop app, it belongs under `platform`.

## Related Issue
Follow-up to #1315.

## Human Review Status
Pending

## Review Focus
Confirm the notice version matches the OpenCLI dependency bumped in #1315, and that root third-party notice changes are routed as platform PRs.

## Risk Notes
No product behavior risk. This updates bundled third-party attribution text and a PR-triage labeler rule. No visible UI check is needed because the packaged notice file changes, not app UI copy.

## How To Verify
```text
RED: cd packages/desktop-electron && bun test ./electron-builder-app-update.test.ts failed with Expected to contain: "Version: 1.8.4".
GREEN: cd packages/desktop-electron && bun test ./electron-builder-app-update.test.ts passed, 19 tests.
RED: cd packages/opencode && bun test ./test/github/pr-triage-workflow.test.ts failed because THIRD_PARTY_NOTICES.md had no platform route.
GREEN: cd packages/opencode && bun test ./test/github/pr-triage-workflow.test.ts passed, 12 tests.
Related CI surface: cd packages/desktop-electron && bun run test:ci passed, 529 tests plus CDP smoke.
```

## Screenshots or Recordings
Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.