### PR TITLE
refactor(opencode): name instance route effect boundaries

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -394,10 +394,11 @@ Decision table for the design:
 - Experimental route boundary — migrated 2026-06-15. The current `server/instance/experimental.ts` owner now routes Console state/org switch, tool ids/list, worktree create/list/remove/reset, and MCP resources through named `Effect.fn(...)` route boundaries that yield `Config.Service`, `Account.Service`, `ToolRegistry.Service`, `Agent.Service`, `Worktree.Service`, and `MCP.Service`. The `/experimental/session` list route intentionally remains on the existing `Session.listGlobal(...)` async iterator because migrating it would broaden the slice into Session pagination/cursor internals.
 - Instance root route boundary — migrated 2026-06-18. The current `server/instance/index.ts` owner now routes instance dispose, path metadata, root VCS JSON/diff/status/raw/apply, command list, agent list, skill list, and LSP status through named `Effect.fn(...)` route boundaries with one shared `AppRuntime.runPromise` bridge. VCS handlers still yield `Vcs.Service` and preserve raw/apply error mappings; `/instance/dispose` intentionally keeps the existing `Instance.dispose()` compatibility facade inside the Effect boundary because it updates legacy instance directory bookkeeping that is not exposed as an Effect service API.
 - Small instance route owners — migrated 2026-06-18. `server/instance/file.ts`, `server/instance/project.ts`, `server/instance/memory.ts`, and `server/instance/external-result.ts` now route body work through named `Effect.fn(...)` boundaries with one route-local `AppRuntime.runPromise` bridge per owner. File/project/external-result routes yield `Ripgrep.Service`, `File.Service`, `Project.Service`, and `Session.Service` where service APIs already exist. Project init still keeps the existing `Instance.reload(...)` compatibility call inside the route effect, memory still wraps the existing `MemoryService` Promise API, and external-result still uses `MessageV2.get(...)` inside the route effect because those behaviors do not yet have suitable service APIs in this slice.
+- Global/workspace/permission/automation route boundary — migrated 2026-06-18. The current `server/instance/global.ts`, `workspace.ts`, `permission.ts`, and `automation.ts` owners now route their non-streaming service work through named `Effect.fn(...)` boundaries and shared route-local AppRuntime bridges. Global config/dispose/upgrade, workspace create/list/status/remove, permission e2e ask/reply/list, and automation list/create/get/update/pause/resume/delete/run/runs preserve their existing HTTP shapes; automation intentionally keeps its `runPromiseExit` typed error mapper so `ValidationError`, `ConflictError`, and `ActiveRunStillRunningError` still map to the same `422`/`409` responses. Global health and SSE routes stay direct because they do not cross a service runtime boundary.
 
 ## Route handler effectification
 
-Route handlers should wrap their entire body in a single `AppRuntime.runPromise(Effect.gen(...))` call, yielding services from context rather than calling facades one-by-one. This eliminates multiple `runPromise` round-trips and lets handlers compose naturally.
+Route handlers should keep effectful service work behind named `Effect.fn(...)` route boundaries and run each handler through one AppRuntime bridge, yielding services from context rather than calling facades one-by-one. This eliminates multiple `runPromise` round-trips and gives route effects stable trace names.
 
 ```ts
 // Before — one facade call per service
@@ -407,16 +408,16 @@ Route handlers should wrap their entire body in a single `AppRuntime.runPromise(
   return c.json(true)
 }
 
