### PR TITLE
chore(opencode): fetch route inventory from opencode remote

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -565,7 +565,7 @@ function mark(value: boolean) {
 
 async function main() {
   const root = repoRoot()
-  git(root, ["fetch", "upstream", "dev"])
+  git(root, ["fetch", "opencode", "dev"])
   const inventory = await buildRouteInventory({ root, requireUpstream: true })
   const report = renderRouteInventoryReport(inventory)
   const date = new Date().toISOString().slice(0, 10)

--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -563,9 +563,24 @@ function mark(value: boolean) {
   return value ? "yes" : "no"
 }
 
+export function fetchOpencodeDev(root: string) {
+  try {
+    git(root, ["fetch", "opencode", "dev"])
+  } catch (cause) {
+    throw new Error(
+      [
+        "Failed to fetch opencode/dev.",
+        "Ensure remote 'opencode' exists (for example: git remote rename upstream opencode,",
+        "or git remote add opencode https://github.com/anomalyco/opencode.git).",
+      ].join(" "),
+      { cause },
+    )
+  }
+}
+
 async function main() {
   const root = repoRoot()
-  git(root, ["fetch", "opencode", "dev"])
+  fetchOpencodeDev(root)
   const inventory = await buildRouteInventory({ root, requireUpstream: true })
   const report = renderRouteInventoryReport(inventory)
   const date = new Date().toISOString().slice(0, 10)

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
+import { execFileSync } from "node:child_process"
+import { mkdtemp, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import {
   buildRouteInventory,
+  fetchOpencodeDev,
   findWorkspaceRoot,
   getHonoRouteSourceCoverage,
   getMissingHonoRouteSources,
@@ -146,6 +151,25 @@ describe("route inventory harness", () => {
     await expect(buildRouteInventory({ root, upstreamRef: "HEAD", requireUpstream: true })).rejects.toThrow(
       /Unable to read upstream HttpApi route tree/,
     )
+  })
+
+  test("explains how to configure the opencode remote when fetch fails", async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "route-inventory-"))
+    try {
+      execFileSync("git", ["init"], { cwd: workspace, stdio: "ignore" })
+
+      const remoteGuidance = new RegExp(
+        [
+          "Failed to fetch opencode/dev",
+          "git remote rename upstream opencode",
+          "git remote add opencode https://github\\.com/anomalyco/opencode\\.git",
+        ].join(".*"),
+        "s",
+      )
+      expect(() => fetchOpencodeDev(workspace)).toThrow(remoteGuidance)
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+    }
   })
 
   test("covers every current Hono route implementation module in the inventory source list", async () => {


### PR DESCRIPTION
## Summary

Update the route inventory maintenance script to fetch from the local `opencode` remote instead of `upstream`.

There is no related issue because this is a narrow maintainer tooling follow-up to a local remote rename needed to keep Claude Code PR status detection from treating `anomalyco/opencode` as PawWork's PR parent.

## Why

PawWork no longer rebases wholesale against `anomalyco/opencode`; that repository is now a reference source. Naming the local remote `upstream` also trips Claude Code 2.1.181's PR footer heuristic, which checks `remote.upstream.url` and then queries the wrong repository for branch PRs.

The local remote is now named `opencode`, so this script needs to fetch from that remote when rebuilding the route inventory report.

## Related Issue

None. Narrow maintainer tooling compatibility change.

## Human Review Status

Pending

## Review Focus

Confirm that the route inventory script is the only committed code path that should hard-code the maintainer reference remote name.

## Risk Notes

No runtime or product behavior risk. The maintenance script now expects the maintainer checkout to use `opencode` for `https://github.com/anomalyco/opencode.git`; older local checkouts that still use `upstream` need to rename the remote or add an `opencode` remote before running this script.

Skipped checklist items:
- Visible UI check: not applicable, no UI or copy changed.
- Platform check: not applicable, no desktop/runtime/platform surface changed.
- Docs/release/dependency/generated content check: not applicable, no tracked docs, release notes, dependencies, permissions, or generated files changed.

## How To Verify

```text
Diff check: git diff --check passed with no whitespace errors.
Remote fetch smoke: git fetch opencode dev --dry-run succeeded and resolved https://github.com/anomalyco/opencode.git.
PR detection precondition: git config --get remote.upstream.url returns no value, while remote.opencode.url points at anomalyco/opencode.
GitHub PR lookup: repos/Astro-Han/pawwork/pulls?head=Astro-Han:claude/context-panel-redesign&state=open returns PR #1359.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the route inventory build process to fetch upstream revisions from an alternative source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->