### PR TITLE
fix: update workflow contract tests for install-matrix job

### DIFF
--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -282,6 +282,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
           bun-version: "1.3.14"
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5

--- a/packages/opencode/test/github/bun-version-workflow.test.ts
+++ b/packages/opencode/test/github/bun-version-workflow.test.ts
@@ -48,7 +48,7 @@ describe("GitHub workflow Bun version pin", () => {
     }
 
     expect(collectSetupBunPins(workflow, "synthetic.yml")).toEqual([
-      "synthetic.yml:unpinned:step-1:bun-version: \"<missing>\"",
+      'synthetic.yml:unpinned:step-1:bun-version: "<missing>"',
     ])
   })
 
@@ -83,15 +83,16 @@ describe("GitHub workflow Bun version pin", () => {
     }
 
     expect(setupBunPins).toEqual([
-      ".github/workflows/build.yml:build-electron:step-5:bun-version: \"1.3.14\"",
-      ".github/workflows/deploy-site.yml:build-and-deploy:step-2:bun-version: \"1.3.14\"",
-      ".github/workflows/desktop-smoke.yml:smoke-macos-arm64:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/dev-dep-audit.yml:dev-dep-audit:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/e2e-artifacts.yml:e2e-artifacts:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/mirror-release-to-r2.yml:mirror:step-2:bun-version: \"1.3.14\"",
-      ".github/workflows/officecli-bump.yml:officecli-bump:step-3:bun-version: \"1.3.14\"",
-      ".github/workflows/perf-probe-baseline.yml:perf-probe-baseline:step-7:bun-version: \"1.3.14\"",
-      ".github/workflows/windows-advisory.yml:unit-windows:step-3:bun-version: \"1.3.14\"",
+      '.github/workflows/build.yml:build-electron:step-5:bun-version: "1.3.14"',
+      '.github/workflows/deploy-site.yml:build-and-deploy:step-2:bun-version: "1.3.14"',
+      '.github/workflows/desktop-smoke.yml:smoke-macos-arm64:step-3:bun-version: "1.3.14"',
+      '.github/workflows/desktop-smoke.yml:install-matrix:step-3:bun-version: "1.3.14"',
+      '.github/workflows/dev-dep-audit.yml:dev-dep-audit:step-3:bun-version: "1.3.14"',
+      '.github/workflows/e2e-artifacts.yml:e2e-artifacts:step-3:bun-version: "1.3.14"',
+      '.github/workflows/mirror-release-to-r2.yml:mirror:step-2:bun-version: "1.3.14"',
+      '.github/workflows/officecli-bump.yml:officecli-bump:step-3:bun-version: "1.3.14"',
+      '.github/workflows/perf-probe-baseline.yml:perf-probe-baseline:step-7:bun-version: "1.3.14"',
+      '.github/workflows/windows-advisory.yml:unit-windows:step-3:bun-version: "1.3.14"',
     ])
     expect(missingComments).toEqual([])
 

--- a/packages/opencode/test/github/desktop-smoke-workflow.test.ts
+++ b/packages/opencode/test/github/desktop-smoke-workflow.test.ts
@@ -43,7 +43,7 @@ describe("desktop smoke workflow", () => {
     expect(parsed.concurrency?.group).toContain("github.event.pull_request.number || github.ref")
     expect(parsed.concurrency?.["cancel-in-progress"]).toBe("${{ github.ref != 'refs/heads/dev' }}")
     expect(parsed.permissions).toEqual({ contents: "read", "pull-requests": "read" })
-    expect(Object.keys(jobs).sort()).toEqual(["changes", "check", "smoke-macos-arm64"])
+    expect(Object.keys(jobs).sort()).toEqual(["changes", "check", "install-matrix", "smoke-macos-arm64"])
     expect(changesCheckoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
     expect(smokeCheckoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
 
@@ -67,10 +67,7 @@ describe("desktop smoke workflow", () => {
     expect(smoke?.if).toBe("needs.changes.outputs.docs_only != 'true'")
     expect(smoke?.["runs-on"]).toBe("macos-14")
     expect(check?.if).toBe("always()")
-    expect(check?.needs).toEqual(["changes", "smoke-macos-arm64"])
-
-    expect(workflow).not.toContain("strategy:")
-    expect(workflow).not.toContain("matrix:")
+    expect(check?.needs).toEqual(["changes", "smoke-macos-arm64", "install-matrix"])
 
     expect(smokeCheckoutStep?.with).toEqual({ "persist-credentials": false })
     expect(smokeBunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")

--- a/packages/opencode/test/github/desktop-smoke-workflow.test.ts
+++ b/packages/opencode/test/github/desktop-smoke-workflow.test.ts
@@ -76,7 +76,8 @@ describe("desktop smoke workflow", () => {
     expect(install?.if).toBe("needs.changes.outputs.docs_only != 'true'")
     expect(install?.["runs-on"]).toBe("macos-14")
     expect(install?.["timeout-minutes"]).toBe(10)
-    expect(install?.strategy?.matrix?.["node-version"]).toEqual(["24", "26"])
+    const installMatrix = install?.strategy?.matrix as { "node-version"?: unknown } | undefined
+    expect(installMatrix?.["node-version"]).toEqual(["24", "26"])
     const installCheckout = installSteps.find((step) => step.uses?.startsWith("actions/checkout@"))
     expect(installCheckout?.with?.["persist-credentials"]).toBe(false)
     const installSetupNode = installSteps.find((step) => step.uses?.startsWith("actions/setup-node@"))

--- a/packages/opencode/test/github/desktop-smoke-workflow.test.ts
+++ b/packages/opencode/test/github/desktop-smoke-workflow.test.ts
@@ -69,6 +69,33 @@ describe("desktop smoke workflow", () => {
     expect(check?.if).toBe("always()")
     expect(check?.needs).toEqual(["changes", "smoke-macos-arm64", "install-matrix"])
 
+    // install-matrix job: validates Electron install on Node 24 and 26
+    const install = jobs["install-matrix"]
+    const installSteps = install?.steps ?? []
+    expect(install?.needs).toBe("changes")
+    expect(install?.if).toBe("needs.changes.outputs.docs_only != 'true'")
+    expect(install?.["runs-on"]).toBe("macos-14")
+    expect(install?.["timeout-minutes"]).toBe(10)
+    expect(install?.strategy?.matrix?.["node-version"]).toEqual(["24", "26"])
+    const installCheckout = installSteps.find((step) => step.uses?.startsWith("actions/checkout@"))
+    expect(installCheckout?.with?.["persist-credentials"]).toBe(false)
+    const installSetupNode = installSteps.find((step) => step.uses?.startsWith("actions/setup-node@"))
+    expect(installSetupNode?.with?.["node-version"]).toBe("${{ matrix.node-version }}")
+    const installBunStep = installSteps.find((step) => step.uses?.startsWith("oven-sh/setup-bun@"))
+    expect(installBunStep?.with?.["bun-version"]).toBe("1.3.14")
+    const installDepsStep = installSteps.find((step) => step.name === "Install dependencies")
+    expect(installDepsStep?.run).toBe("bun install --frozen-lockfile")
+    const assertStep = installSteps.find((step) => step.name === "Assert Electron install complete")
+    expect(assertStep?.run).toBe("node ./scripts/repair-electron-install.mjs --assert-complete")
+    expect(assertStep?.["working-directory"]).toBe("packages/desktop-electron")
+
+    // smoke-macos-arm64 must not use strategy/matrix (install-matrix is the only job that does)
+    expect(workflow).toContain("strategy:")
+    expect(workflow).toContain("matrix:")
+    const smokeRaw = workflow.slice(workflow.indexOf("smoke-macos-arm64:"), workflow.indexOf("install-matrix:"))
+    expect(smokeRaw).not.toContain("strategy:")
+    expect(smokeRaw).not.toContain("matrix:")
+
     expect(smokeCheckoutStep?.with).toEqual({ "persist-credentials": false })
     expect(smokeBunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
     expect(installStep?.run).toBe("bun install --frozen-lockfile")


### PR DESCRIPTION
## Summary

Update workflow contract tests to account for the new `install-matrix` job added in PR #1352, and keep the new matrix assertion type-safe under `tsgo`.

## Why

PR #1352 added an `install-matrix` job to `desktop-smoke.yml` but didn't update the contract tests that validate the workflow structure. This caused `dev` CI to fail on the merged commit.

## Changes

- `desktop-smoke-workflow.test.ts`: add `install-matrix` to expected job list and `check.needs`; assert the new Node 24/26 install matrix through a type-safe matrix record.
- `bun-version-workflow.test.ts`: add the `install-matrix` setup-bun pin to the expected list.
- `desktop-smoke.yml`: add an audit comment to `install-matrix`'s `bun-version` line.

## How To Verify

```text
bun install --frozen-lockfile: passes
bun run typecheck (packages/opencode): passes
bun test test/github/desktop-smoke-workflow.test.ts test/github/bun-version-workflow.test.ts (packages/opencode): 4 pass, 0 fail
bun run test:ci (packages/opencode): 4008 tests, 3998 pass, 9 skip, 1 todo, 0 fail
git diff --check: clean
```

## Checklist

- [x] Type label: `bug`
- [x] Routing labels: `ci`, `harness`
- [x] Priority label: `P1`
- [x] Human Review Status: Pending
- [x] Linked related issue: PR #1352
- [x] Review focus: test expectations match workflow structure
- [x] Risk notes: None; test/workflow-contract-only change
- [x] How To Verify: replaced with real verification
- [x] No unrelated changes
- [x] No visible UI changes
- [x] Platform impact considered: validates macOS install-matrix workflow contract only
- [x] No docs/release notes needed
- [x] Reviewed final diff
- [x] Targeting dev, Conventional Commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workflow automation tests to reflect the added job and revised step expectations for install and verification flows.

* **Chores**
  * Added an internal documentation note highlighting the importance of preserving Bun audit exit-code semantics during workflow version changes.

**Note:** This release updates internal CI workflow coverage and documentation only, with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->