### PR TITLE
feat(browser): give the embedded browser a faithful Chrome user-agent

### DIFF
--- a/packages/desktop-electron/src/main/browser/controller.ts
+++ b/packages/desktop-electron/src/main/browser/controller.ts
@@ -1,6 +1,7 @@
-import { BrowserWindow, WebContentsView, shell } from "electron"
+import { BrowserWindow, WebContentsView, session, shell } from "electron"
 import type { BrowserState, BrowserViewLayout } from "@opencode-ai/app/desktop-api"
-import { browserViewWebPreferences } from "./options"
+import { BROWSER_PARTITION, browserViewWebPreferences } from "./options"
+import { toChromeUserAgent } from "./user-agent"
 import {
   clearDataReloadAction,
   computeViewBounds,
@@ -23,6 +24,27 @@ export const BROWSER_DISPLAY_TAKEN_CHANNEL = "browser:display-taken"
  */
 const DEFAULT_VIEW_BOUNDS = { x: 0, y: 0, width: 1280, height: 720 }
 
+let partitionUserAgentConfigured = false
+/**
+ * Give the embedded browser's shared partition a faithful Chrome user-agent,
+ * once. Electron's default UA carries an `Electron/<ver>` token and the app's own
+ * product token where a real Chrome UA has nothing — both are obvious "not a
+ * normal browser" tells that anti-automation risk control keys on. The view IS
+ * real Chromium, so we present it as the Chrome/Chromium it actually is rather
+ * than impersonating a specific brand: the Chrome major is derived from
+ * `process.versions.chrome` so it tracks the engine, and the partition session UA
+ * applies to BOTH manual browsing and CDP-driven automation. Client Hints are
+ * deliberately left at Chromium's correct defaults — manual and automation then
+ * present one consistent identity (see PR notes), which is the whole point.
+ * Scoped to the browser partition; the app renderer keeps its own UA.
+ */
+function ensureBrowserPartitionUserAgent() {
+  if (partitionUserAgentConfigured) return
+  partitionUserAgentConfigured = true
+  const sess = session.fromPartition(BROWSER_PARTITION)
+  sess.setUserAgent(toChromeUserAgent(sess.getUserAgent(), process.versions.chrome ?? ""))
+}
+
 /**
  * Owns one embedded browser per CONVERSATION (root session) — or a per-window
  * draft on Home. The view lives unattached to any window; a window is just a
@@ -41,6 +63,9 @@ export class BrowserViewController {
   private throttlingBefore: boolean | null = null
 
   constructor(private target: string) {
+    // Configure the partition UA before the view exists, so its very first
+    // request already carries the faithful Chrome UA.
+    ensureBrowserPartitionUserAgent()
     this.view = new WebContentsView({ webPreferences: browserViewWebPreferences() })
     this.view.setVisible(false)
     this.view.setBounds(DEFAULT_VIEW_BOUNDS)

--- a/packages/desktop-electron/src/main/browser/controller.ts
+++ b/packages/desktop-electron/src/main/browser/controller.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, WebContentsView, session, shell } from "electron"
 import type { BrowserState, BrowserViewLayout } from "@opencode-ai/app/desktop-api"
 import { BROWSER_PARTITION, browserViewWebPreferences } from "./options"
-import { toChromeUserAgent } from "./user-agent"
+import { configurePartitionUserAgent } from "./user-agent"
 import {
   clearDataReloadAction,
   computeViewBounds,
@@ -26,23 +26,15 @@ const DEFAULT_VIEW_BOUNDS = { x: 0, y: 0, width: 1280, height: 720 }
 
 let partitionUserAgentConfigured = false
 /**
- * Give the embedded browser's shared partition a faithful Chrome user-agent,
- * once. Electron's default UA carries an `Electron/<ver>` token and the app's own
- * product token where a real Chrome UA has nothing — both are obvious "not a
- * normal browser" tells that anti-automation risk control keys on. The view IS
- * real Chromium, so we present it as the Chrome/Chromium it actually is rather
- * than impersonating a specific brand: the Chrome major is derived from
- * `process.versions.chrome` so it tracks the engine, and the partition session UA
- * applies to BOTH manual browsing and CDP-driven automation. Client Hints are
- * deliberately left at Chromium's correct defaults — manual and automation then
- * present one consistent identity (see PR notes), which is the whole point.
- * Scoped to the browser partition; the app renderer keeps its own UA.
+ * Configure the browser partition's UA before the first view/request, exactly
+ * once: present the partition as the faithful Chrome it is (rewrite + rationale
+ * in user-agent.ts and the PR). Scoped to the browser partition; the app
+ * renderer keeps its own UA.
  */
 function ensureBrowserPartitionUserAgent() {
   if (partitionUserAgentConfigured) return
   partitionUserAgentConfigured = true
-  const sess = session.fromPartition(BROWSER_PARTITION)
-  sess.setUserAgent(toChromeUserAgent(sess.getUserAgent(), process.versions.chrome ?? ""))
+  configurePartitionUserAgent(session.fromPartition(BROWSER_PARTITION), process.versions.chrome ?? "")
 }
 
 /**

--- a/packages/desktop-electron/src/main/browser/user-agent.test.ts
+++ b/packages/desktop-electron/src/main/browser/user-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { chromeMajorVersion, toChromeUserAgent } from "./user-agent"
+import { chromeMajorVersion, configurePartitionUserAgent, toChromeUserAgent } from "./user-agent"
 
 // Real Electron 40.8.0 UA shapes (Chromium 144). The app product token is
 // "PawWork Dev/<ver>" by default and "opencode/<ver>" after index.ts's rewrite —
@@ -47,6 +47,23 @@ describe("toChromeUserAgent", () => {
 
   test("leaves the Chrome token alone when the version is unparseable", () => {
     expect(toChromeUserAgent(MAC_ELECTRON, "unknown")).toContain("Chrome/144.0.7559.236")
+  })
+})
+
+describe("configurePartitionUserAgent", () => {
+  test("sets the cleaned Chrome UA on the partition session (no Electron/app token)", () => {
+    let applied: string | undefined
+    const sess = {
+      getUserAgent: () => MAC_ELECTRON,
+      setUserAgent: (ua: string) => {
+        applied = ua
+      },
+    }
+    configurePartitionUserAgent(sess, "144.0.7559.236")
+    // The seam must hand the partition the cleaned UA — this is what is in place
+    // before the controller creates the first view.
+    expect(applied).toBe(MAC_CHROME)
+    expect(applied).not.toContain("Electron")
   })
 })
 

--- a/packages/desktop-electron/src/main/browser/user-agent.test.ts
+++ b/packages/desktop-electron/src/main/browser/user-agent.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { chromeMajorVersion, toChromeUserAgent } from "./user-agent"
+
+// Real Electron 40.8.0 UA shapes (Chromium 144). The app product token is
+// "PawWork Dev/<ver>" by default and "opencode/<ver>" after index.ts's rewrite —
+// both must be stripped.
+const MAC_ELECTRON =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) PawWork Dev/2026.6.7 Chrome/144.0.7559.236 Electron/40.8.0 Safari/537.36"
+const MAC_ELECTRON_REWRITTEN =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) opencode/2026.6.7 Chrome/144.0.7559.236 Electron/40.8.0 Safari/537.36"
+const WIN_ELECTRON =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) opencode/2026.6.7 Chrome/144.0.7559.236 Electron/40.8.0 Safari/537.36"
+
+const MAC_CHROME =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
+const WIN_CHROME =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
+
+describe("toChromeUserAgent", () => {
+  test("strips Electron + spaced app token and pins the reduced Chrome version (macOS)", () => {
+    expect(toChromeUserAgent(MAC_ELECTRON, "144.0.7559.236")).toBe(MAC_CHROME)
+  })
+
+  test("handles the index.ts-rewritten opencode token", () => {
+    expect(toChromeUserAgent(MAC_ELECTRON_REWRITTEN, "144.0.7559.236")).toBe(MAC_CHROME)
+  })
+
+  test("preserves the Windows platform token", () => {
+    expect(toChromeUserAgent(WIN_ELECTRON, "144.0.7559.236")).toBe(WIN_CHROME)
+  })
+
+  test("leaves no Electron / opencode / PawWork token or double space behind", () => {
+    const ua = toChromeUserAgent(MAC_ELECTRON, "144.0.7559.236")
+    expect(ua).not.toContain("Electron")
+    expect(ua).not.toContain("opencode")
+    expect(ua).not.toContain("PawWork")
+    expect(ua).not.toMatch(/ {2,}/)
+  })
+
+  test("is idempotent on an already-clean Chrome UA", () => {
+    expect(toChromeUserAgent(MAC_CHROME, "144.0.7559.236")).toBe(MAC_CHROME)
+  })
+
+  test("accepts a major-only version", () => {
+    expect(toChromeUserAgent(MAC_ELECTRON, "144")).toContain("Chrome/144.0.0.0")
+  })
+
+  test("leaves the Chrome token alone when the version is unparseable", () => {
+    expect(toChromeUserAgent(MAC_ELECTRON, "unknown")).toContain("Chrome/144.0.7559.236")
+  })
+})
+
+describe("chromeMajorVersion", () => {
+  test("extracts the major", () => {
+    expect(chromeMajorVersion("144.0.7559.236")).toBe("144")
+    expect(chromeMajorVersion("144")).toBe("144")
+  })
+
+  test("returns null for a non-numeric version", () => {
+    expect(chromeMajorVersion("unknown")).toBeNull()
+    expect(chromeMajorVersion("")).toBeNull()
+  })
+})

--- a/packages/desktop-electron/src/main/browser/user-agent.ts
+++ b/packages/desktop-electron/src/main/browser/user-agent.ts
@@ -1,16 +1,11 @@
 /**
- * The embedded browser's user-agent string. The view is real Chromium (Electron),
- * so the honest, low-false-positive identity is a faithful Chrome UA. Electron's
- * default string carries an `Electron/<ver>` token plus the app's own product
- * token (`opencode/<ver>` after index.ts's rewrite, or `PawWork .../<ver>` before
- * it) right where a real Chrome UA has nothing — both are obvious "not a normal
- * browser" tells that anti-automation risk control keys on. We strip them and pin
- * the Chrome token to the reduced `<major>.0.0.0` form modern Chrome reports,
- * deriving the major from the real embedded Chromium (`process.versions.chrome`)
- * so it can never drift from the engine actually running.
- *
- * Pure (no electron import) so it is unit-pinned; the wiring onto the browser
- * partition lives in controller.ts.
+ * The embedded browser's user-agent. The view is real Chromium, so the faithful
+ * identity is a plain Chrome UA: strip Electron's `Electron/` and app product
+ * tokens (a real Chrome UA has nothing where Electron injects them) and pin the
+ * Chrome token to the `<major>.0.0.0` form, deriving the major from the running
+ * engine (`process.versions.chrome`). Pure (no electron import) so it stays
+ * unit-tested; the partition wiring is configurePartitionUserAgent, called from
+ * controller.ts. Full rationale in the PR description.
  */
 
 /** Major version of a Chromium version string, or null if it has no leading number. */
@@ -34,4 +29,19 @@ export function toChromeUserAgent(rawUserAgent: string, chromeVersion: string): 
   // Pin the Chrome token to the reduced major.0.0.0 form real Chrome reports.
   if (major) ua = ua.replace(/Chrome\/\S+/, `Chrome/${major}.0.0.0`)
   return ua.replace(/ {2,}/g, " ").trim()
+}
+
+/** Minimal Session surface the partition wiring needs — narrowed so the rewrite is testable without an Electron runtime. */
+export interface UserAgentSession {
+  getUserAgent(): string
+  setUserAgent(userAgent: string): void
+}
+
+/**
+ * Apply the faithful Chrome UA to the embedded browser's partition session. The
+ * seam controller.ts calls (on the real partition session) before the first view
+ * is created, so the cleaned UA is in place before any embedded load.
+ */
+export function configurePartitionUserAgent(sess: UserAgentSession, chromeVersion: string): void {
+  sess.setUserAgent(toChromeUserAgent(sess.getUserAgent(), chromeVersion))
 }

