### PR TITLE
fix(retry): add equal jitter to 429 retry backoff to prevent parallel lockstep

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -35,6 +35,16 @@ function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
 }
 
+// Equal jitter (50-100% of the computed delay) so parallel retrying callers —
+// e.g. several subagents hitting the same provider 429 at once — spread their
+// retries across different moments instead of retrying in lockstep and
+// re-triggering the rate limit together. Applied only to the exponential
+// backoff branch; explicit Retry-After values are server directives and stay
+// exact. See https://github.com/Astro-Han/pawwork/issues/1348
+function withJitter(ms: number) {
+  return Math.round(ms * (0.5 + Math.random() * 0.5))
+}
+
 export function delay(attempt: number, error?: MessageV2.APIError) {
   if (error) {
     const headers = error.data.responseHeaders
@@ -61,11 +71,11 @@ export function delay(attempt: number, error?: MessageV2.APIError) {
         }
       }
 
-      return cap(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1))
+      return cap(withJitter(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)))
     }
   }
 
-  return cap(Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS))
+  return cap(withJitter(Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS)))
 }
 
 export function classifyRetry(error: Err): RetryClassification | undefined {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import type { NamedError } from "@opencode-ai/util/error"
 import { APICallError } from "ai"
 import { setTimeout as sleep } from "node:timers/promises"
@@ -43,18 +43,27 @@ describe("session.retry.delay", () => {
     })
   })
 
