### PR TITLE
docs(browser): record embedded-browser fingerprint parity and ship the probe

### DIFF
--- a/packages/desktop-electron/scripts/fingerprint-parity.md
+++ b/packages/desktop-electron/scripts/fingerprint-parity.md
@@ -34,12 +34,12 @@ Client Hints, `navigator.webdriver`, plugins, `permissions.query` states,
 window/screen shape, timezone/locale, WebGL renderer, codecs, EME/Widevine,
 `enumerateDevices`, and WebRTC.
 
-These results assume **#1343 (UA) and #1344 (permissions) are applied**: they
-were measured with Electron 40.8.0 (Chromium 144) using the exact
+These results assume the **UA rewrite (#1343) and permission policy (#1344) are
+applied**: they were measured with Electron 40.8.0 (Chromium 144) using the exact
 `browserViewWebPreferences()` config plus the partition UA from #1343, and the
-permission rows reflect the policy from #1344. Neither change is on `dev` yet, so
-**land this PR after both of them** — on its own it is a forward-looking baseline,
-not a record of current `dev` behavior.
+permission rows reflect the policy from #1344. This baseline holds only with both
+of those changes present — without them the embedded browser does not yet match
+the rows below.
 
 ## Parity (matches real Chrome on the same machine)
 

--- a/packages/desktop-electron/scripts/fingerprint-parity.md
+++ b/packages/desktop-electron/scripts/fingerprint-parity.md
@@ -14,9 +14,19 @@ apply).
 ## How to measure
 
 `scripts/fingerprint-probe.html` dumps the fingerprint surface and flags obvious
-tells red. Open it in **both**:
+tells red. The embedded browser only navigates `http(s):` (it rejects `file://`),
+so serve the probe over a local HTTP server and open the **same** URL in both
+browsers — same origin, apples to apples:
 
-1. PawWork's embedded browser (run `dev:desktop`, load the file), and
+```sh
+# from the repo root; any static server works
+npx serve packages/desktop-electron/scripts   # or: python3 -m http.server -d packages/desktop-electron/scripts
+```
+
+Then open `http://127.0.0.1:<port>/fingerprint-probe.html` in **both**:
+
+1. PawWork's embedded browser (run `dev:desktop`, then `browser_navigate` to the
+   local URL), and
 2. a real external Chrome,
 
 then compare (the **Copy JSON** button makes diffing easy). It covers UA + UA
@@ -24,9 +34,12 @@ Client Hints, `navigator.webdriver`, plugins, `permissions.query` states,
 window/screen shape, timezone/locale, WebGL renderer, codecs, EME/Widevine,
 `enumerateDevices`, and WebRTC.
 
-The measured results below were taken with Electron 40.8.0 (Chromium 144) using
-the exact `browserViewWebPreferences()` config plus the partition UA from
-#1343; the permission rows reflect the policy from #1344.
+These results assume **#1343 (UA) and #1344 (permissions) are applied**: they
+were measured with Electron 40.8.0 (Chromium 144) using the exact
+`browserViewWebPreferences()` config plus the partition UA from #1343, and the
+permission rows reflect the policy from #1344. Neither change is on `dev` yet, so
+**land this PR after both of them** — on its own it is a forward-looking baseline,
+not a record of current `dev` behavior.
 
 ## Parity (matches real Chrome on the same machine)
 