--- a/packages/desktop-electron/src/main/browser/user-agent.ts
+++ b/packages/desktop-electron/src/main/browser/user-agent.ts
@@ -1,0 +1,37 @@
+/**
+ * The embedded browser's user-agent string. The view is real Chromium (Electron),
+ * so the honest, low-false-positive identity is a faithful Chrome UA. Electron's
+ * default string carries an `Electron/<ver>` token plus the app's own product
+ * token (`opencode/<ver>` after index.ts's rewrite, or `PawWork .../<ver>` before
+ * it) right where a real Chrome UA has nothing — both are obvious "not a normal
+ * browser" tells that anti-automation risk control keys on. We strip them and pin
+ * the Chrome token to the reduced `<major>.0.0.0` form modern Chrome reports,
+ * deriving the major from the real embedded Chromium (`process.versions.chrome`)
+ * so it can never drift from the engine actually running.
+ *
+ * Pure (no electron import) so it is unit-pinned; the wiring onto the browser
+ * partition lives in controller.ts.
+ */
+
+/** Major version of a Chromium version string, or null if it has no leading number. */
+export function chromeMajorVersion(chromeVersion: string): string | null {
+  const major = chromeVersion.trim().split(".")[0]
+  return /^\d+$/.test(major) ? major : null
+}
+
+/**
+ * Rewrite an Electron user-agent into the faithful Chrome UA the embedded view
+ * should present. Idempotent: an already-clean Chrome UA passes through unchanged.
+ */
+export function toChromeUserAgent(rawUserAgent: string, chromeVersion: string): string {
+  const major = chromeMajorVersion(chromeVersion)
+  let ua = rawUserAgent
+    // Drop the Electron product token — the loudest non-Chrome tell.
+    .replace(/ Electron\/\S+/g, "")
+    // Drop the app/product token Electron injects between the engine comment and
+    // the Chrome token (a real Chrome UA has nothing there).
+    .replace(/(\(KHTML, like Gecko\) ).*?(Chrome\/)/, "$1$2")
+  // Pin the Chrome token to the reduced major.0.0.0 form real Chrome reports.
+  if (major) ua = ua.replace(/Chrome\/\S+/, `Chrome/${major}.0.0.0`)
+  return ua.replace(/ {2,}/g, " ").trim()
+}


