### PR TITLE
fix: avoid maintenance lifecycle close starvation

### DIFF
--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -245,6 +245,26 @@ export const layer = Layer.effect(
         error,
       })
 
+    const deferMaintenanceClose = (
+      directories: readonly string[],
+      close: () => Promise<unknown>,
+    ): Promise<void> => {
+      const targetDirectories = [...new Set(directories)]
+      const waitAndClose = async (): Promise<void> => {
+        await whenAllRunsIdle(targetDirectories)
+        const releaseClose = beginLifecycleClose(targetDirectories)
+        let retry = false
+        try {
+          if (hasActiveRuns(targetDirectories)) retry = true
+          else await close()
+        } finally {
+          releaseClose()
+        }
+        if (retry) await waitAndClose()
+      }
+      return waitAndClose()
+    }
+
     const disposeEntryNow = (
       directory: string,
       entry: Entry,
@@ -281,10 +301,11 @@ export const layer = Layer.effect(
 
         const releaseClose = beginLifecycleClose([ctx.directory])
         if (hasActiveRuns([ctx.directory])) {
-          const completed = whenAllRunsIdle([ctx.directory])
-            .then(() => Effect.runPromise(disposeEntryNow(directory, entry, ctx, closeAction, options)))
+          releaseClose()
+          const completed = deferMaintenanceClose([ctx.directory], () =>
+            Effect.runPromise(disposeEntryNow(directory, entry, ctx, closeAction, options)),
+          )
             .catch((error) => reportDeferredFailure("disposeEntry", ctx.directory, closeAction, error))
-            .finally(releaseClose)
             .then(() => undefined)
           void completed
           return false
@@ -311,15 +332,16 @@ export const layer = Layer.effect(
             releaseClose = beginLifecycleClose([directory])
             const exit = yield* restore(Deferred.await(previous.deferred)).pipe(Effect.exit)
             if (Exit.isSuccess(exit) && hasActiveRuns([exit.value.directory])) {
-              const releaseDeferredClose = releaseClose
               const deferredAction = createLifecycleCloseAction("instance_reload", {
                 affectedDirectories: [exit.value.directory],
                 ...lifecycleContext("instance.reload", reason),
               })
-              void whenAllRunsIdle([exit.value.directory])
-                .then(() => Effect.runPromise(reload(input, reason, { mode: "force" })))
+              releaseClose()
+              releaseClose = undefined
+              void deferMaintenanceClose([exit.value.directory], () =>
+                Effect.runPromise(reload(input, reason, { mode: "force" })),
+              )
                 .catch((error) => reportDeferredFailure("reload", exit.value.directory, deferredAction, error))
-                .finally(releaseDeferredClose)
                 .then(() => undefined)
               return exit.value
             }
@@ -477,13 +499,12 @@ export const layer = Layer.effect(
         if ((options?.mode ?? "maintenance") === "maintenance") {
           const releaseClose = beginLifecycleClose(activeDirectories)
           if (hasActiveRuns(activeDirectories)) {
-            const completed = whenAllRunsIdle(activeDirectories)
-              .then(() => Effect.runPromise(close))
+            releaseClose()
+            const completed = deferMaintenanceClose(activeDirectories, () => Effect.runPromise(close))
               .catch((error) => {
                 reportDeferredFailure("disposeAll", undefined, action, error)
                 throw error
               })
-              .finally(releaseClose)
             void completed.catch(() => undefined)
             return resultFor("deferred", action, completed)
           }

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -245,24 +245,23 @@ export const layer = Layer.effect(
         error,
       })
 
-    const deferMaintenanceClose = (
+    const deferMaintenanceClose = async (
       directories: readonly string[],
       close: () => Promise<unknown>,
     ): Promise<void> => {
       const targetDirectories = [...new Set(directories)]
-      const waitAndClose = async (): Promise<void> => {
+      while (true) {
         await whenAllRunsIdle(targetDirectories)
         const releaseClose = beginLifecycleClose(targetDirectories)
-        let retry = false
         try {
-          if (hasActiveRuns(targetDirectories)) retry = true
-          else await close()
+          if (!hasActiveRuns(targetDirectories)) {
+            await close()
+            return
+          }
         } finally {
           releaseClose()
         }
-        if (retry) await waitAndClose()
       }
-      return waitAndClose()
     }
 
     const disposeEntryNow = (

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -211,6 +211,45 @@ describe("InstanceStore", () => {
     }),
   )
 
+  it.live("does not close when a run starts after maintenance dispose becomes idle", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const store = yield* InstanceStore.Service
+      const disposed = Promise.withResolvers<void>()
+      const completed = Promise.withResolvers<void>()
+      const off = registerDisposer(async (directory) => {
+        if (directory === dir) disposed.resolve()
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(off))
+
+      const firstContext = yield* store.load({ directory: dir })
+      const first = trackActiveRun(dir)
+      const releaseFirst = yield* Effect.promise(() => first.promise)
+
+      const result = yield* store.disposeDirectory(dir, { onCompleted: () => completed.resolve() })
+      expect(result).toBe(false)
+
+      releaseFirst()
+      const second = trackActiveRun(dir)
+      const secondExit = yield* Effect.promise(() => second.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
+      let releaseSecond: (() => void) | undefined
+      if (Exit.isSuccess(secondExit)) releaseSecond = secondExit.value
+      expect(Exit.isSuccess(secondExit)).toBe(true)
+
+      try {
+        const earlyDispose = yield* Effect.promise(() => disposed.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
+        expect(Exit.isFailure(earlyDispose)).toBe(true)
+      } finally {
+        releaseSecond?.()
+      }
+
+      const completedExit = yield* Effect.promise(() => completed.promise).pipe(Effect.timeout("1 second"), Effect.exit)
+      expect(Exit.isSuccess(completedExit)).toBe(true)
+      const current = yield* store.load({ directory: dir })
+      expect(current).not.toBe(firstContext)
+    }),
+  )
+
   it.live("does not gate new runs while a maintenance reload waits for idle", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped()

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -191,23 +191,26 @@ describe("InstanceStore", () => {
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped()
       const store = yield* InstanceStore.Service
+      const completed = Promise.withResolvers<void>()
       yield* store.load({ directory: dir })
 
       const first = trackActiveRun(dir)
       const releaseFirst = yield* Effect.promise(() => first.promise)
       let releaseSecond: (() => void) | undefined
       try {
-        const result = yield* store.disposeDirectory(dir)
+        const result = yield* store.disposeDirectory(dir, { onCompleted: () => completed.resolve() })
         expect(result).toBe(false)
 
         const second = trackActiveRun(dir)
-        const secondExit = yield* Effect.promise(() => second.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
-        if (Exit.isSuccess(secondExit)) releaseSecond = secondExit.value
-        expect(Exit.isSuccess(secondExit)).toBe(true)
+        expect(second.wait).toBeUndefined()
+        releaseSecond = yield* Effect.promise(() => second.promise)
       } finally {
         releaseSecond?.()
         releaseFirst()
       }
+
+      const completedExit = yield* Effect.promise(() => completed.promise).pipe(Effect.timeout("1 second"), Effect.exit)
+      expect(Exit.isSuccess(completedExit)).toBe(true)
     }),
   )
 
@@ -231,10 +234,9 @@ describe("InstanceStore", () => {
 
       releaseFirst()
       const second = trackActiveRun(dir)
-      const secondExit = yield* Effect.promise(() => second.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
       let releaseSecond: (() => void) | undefined
-      if (Exit.isSuccess(secondExit)) releaseSecond = secondExit.value
-      expect(Exit.isSuccess(secondExit)).toBe(true)
+      expect(second.wait).toBeUndefined()
+      releaseSecond = yield* Effect.promise(() => second.promise)
 
       try {
         const earlyDispose = yield* Effect.promise(() => disposed.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
@@ -269,9 +271,8 @@ describe("InstanceStore", () => {
         expect(reloaded).toBe(firstContext)
 
         const second = trackActiveRun(dir)
-        const secondExit = yield* Effect.promise(() => second.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
-        if (Exit.isSuccess(secondExit)) releaseSecond = secondExit.value
-        expect(Exit.isSuccess(secondExit)).toBe(true)
+        expect(second.wait).toBeUndefined()
+        releaseSecond = yield* Effect.promise(() => second.promise)
       } finally {
         releaseSecond?.()
         releaseFirst()
@@ -300,9 +301,8 @@ describe("InstanceStore", () => {
         completed = result.completed
 
         const second = trackActiveRun(dir)
-        const secondExit = yield* Effect.promise(() => second.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
-        if (Exit.isSuccess(secondExit)) releaseSecond = secondExit.value
-        expect(Exit.isSuccess(secondExit)).toBe(true)
+        expect(second.wait).toBeUndefined()
+        releaseSecond = yield* Effect.promise(() => second.promise)
       } finally {
         releaseSecond?.()
         releaseFirst()

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -11,7 +11,7 @@ import { InstanceStore } from "../../src/project/instance-store"
 import { Project } from "../../src/project/project"
 import { ProjectTable } from "../../src/project/project.sql"
 import { Database, eq } from "../../src/storage/db"
-import { currentLifecycleCloseAction, directoryKey } from "../../src/session/lifecycle-provenance"
+import { currentLifecycleCloseAction, directoryKey, trackActiveRun } from "../../src/session/lifecycle-provenance"
 import { disposeAllInstances, tmpdir, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -184,6 +184,96 @@ describe("InstanceStore", () => {
       yield* store.disposeDirectory(loaded)
 
       expect(disposed).toEqual([loaded])
+    }),
+  )
+
+  it.live("does not gate new runs while a maintenance dispose waits for idle", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const store = yield* InstanceStore.Service
+      yield* store.load({ directory: dir })
+
+      const first = trackActiveRun(dir)
+      const releaseFirst = yield* Effect.promise(() => first.promise)
+      let releaseSecond: (() => void) | undefined
+      try {
+        const result = yield* store.disposeDirectory(dir)
+        expect(result).toBe(false)
+
+        const second = trackActiveRun(dir)
+        const secondExit = yield* Effect.promise(() => second.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
+        if (Exit.isSuccess(secondExit)) releaseSecond = secondExit.value
+        expect(Exit.isSuccess(secondExit)).toBe(true)
+      } finally {
+        releaseSecond?.()
+        releaseFirst()
+      }
+    }),
+  )
+
+  it.live("does not gate new runs while a maintenance reload waits for idle", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const store = yield* InstanceStore.Service
+      const disposed = Promise.withResolvers<void>()
+      const off = registerDisposer(async (directory) => {
+        if (directory === dir) disposed.resolve()
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(off))
+
+      const firstContext = yield* store.load({ directory: dir })
+      const first = trackActiveRun(dir)
+      const releaseFirst = yield* Effect.promise(() => first.promise)
+      let releaseSecond: (() => void) | undefined
+      try {
+        const reloaded = yield* store.reload({ directory: dir })
+        expect(reloaded).toBe(firstContext)
+
+        const second = trackActiveRun(dir)
+        const secondExit = yield* Effect.promise(() => second.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
+        if (Exit.isSuccess(secondExit)) releaseSecond = secondExit.value
+        expect(Exit.isSuccess(secondExit)).toBe(true)
+      } finally {
+        releaseSecond?.()
+        releaseFirst()
+      }
+
+      const disposedExit = yield* Effect.promise(() => disposed.promise).pipe(Effect.timeout("1 second"), Effect.exit)
+      expect(Exit.isSuccess(disposedExit)).toBe(true)
+      const current = yield* store.load({ directory: dir })
+      expect(current).not.toBe(firstContext)
+    }),
+  )
+
+  it.live("does not gate new runs while a maintenance disposeAll waits for idle", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const store = yield* InstanceStore.Service
+      yield* store.load({ directory: dir })
+
+      const first = trackActiveRun(dir)
+      const releaseFirst = yield* Effect.promise(() => first.promise)
+      let releaseSecond: (() => void) | undefined
+      let completed: Promise<void> | undefined
+      try {
+        const result = yield* store.disposeAll()
+        expect(result.status).toBe("deferred")
+        completed = result.completed
+
+        const second = trackActiveRun(dir)
+        const secondExit = yield* Effect.promise(() => second.promise).pipe(Effect.timeout("100 millis"), Effect.exit)
+        if (Exit.isSuccess(secondExit)) releaseSecond = secondExit.value
+        expect(Exit.isSuccess(secondExit)).toBe(true)
+      } finally {
+        releaseSecond?.()
+        releaseFirst()
+      }
+
+      const completedExit = yield* Effect.promise(() => completed ?? Promise.resolve()).pipe(
+        Effect.timeout("1 second"),
+        Effect.exit,
+      )
+      expect(Exit.isSuccess(completedExit)).toBe(true)
     }),
   )
 


### PR DESCRIPTION
## Summary

Fixes a reproduced installed-app concurrency bug where newly started sessions could remain stuck in the thinking state while a maintenance instance close was waiting for an active run to finish. There is no tracked issue yet; this PR comes from the live user report and local reproduction.

Review follow-ups pin the idle-then-new-run retry window with a deterministic regression test, simplify the maintenance close retry loop, and tighten the tests so deferred maintenance completion is awaited and immediate run admission is asserted through `trackActiveRun().wait` instead of timing-based success checks.

## Why

Maintenance `dispose`, `reload`, and `disposeAll` paths were holding the lifecycle close gate while waiting for active runs to become idle. That made the waiting cleanup look like an active close to subsequent runs in the same directory, so a new session could block behind maintenance work that was intentionally supposed to be deferred.

## Related Issue

None.

## Human Review Status

Pending

## Review Focus

Please focus on the lifecycle ordering in `InstanceStore`: maintenance work should wait for idle without holding the close gate, briefly acquire the gate only while actually closing, and retry if a new run starts between the idle check and the close gate acquisition.

## Risk Notes

The behavior change is in session lifecycle coordination, not UI. The main risk is changing close/reload ordering for active runs; this is covered by new regression tests for `disposeDirectory`, `reload`, and `disposeAll`, plus existing `SessionRunState` lifecycle tests and the full `packages/opencode` suite.

Skipped checklist items:

- Visible UI or copy check: no visible UI or copy changed.
- macOS/Windows platform check: no platform, packaging, updater, signing, path, shell, or permissions surface changed.
- Docs/release/dependency/permission/generated/local-file note: no docs, release notes, dependencies, permissions, generated files, or repo-local config files changed.

## How To Verify

```text
RED review follow-up: with the idle-after-gate active-run recheck intentionally removed, bun test --timeout 30000 ./test/project/instance-store.test.ts -t "does not close when a run starts after maintenance dispose becomes idle" failed at the earlyDispose assertion as expected.
Focused review follow-up tests: bun test --timeout 30000 ./test/project/instance-store.test.ts -t "does not gate new runs while a maintenance" -> 3 pass, 0 fail.
Adjacent lifecycle tests: bun test --timeout 30000 ./test/project/instance-store.test.ts ./test/session/run-state.test.ts -> 38 pass, 0 fail, 140 expect() calls.
Typecheck: bun run typecheck -> pass.
Full package tests before the final test-only tightening commit: bun test --timeout 30000 -> 4012 pass, 9 skip, 1 todo, 0 fail, 15260 expect() calls across 296 files.
Diff check: git diff --check -> pass.
```

## Screenshots or Recordings

Not applicable, no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
