### PR TITLE
feat(browser): caution the model and user when automating high-risk sites

### DIFF
--- a/packages/opencode/src/tool/browser-click.ts
+++ b/packages/opencode/src/tool/browser-click.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-click.txt"
-import { normalizeElementRef, runBrowserAction, takeoverNote } from "./browser-shared"
+import { normalizeElementRef, runBrowserAction, trailingNotes } from "./browser-shared"
 
 export const Parameters = Schema.Struct({
   ref: Schema.String.annotate({
@@ -31,7 +31,7 @@ export const BrowserClickTool = Tool.define(
           output:
             `Clicked ${params.ref} (matched ${matches_n} element${matches_n === 1 ? "" : "s"}, ${match_level} match).` +
             (matches_n > 1 ? " Multiple matches — verify the right element reacted, or re-snapshot for a tighter ref." : "") +
-            takeoverNote(result.info),
+            trailingNotes(result.info),
           metadata: { ref: params.ref, matches: matches_n, matchLevel: match_level },
         }
       }),

--- a/packages/opencode/src/tool/browser-click.ts
+++ b/packages/opencode/src/tool/browser-click.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-click.txt"
-import { normalizeElementRef, runBrowserAction, trailingNotes } from "./browser-shared"
+import { normalizeElementRef, runBrowserAction, withNotes } from "./browser-shared"
 
 export const Parameters = Schema.Struct({
   ref: Schema.String.annotate({
@@ -28,10 +28,11 @@ export const BrowserClickTool = Tool.define(
         const { matches_n, match_level } = result.outcome
         return {
           title: `Clicked ${params.ref}`,
-          output:
+          output: withNotes(
+            result.info,
             `Clicked ${params.ref} (matched ${matches_n} element${matches_n === 1 ? "" : "s"}, ${match_level} match).` +
-            (matches_n > 1 ? " Multiple matches — verify the right element reacted, or re-snapshot for a tighter ref." : "") +
-            trailingNotes(result.info),
+              (matches_n > 1 ? " Multiple matches — verify the right element reacted, or re-snapshot for a tighter ref." : ""),
+          ),
           metadata: { ref: params.ref, matches: matches_n, matchLevel: match_level },
         }
       }),

--- a/packages/opencode/src/tool/browser-extract.ts
+++ b/packages/opencode/src/tool/browser-extract.ts
@@ -2,7 +2,7 @@ import { Effect, Schema } from "effect"
 import { htmlToMarkdown } from "@jackwener/opencli/utils"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-extract.txt"
-import { runBrowserAction, trailingNotes } from "./browser-shared"
+import { runBrowserAction, withNotes } from "./browser-shared"
 
 /** Per-call markdown budget; long pages page through `start`/`next_start_char`. */
 const EXTRACT_CHAR_LIMIT = 16_000
@@ -76,15 +76,16 @@ export const BrowserExtractTool = Tool.define(
         const hasMore = nextStart < markdown.length
         return {
           title: result.url || "Extracted content",
-          output:
+          output: withNotes(
+            result.info,
             chunk +
-            (hasMore
-              ? `\n\n(Content continues — call browser_extract again with start=${nextStart}. next_start_char: ${nextStart})`
-              : "") +
-            (result.read.truncated
-              ? "\n\n(The page's HTML was larger than the extraction ceiling; trailing content was dropped before conversion. Use `selector` to target the part you need.)"
-              : "") +
-            trailingNotes(result.info),
+              (hasMore
+                ? `\n\n(Content continues — call browser_extract again with start=${nextStart}. next_start_char: ${nextStart})`
+                : "") +
+              (result.read.truncated
+                ? "\n\n(The page's HTML was larger than the extraction ceiling; trailing content was dropped before conversion. Use `selector` to target the part you need.)"
+                : ""),
+          ),
           metadata: {
             url: result.url,
             selector: params.selector,

--- a/packages/opencode/src/tool/browser-extract.ts
+++ b/packages/opencode/src/tool/browser-extract.ts
@@ -2,7 +2,7 @@ import { Effect, Schema } from "effect"
 import { htmlToMarkdown } from "@jackwener/opencli/utils"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-extract.txt"
-import { runBrowserAction, takeoverNote } from "./browser-shared"
+import { runBrowserAction, trailingNotes } from "./browser-shared"
 
 /** Per-call markdown budget; long pages page through `start`/`next_start_char`. */
 const EXTRACT_CHAR_LIMIT = 16_000
@@ -84,7 +84,7 @@ export const BrowserExtractTool = Tool.define(
             (result.read.truncated
               ? "\n\n(The page's HTML was larger than the extraction ceiling; trailing content was dropped before conversion. Use `selector` to target the part you need.)"
               : "") +
-            takeoverNote(result.info),
+            trailingNotes(result.info),
           metadata: {
             url: result.url,
             selector: params.selector,

--- a/packages/opencode/src/tool/browser-navigate.ts
+++ b/packages/opencode/src/tool/browser-navigate.ts
@@ -3,6 +3,7 @@ import * as Tool from "./tool"
 import DESCRIPTION from "./browser-navigate.txt"
 import { parseNavigableUrl } from "@/browser/session"
 import { browserAlwaysPatterns, runBrowserAction, trailingNotes } from "./browser-shared"
+import { highRiskSiteNotice } from "./high-risk-site"
 
 // Above opencli's internal 30s CDP guard so a slow load surfaces the CDP
 // command timeout (which names the navigation) rather than our generic one.
@@ -64,13 +65,18 @@ export const BrowserNavigateTool = Tool.define(
             metadata: { action: "navigate", url: landed, redirectedFrom: url },
           })
         }
+        // The centralized notice keys on the REQUESTED url; a redirect can land
+        // on a high-risk site the request never named. Append the landed-url
+        // caution when the centralized one didn't already fire (so no dupe).
+        const landedNotice = result.info.highRiskNotice ? null : highRiskSiteNotice(result.landed)
         return {
           title: result.title || result.landed,
           output:
             [`Loaded ${result.landed}`, result.title ? `Title: ${result.title}` : undefined]
               .filter(Boolean)
               .join("\n") +
-            trailingNotes(result.info),
+            trailingNotes(result.info) +
+            (landedNotice ? `\n\n${landedNotice}` : ""),
           metadata: { url: result.landed, pageTitle: result.title },
         }
       }),

--- a/packages/opencode/src/tool/browser-navigate.ts
+++ b/packages/opencode/src/tool/browser-navigate.ts
@@ -2,7 +2,7 @@ import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-navigate.txt"
 import { parseNavigableUrl } from "@/browser/session"
-import { browserAlwaysPatterns, runBrowserAction, trailingNotes } from "./browser-shared"
+import { browserAlwaysPatterns, runBrowserAction, withNotes } from "./browser-shared"
 import { highRiskSiteNotice } from "./high-risk-site"
 
 // Above opencli's internal 30s CDP guard so a slow load surfaces the CDP
@@ -66,17 +66,21 @@ export const BrowserNavigateTool = Tool.define(
           })
         }
         // The centralized notice keys on the REQUESTED url; a redirect can land
-        // on a high-risk site the request never named. Append the landed-url
-        // caution when the centralized one didn't already fire (so no dupe).
-        const landedNotice = result.info.highRiskNotice ? null : highRiskSiteNotice(result.landed)
+        // on a high-risk site the request never named. Fall back to the landed-url
+        // caution when the centralized one didn't fire (so no dupe), and let
+        // withNotes lead the output with whichever applies.
+        const info = {
+          ...result.info,
+          highRiskNotice: result.info.highRiskNotice ?? highRiskSiteNotice(result.landed),
+        }
         return {
           title: result.title || result.landed,
-          output:
+          output: withNotes(
+            info,
             [`Loaded ${result.landed}`, result.title ? `Title: ${result.title}` : undefined]
               .filter(Boolean)
-              .join("\n") +
-            trailingNotes(result.info) +
-            (landedNotice ? `\n\n${landedNotice}` : ""),
+              .join("\n"),
+          ),
           metadata: { url: result.landed, pageTitle: result.title },
         }
       }),

--- a/packages/opencode/src/tool/browser-navigate.ts
+++ b/packages/opencode/src/tool/browser-navigate.ts
@@ -2,8 +2,7 @@ import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-navigate.txt"
 import { parseNavigableUrl } from "@/browser/session"
-import { browserAlwaysPatterns, runBrowserAction, takeoverNote } from "./browser-shared"
-import { highRiskSiteNotice } from "./high-risk-site"
+import { browserAlwaysPatterns, runBrowserAction, trailingNotes } from "./browser-shared"
 
 // Above opencli's internal 30s CDP guard so a slow load surfaces the CDP
 // command timeout (which names the navigation) rather than our generic one.
@@ -65,15 +64,13 @@ export const BrowserNavigateTool = Tool.define(
             metadata: { action: "navigate", url: landed, redirectedFrom: url },
           })
         }