### PR DESCRIPTION
## Summary

Give the embedded browser a faithful Chrome user-agent. Electron's default UA carries an `Electron/<ver>` token and the app's own product token (`opencode/<ver>` after `index.ts`'s rewrite, `PawWork .../<ver>` before it) exactly where a real Chrome UA has nothing — both are obvious "not a normal browser" tells. We strip them and pin the Chrome token to the reduced `Chrome/<major>.0.0.0` form real Chrome reports, deriving the major from `process.versions.chrome` so it tracks the embedded Chromium and never drifts. The clean UA is set on the `persist:pawwork-browser` partition, so it applies to **both** manual browsing and CDP-driven automation.

This is the first stealth-fidelity change after a real Xiaohongshu "suspected automation" warning. It is legitimate fingerprint *fidelity*: the view IS real Chromium (Electron), and we present it as the Chromium it actually is — for users operating their own accounts — rather than leaking Electron/app tokens that look like a bot.

## Why this shape (Client Hints left at Chromium defaults — deliberate)

Codex consult + Electron/Chromium source confirmed:
- Electron does **not** invent its own UA Client Hints; it delegates to Chromium's `embedder_support::GetUserAgentMetadata()`. So default `navigator.userAgentData` brands as **Chromium** (+ a GREASE brand) and **does not leak "Electron" or the app name**.
- `session.setUserAgent` sets only the UA string + Accept-Language. The only way to set Client Hints for *manual* browsing would be a permanent CDP debugger attach, which is itself a detectable signal and is explicitly not worth it.

So the chosen identity is **faithful, consistent Chromium**, not impersonated Google Chrome:
- A real Chromium build reports UA `Chrome/<major>.0.0.0` **and** CH brand `Chromium` — exactly what we now produce. Internally consistent, nothing faked.
- The rejected alternative (add a "Google Chrome" brand via CDP on the automation path only) would make the **same profile** present as Chromium when browsed manually and Google Chrome when the agent drives — an intra-profile identity flip a real browser never does, i.e. a *new* tell. Consistency is the better stealth.
- Verified opencli's automation path does not override UA or touch `navigator.userAgentData` (only `Emulation.setDeviceMetricsOverride` + `Network.enable`), so automation inherits the same consistent identity; its stealth script handles the automation-specific JS tells (`webdriver`, `chrome`, plugins, languages).

Honest ceiling: this fixes the *fingerprint* layer only. It does not make automation "safe" on a mature behavioral risk-control platform (speed/rhythm/trajectory still matter). It removes the loud UA tell that this browser is not a normal one.

## Related Issue

None — follow-up from a maintainer report; no tracking issue yet.

## Human Review Status

Pending

## Review Focus

- `toChromeUserAgent` in `user-agent.ts`: token stripping is robust to both the `opencode/` (post-rewrite) and `PawWork .../` (pre-rewrite, app name with a space) forms, preserves the OS platform token (macOS vs Windows), and is idempotent.
- Placement/scope in `controller.ts`: partition-scoped (app renderer UA untouched), once-guarded, set before the first view's first request.
- The Client-Hints decision above — is "faithful Chromium, consistent across manual+auto" the identity we want, vs. impersonating Google Chrome?

## Risk Notes

- Scope is the `persist:pawwork-browser` partition only; `app.userAgentFallback` (app renderer) is intentionally left as-is.
- Client Hints are unchanged (Chromium defaults). If a site compares UA string vs CH it sees a consistent real-Chromium browser.
- No visible UI/copy changed; this is network-level identity.

## How To Verify

Verified by me (CI-checkable):

```text
packages/desktop-electron:
typecheck (tsgo -b): clean
test src/main/browser/: 58 pass (incl. user-agent.test.ts 10 pass — Electron/opencode/PawWork tokens stripped, Chrome version pinned, macOS+Windows shapes, idempotent, unparseable-version fallback, and the configurePartitionUserAgent seam applies the cleaned UA to the partition session)
```

Runtime check (needs the desktop GUI — your machine), using the fingerprint probe I sent separately:

1. Run `dev:desktop`, open the embedded browser, load the probe HTML.
2. Confirm `navigator.userAgent` = `...Chrome/<major>.0.0.0 Safari/537.36` with **no** `Electron` / `opencode` / `PawWork` (probe flags these red).
3. Confirm `navigator.userAgentData.brands` shows `Chromium` (+ GREASE), no Electron/app leak.
4. Compare against an external Chrome — UA string and CH should both read as a coherent Chromium/Chrome browser.

## Screenshots or Recordings

N/A — no visible UI change (network-level UA).

## Checklist

- [x] **Type label** — exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed. Left unticked: no visible UI/copy changed.
- [x] **(conditional)** I considered macOS and Windows impact — the UA platform token differs per OS; `toChromeUserAgent` preserves Electron's frozen per-OS token and is tested for both macOS and Windows shapes.
- [ ] **(conditional)** docs/release notes/deps/permissions/credentials/deletion/generated content/local files — none touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser now automatically identifies itself to web servers using Chrome user agent format instead of Electron
  * Browser initialization updated to apply the correct user agent from the first request onward

* **Tests**
  * Added tests validating user agent string normalization, Chrome version extraction, and proper format conversion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