--- a/packages/desktop-electron/scripts/fingerprint-parity.md
+++ b/packages/desktop-electron/scripts/fingerprint-parity.md
@@ -1,0 +1,65 @@
+# Embedded browser fingerprint parity
+
+The embedded browser (`WebContentsView` on `persist:pawwork-browser`) is real
+Chromium (Electron). For users operating their **own** accounts, it should
+present as the faithful Chromium it is, so normal automated browsing is not
+mistaken for a bot. This records the measured parity vs a real external Chrome
+and the one known gap, so future changes have a baseline and a way to re-check.
+
+This is fingerprint **fidelity**, not behavioral evasion: it removes "this isn't
+a normal browser" tells. It does **not** make automation safe on a platform with
+mature behavioral risk control (speed, rhythm, and interaction patterns still
+apply).
+
+## How to measure
+
+`scripts/fingerprint-probe.html` dumps the fingerprint surface and flags obvious
+tells red. Open it in **both**:
+
+1. PawWork's embedded browser (run `dev:desktop`, load the file), and
+2. a real external Chrome,
+
+then compare (the **Copy JSON** button makes diffing easy). It covers UA + UA
+Client Hints, `navigator.webdriver`, plugins, `permissions.query` states,
+window/screen shape, timezone/locale, WebGL renderer, codecs, EME/Widevine,
+`enumerateDevices`, and WebRTC.
+
+The measured results below were taken with Electron 40.8.0 (Chromium 144) using
+the exact `browserViewWebPreferences()` config plus the partition UA from
+#1343; the permission rows reflect the policy from #1344.
+
+## Parity (matches real Chrome on the same machine)
+
+| Surface | Embedded browser | Notes |
+| --- | --- | --- |
+| UA string | `…Chrome/144.0.0.0 Safari/537.36` | Electron/app tokens stripped (#1343) |
+| UA Client Hints | `Chromium`;v=144 + GREASE | consistent real-Chromium identity; no Electron/app leak |
+| `navigator.webdriver` | `false` | (opencli's stealth keeps it false under automation too) |
+| `permissions.query` | Chrome-like (#1344) | sensitive = denied, default-granted = granted; no impossible "all granted" |
+| WebGL vendor/renderer | real GPU via ANGLE/Metal | same as external Chrome on this machine |
+| Codecs | H.264 + AAC supported, MSE H.264 `true` | Electron's official build ships proprietary codecs |
+| `enumerateDevices` | real device list | not empty |
+| Timezone / locale | system values | same as external Chrome |
+| `navigator.plugins` | 5 (standard PDF set) | not empty |
+| `window.chrome` | present | |
+
+## Known gap: EME / Widevine (deferred)
+
+`navigator.requestMediaKeySystemAccess("com.widevine.alpha", …)` rejects with
+`NotSupportedError` in the embedded browser, while a real Chrome supports it.
+**Electron does not bundle the Widevine CDM** — this is by design, not a config
+mistake.
+
+- **Functional impact:** DRM video (Netflix, etc.) won't play in the embedded
+  browser.
+- **Fingerprint impact:** a difference from stock Chrome, but a relatively weak
+  bot signal — many real browser configurations lack Widevine, and the loud
+  tells (UA, permission states) are already fixed.
+- **Why deferred:** adding Widevine means switching to a Widevine-enabled
+  Electron distribution (e.g. `castlabs/electron-releases` ECx builds), which
+  touches packaging, signing, and the updater across the whole app. That is a
+  separate product decision (DRM playback support), not a casual stealth change,
+  and is out of scope here.
+
+If DRM playback or full Chrome parity is later required, evaluate a
+castlabs-based Electron build as a dedicated change.

--- a/packages/desktop-electron/scripts/fingerprint-probe.html
+++ b/packages/desktop-electron/scripts/fingerprint-probe.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>PawWork fingerprint probe</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; margin: 16px; }
+  h1 { font-size: 15px; margin: 0 0 4px; }
+  p.note { opacity: .7; margin: 0 0 12px; }
+  button { font: inherit; padding: 4px 10px; margin: 0 6px 12px 0; cursor: pointer; }
+  table { border-collapse: collapse; width: 100%; }
+  td { vertical-align: top; padding: 3px 8px; border-bottom: 1px solid rgba(128,128,128,.25); }
+  td.k { white-space: nowrap; opacity: .8; width: 1%; }
+  td.v { word-break: break-word; }
+  .flag-bad { color: #d33; font-weight: 600; }
+  .flag-ok { color: #2a2; }
+  textarea { width: 100%; height: 220px; font: inherit; margin-top: 12px; }
+</style>
+</head>
+<body>
+<h1>PawWork fingerprint probe</h1>
+<p class="note">Open this in the <b>embedded browser</b> and in an <b>external Chrome</b>, then compare. Rows flagged red are obvious automation / non-Chrome tells.</p>
+<button id="copy">Copy JSON</button>
+<button id="reload">Re-run</button>
+<table id="out"><tbody></tbody></table>
+<textarea id="json" readonly spellcheck="false"></textarea>
+<script>
+const rows = [];
+function add(key, value, flag) { rows.push({ key, value, flag: flag || null }); }
+
+async function collect() {
+  rows.length = 0;
+
+  // --- UA + Client Hints (PR2 surface) ---
+  const ua = navigator.userAgent;
+  add("navigator.userAgent", ua, /Electron|opencode|PawWork/i.test(ua) ? "bad" : "ok");
+  add("navigator.appVersion", navigator.appVersion);
+  add("navigator.platform", navigator.platform);
+  add("navigator.webdriver", String(navigator.webdriver), navigator.webdriver ? "bad" : "ok");
+  add("navigator.languages", JSON.stringify(navigator.languages));
+
+  const uaData = navigator.userAgentData;
+  if (uaData) {
+    const brands = JSON.stringify(uaData.brands);
+    add("userAgentData.brands", brands, /Electron|opencode|PawWork/i.test(brands) ? "bad" : "ok");
+    add("userAgentData.mobile", String(uaData.mobile));
+    add("userAgentData.platform", uaData.platform);
+    try {
+      const hi = await uaData.getHighEntropyValues([
+        "architecture", "bitness", "model", "platformVersion",
+        "uaFullVersion", "fullVersionList", "wow64",
+      ]);
+      add("UA-CH fullVersionList", JSON.stringify(hi.fullVersionList), /Electron|opencode/i.test(JSON.stringify(hi.fullVersionList)) ? "bad" : null);
+      add("UA-CH platformVersion", hi.platformVersion);
+      add("UA-CH architecture", hi.architecture + " / bitness " + hi.bitness + (hi.wow64 ? " / wow64" : ""));
+      add("UA-CH model", JSON.stringify(hi.model));
+      add("UA-CH uaFullVersion", hi.uaFullVersion);
+    } catch (e) { add("UA-CH highEntropy", "ERR " + e); }
+  } else {
+    add("navigator.userAgentData", "undefined (no UA Client Hints)", "bad");
+  }
+
+  // --- automation / environment tells ---
+  add("window.chrome", typeof window.chrome === "object" ? "present" : "MISSING", typeof window.chrome === "object" ? "ok" : "bad");
+  add("navigator.plugins.length", String(navigator.plugins.length), navigator.plugins.length === 0 ? "bad" : "ok");
+  add("navigator.hardwareConcurrency", String(navigator.hardwareConcurrency));
+  add("navigator.deviceMemory", String(navigator.deviceMemory));
+  add("navigator.maxTouchPoints", String(navigator.maxTouchPoints));
+
+  // --- permission states (PR3 surface) ---
+  const notif = (typeof Notification !== "undefined") ? Notification.permission : "no Notification API";
+  add("Notification.permission", notif);
+  for (const name of ["notifications", "geolocation", "camera", "microphone", "clipboard-read", "midi"]) {
+    try {
+      const st = await navigator.permissions.query({ name });
+      // Classic headless tell: notifications query "prompt"/"granted" while
+      // Notification.permission is "denied" (or vice versa).
+      const bad = name === "notifications" && ((st.state === "denied") !== (notif === "denied"));
+      add("permissions.query(" + name + ")", st.state, bad ? "bad" : null);
+    } catch (e) { add("permissions.query(" + name + ")", "ERR " + e.name); }
+  }
+
+  // --- window / screen shape ---
+  add("window.outer WxH", window.outerWidth + " x " + window.outerHeight, (window.outerWidth === 0 || window.outerHeight === 0) ? "bad" : null);
+  add("window.inner WxH", window.innerWidth + " x " + window.innerHeight);
+  add("screen WxH", screen.width + " x " + screen.height);
+  add("screen avail WxH", screen.availWidth + " x " + screen.availHeight);
+  add("devicePixelRatio", String(window.devicePixelRatio));
+
+  // --- locale / timezone (PR4 surface) ---
+  const tz = Intl.DateTimeFormat().resolvedOptions();
+  add("timeZone", tz.timeZone);
+  add("Intl locale", tz.locale);
+  add("Date tz offset (min)", String(new Date().getTimezoneOffset()));
+
+  // --- WebGL renderer (PR4 surface) ---
+  try {
+    const gl = document.createElement("canvas").getContext("webgl");
+    const dbg = gl && gl.getExtension("WEBGL_debug_renderer_info");
+    add("WebGL vendor", dbg ? gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) : "n/a");
+    add("WebGL renderer", dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : "n/a");
+    add("WebGL version", gl ? gl.getParameter(gl.VERSION) : "no webgl", gl ? null : "bad");
+  } catch (e) { add("WebGL", "ERR " + e); }
+
+  // --- codecs (PR4 surface) ---
+  const v = document.createElement("video");
+  add("video h264 (avc1.42E01E)", v.canPlayType('video/mp4; codecs="avc1.42E01E"') || "(empty)");
+  add("audio aac (mp4a.40.2)", v.canPlayType('audio/mp4; codecs="mp4a.40.2"') || "(empty)");
+  if (window.MediaSource) {
+    add("MSE h264", String(MediaSource.isTypeSupported('video/mp4; codecs="avc1.42E01E"')));
+  } else add("MediaSource", "undefined", "bad");
+
+  // --- EME / Widevine (PR4 surface) ---
+  if (navigator.requestMediaKeySystemAccess) {
+    try {
+      await navigator.requestMediaKeySystemAccess("com.widevine.alpha", [{
+        initDataTypes: ["cenc"],
+        videoCapabilities: [{ contentType: 'video/mp4; codecs="avc1.42E01E"' }],
+      }]);
+      add("EME Widevine", "supported");
+    } catch (e) { add("EME Widevine", "NOT supported (" + e.name + ")", "bad"); }
+  } else add("requestMediaKeySystemAccess", "undefined", "bad");
+
+  // --- devices / WebRTC (PR4 surface) ---
+  try {
+    const devs = await navigator.mediaDevices.enumerateDevices();
+    const kinds = {};
+    devs.forEach((d) => { kinds[d.kind] = (kinds[d.kind] || 0) + 1; });
+    add("enumerateDevices", devs.length + " device(s) " + JSON.stringify(kinds), devs.length === 0 ? "bad" : null);
+  } catch (e) { add("enumerateDevices", "ERR " + e); }
+  add("RTCPeerConnection", typeof window.RTCPeerConnection === "function" ? "present" : "MISSING", typeof window.RTCPeerConnection === "function" ? "ok" : "bad");
+
+  render();
+}
+
+function render() {
+  const tb = document.querySelector("#out tbody");
+  tb.innerHTML = "";
+  for (const r of rows) {
+    const tr = document.createElement("tr");
+    const k = document.createElement("td"); k.className = "k"; k.textContent = r.key;
+    const val = document.createElement("td"); val.className = "v";
+    if (r.flag === "bad") val.classList.add("flag-bad");
+    if (r.flag === "ok") val.classList.add("flag-ok");
+    val.textContent = r.value;
+    tr.append(k, val); tb.append(tr);
+  }
+  const obj = {};
+  for (const r of rows) obj[r.key] = r.value;
+  document.querySelector("#json").value = JSON.stringify(obj, null, 2);
+}
+
+document.querySelector("#copy").onclick = () => {
+  const ta = document.querySelector("#json"); ta.select();
+  navigator.clipboard?.writeText(ta.value).catch(() => document.execCommand("copy"));
+};
+document.querySelector("#reload").onclick = collect;
+collect();
+</script>
+</body>
+</html>

--- a/packages/desktop-electron/scripts/fingerprint-probe.html
+++ b/packages/desktop-electron/scripts/fingerprint-probe.html
@@ -16,12 +16,13 @@
   td.v { word-break: break-word; }
   .flag-bad { color: #d33; font-weight: 600; }
   .flag-ok { color: #2a2; }
+  .flag-warn { color: #c80; font-weight: 600; }
   textarea { width: 100%; height: 220px; font: inherit; margin-top: 12px; }
 </style>
 </head>
 <body>
 <h1>PawWork fingerprint probe</h1>
-<p class="note">Open this in the <b>embedded browser</b> and in an <b>external Chrome</b>, then compare. Rows flagged red are obvious automation / non-Chrome tells.</p>
+<p class="note">Open this in the <b>embedded browser</b> and in an <b>external Chrome</b>, then compare. <span class="flag-bad">Red</span> rows are obvious automation / non-Chrome tells; <span class="flag-warn">amber</span> rows are known, deferred gaps (e.g. Widevine), expected to differ.</p>
 <button id="copy">Copy JSON</button>
 <button id="reload">Re-run</button>
 <table id="out"><tbody></tbody></table>
@@ -134,8 +135,10 @@ async function collect() {
         videoCapabilities: [{ contentType: 'video/mp4; codecs="avc1.42E01E"' }],
       }]);
       add("EME Widevine", "supported");
-    } catch (e) { add("EME Widevine", "NOT supported (" + e.name + ")", "bad"); }
-  } else add("requestMediaKeySystemAccess", "undefined", "bad");
+      // Amber, not red: Electron ships without the Widevine CDM by design, so
+      // "NOT supported" here is the known, deferred gap — expected, not a failure.
+    } catch (e) { add("EME Widevine", "NOT supported (" + e.name + ") — known gap, deferred", "warn"); }
+  } else add("requestMediaKeySystemAccess", "undefined — known gap, deferred", "warn");
 
   // --- devices / WebRTC (PR4 surface) ---
   try {
@@ -158,6 +161,7 @@ function render() {
     const val = document.createElement("td"); val.className = "v";
     if (r.flag === "bad") val.classList.add("flag-bad");
     if (r.flag === "ok") val.classList.add("flag-ok");
+    if (r.flag === "warn") val.classList.add("flag-warn");
     val.textContent = r.value;
     tr.append(k, val); tb.append(tr);
   }
@@ -168,7 +172,13 @@ function render() {
 
 document.querySelector("#copy").onclick = () => {
   const ta = document.querySelector("#json"); ta.select();
-  navigator.clipboard?.writeText(ta.value).catch(() => document.execCommand("copy"));
+  // Prefer the async Clipboard API; fall back to execCommand when it's absent
+  // (the optional-chain version skipped the fallback entirely when undefined).
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(ta.value).catch(() => document.execCommand("copy"));
+  } else {
+    document.execCommand("copy");
+  }
 };
 document.querySelector("#reload").onclick = collect;
 collect();

--- a/packages/desktop-electron/scripts/fingerprint-probe.html
+++ b/packages/desktop-electron/scripts/fingerprint-probe.html
@@ -70,16 +70,30 @@ async function collect() {
   add("navigator.maxTouchPoints", String(navigator.maxTouchPoints));
 
   // --- permission states (PR3 surface) ---
+  // Expected default in a fresh real Chrome (measured): SENSITIVE permissions
+  // are "prompt" (we map to "denied"), EXPECT_GRANTED are "granted". Either
+  // direction of mismatch is a tell, so encode both and flag red:
+  //   - a SENSITIVE permission reporting "granted"  → impossible on a fresh
+  //     profile (the loud automation tell PR3 fixes)
+  //   - an EXPECT_GRANTED permission NOT "granted"   → diverges from real Chrome
+  const SENSITIVE = ["notifications", "geolocation", "camera", "microphone", "clipboard-read", "midi", "persistent-storage"];
+  const EXPECT_GRANTED = ["clipboard-write", "background-sync", "accelerometer", "payment-handler"];
   const notif = (typeof Notification !== "undefined") ? Notification.permission : "no Notification API";
   add("Notification.permission", notif);
-  for (const name of ["notifications", "geolocation", "camera", "microphone", "clipboard-read", "midi"]) {
+  for (const name of [...SENSITIVE, ...EXPECT_GRANTED]) {
     try {
       const st = await navigator.permissions.query({ name });
-      // Classic headless tell: notifications query "prompt"/"granted" while
-      // Notification.permission is "denied" (or vice versa).
-      const bad = name === "notifications" && ((st.state === "denied") !== (notif === "denied"));
-      add("permissions.query(" + name + ")", st.state, bad ? "bad" : null);
-    } catch (e) { add("permissions.query(" + name + ")", "ERR " + e.name); }
+      let bad;
+      if (SENSITIVE.includes(name)) {
+        bad = st.state === "granted";
+        // Notifications has an extra tell: the query state must agree with
+        // Notification.permission.
+        if (name === "notifications") bad = bad || ((st.state === "denied") !== (notif === "denied"));
+      } else {
+        bad = st.state !== "granted";
+      }
+      add("permissions.query(" + name + ")", st.state, bad ? "bad" : "ok");
+    } catch (e) { add("permissions.query(" + name + ")", "ERR " + e.name, "bad"); }
   }
 
   // --- window / screen shape ---


### PR DESCRIPTION
## Summary

Record the embedded browser's fingerprint **parity audit** and ship the probe that produced it. After the UA work (#1343) and permission work (#1344), I measured the embedded browser (`WebContentsView` on `persist:pawwork-browser`) against a real external Chrome across the full fingerprint surface. The finding: **it is at parity with Chrome on everything measured except EME/Widevine**, which Electron does not bundle by design.

So PR4 deliberately makes **no fingerprint code change** — measurement showed nothing left to fix that is in scope. Inventing WebGL/codec/timezone "fixes" for things already at parity would be noise. Instead this adds:

- `scripts/fingerprint-probe.html` — a self-contained probe (open in the embedded browser and in external Chrome, compare; obvious tells flagged red). Reusable for future stealth checks.
- `scripts/fingerprint-parity.md` — the audit results, the one known gap (Widevine) with why it's deferred, and how to re-measure.

## Why no code change (measured, not assumed)

Measured with an Electron 40.8.0 (Chromium 144) harness reproducing `browserViewWebPreferences()` + the partition UA:

| Surface | Result |
| --- | --- |
| WebGL vendor/renderer | real GPU via ANGLE/Metal — **parity** |
| H.264 / AAC / MSE | supported — **parity** (Electron's official build ships proprietary codecs) |
| `enumerateDevices` | real device list — **parity** |
| timezone / locale | system values — **parity** |
| plugins / `window.chrome` / `webdriver` | 5 / present / false — fine |
| **EME / Widevine** | **`NotSupportedError`** — the one gap |

Widevine is absent because Electron doesn't bundle the CDM. Fixing it means switching to a Widevine-enabled Electron distribution (e.g. `castlabs/electron-releases`), which touches packaging/signing/updater app-wide — a separate product decision (DRM playback), out of scope for stealth. Its bot-signal impact is minor next to the UA/permission tells already fixed. Documented in `fingerprint-parity.md` as a deferred follow-up.

## Related Issue

None — follow-up from a maintainer report; no tracking issue yet.

## Human Review Status

Pending

## Review Focus

- The decision to ship no fingerprint code change — agree the measured parity (everything but Widevine) means there's nothing in-scope to "fix"?
- The Widevine deferral rationale in `fingerprint-parity.md`.
- Whether the probe belongs in `scripts/` (alongside the other dev/smoke scripts) or elsewhere.

## Risk Notes

- No product code changed — only a static HTML probe and a markdown doc under `scripts/`. No runtime/build/packaging impact.
- The probe is a manual dev tool (not wired into CI).
- **Merge order:** the parity table assumes #1343 (UA) and #1344 (permissions) are applied; neither is on `dev` yet. Land this PR **after both** — on its own it is a forward-looking baseline, not a record of current `dev` behavior (called out in the doc).

## How To Verify

```text
No code change to test. Doc + static probe only.
The embedded browser rejects file://, so serve the probe over local HTTP and open
the SAME URL in both browsers:
  npx serve packages/desktop-electron/scripts   # or python3 -m http.server -d ...
Then open http://127.0.0.1:<port>/fingerprint-probe.html in
  (1) the embedded browser (dev:desktop, browser_navigate to the local URL) and
  (2) external Chrome; compare the JSON via the Copy JSON button.
Expected: all rows parity except "EME Widevine" = NOT supported in the embedded browser.
(Measured with #1343 + #1344 applied.)
```

## Screenshots or Recordings

N/A — dev tooling + docs.

## Checklist

- [x] **Type label** — exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed. Left unticked: no app UI/copy changed.
- [ ] **(conditional)** macOS/Windows impact. Left unticked: no platform/packaging surface touched (static probe + doc only).
- [x] **(conditional)** I called out the Widevine known gap and its deferral.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
