### PR TITLE
feat(browser): report realistic permission states from the embedded browser

### DIFF
--- a/packages/desktop-electron/src/main/browser/controller.ts
+++ b/packages/desktop-electron/src/main/browser/controller.ts
@@ -90,14 +90,9 @@ export class BrowserViewController {
       this.openExternal(url)
     })
 
-    // Permission policy: grant exactly what a fresh Chrome grants without a
-    // prompt and deny everything else — applied to BOTH actual requests and
-    // navigator.permissions.query checks. The check handler matters for stealth:
-    // Electron otherwise answers every check "granted", which is impossible in a
-    // real Chrome (camera+mic+geolocation+notifications all granted, unprompted)
-    // and flags the browser as automated. Both handlers share one policy so the
-    // queried state and the request outcome always agree. Camera/mic/geolocation
-    // stay denied — a content viewer must not silently grant them.
+    // Apply the shared permission policy (logic.ts) to BOTH actual requests and
+    // navigator.permissions.query checks, so the queried state and the request
+    // outcome always agree.
     wc.session.setPermissionRequestHandler((_wc, permission, callback) =>
       callback(isDefaultGrantedPermission(permission)),
     )

--- a/packages/desktop-electron/src/main/browser/controller.ts
+++ b/packages/desktop-electron/src/main/browser/controller.ts
@@ -6,6 +6,7 @@ import {
   computeViewBounds,
   deriveBrowserState,
   displayDecision,
+  isDefaultGrantedPermission,
   parseNavigable,
   safeExternalUrl,
 } from "./logic"
@@ -89,9 +90,18 @@ export class BrowserViewController {
       this.openExternal(url)
     })
 
-    // Deny every permission request by default — a v1 content viewer should not
-    // silently grant camera/mic/geolocation/etc.
-    wc.session.setPermissionRequestHandler((_wc, _permission, callback) => callback(false))
+    // Permission policy: grant exactly what a fresh Chrome grants without a
+    // prompt and deny everything else — applied to BOTH actual requests and
+    // navigator.permissions.query checks. The check handler matters for stealth:
+    // Electron otherwise answers every check "granted", which is impossible in a
+    // real Chrome (camera+mic+geolocation+notifications all granted, unprompted)
+    // and flags the browser as automated. Both handlers share one policy so the
+    // queried state and the request outcome always agree. Camera/mic/geolocation
+    // stay denied — a content viewer must not silently grant them.
+    wc.session.setPermissionRequestHandler((_wc, permission, callback) =>
+      callback(isDefaultGrantedPermission(permission)),
+    )
+    wc.session.setPermissionCheckHandler((_wc, permission) => isDefaultGrantedPermission(permission))
   }
 
   private openExternal(url: string) {

--- a/packages/desktop-electron/src/main/browser/logic.test.ts
+++ b/packages/desktop-electron/src/main/browser/logic.test.ts
@@ -4,6 +4,7 @@ import {
   computeViewBounds,
   deriveBrowserState,
   displayDecision,
+  isDefaultGrantedPermission,
   parseNavigable,
   safeExternalUrl,
   type BrowserStateSnapshot,
@@ -134,5 +135,25 @@ describe("displayDecision", () => {
     // The exact race this exists for: a resize frame in flight when the
     // display changed hands must not steal the view back.
     expect(displayDecision({ isHost: false, hasLiveHost: true, claim: false })).toBe("drop")
+  })
+})
+
+describe("isDefaultGrantedPermission", () => {
+  test("grants exactly what a fresh Chrome grants without prompting", () => {
+    for (const p of ["midi", "clipboard-sanitized-write", "background-sync", "sensors"]) {
+      expect(isDefaultGrantedPermission(p)).toBe(true)
+    }
+  })
+
+  test("denies sensitive / prompt-type permissions (Electron would default them to granted)", () => {
+    // "media" is what camera AND microphone queries arrive as.
+    for (const p of ["media", "geolocation", "notifications", "clipboard-read", "persistent-storage", "payment-handler"]) {
+      expect(isDefaultGrantedPermission(p)).toBe(false)
+    }
+  })
+
+  test("denies unknown permissions", () => {
+    expect(isDefaultGrantedPermission("unknown")).toBe(false)
+    expect(isDefaultGrantedPermission("")).toBe(false)
   })
 })

--- a/packages/desktop-electron/src/main/browser/logic.test.ts
+++ b/packages/desktop-electron/src/main/browser/logic.test.ts
@@ -146,6 +146,12 @@ describe("isDefaultGrantedPermission", () => {
     }
   })
 
