### PR TITLE
fix: stabilize connect-timeout retry test

### DIFF
--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -113,16 +113,17 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: windows-latest
-    # Windows unit jobs are advisory, package-scoped or shard-scoped. The
-    # 20-minute budget applies per matrix child; opencode has three parallel
-    # shards, so a full stall can consume up to three Windows runner slots.
-    timeout-minutes: 20
+    # Windows unit jobs are advisory, package-scoped or shard-scoped. Timeout
+    # budgets are explicit per matrix child; opencode has three parallel
+    # shards, so a full stall can still consume multiple Windows runner slots.
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - package: app
             uses_turbo: true
+            timeout_minutes: 20
             command: bun turbo test:ci --filter=@opencode-ai/app
             report_path: packages/app/.artifacts/unit/junit.xml
           # The opencode-* package values below are synthetic shard names for
@@ -134,6 +135,7 @@ jobs:
           # tests to keep the Windows shard runtimes close.
           - package: opencode-session
             uses_turbo: false
+            timeout_minutes: 30
             command: >-
               cd packages/opencode && bun test
               --timeout 30000
@@ -152,6 +154,7 @@ jobs:
           # and GitHub workflow tests.
           - package: opencode-config-project
             uses_turbo: false
+            timeout_minutes: 20
             command: >-
               cd packages/opencode && bun test
               --timeout 30000
@@ -170,6 +173,7 @@ jobs:
           # why it has more entries than the other two opencode shards.
           - package: opencode-server-tools
             uses_turbo: false
+            timeout_minutes: 20
             command: >-
               cd packages/opencode && bun test
               --timeout 30000
@@ -209,6 +213,7 @@ jobs:
             report_path: packages/opencode/.artifacts/unit/junit-windows-server-tools.xml
           - package: desktop
             uses_turbo: true