-        const riskNotice = highRiskSiteNotice(result.landed)
         return {
           title: result.title || result.landed,
           output:
             [`Loaded ${result.landed}`, result.title ? `Title: ${result.title}` : undefined]
               .filter(Boolean)
               .join("\n") +
-            takeoverNote(result.info) +
-            (riskNotice ? `\n\n${riskNotice}` : ""),
+            trailingNotes(result.info),
           metadata: { url: result.landed, pageTitle: result.title },
         }
       }),

--- a/packages/opencode/src/tool/browser-navigate.ts
+++ b/packages/opencode/src/tool/browser-navigate.ts
@@ -3,6 +3,7 @@ import * as Tool from "./tool"
 import DESCRIPTION from "./browser-navigate.txt"
 import { parseNavigableUrl } from "@/browser/session"
 import { browserAlwaysPatterns, runBrowserAction, takeoverNote } from "./browser-shared"
+import { highRiskSiteNotice } from "./high-risk-site"
 
 // Above opencli's internal 30s CDP guard so a slow load surfaces the CDP
 // command timeout (which names the navigation) rather than our generic one.
@@ -64,12 +65,15 @@ export const BrowserNavigateTool = Tool.define(
             metadata: { action: "navigate", url: landed, redirectedFrom: url },
           })
         }
+        const riskNotice = highRiskSiteNotice(result.landed)
         return {
           title: result.title || result.landed,
           output:
             [`Loaded ${result.landed}`, result.title ? `Title: ${result.title}` : undefined]
               .filter(Boolean)
-              .join("\n") + takeoverNote(result.info),
+              .join("\n") +
+            takeoverNote(result.info) +
+            (riskNotice ? `\n\n${riskNotice}` : ""),
           metadata: { url: result.landed, pageTitle: result.title },
         }
       }),