+  test("grants the user-gesture permissions Chrome allows without a prompt (fullscreen, pointer lock)", () => {
+    for (const p of ["fullscreen", "pointerLock"]) {
+      expect(isDefaultGrantedPermission(p)).toBe(true)
+    }
+  })
+
   test("denies sensitive / prompt-type permissions (Electron would default them to granted)", () => {
     // "media" is what camera AND microphone queries arrive as. "midi" belongs
     // here: Chrome gates Web MIDI behind a prompt (Chrome 124+), so it must NOT

--- a/packages/desktop-electron/src/main/browser/logic.test.ts
+++ b/packages/desktop-electron/src/main/browser/logic.test.ts
@@ -140,14 +140,17 @@ describe("displayDecision", () => {
 
 describe("isDefaultGrantedPermission", () => {
   test("grants exactly what a fresh Chrome grants without prompting", () => {
-    for (const p of ["midi", "clipboard-sanitized-write", "background-sync", "sensors"]) {
+    // Verified against real Chrome: these four return "granted" by default.
+    for (const p of ["clipboard-sanitized-write", "background-sync", "sensors", "payment-handler"]) {
       expect(isDefaultGrantedPermission(p)).toBe(true)
     }
   })
 
   test("denies sensitive / prompt-type permissions (Electron would default them to granted)", () => {
-    // "media" is what camera AND microphone queries arrive as.
-    for (const p of ["media", "geolocation", "notifications", "clipboard-read", "persistent-storage", "payment-handler"]) {
+    // "media" is what camera AND microphone queries arrive as. "midi" belongs
+    // here: Chrome gates Web MIDI behind a prompt (Chrome 124+), so it must NOT
+    // be auto-granted.
+    for (const p of ["media", "geolocation", "notifications", "clipboard-read", "persistent-storage", "midi", "midiSysex"]) {
       expect(isDefaultGrantedPermission(p)).toBe(false)
     }
   })

--- a/packages/desktop-electron/src/main/browser/logic.ts
+++ b/packages/desktop-electron/src/main/browser/logic.ts
@@ -33,6 +33,33 @@ export function safeExternalUrl(url: string): string | null {
 }
 
 /**
+ * Permission policy for the embedded browser, used by BOTH the request handler
+ * (whether an actual permission request is granted) and the check handler (what
+ * navigator.permissions.query reports). They must agree.
+ *
+ * Electron's default is to answer every permission check "granted", which is
+ * impossible in a real Chrome — camera + microphone + geolocation + notifications
+ * all granted, unprompted — and an obvious automation tell. Electron's boolean
+ * handler cannot express Chrome's "prompt" default, so the faithful, consistent
+ * answer is: grant exactly the permissions a fresh Chrome grants WITHOUT
+ * prompting, and deny the rest (Chrome shows "prompt"; "denied" is a normal
+ * privacy state and far better than the impossible "granted").
+ *
+ * Strings are Electron's check-permission names — camera and microphone both
+ * arrive as "media", so neither is granted here.
+ */
+const DEFAULT_GRANTED_PERMISSIONS = new Set([
+  "midi", // basic MIDI: granted by default in Chrome
+  "clipboard-sanitized-write", // navigator.clipboard.writeText: granted by default
+  "background-sync", // granted by default
+  "sensors", // accelerometer / gyroscope / magnetometer: granted by default
+])
+
+export function isDefaultGrantedPermission(permission: string): boolean {
+  return DEFAULT_GRANTED_PERMISSIONS.has(permission)
+}
+
+/**
  * Convert a CSS-pixel viewport rect (reported by the renderer) into the
  * device-independent pixel bounds a WebContentsView expects. The renderer is
  * zoom-agnostic; the window's zoom factor is applied here as the single source

--- a/packages/desktop-electron/src/main/browser/logic.ts
+++ b/packages/desktop-electron/src/main/browser/logic.ts
@@ -60,6 +60,13 @@ const DEFAULT_GRANTED_PERMISSIONS = new Set([
   "background-sync", // granted by default
   "sensors", // accelerometer / gyroscope / magnetometer: granted by default
   "payment-handler", // navigator.permissions.query("payment-handler"): granted by default in Chrome
+  // Request-only (not exposed via permissions.query): Chrome allows these on a
+  // user gesture WITHOUT a prompt, so denying them would break ordinary browsing
+  // (e.g. fullscreen video) and be a tell. "fullscreen" is measurement-confirmed
+  // to reach the request handler; "pointerLock" is Electron's documented request
+  // permission name for the same allow-on-gesture API.
+  "fullscreen",
+  "pointerLock",
 ])
 
 export function isDefaultGrantedPermission(permission: string): boolean {

--- a/packages/desktop-electron/src/main/browser/logic.ts
+++ b/packages/desktop-electron/src/main/browser/logic.ts
@@ -47,12 +47,19 @@ export function safeExternalUrl(url: string): string | null {
  *
  * Strings are Electron's check-permission names — camera and microphone both
  * arrive as "media", so neither is granted here.
+ *
+ * The set was verified against a fresh real Chrome (measured both sides via
+ * navigator.permissions.query): the four below are exactly what Chrome returns
+ * "granted" by default; everything else returns "prompt", which we map to
+ * "denied". Note `midi` is NOT here — Chrome gates Web MIDI behind a prompt
+ * since Chrome 124 (BlockMidiByDefault), so granting it would be both a privacy
+ * footgun (silent requestMIDIAccess) and a tell (granted vs Chrome's prompt).
  */
 const DEFAULT_GRANTED_PERMISSIONS = new Set([
-  "midi", // basic MIDI: granted by default in Chrome
   "clipboard-sanitized-write", // navigator.clipboard.writeText: granted by default
   "background-sync", // granted by default
   "sensors", // accelerometer / gyroscope / magnetometer: granted by default
+  "payment-handler", // navigator.permissions.query("payment-handler"): granted by default in Chrome
 ])
 
 export function isDefaultGrantedPermission(permission: string): boolean {

--- a/packages/desktop-electron/src/main/browser/logic.ts
+++ b/packages/desktop-electron/src/main/browser/logic.ts
@@ -33,27 +33,15 @@ export function safeExternalUrl(url: string): string | null {
 }
 
 /**
- * Permission policy for the embedded browser, used by BOTH the request handler
- * (whether an actual permission request is granted) and the check handler (what
- * navigator.permissions.query reports). They must agree.
- *
- * Electron's default is to answer every permission check "granted", which is
- * impossible in a real Chrome — camera + microphone + geolocation + notifications
- * all granted, unprompted — and an obvious automation tell. Electron's boolean
- * handler cannot express Chrome's "prompt" default, so the faithful, consistent
- * answer is: grant exactly the permissions a fresh Chrome grants WITHOUT
- * prompting, and deny the rest (Chrome shows "prompt"; "denied" is a normal
- * privacy state and far better than the impossible "granted").
- *
- * Strings are Electron's check-permission names — camera and microphone both
- * arrive as "media", so neither is granted here.
- *
- * The set was verified against a fresh real Chrome (measured both sides via
- * navigator.permissions.query): the four below are exactly what Chrome returns
- * "granted" by default; everything else returns "prompt", which we map to
- * "denied". Note `midi` is NOT here — Chrome gates Web MIDI behind a prompt
- * since Chrome 124 (BlockMidiByDefault), so granting it would be both a privacy
- * footgun (silent requestMIDIAccess) and a tell (granted vs Chrome's prompt).
+ * Permission policy for the embedded browser, shared by the request handler and
+ * the check handler (navigator.permissions.query) so the queried state and a
+ * request outcome always agree. Grant exactly what a fresh Chrome grants without
+ * a prompt; deny the rest — Electron's boolean handler can't express Chrome's
+ * "prompt", and "denied" is the faithful substitute for the impossible "granted"
+ * (Electron's default). Strings are Electron's permission names — camera and
+ * microphone both arrive as "media". The set is measured against a fresh real
+ * Chrome; the per-permission rationale (why midi is denied, payment-handler
+ * granted) is in the PR description.
  */
 const DEFAULT_GRANTED_PERMISSIONS = new Set([
   "clipboard-sanitized-write", // navigator.clipboard.writeText: granted by default


### PR DESCRIPTION
## Summary

Make the embedded browser report **realistic permission states**. Electron's default is to answer every permission *check* "granted", so `navigator.permissions.query(...)` returns `granted` for notifications, geolocation, camera, microphone, midi and clipboard — a state that is **impossible in a real Chrome** (you cannot have camera + microphone + geolocation + notifications all granted, unprompted, on a fresh profile) and an obvious automation tell. The app's existing handler only covered permission *requests*, not *checks*.

This introduces one shared policy (`isDefaultGrantedPermission`) used by **both** the request handler and a new check handler: grant exactly the permissions a fresh Chrome grants without prompting (`clipboard-sanitized-write`, `background-sync`, `sensors`, `payment-handler`) and deny the rest. Electron's boolean handler cannot express Chrome's `prompt` default, so denied is the faithful substitute — a normal privacy state, and far better than the impossible `granted`. Camera/microphone/geolocation stay denied, preserving the original "a content viewer must not silently grant them" intent.

The grant set was verified by measuring `navigator.permissions.query` on **both** sides — a fresh real Chrome 149 and the embedded browser through the same check handler. Notably `midi` is **denied**, not granted: Chrome gates Web MIDI behind a prompt since Chrome 124 (`BlockMidiByDefault`), so granting it would be both a privacy footgun (silent `requestMIDIAccess`) and a tell; and `payment-handler` is **granted** to match Chrome's default.

Second of the embedded-browser stealth-fidelity changes (after the UA work in #1343). Flat/independent of it.

## Why this exact shape (measured, not guessed)

I reproduced PawWork's embedded-browser config in a standalone Electron 40.8.0 (Chromium 144) harness and measured `navigator.permissions.query` before and after:

```
permission         Electron default (current)   this PR        real Chrome (fresh, measured)
notifications      granted   ← impossible        denied         prompt
geolocation        granted   ← impossible        denied         prompt
camera (media)     granted   ← impossible        denied         prompt
microphone (media) granted   ← impossible        denied         prompt
clipboard-read     granted                       denied         prompt
persistent-storage granted                       denied         prompt
midi               granted   ← was wrong         denied         prompt   (BlockMidiByDefault, Chrome 124+)
clipboard-write    granted                       granted        granted   ✓
background-sync    granted                       granted        granted   ✓
accelerometer/gyro granted                       granted        granted   ✓
payment-handler    granted                       granted        granted   ✓  (now matched; was denied)
Notification.permission  granted ← impossible    denied (consistent with query)
```

The harness captured the exact Electron check-permission strings (camera and microphone both arrive as `media`; `payment-handler` and `midi` both reach the handler), so the policy keys on real names rather than guesses. Every "this PR" / "real Chrome" cell above was measured, not assumed.

Honest scope: this fixes the *permission-state* fingerprint only; it is not a behavioral-risk-control fix.

## Related Issue

None — follow-up from a maintainer report; no tracking issue yet.

## Human Review Status

Pending

## Review Focus

- The grant set in `isDefaultGrantedPermission` (`logic.ts`) — is "match Chrome's default-granted, deny the rest" the right policy? `denied` substitutes for Chrome's `prompt` because Electron's handler can't return `prompt`.
- Both handlers now share the policy, so `permissions.query` state and an actual request outcome always agree. The original deny-all is relaxed only for the four benign default-granted permissions (no camera/mic/geo/notifications).

## Risk Notes

- Behavior change: the request handler now grants `clipboard-sanitized-write` / `background-sync` / `sensors` / `payment-handler` (previously denied all). These are the permissions a normal Chrome grants without a prompt and carry no camera/mic/geo/personal-data exposure.
- Request-only permissions: the handler also grants `fullscreen` and `pointerLock`, which Chrome allows on a user gesture without a prompt. They are not exposed via `permissions.query` (so the fingerprint table above is unchanged), but the old deny-all broke fullscreen video and pointer-lock pages and a rejected `requestFullscreen` is itself a tell. `fullscreen` is measurement-confirmed to reach the request handler; `pointerLock` is Electron's documented request-permission name for the same API.
- Scope is the embedded browser partition's session handlers only.
- No visible UI/copy changed.

## How To Verify

Verified by me (CI-checkable):

```text
packages/desktop-electron:
typecheck (tsgo -b): clean
test src/main/browser/logic.test.ts: 20 pass (isDefaultGrantedPermission grants clipboard-sanitized-write/background-sync/sensors/payment-handler, denies media/geolocation/notifications/clipboard-read/persistent-storage/midi/midiSysex/unknown)
```

Empirical (Electron 40.8.0 harness reproducing the embedded config): the before/after table above — every `permissions.query` was `granted` before; after, the sensitive/prompt-type ones are `denied` and `Notification.permission` is consistent with its query.

Optional runtime re-check (your machine): open the fingerprint probe in `dev:desktop`'s embedded browser; the permission rows should match the "this PR" column (probe flags the notifications inconsistency red — it stays green here).

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed. Left unticked: no visible UI/copy changed.
- [x] **(conditional)** I considered macOS and Windows impact — permission semantics are Chromium-level and OS-independent; the policy is a pure string set, unit-tested.
- [x] **(conditional)** I called out the permission behavior change in Risk Notes (request handler now grants four benign default-granted permissions).
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

