### PR TITLE
refactor: name remaining tool execute wrappers

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -252,6 +252,8 @@ Tool tests should use the existing Effect helpers in `packages/opencode/test/lib
 
 This keeps migrated tool tests aligned with the production service graph today, and makes the eventual `Tool.Info` → `Effect` cleanup mostly mechanical later.
 
+As of the tool-wrapper cleanup slice, `packages/opencode/src/tool/*.ts` no longer has plain `execute:` declarations in the inventory: each execute boundary is named with `Effect.fn(...)`. `tool/registry.ts` still contains compatibility adapters for plugin tools and `tool_info` availability injection, but those wrappers are also named Effect boundaries rather than Promise-returning tool definitions.
+
 Individual tools, ordered by value:
 
 - [x] `apply_patch.ts` — HIGH: multi-step orchestration, error accumulation, Bus events

--- a/packages/opencode/src/tool/automate-manage.ts
+++ b/packages/opencode/src/tool/automate-manage.ts
@@ -85,46 +85,45 @@ export function createAutomateManageDefinition(
       "Use action list first when the user has not provided an exact automation id. Pause and resume are reversible and do not need confirmation. Delete is destructive and must ask the user for confirmation before removing anything.",
     ].join("\n\n"),
     parameters: AutomateManageParameters,
-    execute: (params, ctx) =>
-      Effect.gen(function* () {
-        if (params.action === "list") {
-          const items = yield* automation.list()
-          return {
-            title: "Automations",
-            metadata: { automationDefinitions: items },
-            output: JSON.stringify({ items: items.map(item) }, null, 2),
-          }
-        }
-
-        const id = yield* requireID(params)
-        const previous = yield* getAutomation(automation, id)
-        if (params.action === "pause" || params.action === "resume") {
-          const definition = yield* readableAutomationEffect(automation.update(id, { paused: params.action === "pause" }), id)
-          if (definition.revision !== previous.revision) {
-            yield* automation.publishDefinitionUpdated(definition)
-          }
-          return {
-            title: params.action === "pause" ? "Automation paused" : "Automation resumed",
-            metadata: { automationDefinition: definition },
-            output: JSON.stringify(item(definition), null, 2),
-          }
-        }
-
-        yield* ctx.ask({
-          permission: "automate_manage",
-          patterns: [id],
-          always: [],
-          metadata: { action: "delete", id, title: previous.title },
-        })
-        const removed = yield* readableAutomationEffect(automation.remove(id), id)
-        if (removed.stoppedRun) yield* automation.publishRunUpdated(removed.stoppedRun)
-        yield* automation.publishDefinitionDeleted(removed.tombstone)
+    execute: Effect.fn("AutomateManageTool.execute")(function* (params: Parameters, ctx: Tool.Context) {
+      if (params.action === "list") {
+        const items = yield* automation.list()
         return {
-          title: "Automation deleted",
-          metadata: { automationTombstone: removed.tombstone, stoppedRun: removed.stoppedRun },
-          output: JSON.stringify(removed.tombstone, null, 2),
+          title: "Automations",
+          metadata: { automationDefinitions: items },
+          output: JSON.stringify({ items: items.map(item) }, null, 2),
         }
-      }),
+      }
+
+      const id = yield* requireID(params)
+      const previous = yield* getAutomation(automation, id)
+      if (params.action === "pause" || params.action === "resume") {
+        const definition = yield* readableAutomationEffect(automation.update(id, { paused: params.action === "pause" }), id)
+        if (definition.revision !== previous.revision) {
+          yield* automation.publishDefinitionUpdated(definition)
+        }
+        return {
+          title: params.action === "pause" ? "Automation paused" : "Automation resumed",
+          metadata: { automationDefinition: definition },
+          output: JSON.stringify(item(definition), null, 2),
+        }
+      }
+
+      yield* ctx.ask({
+        permission: "automate_manage",
+        patterns: [id],
+        always: [],
+        metadata: { action: "delete", id, title: previous.title },
+      })
+      const removed = yield* readableAutomationEffect(automation.remove(id), id)
+      if (removed.stoppedRun) yield* automation.publishRunUpdated(removed.stoppedRun)
+      yield* automation.publishDefinitionDeleted(removed.tombstone)
+      return {
+        title: "Automation deleted",
+        metadata: { automationTombstone: removed.tombstone, stoppedRun: removed.stoppedRun },
+        output: JSON.stringify(removed.tombstone, null, 2),
+      }
+    }),
   }
 }
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -197,7 +197,7 @@ export namespace ToolRegistry {
               id,
               parameters,
               description: def.description,
-              execute: (args, toolCtx) =>
+              execute: Effect.fn("ToolRegistry.plugin.execute")((args, toolCtx) =>
                 Effect.gen(function* () {
                   // Plugin tools see `ask`/`metadata` as Promise/void (see
                   // @opencode-ai/plugin), but the framework versions are Effects.
@@ -240,6 +240,7 @@ export namespace ToolRegistry {
                     },
                   }),
                 ),
+              ),
             }
           }
 
@@ -473,7 +474,7 @@ export namespace ToolRegistry {
             yield* plugin.trigger("tool.definition", { toolID: tool.id }, output)
             const execute: Tool.Def["execute"] =
               tool.id === TOOL_INFO_ID
-                ? ((args, ctx) => {
+                ? Effect.fn("ToolRegistry.toolInfo.execute")((args, ctx) => {
                     const contextDeferredAvailable = ctx.extra?.["deferredAvailable"] as
                       | ((id: string) => boolean)
                       | undefined

--- a/packages/opencode/src/tool/tool-info.ts
+++ b/packages/opencode/src/tool/tool-info.ts
@@ -395,56 +395,58 @@ export const ToolInfoTool = (
       return {
         description: PREFACE,
         parameters: Parameters,
-        execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
-          Effect.gen(function* () {
-            // Canonicalise first so a CamelCase echo (e.g. "Enter-Worktree") resolves
-            // to the real id instead of burning a turn on an "unknown tool" error.
-            // Target ids are canonical by construction, so every downstream string and
-            // the activation metadata use the canonical form.
-            const target = canonicalActivationTarget(params.name)
-            if (!target) {
-              const names = [...DEFERRED_GROUP_IDS, ...DEFERRED.filter((d) => !d.group).map((d) => d.id)].join(", ")
-              return yield* Effect.fail(
-                new Error(`Unknown deferred tool "${params.name}". Available: ${names || "none"}`),
-              )
-            }
-            const isAvailable = ctx.extra?.["deferredAvailable"] as ((id: string) => boolean) | undefined
-            // Render only the members the registry will actually expose next
-            // step (it filters per member): announcing a disabled member would
-            // point the model at a tool that never appears in its list.
-            const allEntries =
-              target.kind === "group" ? deferredGroupMembers(target.id).map((id) => BY_ID[id]) : [BY_ID[target.id]]
-            const entries = isAvailable ? allEntries.filter((entry) => isAvailable(entry.id)) : allEntries
-            if (entries.length === 0) {
-              return yield* Effect.fail(new Error(`Deferred tool "${target.id}" is not available in this context.`))
-            }
-            const model = ctx.extra?.["model"] as Provider.Model | undefined
-            const blocks: string[] = []
-            for (const entry of entries) {
-              const processed = { description: entry.description, parameters: entry.parameters }
-              yield* applyPluginDefinition(entry.id, processed)
-              blocks.push(renderToolBlock(entry, processed, model))
-            }
-            const callable =
-              target.kind === "group"
-                ? `The ${target.id} tools (${entries.map((entry) => entry.id).join(", ")}) are now in your tool list. Call them directly (there is no tool named "${target.id}"). Do not call tool_info again for this group.`
-                : `${target.id} is now in your tool list. Call ${target.id} directly. Do not call tool_info again for this tool.`
-            return {
-              title: `Loaded ${target.kind === "group" ? "tool group" : "tool"}: ${target.id}`,
-              output: [...blocks, "", callable].join("\n"),
-              // truncated:false opts this tool out of output truncation (see tool.ts
-              // wrap): tool_info exists to hand the model a *complete* schema, so a
-              // large deferred tool's parameters must never be clipped mid-load.
-              // For a group, `members` records the members actually rendered
-              // (availability-filtered) so the activation reminder lists the
-              // same set instead of the full roster.
-              metadata: {
-                activated: target.id,
-                ...(target.kind === "group" ? { members: entries.map((entry) => entry.id) } : {}),
-                truncated: false,
-              },
-            }
-          }),
+        execute: Effect.fn("ToolInfoTool.execute")(function* (
+          params: Schema.Schema.Type<typeof Parameters>,
+          ctx: Tool.Context,
+        ) {
+          // Canonicalise first so a CamelCase echo (e.g. "Enter-Worktree") resolves
+          // to the real id instead of burning a turn on an "unknown tool" error.
+          // Target ids are canonical by construction, so every downstream string and
+          // the activation metadata use the canonical form.
+          const target = canonicalActivationTarget(params.name)
+          if (!target) {
+            const names = [...DEFERRED_GROUP_IDS, ...DEFERRED.filter((d) => !d.group).map((d) => d.id)].join(", ")
+            return yield* Effect.fail(
+              new Error(`Unknown deferred tool "${params.name}". Available: ${names || "none"}`),
+            )
+          }
+          const isAvailable = ctx.extra?.["deferredAvailable"] as ((id: string) => boolean) | undefined
+          // Render only the members the registry will actually expose next
+          // step (it filters per member): announcing a disabled member would
+          // point the model at a tool that never appears in its list.
+          const allEntries =
+            target.kind === "group" ? deferredGroupMembers(target.id).map((id) => BY_ID[id]) : [BY_ID[target.id]]
+          const entries = isAvailable ? allEntries.filter((entry) => isAvailable(entry.id)) : allEntries
+          if (entries.length === 0) {
+            return yield* Effect.fail(new Error(`Deferred tool "${target.id}" is not available in this context.`))
+          }
+          const model = ctx.extra?.["model"] as Provider.Model | undefined
+          const blocks: string[] = []
+          for (const entry of entries) {
+            const processed = { description: entry.description, parameters: entry.parameters }
+            yield* applyPluginDefinition(entry.id, processed)
+            blocks.push(renderToolBlock(entry, processed, model))
+          }
+          const callable =
+            target.kind === "group"
+              ? `The ${target.id} tools (${entries.map((entry) => entry.id).join(", ")}) are now in your tool list. Call them directly (there is no tool named "${target.id}"). Do not call tool_info again for this group.`
+              : `${target.id} is now in your tool list. Call ${target.id} directly. Do not call tool_info again for this tool.`
+          return {
+            title: `Loaded ${target.kind === "group" ? "tool group" : "tool"}: ${target.id}`,
+            output: [...blocks, "", callable].join("\n"),
+            // truncated:false opts this tool out of output truncation (see tool.ts
+            // wrap): tool_info exists to hand the model a *complete* schema, so a
+            // large deferred tool's parameters must never be clipped mid-load.
+            // For a group, `members` records the members actually rendered
+            // (availability-filtered) so the activation reminder lists the
+            // same set instead of the full roster.
+            metadata: {
+              activated: target.id,
+              ...(target.kind === "group" ? { members: entries.map((entry) => entry.id) } : {}),
+              truncated: false,
+            },
+          }
+        }),
       }
     }),
   )


### PR DESCRIPTION
## Summary

Name the remaining tool-layer `execute` wrapper boundaries with `Effect.fn(...)` and record the completed tool execute inventory.

## Why

This continues the #936 Effect migration cleanup by removing the last plain `execute:` declarations from `packages/opencode/src/tool/*.ts` without rewriting the ToolRegistry architecture.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the ToolRegistry plugin and `tool_info` compatibility adapters still preserve their existing contracts while gaining named Effect boundaries.

## Risk Notes

No behavior change intended. The registry plugin and `tool_info` wrappers remain compatibility adapters; this PR only names those boundaries. No visible UI changes, so the UI checklist item is left unticked. No platform, packaging, updater, signing, path, shell, or permission surface was touched, so the platform checklist item is left unticked. The Effect migration spec was updated only to record the proven tool execute inventory state.

## How To Verify

```text
Install: bun install --frozen-lockfile completed in the new worktree.
Baseline focused tests: bun test test/tool/automate-manage.test.ts test/tool/tool-info.test.ts test/tool/registry.test.ts passed before changes (81 pass).
Focused tests: bun test test/tool/automate-manage.test.ts test/tool/tool-info.test.ts test/tool/registry.test.ts passed after the final change (81 pass).
Diff check: git diff --check passed.
Typecheck: bun run typecheck from packages/opencode passed (tsgo --noEmit).
Inventory: every packages/opencode/src/tool/*.ts execute declaration reported as effect; there were no plain results.
Fresh-eye review: no P0/P1/P2/P3 findings after the final diff.
Claude review: no P0/P1/P2 findings after the final diff; noted only an acceptable P3 about nested spans with no action recommended.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