--- a/packages/opencode/src/tool/browser-screenshot.ts
+++ b/packages/opencode/src/tool/browser-screenshot.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-screenshot.txt"
-import { runBrowserAction, takeoverNote } from "./browser-shared"
+import { runBrowserAction, trailingNotes } from "./browser-shared"
 
 export const Parameters = Schema.Struct({
   annotate: Schema.optional(Schema.Boolean).annotate({
@@ -37,7 +37,7 @@ export const BrowserScreenshotTool = Tool.define(
             `Captured a screenshot of ${result.url || "the current page"}${
               result.annotated ? " with element reference annotations" : ""
             }${params.annotate && !result.annotated ? " (annotation unavailable; plain capture)" : ""}.` +
-            takeoverNote(result.info),
+            trailingNotes(result.info),
           metadata: { url: result.url, annotated: result.annotated },
           attachments: [
             {

--- a/packages/opencode/src/tool/browser-screenshot.ts
+++ b/packages/opencode/src/tool/browser-screenshot.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-screenshot.txt"
-import { runBrowserAction, trailingNotes } from "./browser-shared"
+import { runBrowserAction, withNotes } from "./browser-shared"
 
 export const Parameters = Schema.Struct({
   annotate: Schema.optional(Schema.Boolean).annotate({
@@ -33,11 +33,12 @@ export const BrowserScreenshotTool = Tool.define(
         })
         return {
           title: result.url || "Screenshot",
-          output:
+          output: withNotes(
+            result.info,
             `Captured a screenshot of ${result.url || "the current page"}${
               result.annotated ? " with element reference annotations" : ""
-            }${params.annotate && !result.annotated ? " (annotation unavailable; plain capture)" : ""}.` +
-            trailingNotes(result.info),
+            }${params.annotate && !result.annotated ? " (annotation unavailable; plain capture)" : ""}.`,
+          ),
           metadata: { url: result.url, annotated: result.annotated },
           attachments: [
             {

--- a/packages/opencode/src/tool/browser-shared.ts
+++ b/packages/opencode/src/tool/browser-shared.ts
@@ -2,6 +2,10 @@ import { Effect } from "effect"
 import type { IPage } from "@jackwener/opencli/types"
 import * as Tool from "./tool"
 import { browserPageProbe, withBrowserPage } from "@/browser/session"
+import { highRiskSiteNotice } from "./high-risk-site"
+
+/** Info handed to every browser action's `run` callback and used to build the trailing notes on its output. */
+export type BrowserActionInfo = { takeoverReloaded: boolean; highRiskNotice: string | null }
 
 /**
  * Shared execution path for the browser_* tools: ask the `browser` permission
@@ -23,7 +27,7 @@ export function runBrowserAction<T>(input: {
   patterns?: string[]
   metadata?: Record<string, unknown>
   timeoutMs?: number
-  run: (page: IPage, info: { takeoverReloaded: boolean }) => Promise<T>
+  run: (page: IPage, info: BrowserActionInfo) => Promise<T>
 }) {
   return Effect.gen(function* () {
     // EVERY action starts by reading the session's own page URL. The
@@ -52,12 +56,16 @@ export function runBrowserAction<T>(input: {
     // An unchanged URL — the common case — skips this entirely. Explicit-
     // pattern actions (navigate) were judged against their destination, which
     // no amount of meanwhile-browsing changes.
+    // The URL the action actually operates on: navigate's destination, or the
+    // page the session is on (updated if it moved while the ask was open).
+    let actedUrl = input.patterns?.[0] ?? probe.url
     if (!input.patterns) {
       const recheck = yield* Effect.tryPromise({
         try: () => browserPageProbe(input.ctx.sessionID),
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       })
       if (recheck.url !== probe.url) {
+        actedUrl = recheck.url
         const moved = [recheck.url ?? "*"]
         yield* input.ctx.ask({
           permission: "browser",
@@ -67,15 +75,24 @@ export function runBrowserAction<T>(input: {
         })
       }
     }
+    // Compute the high-risk caution once, here, so EVERY browser action (not
+    // just navigate) surfaces it when it touches a flagged site — the tools
+    // append it via trailingNotes(info).
+    const highRiskNotice = actedUrl ? highRiskSiteNotice(actedUrl) : null
     return yield* Effect.tryPromise({
       try: () =>
-        withBrowserPage(input.ctx.sessionID, input.label, input.run, {
-          timeoutMs: input.timeoutMs,
-          // User stop must reach the page driver: on abort the session severs
-          // the CDP connection so the in-flight action cannot keep operating
-          // the page after the user canceled it.
-          abort: input.ctx.abort,
-        }),
+        withBrowserPage(
+          input.ctx.sessionID,
+          input.label,
+          (page, info) => input.run(page, { ...info, highRiskNotice }),
+          {
+            timeoutMs: input.timeoutMs,
+            // User stop must reach the page driver: on abort the session severs
+            // the CDP connection so the in-flight action cannot keep operating
+            // the page after the user canceled it.
+            abort: input.ctx.abort,
+          },
+        ),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     })
   })
@@ -101,6 +118,16 @@ export function browserAlwaysPatterns(patterns: string[]): string[] {
 /** One-line note appended to the first action after the agent takes over an already-open page. */
 export function takeoverNote(info: { takeoverReloaded: boolean }): string {
   return info.takeoverReloaded ? "\n\nNote: attached to the page that was already open; it was reloaded once to apply automation hardening." : ""
+}
+
+/**
+ * All trailing notes a browser tool appends to its output: the takeover reload
+ * note plus the high-risk-site caution. Computed centrally in runBrowserAction
+ * and carried on `info`, so every browser tool gets identical coverage by
+ * appending this once.
+ */
+export function trailingNotes(info: BrowserActionInfo): string {
+  return takeoverNote(info) + (info.highRiskNotice ? `\n\n${info.highRiskNotice}` : "")
 }
 
 /**

--- a/packages/opencode/src/tool/browser-shared.ts
+++ b/packages/opencode/src/tool/browser-shared.ts
@@ -77,7 +77,8 @@ export function runBrowserAction<T>(input: {
     }
     // Compute the high-risk caution once, here, so EVERY browser action (not
     // just navigate) surfaces it when it touches a flagged site — the tools
-    // append it via trailingNotes(info).
+    // surface it via withNotes(info), which leads the output so head-first
+    // truncation can't drop it.
     const highRiskNotice = actedUrl ? highRiskSiteNotice(actedUrl) : null
     return yield* Effect.tryPromise({
       try: () =>
@@ -121,13 +122,18 @@ export function takeoverNote(info: { takeoverReloaded: boolean }): string {
 }
 
 /**
- * All trailing notes a browser tool appends to its output: the takeover reload
- * note plus the high-risk-site caution. Computed centrally in runBrowserAction
- * and carried on `info`, so every browser tool gets identical coverage by
- * appending this once.
+ * Compose a browser tool's output with its notes, safety-first. Tool results are
+ * truncated head-first (the tail is dropped and replaced by a "...truncated..."
+ * hint), so the high-risk caution must LEAD the output — appended after a large
+ * body (a full snapshot, extracted page text) it would be silently cut on
+ * exactly the high-risk pages that matter. The informational takeover note (fine
+ * to lose) stays trailing. Both are computed centrally in runBrowserAction and
+ * carried on `info`, so every browser tool gets identical coverage from this one
+ * call.
  */
-export function trailingNotes(info: BrowserActionInfo): string {
-  return takeoverNote(info) + (info.highRiskNotice ? `\n\n${info.highRiskNotice}` : "")
+export function withNotes(info: BrowserActionInfo, body: string): string {
+  const lead = info.highRiskNotice ? `${info.highRiskNotice}\n\n` : ""
+  return lead + body + takeoverNote(info)
 }
 
 /**

--- a/packages/opencode/src/tool/browser-shared.ts
+++ b/packages/opencode/src/tool/browser-shared.ts
@@ -85,7 +85,24 @@ export function runBrowserAction<T>(input: {
         withBrowserPage(
           input.ctx.sessionID,
           input.label,
-          (page, info) => input.run(page, { ...info, highRiskNotice }),
+          async (page, info) => {
+            // The tools surface this object via withNotes(info); they return the
+            // same reference as result.info, so filling it post-action below
+            // reaches their output.
+            const actionInfo = { ...info, highRiskNotice }
+            const result = await input.run(page, actionInfo)
+            // A navigable action — a click or submit on a link — can land on a
+            // high-risk site the PRE-action URL never named, so the pre-action
+            // caution above would miss it. When the start page wasn't already
+            // flagged, re-read the page's real URL and fill the caution from
+            // where it ended up. Additive: it can only add a missing caution,
+            // never drop one.
+            if (!actionInfo.highRiskNotice) {
+              const landed = await page.evaluate<string>("window.location.href").catch(() => null)
+              if (typeof landed === "string" && landed) actionInfo.highRiskNotice = highRiskSiteNotice(landed)
+            }
+            return result
+          },
           {
             timeoutMs: input.timeoutMs,
             // User stop must reach the page driver: on abort the session severs

--- a/packages/opencode/src/tool/browser-snapshot.ts
+++ b/packages/opencode/src/tool/browser-snapshot.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-snapshot.txt"
-import { runBrowserAction, takeoverNote } from "./browser-shared"
+import { runBrowserAction, trailingNotes } from "./browser-shared"
 
 export const Parameters = Schema.Struct({
   interactive: Schema.optional(Schema.Boolean).annotate({
@@ -38,7 +38,7 @@ export const BrowserSnapshotTool = Tool.define(
           typeof result.snapshot === "string" ? result.snapshot : JSON.stringify(result.snapshot, null, 2)
         return {
           title: result.url || "Page snapshot",
-          output: text + takeoverNote(result.info),
+          output: text + trailingNotes(result.info),
           metadata: { url: result.url, interactive: params.interactive ?? true },
         }
       }),

--- a/packages/opencode/src/tool/browser-snapshot.ts
+++ b/packages/opencode/src/tool/browser-snapshot.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-snapshot.txt"
-import { runBrowserAction, trailingNotes } from "./browser-shared"
+import { runBrowserAction, withNotes } from "./browser-shared"
 
 export const Parameters = Schema.Struct({
   interactive: Schema.optional(Schema.Boolean).annotate({
@@ -38,7 +38,7 @@ export const BrowserSnapshotTool = Tool.define(
           typeof result.snapshot === "string" ? result.snapshot : JSON.stringify(result.snapshot, null, 2)
         return {
           title: result.url || "Page snapshot",
-          output: text + trailingNotes(result.info),
+          output: withNotes(result.info, text),
           metadata: { url: result.url, interactive: params.interactive ?? true },
         }
       }),

--- a/packages/opencode/src/tool/browser-type.ts
+++ b/packages/opencode/src/tool/browser-type.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-type.txt"
-import { normalizeElementRef, runBrowserAction, takeoverNote } from "./browser-shared"
+import { normalizeElementRef, runBrowserAction, trailingNotes } from "./browser-shared"
 
 export const Parameters = Schema.Struct({
   ref: Schema.String.annotate({
@@ -44,7 +44,7 @@ export const BrowserTypeTool = Tool.define(
         ]
         return {
           title: `Typed into ${params.ref}`,
-          output: lines.join("\n") + takeoverNote(result.info),
+          output: lines.join("\n") + trailingNotes(result.info),
           metadata: {
             ref: params.ref,
             filled,

--- a/packages/opencode/src/tool/browser-type.ts
+++ b/packages/opencode/src/tool/browser-type.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-type.txt"
-import { normalizeElementRef, runBrowserAction, trailingNotes } from "./browser-shared"
+import { normalizeElementRef, runBrowserAction, withNotes } from "./browser-shared"
 
 export const Parameters = Schema.Struct({
   ref: Schema.String.annotate({
@@ -44,7 +44,7 @@ export const BrowserTypeTool = Tool.define(
         ]
         return {
           title: `Typed into ${params.ref}`,
-          output: lines.join("\n") + trailingNotes(result.info),
+          output: withNotes(result.info, lines.join("\n")),
           metadata: {
             ref: params.ref,
             filled,

--- a/packages/opencode/src/tool/browser-wait.ts
+++ b/packages/opencode/src/tool/browser-wait.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-wait.txt"
-import { runBrowserAction, takeoverNote } from "./browser-shared"
+import { runBrowserAction, trailingNotes } from "./browser-shared"
 
 const MAX_WAIT_SECONDS = 120
 
@@ -92,7 +92,7 @@ export const BrowserWaitTool = Tool.define(
           // When taking over an already-open page reloaded it, say so — a
           // wait may be the takeover's first action, and the condition it
           // just satisfied happened on the freshly reloaded document.
-          output: `Done: ${condition}.` + takeoverNote(info),
+          output: `Done: ${condition}.` + trailingNotes(info),
           metadata: { condition },
         }
       }),

--- a/packages/opencode/src/tool/browser-wait.ts
+++ b/packages/opencode/src/tool/browser-wait.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./browser-wait.txt"
-import { runBrowserAction, trailingNotes } from "./browser-shared"
+import { runBrowserAction, withNotes } from "./browser-shared"
 
 const MAX_WAIT_SECONDS = 120
 
@@ -92,7 +92,7 @@ export const BrowserWaitTool = Tool.define(
           // When taking over an already-open page reloaded it, say so — a
           // wait may be the takeover's first action, and the condition it
           // just satisfied happened on the freshly reloaded document.
-          output: `Done: ${condition}.` + trailingNotes(info),
+          output: withNotes(info, `Done: ${condition}.`),
           metadata: { condition },
         }
       }),

--- a/packages/opencode/src/tool/high-risk-site.ts
+++ b/packages/opencode/src/tool/high-risk-site.ts
@@ -1,0 +1,51 @@
+/**
+ * High-risk sites: platforms that run aggressive anti-automation risk control,
+ * where automated browsing/viewing/posting can flag an account even when the
+ * user is operating their own. We append a one-line caution to the browser
+ * tool result so the model both adjusts (minimal, human-paced actions) and
+ * relays the risk to the user — the embedded browser cannot fully match a real
+ * Chrome profile's trust, so the residual risk is real and worth disclosing.
+ *
+ * Scope starts at Xiaohongshu (RedNote), the only platform we have actually
+ * seen flag an account. Add an entry when a new platform shows the same
+ * behavior; keep the list small and evidence-driven rather than guessing.
+ */
+type HighRiskSite = { name: string; hosts: string[] }
+
+const HIGH_RISK_SITES: HighRiskSite[] = [{ name: "Xiaohongshu (RedNote)", hosts: ["xiaohongshu.com", "xhslink.com"] }]
+
+/** Hostname of a full URL, or a bare host string (opencli's command.domain); null when empty. */
+function hostnameOf(urlOrHost: string): string | null {
+  const trimmed = urlOrHost.trim()
+  if (!trimmed) return null
+  try {
+    return new URL(trimmed).hostname.toLowerCase()
+  } catch {
+    // Not a full URL — treat the input as a bare hostname.
+    return trimmed.toLowerCase().replace(/^\.+/, "").split("/")[0] || null
+  }
+}
+
+function matchSite(urlOrHost: string): HighRiskSite | null {
+  const host = hostnameOf(urlOrHost)
+  if (!host) return null
+  // Exact host or a subdomain of it. The leading dot stops `notxiaohongshu.com`
+  // and `xiaohongshu.com.evil.com` from matching `xiaohongshu.com`.
+  return HIGH_RISK_SITES.find((site) => site.hosts.some((h) => host === h || host.endsWith(`.${h}`))) ?? null
+}
+
+/**
+ * A caution to append to a browser tool result when it touches a high-risk
+ * site, or null otherwise. Written for the model: it informs the agent and
+ * tells it to relay the risk to the user.
+ */
+export function highRiskSiteNotice(urlOrHost: string): string | null {
+  const site = matchSite(urlOrHost)
+  if (!site) return null
+  return (
+    `Note: ${site.name} enforces strict anti-automation risk control. Automated browsing, viewing, or posting ` +
+    `may trigger account risk warnings or restrictions, even when operating the user's own account. Tell the user ` +
+    `about this risk, keep actions minimal and human-paced, and for anything sensitive (login or posting) suggest ` +
+    `doing it manually in their own Chrome.`
+  )
+}

--- a/packages/opencode/src/tool/high-risk-site.ts
+++ b/packages/opencode/src/tool/high-risk-site.ts
@@ -18,12 +18,16 @@ const HIGH_RISK_SITES: HighRiskSite[] = [{ name: "Xiaohongshu (RedNote)", hosts:
 function hostnameOf(urlOrHost: string): string | null {
   const trimmed = urlOrHost.trim()
   if (!trimmed) return null
+  // Parse everything through `new URL` so ports, queries, paths, and
+  // protocol-relative ("//host/x") inputs all resolve to the bare hostname.
+  // A protocol-less host gets a scheme prepended; leading slashes are dropped
+  // first so "//host" doesn't become an empty authority.
+  const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : "http://" + trimmed.replace(/^\/+/, "")
   let host: string
   try {
-    host = new URL(trimmed).hostname.toLowerCase()
+    host = new URL(candidate).hostname.toLowerCase()
   } catch {
-    // Not a full URL — treat the input as a bare hostname.
-    host = trimmed.toLowerCase().split("/")[0]
+    return null
   }
   // A fully-qualified name can carry a root-label trailing dot
   // ("xiaohongshu.com." resolves to the same site, and `new URL` keeps it), so
@@ -54,4 +58,20 @@ export function highRiskSiteNotice(urlOrHost: string): string | null {
     `about this risk, keep actions minimal and human-paced, and for anything sensitive (login or posting) suggest ` +
     `doing it manually in their own Chrome.`
   )
+}
+
+/**
+ * High-risk caution for an OpenCLI command, checking BOTH its `domain` and a
+ * string `navigateBefore` target — an adapter can navigate to a flagged site
+ * that its `domain` field doesn't name. Null when neither is high-risk.
+ */
+export function highRiskCommandNotice(command: { domain?: string | null; navigateBefore?: unknown }): string | null {
+  const targets = [command.domain, typeof command.navigateBefore === "string" ? command.navigateBefore : null]
+  for (const target of targets) {
+    if (target) {
+      const notice = highRiskSiteNotice(target)
+      if (notice) return notice
+    }
+  }
+  return null
 }

--- a/packages/opencode/src/tool/high-risk-site.ts
+++ b/packages/opencode/src/tool/high-risk-site.ts
@@ -18,12 +18,18 @@ const HIGH_RISK_SITES: HighRiskSite[] = [{ name: "Xiaohongshu (RedNote)", hosts:
 function hostnameOf(urlOrHost: string): string | null {
   const trimmed = urlOrHost.trim()
   if (!trimmed) return null
+  let host: string
   try {
-    return new URL(trimmed).hostname.toLowerCase()
+    host = new URL(trimmed).hostname.toLowerCase()
   } catch {
     // Not a full URL — treat the input as a bare hostname.
-    return trimmed.toLowerCase().replace(/^\.+/, "").split("/")[0] || null
+    host = trimmed.toLowerCase().split("/")[0]
   }
+  // A fully-qualified name can carry a root-label trailing dot
+  // ("xiaohongshu.com." resolves to the same site, and `new URL` keeps it), so
+  // strip leading/trailing dots before the suffix match — otherwise a trailing
+  // dot slips past `endsWith(".xiaohongshu.com")`.
+  return host.replace(/^\.+|\.+$/g, "") || null
 }
 
 function matchSite(urlOrHost: string): HighRiskSite | null {

--- a/packages/opencode/src/tool/opencli-run.ts
+++ b/packages/opencode/src/tool/opencli-run.ts
@@ -146,7 +146,9 @@ export const OpenCliRunTool = Tool.define(
           command.browser !== false ? highRiskCommandNotice(openCliCommandSummaryFromCommand(command)) : null
         return {
           title: `OpenCLI ${fullName(command)}`,
-          output: formatAdapterOutput(value) + (riskNotice ? `\n\n${riskNotice}` : ""),
+          // Lead with the caution: tool output is truncated head-first, so a
+          // caution after a long adapter body would be silently dropped.
+          output: (riskNotice ? `${riskNotice}\n\n` : "") + formatAdapterOutput(value),
           metadata: {
             command: fullName(command),
             access: command.access,

--- a/packages/opencode/src/tool/opencli-run.ts
+++ b/packages/opencode/src/tool/opencli-run.ts
@@ -5,6 +5,7 @@ import DESCRIPTION from "./opencli-run.txt"
 import { openCliCommand, openCliCommandSummaryFromCommand, type OpenCliCommandSummary } from "@/opencli/adapter-registry"
 import { prepareOpenCliCommandArgs, runOpenCliAdapterCommand } from "@/opencli/adapter-runner"
 import { browserAlwaysPatterns, runBrowserAction } from "./browser-shared"
+import { highRiskSiteNotice } from "./high-risk-site"
 
 const OPENCLI_RUN_TIMEOUT_MS = 60_000
 type OpenCliCommand = NonNullable<Awaited<ReturnType<typeof openCliCommand>>>
@@ -141,9 +142,10 @@ export const OpenCliRunTool = Tool.define(
             })
           : yield* runBrowserCommand(command, args, ctx)
 
+        const riskNotice = command.browser !== false && command.domain ? highRiskSiteNotice(command.domain) : null
         return {
           title: `OpenCLI ${fullName(command)}`,
-          output: formatAdapterOutput(value),
+          output: formatAdapterOutput(value) + (riskNotice ? `\n\n${riskNotice}` : ""),
           metadata: {
             command: fullName(command),
             access: command.access,

--- a/packages/opencode/src/tool/opencli-run.ts
+++ b/packages/opencode/src/tool/opencli-run.ts
@@ -5,7 +5,7 @@ import DESCRIPTION from "./opencli-run.txt"
 import { openCliCommand, openCliCommandSummaryFromCommand, type OpenCliCommandSummary } from "@/opencli/adapter-registry"
 import { prepareOpenCliCommandArgs, runOpenCliAdapterCommand } from "@/opencli/adapter-runner"
 import { browserAlwaysPatterns, runBrowserAction } from "./browser-shared"
-import { highRiskSiteNotice } from "./high-risk-site"
+import { highRiskCommandNotice } from "./high-risk-site"
 
 const OPENCLI_RUN_TIMEOUT_MS = 60_000
 type OpenCliCommand = NonNullable<Awaited<ReturnType<typeof openCliCommand>>>
@@ -142,7 +142,8 @@ export const OpenCliRunTool = Tool.define(
             })
           : yield* runBrowserCommand(command, args, ctx)
 
-        const riskNotice = command.browser !== false && command.domain ? highRiskSiteNotice(command.domain) : null
+        const riskNotice =
+          command.browser !== false ? highRiskCommandNotice(openCliCommandSummaryFromCommand(command)) : null
         return {
           title: `OpenCLI ${fullName(command)}`,
           output: formatAdapterOutput(value) + (riskNotice ? `\n\n${riskNotice}` : ""),

--- a/packages/opencode/src/tool/opencli-run.ts
+++ b/packages/opencode/src/tool/opencli-run.ts
@@ -43,15 +43,11 @@ function askOpenCliAccessPermission(
   args: Record<string, unknown>,
 ) {
   const permission = command.access === "write" ? "opencli_write" : "opencli_read"
-  // Surface the high-risk caution at the permission step — BEFORE the command
-  // runs — so a browser/write adapter (e.g. posting) can't reach a flagged site
-  // before anyone sees the warning. The post-run output note alone is too late.
-  const caution = command.browser !== false && command.domain ? highRiskSiteNotice(command.domain) : null
   return ctx.ask({
     permission,
     patterns: [command.name],
     always: [command.name],
-    metadata: { ...commandMetadata(command, args), ...(caution ? { caution } : {}) },
+    metadata: commandMetadata(command, args),
   })
 }
 

--- a/packages/opencode/src/tool/opencli-run.ts
+++ b/packages/opencode/src/tool/opencli-run.ts
@@ -43,11 +43,15 @@ function askOpenCliAccessPermission(
   args: Record<string, unknown>,
 ) {
   const permission = command.access === "write" ? "opencli_write" : "opencli_read"
+  // Surface the high-risk caution at the permission step — BEFORE the command
+  // runs — so a browser/write adapter (e.g. posting) can't reach a flagged site
+  // before anyone sees the warning. The post-run output note alone is too late.
+  const caution = command.browser !== false && command.domain ? highRiskSiteNotice(command.domain) : null
   return ctx.ask({
     permission,
     patterns: [command.name],
     always: [command.name],
-    metadata: commandMetadata(command, args),
+    metadata: { ...commandMetadata(command, args), ...(caution ? { caution } : {}) },
   })
 }
 

--- a/packages/opencode/src/tool/opencli-search.ts
+++ b/packages/opencode/src/tool/opencli-search.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./opencli-search.txt"
 import { searchOpenCliCommands, type OpenCliCommandSummary } from "@/opencli/adapter-registry"
+import { highRiskSiteNotice } from "./high-risk-site"
 
 export const Parameters = Schema.Struct({
   query: Schema.String.annotate({
@@ -41,7 +42,17 @@ export function formatOpenCliSearchOutput(results: OpenCliCommandSummary[]) {
     results.length === 0
       ? "No bundled OpenCLI adapter commands matched this query."
       : results.map(formatOpenCliCommand).join("\n\n")
-  return body
+  // Warn at discovery — BEFORE the model decides to run anything — when a matched
+  // command targets a high-risk site. Dedupe by notice text so several commands
+  // for the same site add a single caution.
+  const cautions = [
+    ...new Set(
+      results
+        .map((command) => (command.domain ? highRiskSiteNotice(command.domain) : null))
+        .filter((notice): notice is string => notice !== null),
+    ),
+  ]
+  return cautions.length > 0 ? `${body}\n\n${cautions.join("\n\n")}` : body
 }
 
 export const OpenCliSearchTool = Tool.define(

--- a/packages/opencode/src/tool/opencli-search.ts
+++ b/packages/opencode/src/tool/opencli-search.ts
@@ -2,7 +2,7 @@ import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION from "./opencli-search.txt"
 import { searchOpenCliCommands, type OpenCliCommandSummary } from "@/opencli/adapter-registry"
-import { highRiskSiteNotice } from "./high-risk-site"
+import { highRiskCommandNotice } from "./high-risk-site"
 
 export const Parameters = Schema.Struct({
   query: Schema.String.annotate({
@@ -48,7 +48,7 @@ export function formatOpenCliSearchOutput(results: OpenCliCommandSummary[]) {
   const cautions = [
     ...new Set(
       results
-        .map((command) => (command.domain ? highRiskSiteNotice(command.domain) : null))
+        .map((command) => highRiskCommandNotice(command))
         .filter((notice): notice is string => notice !== null),
     ),
   ]

--- a/packages/opencode/src/tool/opencli-search.ts
+++ b/packages/opencode/src/tool/opencli-search.ts
@@ -52,7 +52,9 @@ export function formatOpenCliSearchOutput(results: OpenCliCommandSummary[]) {
         .filter((notice): notice is string => notice !== null),
     ),
   ]
-  return cautions.length > 0 ? `${body}\n\n${cautions.join("\n\n")}` : body
+  // Lead with the cautions: tool output is truncated head-first, so cautions
+  // after a long result list could be dropped before the model sees them.
+  return cautions.length > 0 ? `${cautions.join("\n\n")}\n\n${body}` : body
 }
 
 export const OpenCliSearchTool = Tool.define(

--- a/packages/opencode/test/tool/browser-tools.test.ts
+++ b/packages/opencode/test/tool/browser-tools.test.ts
@@ -485,6 +485,26 @@ describe("browser_click", () => {
     expect(result.output).toContain("anti-automation risk control")
     }),
   )
+
+  it.live("an action that navigates to a high-risk site surfaces the caution from the landed URL", () =>
+    Effect.gen(function* () {
+    const server = makeServer()
+    // The click starts on an ordinary page (the pre-action probe), but the
+    // click navigates to a high-risk site — the caution must come from where
+    // the page ended up, not the pre-action URL.
+    server.url = "https://example.com/page"
+    server.handlers.set("Runtime.evaluate", (params) => {
+      const expr = (params as { expression?: string })?.expression ?? ""
+      return expr.includes("location.href")
+        ? { result: { type: "string", value: "https://www.xiaohongshu.com/explore" } }
+        : { result: { type: "object", value: { ok: true, matches_n: 1, match_level: "exact", visible: true, x: 10, y: 10 } } }
+    })
+    provideFakeHost(server)
+    const result = yield* exec(BrowserClickTool, { ref: "[1]" })
+    expect(result.output).toContain("Clicked [1]")
+    expect(result.output).toContain("anti-automation risk control")
+    }),
+  )
 })
 
 describe("normalizeElementRef", () => {

--- a/packages/opencode/test/tool/browser-tools.test.ts
+++ b/packages/opencode/test/tool/browser-tools.test.ts
@@ -455,6 +455,21 @@ describe("browser_click", () => {
     expect(expressions.join("\n")).not.toContain('"[1]"')
     }),
   )
+
+  it.live("a current-page action on a high-risk site surfaces the caution (not just navigate)", () =>
+    Effect.gen(function* () {
+    const server = makeServer()
+    // The user is already on a high-risk page; the click probes that URL.
+    server.url = "https://www.xiaohongshu.com/explore"
+    server.handlers.set("Runtime.evaluate", () => ({
+      result: { type: "object", value: { ok: true, matches_n: 1, match_level: "exact", visible: true, x: 10, y: 10 } },
+    }))
+    provideFakeHost(server)
+    const result = yield* exec(BrowserClickTool, { ref: "[1]" })
+    expect(result.output).toContain("Clicked [1]")
+    expect(result.output).toContain("anti-automation risk control")
+    }),
+  )
 })
 
 describe("normalizeElementRef", () => {

--- a/packages/opencode/test/tool/browser-tools.test.ts
+++ b/packages/opencode/test/tool/browser-tools.test.ts
@@ -297,6 +297,23 @@ describe("browser_navigate", () => {
     }),
   )
 
+  it.live("appends a high-risk caution when navigating to a high-risk site", () =>
+    Effect.gen(function* () {
+    setupServer()
+    const result = yield* exec(BrowserNavigateTool, { url: "https://www.xiaohongshu.com/explore" })
+    expect(result.output).toContain("Loaded https://www.xiaohongshu.com/explore")
+    expect(result.output).toContain("anti-automation risk control")
+    }),
+  )
+
+  it.live("adds no caution for an ordinary site", () =>
+    Effect.gen(function* () {
+    setupServer()
+    const result = yield* exec(BrowserNavigateTool, { url: "https://example.com/page" })
+    expect(result.output).not.toContain("anti-automation risk control")
+    }),
+  )
+
   it.live("a redirect's real landing is reported and re-judged, not the requested URL", () =>
     Effect.gen(function* () {
     const server = makeServer()

--- a/packages/opencode/test/tool/browser-tools.test.ts
+++ b/packages/opencode/test/tool/browser-tools.test.ts
@@ -314,6 +314,21 @@ describe("browser_navigate", () => {
     }),
   )
 
+  it.live("a redirect that lands on a high-risk site still surfaces the caution", () =>
+    Effect.gen(function* () {
+    const server = makeServer()
+    provideFakeHost(server)
+    // Requested URL is ordinary; the document lands on a high-risk site. The
+    // caution must key on where it actually landed, not the request.
+    server.handlers.set("Runtime.evaluate", () => ({
+      result: { type: "string", value: "https://www.xiaohongshu.com/explore" },
+    }))
+    const result = yield* exec(BrowserNavigateTool, { url: "https://ok.example/start" })
+    expect(result.output).toContain("Loaded https://www.xiaohongshu.com/explore")
+    expect(result.output).toContain("anti-automation risk control")
+    }),
+  )
+
   it.live("a redirect's real landing is reported and re-judged, not the requested URL", () =>
     Effect.gen(function* () {
     const server = makeServer()

--- a/packages/opencode/test/tool/high-risk-site.test.ts
+++ b/packages/opencode/test/tool/high-risk-site.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { highRiskSiteNotice } from "../../src/tool/high-risk-site"
+import { highRiskCommandNotice, highRiskSiteNotice } from "../../src/tool/high-risk-site"
 
 describe("highRiskSiteNotice", () => {
   test("flags Xiaohongshu by full URL, bare host, and subdomain", () => {
@@ -13,6 +13,12 @@ describe("highRiskSiteNotice", () => {
       // past the suffix match.
       "https://www.xiaohongshu.com./explore",
       "xiaohongshu.com.",
+      // Bare host with a port, query, path, or protocol-relative prefix all
+      // resolve to the same hostname and must still match.
+      "xiaohongshu.com:443",
+      "xiaohongshu.com?x=1",
+      "xiaohongshu.com/explore",
+      "//xiaohongshu.com/path",
     ]) {
       expect(highRiskSiteNotice(input)).toContain("anti-automation risk control")
     }
@@ -28,5 +34,20 @@ describe("highRiskSiteNotice", () => {
     ]) {
       expect(highRiskSiteNotice(input)).toBeNull()
     }
+  })
+})
+
+describe("highRiskCommandNotice", () => {
+  test("flags a command whose high-risk target is only in navigateBefore", () => {
+    expect(
+      highRiskCommandNotice({ domain: null, navigateBefore: "https://www.xiaohongshu.com/login" }),
+    ).toContain("anti-automation risk control")
+    expect(highRiskCommandNotice({ domain: "xiaohongshu.com" })).toContain("anti-automation risk control")
+  })
+
+  test("returns null when neither domain nor navigateBefore is high-risk", () => {
+    expect(highRiskCommandNotice({ domain: "example.com", navigateBefore: "https://example.com/x" })).toBeNull()
+    expect(highRiskCommandNotice({ domain: null })).toBeNull()
+    expect(highRiskCommandNotice({})).toBeNull()
   })
 })

--- a/packages/opencode/test/tool/high-risk-site.test.ts
+++ b/packages/opencode/test/tool/high-risk-site.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { highRiskSiteNotice } from "../../src/tool/high-risk-site"
+
+describe("highRiskSiteNotice", () => {
+  test("flags Xiaohongshu by full URL, bare host, and subdomain", () => {
+    for (const input of [
+      "https://www.xiaohongshu.com/explore",
+      "xiaohongshu.com",
+      "www.xiaohongshu.com",
+      "https://xhslink.com/abc",
+      "xhslink.com",
+    ]) {
+      expect(highRiskSiteNotice(input)).toContain("anti-automation risk control")
+    }
+  })
+
+  test("does not flag look-alike or unrelated hosts", () => {
+    for (const input of [
+      "https://example.com",
+      "notxiaohongshu.com",
+      "https://xiaohongshu.com.evil.com/path",
+      "github.com",
+      "",
+    ]) {
+      expect(highRiskSiteNotice(input)).toBeNull()
+    }
+  })
+})

--- a/packages/opencode/test/tool/high-risk-site.test.ts
+++ b/packages/opencode/test/tool/high-risk-site.test.ts
@@ -9,6 +9,10 @@ describe("highRiskSiteNotice", () => {
       "www.xiaohongshu.com",
       "https://xhslink.com/abc",
       "xhslink.com",
+      // A root-label trailing dot resolves to the same site; it must not slip
+      // past the suffix match.
+      "https://www.xiaohongshu.com./explore",
+      "xiaohongshu.com.",
     ]) {
       expect(highRiskSiteNotice(input)).toContain("anti-automation risk control")
     }

--- a/packages/opencode/test/tool/high-risk-truncation.test.ts
+++ b/packages/opencode/test/tool/high-risk-truncation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { Truncate } from "../../src/tool/truncate"
+import { withNotes } from "../../src/tool/browser-shared"
+import { formatOpenCliSearchOutput } from "../../src/tool/opencli-search"
+import { highRiskSiteNotice } from "../../src/tool/high-risk-site"
+
+// Tool output is truncated head-first (truncate.ts: keep the first maxLines
+// lines, capped at maxBytes, drop the tail). A high-risk caution must therefore
+// LEAD the output, or it is silently cut on exactly the large, high-risk pages
+// that matter. These pin that the caution lands inside the preserved head.
+function headWindow(text: string): string {
+  const byLines = text.split("\n").slice(0, Truncate.MAX_LINES).join("\n")
+  return Buffer.from(byLines, "utf-8").subarray(0, Truncate.MAX_BYTES).toString("utf-8")
+}
+
+const CAUTION = "anti-automation risk control"
+
+describe("high-risk caution survives head-first truncation", () => {
+  test("withNotes leads with the caution; a body over both limits can't bury it", () => {
+    const notice = highRiskSiteNotice("xiaohongshu.com")
+    expect(notice).not.toBeNull()
+    // A body larger than both the byte and line ceilings — like a full snapshot
+    // or extracted page text of a content-heavy page.
+    const hugeBody = Array.from({ length: Truncate.MAX_LINES + 500 }, () => "x".repeat(200)).join("\n")
+    const out = withNotes({ takeoverReloaded: false, highRiskNotice: notice }, hugeBody)
+    expect(Buffer.byteLength(out, "utf-8")).toBeGreaterThan(Truncate.MAX_BYTES)
+    expect(out.split("\n").length).toBeGreaterThan(Truncate.MAX_LINES)
+    expect(headWindow(out)).toContain(CAUTION)
+  })
+
+  test("opencli_search leads with the caution, ahead of the result body", () => {
+    const out = formatOpenCliSearchOutput([
+      { name: "xhs-post", description: "post a note", access: "write", browser: true, domain: "xiaohongshu.com", args: [] } as never,
+    ])
+    expect(out).toContain(CAUTION)
+    expect(out.indexOf(CAUTION)).toBeLessThan(out.indexOf("xhs-post"))
+  })
+})

--- a/packages/opencode/test/tool/opencli-tools.test.ts
+++ b/packages/opencode/test/tool/opencli-tools.test.ts
@@ -104,6 +104,8 @@ describe("opencli_search", () => {
       expect(result.output).toContain("- query (required) | type: str | help: Question for 点点")
       expect(result.output).toContain("- timeout | type: int | default: 90")
       expect(result.output).toContain("- source-limit | type: int | default: 10")
+      // Discovery warns about the high-risk site before the model runs anything.
+      expect(result.output).toContain("anti-automation risk control")
     }),
   )
 


### PR DESCRIPTION
## Summary

When a browser tool touches a high-risk site (currently Xiaohongshu / RedNote), append a one-line caution to the tool result so the model adjusts to minimal, human-paced actions and relays the risk to the user.

## Why

A real account hit Xiaohongshu's "suspected automation" risk warning while operating through the embedded browser. The embedded browser cannot fully match a real Chrome profile's trust, so automated browsing/viewing/posting on such platforms carries real account risk. Disclosing that (informed consent) is better than silently proceeding. This is the first, self-contained piece of a larger embedded-browser fidelity effort and is independent of the stealth work that follows.

## Related Issue

None — follow-up from a maintainer report; no tracking issue yet.

## Human Review Status

Pending

## Review Focus

- The matcher in `high-risk-site.ts`: subdomain match, and no false positives on look-alike (`notxiaohongshu.com`) or suffix-attack (`xiaohongshu.com.evil.com`) hosts.
- Placement of the caution — `browser_navigate` landing + `opencli_run` browser command domain — and that later in-page actions inherit the already-surfaced note rather than re-warning.
- Wording of the model-facing note.

## Risk Notes

- No visible UI or copy in `packages/app` / `packages/ui` changed; the note is tool-result text, so the conditional UI/screenshot item is left unticked.
- The browser permission is allow-by-default, so its dialog is not a reliable user channel; the note reaches the user via the model relay and the visible tool result. Documented in code.
- No platform/packaging/dependency surface touched.

## How To Verify

```text
packages/opencode:
typecheck (tsgo --noEmit): clean
test/tool/high-risk-site.test.ts: 2 pass — matches Xiaohongshu by full URL / bare host / subdomain; null for look-alike, suffix attack, unrelated, empty
test/tool/browser-tools.test.ts: 30 pass — browser_navigate appends the caution for xiaohongshu.com, none for example.com
test/tool/opencli-tools.test.ts: 16 pass — opencli_run output path unaffected
```

## Screenshots or Recordings

N/A — no visible UI change (tool-result text only).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
