### PR TITLE
chore(release): bump desktop version to 2026.6.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.6.7",
+      "version": "2026.6.8",
       "dependencies": {
         "@opencode-ai/util": "workspace:*",
         "electron-context-menu": "4.1.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.6.7",
+  "version": "2026.6.8",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bumps the PawWork desktop release version from `2026.6.7` to `2026.6.8`. There is no related issue; this is the release bump for the next stable desktop publish.

## Why

`dev` has accumulated release-bound changes since `v2026.6.7`, and the desktop package version needs to advance before the release workflows build and publish the new installers.

## Related Issue

No issue. Release bump only.

## Human Review Status

Not required: automated release version bump only.

## Review Focus

Confirm the diff is limited to the desktop package version and matching `bun.lock` workspace metadata.

## Risk Notes

No product behavior changes. Packaging/update metadata is touched only through the version number. No visible UI or copy changed, so no screenshot or recording is included.

Skipped checklist items:

- Visible UI or copy check: no visible UI or copy changed.

## How To Verify

```text
bun install --frozen-lockfile: completed in a fresh release worktree.
bun install --lockfile-only: updated bun.lock for the new workspace version.
bun install --frozen-lockfile: checked the updated lockfile with no further changes.
git diff --check: passed.
Version check: packages/desktop-electron/package.json reads 2026.6.8.
```

## Screenshots or Recordings

Not applicable. No visible UI or copy changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 2026.6.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->