-// After — one Effect.gen, yield services from context
+// After — one named route effect, yield services from context
+const removeMessage = Effect.fn("SessionRoutes.message.remove")(function* (id, messageID) {
+  const state = yield* SessionRunState.Service
+  const session = yield* Session.Service
+  yield* state.assertNotBusy(id)
+  yield* session.removeMessage({ sessionID: id, messageID })
+})
+
 ;async (c) => {
-  await AppRuntime.runPromise(
-    Effect.gen(function* () {
-      const state = yield* SessionRunState.Service
-      const session = yield* Session.Service
-      yield* state.assertNotBusy(id)
-      yield* session.removeMessage({ sessionID: id, messageID })
-    }),
-  )
+  await AppRuntime.runPromise(removeMessage(id, messageID))
   return c.json(true)
 }
 ```
@@ -426,12 +427,14 @@ When migrating, always use `{ concurrency: "unbounded" }` with `Effect.all` — 
 Route files to convert (each handler that calls facades should be wrapped):
 
 - [ ] `server/routes/session.ts` — heaviest; current owner is `server/instance/session.ts`. The 2026-06-15 straggler pass cleared GET `/session`, share/unshare `Session.get`, summarize `Session.messages`, and deprecated permission response `Permission.reply`; heavier SessionPrompt/SessionRevert/SessionShare/etc. route work remains out of scope.
-- [ ] `server/routes/global.ts` — uses Config, Project, Provider, Vcs, Snapshot, Agent
+- [x] `server/instance/global.ts` — migrated 2026-06-18. Config, dispose, and upgrade service work now uses named route effects plus a shared AppRuntime bridge; health and SSE routes remain direct by design.
 - [x] `server/instance/index.ts` — migrated 2026-06-18. Root instance, path, VCS, command, agent, skill, and LSP handlers now use named route effects plus a shared AppRuntime bridge; `/instance/dispose` keeps `Instance.dispose()` inside the Effect boundary for legacy directory bookkeeping.
 - [x] `server/instance/provider.ts` — migrated 2026-06-15. Provider auth route bodies now yield `ProviderAuth.Service` inside `AppRuntime.runPromise(Effect.gen(...))`; the old `server/routes/provider.ts` checklist path is stale in the current tree.
 - [ ] `server/routes/question.ts` — stale checklist path. The current tree has no `server/instance/question.ts` route; do not claim completion without a live route owner.
 - [x] `server/instance/pty.ts` — migrated 2026-06-15. Connect-token and WebSocket connect route bodies now yield `Pty.Service` for target lookup and connection setup; the old `server/routes/pty.ts` checklist path is stale in the current tree.
-- [x] `server/instance/workspace.ts` — migrated 2026-06-15. Workspace create/list/status/remove handlers now yield `Workspace.Service`; status still lists the current project first and filters global workspace statuses by those ids.
+- [x] `server/instance/workspace.ts` — migrated 2026-06-18. Workspace create/list/status/remove handlers now use named route effects plus a shared AppRuntime bridge; status still lists the current project first and filters global workspace statuses by those ids.
+- [x] `server/instance/permission.ts` — migrated 2026-06-18. E2E ask, reply, and list/prune handlers now use named route effects plus a shared AppRuntime bridge while preserving fire-and-forget logging for the e2e seed route.
+- [x] `server/instance/automation.ts` — migrated 2026-06-18. Automation handlers now use named route effects while preserving the route-local `runPromiseExit` error mapper for typed validation/conflict/active-run HTTP responses.
 - [x] `server/instance/experimental.ts` — migrated 2026-06-15 for Console, tool, worktree, and MCP resource handlers. The old `server/routes/experimental.ts` checklist path is stale in the current tree. `/experimental/session` still calls `Session.listGlobal(...)` directly by design.
 - [x] `server/instance/file.ts` — migrated 2026-06-18. Find/list/read/status handlers now use named route effects and yield `Ripgrep.Service` / `File.Service` through one route-local runtime bridge.
 - [x] `server/instance/project.ts` — migrated 2026-06-18. List/init-git/update handlers now use named route effects and yield `Project.Service`; init-git keeps `Instance.reload(...)` inside the route effect for legacy instance bookkeeping.

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -26,9 +26,20 @@ function activeRunStillRunningError(error: ActiveRunStillRunningError) {
   })
 }
 
-async function settleAutomationScheduler() {
-  await AutomationScheduler.current().settleOwner()
-}
+const AutomationIDParam = z.object({ automationID: AutomationID.Definition.zod })
+const AutomationRunsQuery = z.object({
+  limit: z.coerce.number().int().positive().max(100).optional(),
+  cursor: AutomationID.Run.zod.optional(),
+})
+
+type AutomationIDParam = z.infer<typeof AutomationIDParam>
+type AutomationRunsQuery = z.infer<typeof AutomationRunsQuery>
+
+const settleAutomationScheduler = Effect.fn("AutomationRoutes.scheduler.settle")(function* (
+  scheduler: Pick<AutomationScheduler.Interface, "settleOwner"> = AutomationScheduler.current(),
+) {
+  yield* Effect.promise(() => scheduler.settleOwner())
+})
 
 function modelValidation(
   model: Automation.Model,
@@ -96,6 +107,124 @@ function automationBodyValidationHook(
   )
 }
 
+const listAutomations = Effect.fn("AutomationRoutes.list")(function* (c: Context) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const items = yield* automation.list()
+  return c.json({ items })
+})
+
+const createAutomation = Effect.fn("AutomationRoutes.create")(function* (c: Context, input: Automation.CreateInput) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const modelDetails = yield* modelValidation(input.model, input.variant)
+  if (modelDetails.length) {
+    return c.json(Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }), 422)
+  }
+  const definition = yield* automation.create(input)
+  yield* automation.publishDefinitionUpdated(definition)
+  return c.json(definition)
+})
+
+const getAutomation = Effect.fn("AutomationRoutes.get")(function* (c: Context, automationID: AutomationIDParam["automationID"]) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  return c.json(yield* automation.get(automationID))
+})
+
+const updateAutomation = Effect.fn("AutomationRoutes.update")(function* (
+  c: Context,
+  automationID: AutomationIDParam["automationID"],
+  patch: Automation.UpdateInput,
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const previous = yield* automation.get(automationID)
+  if (patch.model !== undefined || patch.variant !== undefined) {
+    const effectiveModel = patch.model ?? previous.model
+    const effectiveVariant = patch.variant === null ? undefined : (patch.variant ?? previous.variant)
+    const modelDetails = yield* modelValidation(effectiveModel, effectiveVariant)
+    if (modelDetails.length) {
+      return c.json(Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }), 422)
+    }
+  }
+  const definition = yield* automation.update(automationID, patch)
+  if (definition.revision !== previous.revision) {
+    if (definition.where.projectID !== previous.where.projectID) {
+      yield* automation.publishDefinitionDeleted({ id: previous.id, deleted: true, revision: definition.revision })
+      yield* automation.publishDefinitionUpdatedForScope(definition, Automation.getScope(definition.id))
+    } else {
+      yield* automation.publishDefinitionUpdated(definition)
+    }
+  }
+  return c.json(definition)
+})
+
+const pauseAutomation = Effect.fn("AutomationRoutes.pause")(function* (
+  c: Context,
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const previous = yield* automation.get(automationID)
+  const definition = yield* automation.update(automationID, { paused: true })
+  if (definition.revision !== previous.revision) {
+    yield* automation.publishDefinitionUpdated(definition)
+  }
+  return c.json(definition)
+})
+
+const resumeAutomation = Effect.fn("AutomationRoutes.resume")(function* (
+  c: Context,
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const previous = yield* automation.get(automationID)
+  const definition = yield* automation.update(automationID, { paused: false })
+  if (definition.revision !== previous.revision) {
+    yield* automation.publishDefinitionUpdated(definition)
+  }
+  return c.json(definition)
+})
+
+const deleteAutomation = Effect.fn("AutomationRoutes.delete")(function* (
+  c: Context,
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  const scheduler = AutomationScheduler.current()
+  yield* settleAutomationScheduler(scheduler)
+  const removed = yield* automation.remove(automationID)
+  yield* Effect.sync(() => scheduler.cancel(removed.tombstone.id))
+  if (removed.stoppedRun) yield* automation.publishRunUpdated(removed.stoppedRun)
+  yield* automation.publishDefinitionDeleted(removed.tombstone)
+  return c.json(removed.tombstone)
+})
+
+const runAutomationNow = Effect.fn("AutomationRoutes.runNow")(function* (
+  c: Context,
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const run = yield* automation.runNowExecuting(automationID, {
+    executor: sessionPromptExecutor,
+  })
+  yield* automation.publishRunUpdated(run)
+  return c.json(run)
+})
+
+const listAutomationRuns = Effect.fn("AutomationRoutes.runs")(function* (
+  c: Context,
+  automationID: AutomationIDParam["automationID"],
+  query: AutomationRunsQuery,
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  return c.json(yield* automation.runs({ automationID, ...query }))
+})
+
 export const AutomationRoutes = (): Hono =>
   new Hono()
     .get(
@@ -111,16 +240,7 @@ export const AutomationRoutes = (): Hono =>
           },
         },
       }),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            yield* Effect.promise(() => settleAutomationScheduler())
-            const items = yield* automation.list()
-            return c.json({ items })
-          }),
-        ),
+      async (c) => runRoute(c, listAutomations(c)),
     )
     .post(
       "/",
@@ -141,25 +261,7 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("json", Automation.CreateInput, automationBodyValidationHook),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            yield* Effect.promise(() => settleAutomationScheduler())
-            const input = c.req.valid("json")
-            const modelDetails = yield* modelValidation(input.model, input.variant)
-            if (modelDetails.length) {
-              return c.json(
-                Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }),
-                422,
-              )
-            }
-            const definition = yield* automation.create(input)
-            yield* automation.publishDefinitionUpdated(definition)
-            return c.json(definition)
-          }),
-        ),
+      async (c) => runRoute(c, createAutomation(c, c.req.valid("json"))),
     )
     .get(
       "/:automationID",
@@ -175,16 +277,8 @@ export const AutomationRoutes = (): Hono =>
           ...errors(404),
         },
       }),
-      validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            yield* Effect.promise(() => settleAutomationScheduler())
-            return c.json(yield* automation.get(c.req.valid("param").automationID))
-          }),
-        ),
+      validator("param", AutomationIDParam),
+      async (c) => runRoute(c, getAutomation(c, c.req.valid("param").automationID)),
     )
     .put(
       "/:automationID",
@@ -208,40 +302,9 @@ export const AutomationRoutes = (): Hono =>
           ...errors(400, 404),
         },
       }),
-      validator("param", z.object({ automationID: AutomationID.Definition.zod })),
+      validator("param", AutomationIDParam),
       validator("json", Automation.UpdateInput, automationBodyValidationHook),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            const automationID = c.req.valid("param").automationID
-            yield* Effect.promise(() => settleAutomationScheduler())
-            const previous = yield* automation.get(automationID)
-            const patch = c.req.valid("json")
-            if (patch.model !== undefined || patch.variant !== undefined) {
-              const effectiveModel = patch.model ?? previous.model
-              const effectiveVariant = patch.variant === null ? undefined : (patch.variant ?? previous.variant)
-              const modelDetails = yield* modelValidation(effectiveModel, effectiveVariant)
-              if (modelDetails.length) {
-                return c.json(
-                  Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }),
-                  422,
-                )
-              }
-            }
-            const definition = yield* automation.update(automationID, patch)
-            if (definition.revision !== previous.revision) {
-              if (definition.where.projectID !== previous.where.projectID) {
-                yield* automation.publishDefinitionDeleted({ id: previous.id, deleted: true, revision: definition.revision })
-                yield* automation.publishDefinitionUpdatedForScope(definition, Automation.getScope(definition.id))
-              } else {
-                yield* automation.publishDefinitionUpdated(definition)
-              }
-            }
-            return c.json(definition)
-          }),
-        ),
+      async (c) => runRoute(c, updateAutomation(c, c.req.valid("param").automationID, c.req.valid("json"))),
     )
     .post(
       "/:automationID/pause",
@@ -261,22 +324,8 @@ export const AutomationRoutes = (): Hono =>
           ...errors(404),
         },
       }),
-      validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            const automationID = c.req.valid("param").automationID
-            yield* Effect.promise(() => settleAutomationScheduler())
-            const previous = yield* automation.get(automationID)
-            const definition = yield* automation.update(automationID, { paused: true })
-            if (definition.revision !== previous.revision) {
-              yield* automation.publishDefinitionUpdated(definition)
-            }
-            return c.json(definition)
-          }),
-        ),
+      validator("param", AutomationIDParam),
+      async (c) => runRoute(c, pauseAutomation(c, c.req.valid("param").automationID)),
     )
     .post(
       "/:automationID/resume",
@@ -296,22 +345,8 @@ export const AutomationRoutes = (): Hono =>
           ...errors(404),
         },
       }),
-      validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            const automationID = c.req.valid("param").automationID
-            yield* Effect.promise(() => settleAutomationScheduler())
-            const previous = yield* automation.get(automationID)
-            const definition = yield* automation.update(automationID, { paused: false })
-            if (definition.revision !== previous.revision) {
-              yield* automation.publishDefinitionUpdated(definition)
-            }
-            return c.json(definition)
-          }),
-        ),
+      validator("param", AutomationIDParam),
+      async (c) => runRoute(c, resumeAutomation(c, c.req.valid("param").automationID)),
     )
     .delete(
       "/:automationID",
@@ -332,21 +367,8 @@ export const AutomationRoutes = (): Hono =>
           ...errors(404),
         },
       }),
-      validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            const scheduler = AutomationScheduler.current()
-            yield* Effect.promise(() => scheduler.settleOwner())
-            const removed = yield* automation.remove(c.req.valid("param").automationID)
-            yield* Effect.sync(() => scheduler.cancel(removed.tombstone.id))
-            if (removed.stoppedRun) yield* automation.publishRunUpdated(removed.stoppedRun)
-            yield* automation.publishDefinitionDeleted(removed.tombstone)
-            return c.json(removed.tombstone)
-          }),
-        ),
+      validator("param", AutomationIDParam),
+      async (c) => runRoute(c, deleteAutomation(c, c.req.valid("param").automationID)),
     )
     .post(
       "/:automationID/run",
@@ -362,20 +384,8 @@ export const AutomationRoutes = (): Hono =>
           ...errors(404),
         },
       }),
-      validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            yield* Effect.promise(() => settleAutomationScheduler())
-            const run = yield* automation.runNowExecuting(c.req.valid("param").automationID, {
-              executor: sessionPromptExecutor,
-            })
-            yield* automation.publishRunUpdated(run)
-            return c.json(run)
-          }),
-        ),
+      validator("param", AutomationIDParam),
+      async (c) => runRoute(c, runAutomationNow(c, c.req.valid("param").automationID)),
     )
     .get(
       "/:automationID/runs",
@@ -391,21 +401,7 @@ export const AutomationRoutes = (): Hono =>
           ...errors(400, 404),
         },
       }),
-      validator("param", z.object({ automationID: AutomationID.Definition.zod })),
-      validator(
-        "query",
-        z.object({
-          limit: z.coerce.number().int().positive().max(100).optional(),
-          cursor: AutomationID.Run.zod.optional(),
-        }),
-      ),
-      async (c) =>
-        runRoute(
-          c,
-          Effect.gen(function* () {
-            const automation = yield* Automation.Service
-            yield* Effect.promise(() => settleAutomationScheduler())
-            return c.json(yield* automation.runs({ automationID: c.req.valid("param").automationID, ...c.req.valid("query") }))
-          }),
-        ),
+      validator("param", AutomationIDParam),
+      validator("query", AutomationRunsQuery),
+      async (c) => runRoute(c, listAutomationRuns(c, c.req.valid("param").automationID, c.req.valid("query"))),
     )

--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -161,6 +161,55 @@ GlobalBus.on("event", (event) => {
   globalEventReplay.append(event as GlobalEventEnvelope)
 })
 
+const runGlobalRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
+
+const getGlobalConfig = Effect.fn("GlobalRoutes.config.get")(function* () {
+  const service = yield* Config.Service
+  return yield* service.getGlobal()
+})
+
+const updateGlobalConfig = Effect.fn("GlobalRoutes.config.update")(function* (config: Config.Info) {
+  const service = yield* Config.Service
+  return yield* service.updateGlobal(config)
+})
+
+const disposeGlobalInstances = Effect.fn("GlobalRoutes.dispose")(function* () {
+  return yield* Effect.promise(() => Instance.disposeAll({ onCompleted: emitGlobalDisposed }))
+})
+
+type UpgradeResult =
+  | {
+      success: true
+      status: 200
+      version: string
+    }
+  | {
+      success: false
+      status: 400 | 500
+      error: string
+    }
+
+const upgradeInstallation = Effect.fn("GlobalRoutes.upgrade")(function* (target?: string) {
+  const installation = yield* Installation.Service
+  const method = yield* installation.method()
+  if (method === "unknown") {
+    return { success: false, status: 400, error: "Unknown installation method" } satisfies UpgradeResult
+  }
+
+  const resolvedTarget = target || (yield* installation.latest(method))
+  const result = yield* Effect.catch(
+    installation.upgrade(method, resolvedTarget).pipe(Effect.as({ success: true as const, version: resolvedTarget })),
+    (err) =>
+      Effect.succeed({
+        success: false as const,
+        status: 500 as const,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+  )
+  if (!result.success) return result
+  return { ...result, status: 200 } satisfies UpgradeResult
+})
+
 async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>) => () => void, heartbeatMs = 10_000) {
   return streamSSE(c, async (stream) => {
     const q = new AsyncQueue<string | null>()
@@ -392,12 +441,7 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
         },
       }),
       async (c) => {
-        const config = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const service = yield* Config.Service
-            return yield* service.getGlobal()
-          }),
-        )
+        const config = await runGlobalRoute(getGlobalConfig())
         return c.json(config)
       },
     )
@@ -422,12 +466,7 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
       validator("json", Config.Info.zod),
       async (c) => {
         const config = c.req.valid("json")
-        const next = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const service = yield* Config.Service
-            return yield* service.updateGlobal(config)
-          }),
-        )
+        const next = await runGlobalRoute(updateGlobalConfig(config))
         return c.json(next)
       },
     )
@@ -449,7 +488,7 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
         },
       }),
       async (c) => {
-        const result = await Instance.disposeAll({ onCompleted: emitGlobalDisposed })
+        const result = await runGlobalRoute(disposeGlobalInstances())
         return c.json(result)
       },
     )
@@ -490,28 +529,7 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
       ),
       async (c) => {
         const json = c.req.valid("json")
-        const result = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const installation = yield* Installation.Service
-            const method = yield* installation.method()
-            if (method === "unknown") {
-              return { success: false as const, status: 400 as const, error: "Unknown installation method" }
-            }
-
-            const target = json.target || (yield* installation.latest(method))
-            const result = yield* Effect.catch(
-              installation.upgrade(method, target).pipe(Effect.as({ success: true as const, version: target })),
-              (err) =>
-                Effect.succeed({
-                  success: false as const,
-                  status: 500 as const,
-                  error: err instanceof Error ? err.message : String(err),
-                }),
-            )
-            if (!result.success) return result
-            return { ...result, status: 200 as const }
-          }),
-        )
+        const result = await runGlobalRoute(upgradeInstallation(json.target))
         if (!result.success) {
           return c.json({ success: false, error: result.error }, result.status)
         }

--- a/packages/opencode/src/server/instance/permission.ts
+++ b/packages/opencode/src/server/instance/permission.ts
@@ -14,38 +14,65 @@ import { Effect } from "effect"
 
 const log = Log.create({ service: "server" })
 const e2ePermissionRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
+const runPermissionRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
+
+const E2EPermissionAskBody = z.object({
+  sessionID: SessionID.zod,
+  permission: z.string().min(1),
+  patterns: z.array(z.string()).min(1),
+  metadata: z.record(z.string(), z.any()).optional(),
+  always: z.array(z.string()).optional(),
+})
+
+type E2EPermissionAskBody = z.infer<typeof E2EPermissionAskBody>
+type PermissionReplyBody = {
+  reply: z.infer<typeof Permission.Reply>
+  message?: string
+}
+
+const seedE2EPermissionAsk = Effect.fn("PermissionRoutes.e2e.ask")(function* (json: E2EPermissionAskBody) {
+  const permission = yield* Permission.Service
+  yield* permission.ask({
+    sessionID: json.sessionID,
+    permission: json.permission,
+    patterns: json.patterns,
+    metadata: json.metadata ?? {},
+    always: json.always ?? json.patterns,
+    ruleset: [{ permission: json.permission, pattern: "*", action: "ask" }],
+  })
+})
+
+const replyToPermission = Effect.fn("PermissionRoutes.reply")(function* (
+  requestID: PermissionID,
+  json: PermissionReplyBody,
+) {
+  const permission = yield* Permission.Service
+  yield* permission.reply({
+    requestID,
+    reply: json.reply,
+    message: json.message,
+  })
+})
+
+const listPendingPermissions = Effect.fn("PermissionRoutes.list")(function* () {
+  const permission = yield* Permission.Service
+  return yield* permission.list().pipe(
+    Effect.flatMap((items) =>
+      SessionLiveness.pruneDangling(items, (sessionID) => permission.clearSession(sessionID, "dangling_session")),
+    ),
+  )
+})
 
 export const PermissionRoutes = lazy(() =>
   new Hono()
     .post(
       "/__e2e/ask",
-      validator(
-        "json",
-        z.object({
-          sessionID: SessionID.zod,
-          permission: z.string().min(1),
-          patterns: z.array(z.string()).min(1),
-          metadata: z.record(z.string(), z.any()).optional(),
-          always: z.array(z.string()).optional(),
-        }),
-      ),
+      validator("json", E2EPermissionAskBody),
       async (c) => {
         if (!e2ePermissionRoutesEnabled()) return c.notFound()
 
         const json = c.req.valid("json")
-        void AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const permission = yield* Permission.Service
-            yield* permission.ask({
-              sessionID: json.sessionID,
-              permission: json.permission,
-              patterns: json.patterns,
-              metadata: json.metadata ?? {},
-              always: json.always ?? json.patterns,
-              ruleset: [{ permission: json.permission, pattern: "*", action: "ask" }],
-            })
-          }),
-        ).catch((error) => {
+        void runPermissionRoute(seedE2EPermissionAsk(json)).catch((error) => {
           log.error("e2e permission seed failed", { sessionID: json.sessionID, error })
         })
 
@@ -80,16 +107,7 @@ export const PermissionRoutes = lazy(() =>
       async (c) => {
         const params = c.req.valid("param")
         const json = c.req.valid("json")
-        await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const permission = yield* Permission.Service
-            yield* permission.reply({
-              requestID: params.requestID,
-              reply: json.reply,
-              message: json.message,
-            })
-          }),
-        )
+        await runPermissionRoute(replyToPermission(params.requestID, json))
         return c.json(true)
       },
     )
@@ -111,20 +129,7 @@ export const PermissionRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const permissions = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const permission = yield* Permission.Service
-            return yield* permission
-              .list()
-              .pipe(
-                Effect.flatMap((items) =>
-                  SessionLiveness.pruneDangling(items, (sessionID) =>
-                    permission.clearSession(sessionID, "dangling_session"),
-                  ),
-                ),
-              )
-          }),
-        )
+        const permissions = await runPermissionRoute(listPendingPermissions())
         return c.json(permissions)
       },
     ),

--- a/packages/opencode/src/server/instance/workspace.ts
+++ b/packages/opencode/src/server/instance/workspace.ts
@@ -18,6 +18,37 @@ function preserveWorkspaceRouteError<A>(effect: Effect.Effect<A, Workspace.Works
   )
 }
 
+const runWorkspaceRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
+type WorkspaceCreateBody = Omit<Workspace.CreateInput, "projectID">
+
+const createWorkspace = Effect.fn("WorkspaceRoutes.create")(function* (body: WorkspaceCreateBody) {
+  const workspace = yield* Workspace.Service
+  return yield* preserveWorkspaceRouteError(
+    workspace.create({
+      projectID: Instance.project.id,
+      ...body,
+    }),
+  )
+})
+
+const listWorkspaces = Effect.fn("WorkspaceRoutes.list")(function* () {
+  const workspace = yield* Workspace.Service
+  return yield* preserveWorkspaceRouteError(workspace.list(Instance.project))
+})
+
+const getWorkspaceStatus = Effect.fn("WorkspaceRoutes.status")(function* () {
+  const workspace = yield* Workspace.Service
+  const workspaces = yield* preserveWorkspaceRouteError(workspace.list(Instance.project))
+  const ids = new Set(workspaces.map((item) => item.id))
+  const statuses = yield* preserveWorkspaceRouteError(workspace.status())
+  return statuses.filter((item) => ids.has(item.workspaceID))
+})
+
+const removeWorkspace = Effect.fn("WorkspaceRoutes.remove")(function* (id: Workspace.Info["id"]) {
+  const workspace = yield* Workspace.Service
+  return yield* preserveWorkspaceRouteError(workspace.remove(id))
+})
+
 export const WorkspaceRoutes = lazy(() =>
   new Hono()
     .post(
@@ -46,17 +77,7 @@ export const WorkspaceRoutes = lazy(() =>
       ),
       async (c) => {
         const body = c.req.valid("json")
-        const workspace = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const workspaceSvc = yield* Workspace.Service
-            return yield* preserveWorkspaceRouteError(
-              workspaceSvc.create({
-                projectID: Instance.project.id,
-                ...body,
-              }),
-            )
-          }),
-        )
+        const workspace = await runWorkspaceRoute(createWorkspace(body))
         return c.json(workspace)
       },
     )
@@ -78,12 +99,7 @@ export const WorkspaceRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const workspaces = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const workspaceSvc = yield* Workspace.Service
-            return yield* preserveWorkspaceRouteError(workspaceSvc.list(Instance.project))
-          }),
-        )
+        const workspaces = await runWorkspaceRoute(listWorkspaces())
         return c.json(workspaces)
       },
     )
@@ -105,15 +121,7 @@ export const WorkspaceRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const status = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const workspaceSvc = yield* Workspace.Service
-            const workspaces = yield* preserveWorkspaceRouteError(workspaceSvc.list(Instance.project))
-            const ids = new Set(workspaces.map((item) => item.id))
-            const statuses = yield* preserveWorkspaceRouteError(workspaceSvc.status())
-            return statuses.filter((item) => ids.has(item.workspaceID))
-          }),
-        )
+        const status = await runWorkspaceRoute(getWorkspaceStatus())
         return c.json(status)
       },
     )
@@ -143,12 +151,7 @@ export const WorkspaceRoutes = lazy(() =>
       ),
       async (c) => {
         const { id } = c.req.valid("param")
-        const workspace = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const workspaceSvc = yield* Workspace.Service
-            return yield* preserveWorkspaceRouteError(workspaceSvc.remove(id))
-          }),
-        )
+        const workspace = await runWorkspaceRoute(removeWorkspace(id))
         return c.json(workspace)
       },
     ),


### PR DESCRIPTION
## Summary

Name the remaining non-streaming instance route effects for the global, workspace, permission, and automation route owners.

## Why

This continues the #936 Effect migration by moving route bodies out of inline `AppRuntime.runPromise(Effect.gen(...))` blocks and into traceable `Effect.fn(...)` boundaries without changing HTTP behavior.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the extracted route effects preserve response shapes, automation error mapping, scheduler settle ordering, global SSE behavior, and workspace/permission compatibility behavior.

## Risk Notes

- Automation intentionally keeps its `runPromiseExit` mapper so `ValidationError`, `ConflictError`, and `ActiveRunStillRunningError` still map to the existing `422`/`409` responses.
- `effect-migration.md` was updated only for facts proven by this slice.
- Skipped visible UI/copy checklist item: no visible UI or user-facing copy changed.
- Skipped platform checklist item: no platform, packaging, updater, signing, shell, or path behavior changed.

## How To Verify

```text
Install: bun install --frozen-lockfile completed in the new worktree.
Baseline focused route tests before changes: 72 passed across global-config-routes, global-event-replay, event-stream-routes, workspace-routes, permission-routes, and automation-routes.
Focused route tests after changes: 72 passed across the same 6 files.
Typecheck: bun run typecheck passed from packages/opencode.
Diff check: git diff --check passed.
Inventory scan: only the route-local runGlobalRoute/runWorkspaceRoute/runPermissionRoute bridge definitions and automation's intentional runPromiseExit mapper remain.
Fresh-eye read-only review: no findings.
Claude read-only review: no P0/P1/P2 findings; one P3 alias-minimization suggestion was evaluated and left unchanged because the bridge pattern matches the requested route-local boundary and existing InstanceRoutes pattern.
```

## Screenshots or Recordings

Not required; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