-  test("exponential backoff without headers spreads parallel retries via jitter", () => {
+  test("exponential backoff applies equal jitter at 50%, midpoint, and 100% of the base", () => {
     // The core fix for issue #1348: parallel subagents retrying 429s must not retry
     // in lockstep. delay() applies equal jitter (50-100% of exponential base) so
-    // concurrent callers land on different moments.
-    const attempts = Array.from({ length: 20 }, () => SessionRetry.delay(2))
-    const expectedBase = 4000
-    attempts.forEach((d) => {
-      expect(d).toBeGreaterThanOrEqual(Math.round(expectedBase * 0.5))
-      expect(d).toBeLessThanOrEqual(expectedBase)
-    })
-    // with 20 draws in [2000, 4000], at least 3 distinct values should appear
-    expect(new Set(attempts).size).toBeGreaterThanOrEqual(3)
+    // concurrent callers land on different moments. Deterministic via Math.random
+    // stubbing — no probabilistic draws.
+    const base = 4000 // attempt 2, RETRY_INITIAL_DELAY * 2^(2-1)
+    const cases = [
+      { rand: 0, expected: 2000 }, // 50% lower bound: base * (0.5 + 0*0.5)
+      { rand: 0.5, expected: 3000 }, // midpoint: base * (0.5 + 0.5*0.5)
+      { rand: 0.999, expected: 3998 }, // near 100%: base * (0.5 + 0.999*0.5), rounded
+    ]
+    for (const { rand, expected } of cases) {
+      const spy = spyOn(Math, "random").mockReturnValue(rand)
+      try {
+        expect(SessionRetry.delay(2)).toBe(expected)
+      } finally {
+        spy.mockRestore()
+      }
+    }
+    // sanity: base is what we think it is, so the boundaries above are meaningful
+    expect(base).toBe(SessionRetry.RETRY_INITIAL_DELAY * Math.pow(SessionRetry.RETRY_BACKOFF_FACTOR, 2 - 1))
   })
 
   test("prefers retry-after-ms when shorter than exponential", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -32,10 +32,29 @@ function retryableRaw(error: ReturnType<NamedError["toObject"]>): string | undef
 }
 
 describe("session.retry.delay", () => {
-  test("caps delay at 30 seconds when headers missing", () => {
+  test("caps delay at 30 seconds when headers missing, with jitter within 50-100% of the exponential value", () => {
     const error = apiError()
+    const base = [2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000, 30000]
     const delays = Array.from({ length: 10 }, (_, index) => SessionRetry.delay(index + 1, error))
-    expect(delays).toStrictEqual([2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000, 30000])
+    // jitter equal-split: each delay lands in [50%, 100%] of the exponential base, capped at 30s
+    delays.forEach((d, i) => {
+      expect(d).toBeGreaterThanOrEqual(Math.round(base[i] * 0.5))
+      expect(d).toBeLessThanOrEqual(base[i])
+    })
+  })
+
+  test("exponential backoff without headers spreads parallel retries via jitter", () => {
+    // The core fix for issue #1348: parallel subagents retrying 429s must not retry
+    // in lockstep. delay() applies equal jitter (50-100% of exponential base) so
+    // concurrent callers land on different moments.
+    const attempts = Array.from({ length: 20 }, () => SessionRetry.delay(2))
+    const expectedBase = 4000
+    attempts.forEach((d) => {
+      expect(d).toBeGreaterThanOrEqual(Math.round(expectedBase * 0.5))
+      expect(d).toBeLessThanOrEqual(expectedBase)
+    })
+    // with 20 draws in [2000, 4000], at least 3 distinct values should appear
+    expect(new Set(attempts).size).toBeGreaterThanOrEqual(3)
   })
 
   test("prefers retry-after-ms when shorter than exponential", () => {
@@ -56,20 +75,26 @@ describe("session.retry.delay", () => {
     expect(d).toBeLessThanOrEqual(20000)
   })
 
-  test("ignores invalid retry hints", () => {
+  test("ignores invalid retry hints and falls back to jittered exponential", () => {
     const error = apiError({ "retry-after": "not-a-number" })
-    expect(SessionRetry.delay(1, error)).toBe(2000)
+    const d = SessionRetry.delay(1, error)
+    expect(d).toBeGreaterThanOrEqual(1000)
+    expect(d).toBeLessThanOrEqual(2000)
   })
 
-  test("ignores malformed date retry hints", () => {
+  test("ignores malformed date retry hints and falls back to jittered exponential", () => {
     const error = apiError({ "retry-after": "Invalid Date String" })
-    expect(SessionRetry.delay(1, error)).toBe(2000)
+    const d = SessionRetry.delay(1, error)
+    expect(d).toBeGreaterThanOrEqual(1000)
+    expect(d).toBeLessThanOrEqual(2000)
   })
 
-  test("ignores past date retry hints", () => {
+  test("ignores past date retry hints and falls back to jittered exponential", () => {
     const pastDate = new Date(Date.now() - 5000).toUTCString()
     const error = apiError({ "retry-after": pastDate })
-    expect(SessionRetry.delay(1, error)).toBe(2000)
+    const d = SessionRetry.delay(1, error)
+    expect(d).toBeGreaterThanOrEqual(1000)
+    expect(d).toBeLessThanOrEqual(2000)
   })
 
   test("uses retry-after values even when exceeding 10 minutes with headers", () => {
@@ -171,8 +196,14 @@ describe("session.retry.delay", () => {
     })
   })
 
-  test("delay() produces the expected exponential backoff values", () => {
-    expect([SessionRetry.delay(1), SessionRetry.delay(2), SessionRetry.delay(3)]).toEqual([2000, 4000, 8000])
+  test("delay() produces exponential backoff within the jittered range", () => {
+    // Equal jitter (50-100% of exponential base) — see issue #1348.
+    const bases = [2000, 4000, 8000]
+    const got = [SessionRetry.delay(1), SessionRetry.delay(2), SessionRetry.delay(3)]
+    got.forEach((d, i) => {
+      expect(d).toBeGreaterThanOrEqual(Math.round(bases[i] * 0.5))
+      expect(d).toBeLessThanOrEqual(bases[i])
+    })
   })
 
   test("safe recovery policy uses injected delay across the replay budget then stops", async () => {
@@ -216,9 +247,7 @@ describe("session.retry.delay", () => {
     expect(
       statuses.every(
         (status) =>
-          status.message === "" &&
-          status.presentation === "recovery" &&
-          status.reason === "network_connection_dropped",
+          status.message === "" && status.presentation === "recovery" && status.reason === "network_connection_dropped",
       ),
     ).toBe(true)
   })


### PR DESCRIPTION
## Summary

- Add equal jitter (50–100% of the computed delay) to the exponential backoff branch of `delay()` in `packages/opencode/src/session/retry.ts`, so parallel retrying callers spread their retries across different moments instead of retrying in lockstep.
- Explicit `Retry-After` header values stay exact — only the fallback exponential branch is jittered.

## Why

When the main agent dispatches multiple parallel subagents against a low-quota provider (reproduced with `xiaomi-token-plan-cn` / `mimo-v2.5-pro`), all subagents receive HTTP 429 at the same instant, then retry on the identical `2s → 4s → 8s` schedule (no jitter), re-triggering the rate limit together and exhausting retries as a group. Five subagents × 3 retries = 15+ requests inside a few seconds, all on the same beat.

The 429 itself is an external provider limit that PawWork cannot eliminate. But the lockstep retry is a PawWork-side amplifier that turns a rate-limit into a total subagent collapse. Equal jitter (AWS-recommended for parallel retries) spreads the retries so most can recover.

Closes #1348.

## Root cause (evidence-locked)

- Sidecar log `data/pawwork/log/2026-06-17T124207.log`: 16 `ERROR service=llm mode=subagent` entries across 5 sub-sessions in 22 seconds, all `statusCode: 429`, `server: MiFE/3.4.34`, `responseBody: {"error":{"code":"429","message":"Too many requests","type":"limitation"}}`.
- `packages/opencode/src/session/retry.ts:38-69` — `delay()` exponential backoff had no jitter.
- `packages/opencode/src/session/retry.ts:218` — `safeRecoveryPolicy` calls `delay(attempt)` without the `error` argument, so the `Retry-After` header-parsing branch is dead on the live path. (Not fixed in this PR — the reproducing provider does not send `Retry-After`, so it would not help this case. Tracked as follow-up.)
- `packages/opencode/src/session/subagent-run.ts:91` — `MAX_ACTIVE = 5` hardcoded. (Not fixed in this PR — out of scope, tracked in #341.)

## What this PR does NOT change

- `Retry-After` header handling — unchanged (the reproducing provider doesn't send it; enabling it on the live path is a follow-up).
- Subagent concurrency cap — unchanged (5, hardcoded; configurable cap tracked in #341).
- Retry count, classification, safety gate — unchanged.
- `Retry-After` precise values — unchanged (server directives stay exact, no jitter applied).

## How To Verify

```text
TDD red→green:
  RED  — bun --cwd packages/opencode test test/session/retry.test.ts
         "exponential backoff without headers spreads parallel retries via jitter" FAILS
         (delay(2) returns constant 4000, Set.size === 1 < 3)
  GREEN — after adding withJitter(), same test PASSES

Full retry suite:  bun --cwd packages/opencode test test/session/retry.test.ts
  → 36 pass, 0 fail

Related suites (no regression):
  bun --cwd packages/opencode test test/session/retry-decision.test.ts \
    test/session/processor-effect.test.ts test/session/prompt-effect.test.ts
  → 110 pass, 0 fail

  bun --cwd packages/opencode test test/session/subagent-lifecycle-integration.test.ts \
    test/session/subagent-run.test.ts
  → 19 pass, 0 fail

Typecheck: (cd packages/opencode && bun run typecheck) → tsgo --noEmit passed
```

## Risk Notes

Runtime behavior change: retry delays are no longer deterministic. Any code or test that asserted an exact delay value from the exponential branch will need to assert a range instead — that is the intended new contract. The five existing tests that pinned exact values were updated to range assertions in this PR. `Retry-After` header values remain exact and deterministic.

No OS-specific, packaging, or UI surfaces changed.

## Checklist

- [x] **Type label** — `bug`
- [x] **Routing labels** — `harness`
- [x] **Priority label** — `P2`
- [x] Human Review Status: Pending
- [x] I linked the related issue (#1348).
- [x] I described the review focus and risks.
- [x] I replaced the example block in How To Verify with the real verification steps.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** No visible UI or copy changes — screenshots N/A.
- [x] **(conditional)** No platform/packaging surface touched.
- [ ] **(conditional)** No docs, release notes, dependencies, permissions, credentials, or generated content touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] Targeting `dev`, Conventional Commits title in English.