+            timeout_minutes: 20
             command: bun turbo test:ci --filter=@opencode-ai/desktop-electron
             report_path: packages/desktop-electron/.artifacts/unit/junit.xml
     permissions:

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -86,6 +86,7 @@ const windowsOpencodeShards = [
   {
     suffix: "opencode-session",
     usesTurbo: false,
+    timeoutMinutes: 30,
     command:
       "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-session.xml test/session test/plugin test/permission test/util test/skill test/index-runtime-namespace.test.ts test/permission-agent.test.ts test/permission-cleanup.test.ts",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-session.xml",
@@ -93,6 +94,7 @@ const windowsOpencodeShards = [
   {
     suffix: "opencode-config-project",
     usesTurbo: false,
+    timeoutMinutes: 20,
     command:
       "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-config-project.xml test/config test/project test/worktree test/file/ test/github test/opencli test/settings test/settings.test.ts",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-config-project.xml",
@@ -100,6 +102,7 @@ const windowsOpencodeShards = [
   {
     suffix: "opencode-server-tools",
     usesTurbo: false,
+    timeoutMinutes: 20,
     command:
       "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/tool test/browser test/mcp test/question test/effect test/agent test/git/ test/storage test/provider test/pty test/share/ test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth test/automation",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-server-tools.xml",
@@ -110,6 +113,7 @@ const windowsUnitPackages = [
   {
     suffix: "app",
     usesTurbo: true,
+    timeoutMinutes: 20,
     command: "bun turbo test:ci --filter=@opencode-ai/app",
     reportPath: "packages/app/.artifacts/unit/junit.xml",
   },
@@ -117,6 +121,7 @@ const windowsUnitPackages = [
   {
     suffix: "desktop",
     usesTurbo: true,
+    timeoutMinutes: 20,
     command: "bun turbo test:ci --filter=@opencode-ai/desktop-electron",
     reportPath: "packages/desktop-electron/.artifacts/unit/junit.xml",
   },
@@ -557,7 +562,7 @@ describe("ci workflow", () => {
     expect(job?.needs).toBe("changes")
     expect(job?.if).toBe("needs.changes.outputs.docs_only != 'true'")
     expect(job?.["runs-on"]).toBe("windows-latest")
-    expect(job?.["timeout-minutes"]).toBe(20)
+    expect(job?.["timeout-minutes"] as unknown).toBe("${{ matrix.timeout_minutes }}")
     expect(job?.["continue-on-error"]).toBeUndefined()
     expect(job?.strategy?.["fail-fast"]).toBe(false)
     expect(job?.permissions).toEqual({ contents: "read" })
@@ -651,9 +656,10 @@ describe("ci workflow", () => {
     const matrixIncludes = job?.strategy?.matrix?.include ?? []
 
     expect(matrixIncludes).toEqual(
-      windowsUnitJobs.map(({ jobName, usesTurbo, command, reportPath }) => ({
+      windowsUnitJobs.map(({ jobName, usesTurbo, timeoutMinutes, command, reportPath }) => ({
         package: jobName.replace("unit-windows-", ""),
         uses_turbo: usesTurbo,
+        timeout_minutes: timeoutMinutes,
         command,
         report_path: reportPath,
       })),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -343,34 +343,87 @@ function processorEnvWithLLM(llm: LLM.Interface) {
   )
 }
 
+function connectWatchdogFailure(input: LLM.StreamInput): Stream.Stream<LLM.Event, unknown> {
+  const connectTimeoutMs = input.connectTimeoutMs ?? LLM.CONNECT_STREAM_TIMEOUT_MS
+  const streamTimeoutMs = input.streamTimeoutMs ?? LLM.SILENT_STREAM_TIMEOUT_MS
+  const error = new Error(`LLM stream connection timed out after ${connectTimeoutMs}ms without provider progress`)
+  input.trace?.beginStream({
+    collectorCreatedAt: Date.now(),
+    monotonicMs: performance.now(),
+    connectTimeoutMs,
+    streamTimeoutMs,
+  })
+  input.trace?.recordWatchdogFired({
+    phase: "connect",
+    firedAt: Date.now(),
+    monotonicMs: performance.now(),
+  })
+  input.trace?.recordStreamFailure({
+    error,
+    boundary: "watchdog",
+    confidence: "high",
+    evidence: ["watchdog_fired", "watchdog_error"],
+    failedAt: Date.now(),
+    monotonicMs: performance.now(),
+  })
+  return Stream.fail(error)
+}
+
+function textStream(text: string): Stream.Stream<LLM.Event, unknown> {
+  return Stream.make(
+    { type: "start" } satisfies LLM.Event,
+    { type: "text-start", id: "txt-0" } satisfies LLM.Event,
+    { type: "text-delta", id: "txt-0", delta: text, text } as LLM.Event,
+    { type: "text-end", id: "txt-0" } satisfies LLM.Event,
+    {
+      type: "finish-step",
+      finishReason: "stop",
+      rawFinishReason: "stop",
+      response: { id: "res", modelId: "test-model", timestamp: new Date() },
+      providerMetadata: undefined,
+      usage: {
+        inputTokens: 1,
+        outputTokens: 1,
+        totalTokens: 2,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+      },
+    } satisfies LLM.Event,
+    {
+      type: "finish",
+      finishReason: "stop",
+      rawFinishReason: "stop",
+      totalUsage: {
+        inputTokens: 1,
+        outputTokens: 1,
+        totalTokens: 2,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+      },
+    } satisfies LLM.Event,
+  )
+}
+
 const capturedAttemptConnectTimeouts: number[] = []
 const attemptTimeoutIt = testEffect(
   processorEnvWithLLM({
     stream(input) {
-      const connectTimeoutMs = input.connectTimeoutMs ?? LLM.CONNECT_STREAM_TIMEOUT_MS
-      const streamTimeoutMs = input.streamTimeoutMs ?? LLM.SILENT_STREAM_TIMEOUT_MS
-      const error = new Error(`LLM stream connection timed out after ${connectTimeoutMs}ms without provider progress`)
-      capturedAttemptConnectTimeouts.push(connectTimeoutMs)
-      input.trace?.beginStream({
-        collectorCreatedAt: Date.now(),
-        monotonicMs: performance.now(),
-        connectTimeoutMs,
-        streamTimeoutMs,
-      })
-      input.trace?.recordWatchdogFired({
-        phase: "connect",
-        firedAt: Date.now(),
-        monotonicMs: performance.now(),
-      })
-      input.trace?.recordStreamFailure({
-        error,
-        boundary: "watchdog",
-        confidence: "high",
-        evidence: ["watchdog_fired", "watchdog_error"],
-        failedAt: Date.now(),
-        monotonicMs: performance.now(),
-      })
-      return Stream.fail(error)
+      capturedAttemptConnectTimeouts.push(input.connectTimeoutMs ?? LLM.CONNECT_STREAM_TIMEOUT_MS)
+      return connectWatchdogFailure(input)
     },
   }),
 )
@@ -1562,14 +1615,23 @@ it.live("session.processor effect tests publish retry status updates", () =>
   ),
 )
 
-it.live("connect timeout before provider progress auto retries once and succeeds", () =>
-  provideTmpdirServer(
-    ({ dir, llm }) =>
-      Effect.gen(function* () {
-        const { processors, session, provider } = yield* boot()
+let deterministicConnectTimeoutCalls = 0
+const deterministicConnectTimeoutIt = testEffect(
+  processorEnvWithLLM({
+    stream(input) {
+      deterministicConnectTimeoutCalls += 1
+      if (deterministicConnectTimeoutCalls === 1) return connectWatchdogFailure(input)
+      return textStream("after retry")
+    },
+  }),
+)
 
-        yield* llm.hang
-        yield* llm.text("after retry")
+deterministicConnectTimeoutIt.live("connect timeout before provider progress auto retries once and succeeds", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        deterministicConnectTimeoutCalls = 0
+        const { processors, session, provider } = yield* boot()
 
         const chat = yield* session.create({})
         const parent = yield* user(chat.id, "auto retry connect timeout")
@@ -1606,7 +1668,7 @@ it.live("connect timeout before provider progress auto retries once and succeeds
         )
 
         expect(value).toBe("continue")
-        expect(yield* llm.calls).toBe(2)
+        expect(deterministicConnectTimeoutCalls).toBe(2)
         expect(parts.some((part) => part.type === "text" && part.text === "after retry")).toBe(true)
         expect(handle.message.error).toBeUndefined()
         expect(stored?.info.role).toBe("assistant")
@@ -1639,7 +1701,7 @@ it.live("connect timeout before provider progress auto retries once and succeeds
           })
         }
       }),
-    { git: true, config: (url) => providerCfg(url) },
+    { git: true, config: cfg },
   ),
 )
 


### PR DESCRIPTION
## Summary

- Replace the processor retry test's real HTTP connect-timeout race with a deterministic LLM seam that fails the first attempt with the same watchdog trace shape and succeeds the second attempt.
- Reuse the synthetic connect-watchdog failure helper in the existing attempt-timeout test.
- Make the Windows advisory unit timeout matrix-driven and give only `opencode-session` a 30-minute budget; other Windows unit shards stay at 20 minutes.
- No issue; this fixes the advisory Windows `unit-windows-opencode-session` failures observed on PR #1359 and on this PR.

## Why

The original failed test asserted that a connect timeout before provider progress retries exactly once and then succeeds. On the Windows runner, the 20ms real HTTP timeout can fire before the mock server consumes the first queued hang response, leaving the queue misaligned and producing an extra processor attempt. That makes the test timing-sensitive even though the product retry behavior is not the problem.

After the deterministic test fix, this PR's own `unit-windows-opencode-session` run still failed differently: the job was canceled by the 20-minute job timeout after setup/cache/install consumed roughly five minutes and the first unit attempt was still running. The advisory retry wrapper could not run a second attempt because the job-level timeout killed the job first.

This keeps the real LLM connect-watchdog coverage in `llm.test.ts`, makes the processor retry-success test deterministic at the processor seam, and gives the slow Windows session shard enough job-level budget for runner setup variance.

## Related Issue

No issue. CI flakes observed in PR #1359 advisory job `unit-windows-opencode-session`, then reproduced on this PR as a job-level timeout.

## Human Review Status

Pending

## Review Focus

- Confirm the changed processor test still verifies the retry-success behavior and retry observability.
- Confirm the real connect-watchdog behavior remains covered by `test/session/llm.test.ts`.
- Confirm the Windows advisory timeout change is scoped to the `opencode-session` shard and keeps other shard budgets unchanged.

## Risk Notes

No production behavior changed. No visible UI or copy changed. The CI-only risk is slightly higher worst-case Windows runner time for `unit-windows-opencode-session` when it stalls, from 20 minutes to 30 minutes; other Windows unit shards stay at 20 minutes. No product platform, packaging, updater, signing, path, shell, or permission surface changed. No docs, release notes, dependencies, credentials, deletion behavior, generated content, or local-file surfaces were touched.

## How To Verify

```text
bun install --frozen-lockfile: passed
cd packages/opencode && bun test --timeout 30000 test/session/processor-effect.test.ts --test-name-pattern "connect timeout before provider progress auto retries once and succeeds": 1 pass, 48 filtered, 0 fail, 15 expect() calls
cd packages/opencode && bun test --timeout 30000 test/session/processor-effect.test.ts: 49 pass, 0 fail, 337 expect() calls
cd packages/opencode && bun test --timeout 30000 test/session/llm.test.ts --test-name-pattern "connect timeout produces stream failure not success drain": 1 pass, 20 filtered, 0 fail, 3 expect() calls
cd packages/opencode && bun test --timeout 30000 test/github/ci-workflow.test.ts --test-name-pattern "keeps Windows unit package and shard signals in the advisory workflow|defines Windows unit packages and opencode shards": RED before workflow change, then 2 pass, 15 filtered, 0 fail, 53 expect() calls
cd packages/opencode && bun test --timeout 30000 test/github/ci-workflow.test.ts: 17 pass, 0 fail, 328 expect() calls
cd packages/opencode && bun run typecheck: passed
actionlint -color -shellcheck= .github/workflows/windows-advisory.yml: passed
git diff --check: passed
```

## Screenshots or Recordings

N/A. No visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
