### PR TITLE
refactor(opencode): name provider mcp pty route effects

### DIFF
--- a/packages/opencode/src/server/instance/mcp.ts
+++ b/packages/opencode/src/server/instance/mcp.ts
@@ -8,6 +8,54 @@ import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { AppRuntime } from "../../effect/app-runtime"
 
+const runMcpRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
+
+const getMcpStatus = Effect.fn("McpRoutes.status")(function* () {
+  const mcp = yield* MCP.Service
+  return yield* mcp.status()
+})
+
+const addMcpServer = Effect.fn("McpRoutes.add")(function* (input: { name: string; config: Config.Mcp }) {
+  const mcp = yield* MCP.Service
+  return yield* mcp.add(input.name, input.config)
+})
+
+const startMcpAuth = Effect.fn("McpRoutes.auth.start")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  const supportsOAuth = yield* mcp.supportsOAuth(name)
+  if (!supportsOAuth) return { type: "unsupported" as const }
+  const { authorizationUrl, oauthState } = yield* mcp.startAuth(name)
+  return { type: "started" as const, authorizationUrl, oauthState }
+})
+
+const completeMcpAuth = Effect.fn("McpRoutes.auth.callback")(function* (input: { name: string; code: string }) {
+  const mcp = yield* MCP.Service
+  return yield* mcp.finishAuth(input.name, input.code)
+})
+
+const authenticateMcp = Effect.fn("McpRoutes.auth.authenticate")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  const supportsOAuth = yield* mcp.supportsOAuth(name)
+  if (!supportsOAuth) return { type: "unsupported" as const }
+  const status = yield* mcp.authenticate(name)
+  return { type: "authenticated" as const, status }
+})
+
+const removeMcpAuth = Effect.fn("McpRoutes.auth.remove")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  yield* mcp.removeAuth(name)
+})
+
+const connectMcpServer = Effect.fn("McpRoutes.connect")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  yield* mcp.connect(name)
+})
+
+const disconnectMcpServer = Effect.fn("McpRoutes.disconnect")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  yield* mcp.disconnect(name)
+})
+
 export const McpRoutes = lazy(() =>
   new Hono()
     .get(
@@ -28,12 +76,7 @@ export const McpRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const status = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const mcp = yield* MCP.Service
-            return yield* mcp.status()
-          }),
-        )
+        const status = await runMcpRoute(getMcpStatus())
         return c.json(status)
       },
     )
@@ -64,12 +107,7 @@ export const McpRoutes = lazy(() =>
       ),
       async (c) => {
         const { name, config } = c.req.valid("json")
-        const result = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const mcp = yield* MCP.Service
-            return yield* mcp.add(name, config)
-          }),
-        )
+        const result = await runMcpRoute(addMcpServer({ name, config }))
         return c.json(result.status)
       },
     )
@@ -97,15 +135,7 @@ export const McpRoutes = lazy(() =>
       }),
       async (c) => {
         const name = c.req.param("name")
-        const result = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const mcp = yield* MCP.Service
-            const supportsOAuth = yield* mcp.supportsOAuth(name)
-            if (!supportsOAuth) return { type: "unsupported" as const }
-            const { authorizationUrl, oauthState } = yield* mcp.startAuth(name)
-            return { type: "started" as const, authorizationUrl, oauthState }
-          }),
-        )
+        const result = await runMcpRoute(startMcpAuth(name))
         if (result.type === "unsupported") {
           return c.json({ error: `MCP server ${name} does not support OAuth` }, 400)
         }
@@ -140,12 +170,7 @@ export const McpRoutes = lazy(() =>
       async (c) => {
         const name = c.req.param("name")
         const { code } = c.req.valid("json")
-        const status = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const mcp = yield* MCP.Service
-            return yield* mcp.finishAuth(name, code)
-          }),
-        )
+        const status = await runMcpRoute(completeMcpAuth({ name, code }))
         return c.json(status)
       },
     )
@@ -169,15 +194,7 @@ export const McpRoutes = lazy(() =>
       }),
       async (c) => {
         const name = c.req.param("name")
-        const result = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const mcp = yield* MCP.Service
-            const supportsOAuth = yield* mcp.supportsOAuth(name)
-            if (!supportsOAuth) return { type: "unsupported" as const }
-            const status = yield* mcp.authenticate(name)
-            return { type: "authenticated" as const, status }
-          }),
-        )
+        const result = await runMcpRoute(authenticateMcp(name))
         if (result.type === "unsupported") {
           return c.json({ error: `MCP server ${name} does not support OAuth` }, 400)
         }
@@ -204,12 +221,7 @@ export const McpRoutes = lazy(() =>
       }),
       async (c) => {
         const name = c.req.param("name")
-        await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const mcp = yield* MCP.Service
-            yield* mcp.removeAuth(name)
-          }),
-        )
+        await runMcpRoute(removeMcpAuth(name))
         return c.json({ success: true as const })
       },
     )
@@ -233,12 +245,7 @@ export const McpRoutes = lazy(() =>
       validator("param", z.object({ name: z.string() })),
       async (c) => {
         const { name } = c.req.valid("param")
-        await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const mcp = yield* MCP.Service
-            yield* mcp.connect(name)
-          }),
-        )
+        await runMcpRoute(connectMcpServer(name))
         return c.json(true)
       },
     )
@@ -261,12 +268,7 @@ export const McpRoutes = lazy(() =>
       validator("param", z.object({ name: z.string() })),
       async (c) => {
         const { name } = c.req.valid("param")
-        await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const mcp = yield* MCP.Service
-            yield* mcp.disconnect(name)
-          }),
-        )
+        await runMcpRoute(disconnectMcpServer(name))
         return c.json(true)
       },
     ),

--- a/packages/opencode/src/server/instance/provider.ts
+++ b/packages/opencode/src/server/instance/provider.ts
@@ -16,6 +16,63 @@ import { Log } from "@opencode-ai/core/util/log"
 
 const log = Log.create({ service: "server" })
 
+const runProviderRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
+
+const listProviders = Effect.fn("ProviderRoutes.list")(function* () {
+  const config = yield* Config.Service
+  const provider = yield* Provider.Service
+  const [configInfo, allProviders, connected] = yield* Effect.all(
+    [config.get(), Effect.promise(() => ModelsDev.get()), provider.list()],
+    { concurrency: 3 },
+  )
+  const disabled = new Set(configInfo.disabled_providers ?? [])
+  const enabled = configInfo.enabled_providers ? new Set(configInfo.enabled_providers) : undefined
+
+  const filteredProviders: Record<string, (typeof allProviders)[string]> = {}
+  for (const [key, value] of Object.entries(allProviders)) {
+    if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
+      filteredProviders[key] = value
+    }
+  }
+
+  const providers = Object.assign(
+    mapValues(filteredProviders, (item) => Provider.fromModelsDevProvider(item)),
+    connected,
+  )
+  return {
+    all: Object.values(providers),
+    default: mapValues(providers, (item) => Provider.defaultModelID(item)),
+    connected: Object.keys(connected),
+  }
+})
+
+const getAuthMethods = Effect.fn("ProviderRoutes.auth.methods")(function* () {
+  const auth = yield* ProviderAuth.Service
+  return yield* auth.methods()
+})
+
+const authorizeProvider = Effect.fn("ProviderRoutes.oauth.authorize")(function* (input: {
+  providerID: ProviderID
+  method: number
+  inputs?: Record<string, string>
+}) {
+  const auth = yield* ProviderAuth.Service
+  return yield* auth.authorize(input)
+})
+
+const completeProviderAuth = Effect.fn("ProviderRoutes.oauth.callback")(function* (input: {
+  providerID: ProviderID
+  method: number
+  code?: string
+}) {
+  const auth = yield* ProviderAuth.Service
+  yield* auth.callback(input)
+})
+
+const recordRecentModel = Effect.fn("ProviderRoutes.recent.record")(function* (input: ModelState.ModelRef) {
+  yield* Effect.promise(() => ModelState.recordRecent(input))
+})
+
 export const ProviderRoutes = lazy(() =>
   new Hono()
     .get(
@@ -42,34 +99,8 @@ export const ProviderRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const [config, allProviders, connected] = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const config = yield* Config.Service
-            const provider = yield* Provider.Service
-            return yield* Effect.all([config.get(), Effect.promise(() => ModelsDev.get()), provider.list()], {
-              concurrency: 3,
-            })
-          }),
-        )
-        const disabled = new Set(config.disabled_providers ?? [])
-        const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
-
-        const filteredProviders: Record<string, (typeof allProviders)[string]> = {}
-        for (const [key, value] of Object.entries(allProviders)) {
-          if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
-            filteredProviders[key] = value
-          }
-        }
-
-        const providers = Object.assign(
-          mapValues(filteredProviders, (x) => Provider.fromModelsDevProvider(x)),
-          connected,
-        )
-        return c.json({
-          all: Object.values(providers),
-          default: mapValues(providers, (item) => Provider.defaultModelID(item)),
-          connected: Object.keys(connected),
-        })
+        const providers = await runProviderRoute(listProviders())
+        return c.json(providers)
       },
     )
     .get(
@@ -90,12 +121,7 @@ export const ProviderRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const methods = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const auth = yield* ProviderAuth.Service
-            return yield* auth.methods()
-          }),
-        )
+        const methods = await runProviderRoute(getAuthMethods())
         return c.json(methods)
       },
     )
@@ -133,16 +159,7 @@ export const ProviderRoutes = lazy(() =>
       async (c) => {
         const providerID = c.req.valid("param").providerID
         const { method, inputs } = c.req.valid("json")
-        const result = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const auth = yield* ProviderAuth.Service
-            return yield* auth.authorize({
-              providerID,
-              method,
-              inputs,
-            })
-          }),
-        )
+        const result = await runProviderRoute(authorizeProvider({ providerID, method, inputs }))
         return c.json(result)
       },
     )
@@ -180,16 +197,7 @@ export const ProviderRoutes = lazy(() =>
       async (c) => {
         const providerID = c.req.valid("param").providerID
         const { method, code } = c.req.valid("json")
-        await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const auth = yield* ProviderAuth.Service
-            yield* auth.callback({
-              providerID,
-              method,
-              code,
-            })
-          }),
-        )
+        await runProviderRoute(completeProviderAuth({ providerID, method, code }))
         return c.json(true)
       },
     )
@@ -221,7 +229,7 @@ export const ProviderRoutes = lazy(() =>
       ),
       async (c) => {
         const { providerID, modelID } = c.req.valid("json")
-        await ModelState.recordRecent({ providerID, modelID })
+        await runProviderRoute(recordRecentModel({ providerID, modelID }))
         return c.json(true)
       },
     ),

--- a/packages/opencode/src/server/instance/pty.ts
+++ b/packages/opencode/src/server/instance/pty.ts
@@ -1,7 +1,7 @@
 import { Hono, type MiddlewareHandler } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
 import { HTTPException } from "hono/http-exception"
-import type { UpgradeWebSocket } from "hono/ws"
+import type { UpgradeWebSocket, WSEvents } from "hono/ws"
 import z from "zod"
 import { Effect } from "effect"
 import { AppRuntime } from "@/effect/app-runtime"
@@ -30,6 +30,107 @@ type PtyConnectRequest = {
   valid(target: "query"): PtyConnectQuery
 }
 
+type PtyConnectHandler = {
+  onMessage: (message: string | ArrayBuffer) => void
+  onClose: () => void
+}
+
+type PtyConnectSocket = {
+  readyState: number
+  send: (data: string | Uint8Array | ArrayBuffer) => void
+  close: (code?: number, reason?: string) => void
+}
+
+const isPtyConnectSocket = (value: unknown): value is PtyConnectSocket => {
+  if (!value || typeof value !== "object") return false
+  if (!("readyState" in value)) return false
+  if (!("send" in value) || typeof (value as { send?: unknown }).send !== "function") return false
+  if (!("close" in value) || typeof (value as { close?: unknown }).close !== "function") return false
+  return typeof (value as { readyState?: unknown }).readyState === "number"
+}
+
+const runPtyRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
+
+const listPtySessions = Effect.fn("PtyRoutes.list")(function* () {
+  const pty = yield* Pty.Service
+  return yield* pty.list()
+})
+
+const createPtySession = Effect.fn("PtyRoutes.create")(function* (input: Pty.CreateInput) {
+  const pty = yield* Pty.Service
+  return yield* pty.create(input)
+})
+
+const getPtySession = Effect.fn("PtyRoutes.get")(function* (id: PtyID) {
+  const pty = yield* Pty.Service
+  return yield* pty.get(id)
+})
+
+const updatePtySession = Effect.fn("PtyRoutes.update")(function* (input: { id: PtyID; update: Pty.UpdateInput }) {
+  const pty = yield* Pty.Service
+  return yield* pty.update(input.id, input.update)
+})
+
+const removePtySession = Effect.fn("PtyRoutes.remove")(function* (id: PtyID) {
+  const pty = yield* Pty.Service
+  const info = yield* pty.get(id)
+  if (!info) return false
+  yield* pty.remove(id)
+  return true
+})
+
+const assertPtyConnectTokenTarget = Effect.fn("PtyRoutes.connectToken")(function* (id: PtyID) {
+  const pty = yield* Pty.Service
+  assertPtyConnectTarget(yield* pty.get(id))
+})
+
+const connectPtySession = Effect.fn("PtyRoutes.connect")(function* (request: PtyConnectRequest) {
+  const pty = yield* Pty.Service
+  const id = request.valid("param").ptyID
+  const query = request.valid("query")
+  assertPtyConnectTicket({ ptyID: id, ticket: query.ticket })
+  const cursor = (() => {
+    const value = query.cursor
+    if (!value) return
+    const parsed = Number(value)
+    if (!Number.isSafeInteger(parsed) || parsed < -1) return
+    return parsed
+  })()
+  let handler: PtyConnectHandler | undefined
+  assertPtyConnectTarget(yield* pty.get(id))
+
+  const pending: string[] = []
+  let ready = false
+
+  return {
+    async onOpen(_event, ws) {
+      const socket = ws.raw
+      if (!isPtyConnectSocket(socket)) {
+        ws.close()
+        return
+      }
+      handler = await AppRuntime.runPromise(pty.connect(id, socket, cursor))
+      ready = true
+      for (const msg of pending) handler?.onMessage(msg)
+      pending.length = 0
+    },
+    onMessage(event) {
+      if (typeof event.data !== "string") return
+      if (!ready) {
+        pending.push(event.data)
+        return
+      }
+      handler?.onMessage(event.data)
+    },
+    onClose() {
+      handler?.onClose()
+    },
+    onError() {
+      handler?.onClose()
+    },
+  } satisfies WSEvents
+})
+
 export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
   return new Hono()
     .get(
@@ -50,12 +151,7 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
         },
       }),
       async (c) => {
-        const sessions = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const pty = yield* Pty.Service
-            return yield* pty.list()
-          }),
-        )
+        const sessions = await runPtyRoute(listPtySessions())
         return c.json(sessions)
       },
     )
@@ -80,12 +176,7 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       validator("json", Pty.CreateInput),
       async (c) => {
         const input = c.req.valid("json")
-        const info = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const pty = yield* Pty.Service
-            return yield* pty.create(input)
-          }),
-        )
+        const info = await runPtyRoute(createPtySession(input))
         return c.json(info)
       },
     )
@@ -110,12 +201,7 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       validator("param", z.object({ ptyID: PtyID.zod })),
       async (c) => {
         const id = c.req.valid("param").ptyID
-        const info = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const pty = yield* Pty.Service
-            return yield* pty.get(id)
-          }),
-        )
+        const info = await runPtyRoute(getPtySession(id))
         if (!info) {
           throw new NotFoundError({ message: "Session not found" })
         }
@@ -146,12 +232,7 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       async (c) => {
         const id = c.req.valid("param").ptyID
         const input = c.req.valid("json")
-        const info = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const pty = yield* Pty.Service
-            return yield* pty.update(id, input)
-          }),
-        )
+        const info = await runPtyRoute(updatePtySession({ id, update: input }))
         if (!info) {
           throw new NotFoundError({ message: "Session not found" })
         }
@@ -179,15 +260,7 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       validator("param", z.object({ ptyID: PtyID.zod })),
       async (c) => {
         const id = c.req.valid("param").ptyID
-        const removed = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const pty = yield* Pty.Service
-            const info = yield* pty.get(id)
-            if (!info) return false
-            yield* pty.remove(id)
-            return true
-          }),
-        )
+        const removed = await runPtyRoute(removePtySession(id))
         if (!removed) {
           throw new NotFoundError({ message: "Session not found" })
         }
@@ -215,12 +288,7 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       validator("param", z.object({ ptyID: PtyID.zod })),
       async (c) => {
         const id = c.req.valid("param").ptyID
-        await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const pty = yield* Pty.Service
-            assertPtyConnectTarget(yield* pty.get(id))
-          }),
-        )
+        await runPtyRoute(assertPtyConnectTokenTarget(id))
         return c.json(PtyTicket.issue({ ptyID: id }))
       },
     )
@@ -245,73 +313,8 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       validator("param", z.object({ ptyID: PtyID.zod })),
       validator("query", PtyConnectQuery),
       upgradeWebSocket(async (c) => {
-        return AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const pty = yield* Pty.Service
-            const request = c.req as unknown as PtyConnectRequest
-            const id = request.valid("param").ptyID
-            const query = request.valid("query")
-            assertPtyConnectTicket({ ptyID: id, ticket: query.ticket })
-            const cursor = (() => {
-              const value = query.cursor
-              if (!value) return
-              const parsed = Number(value)
-              if (!Number.isSafeInteger(parsed) || parsed < -1) return
-              return parsed
-            })()
-            type PtyConnectHandler = {
-              onMessage: (message: string | ArrayBuffer) => void
-              onClose: () => void
-            }
-            let handler: PtyConnectHandler | undefined
-            assertPtyConnectTarget(yield* pty.get(id))
-
-            type Socket = {
-              readyState: number
-              send: (data: string | Uint8Array | ArrayBuffer) => void
-              close: (code?: number, reason?: string) => void
-            }
-
-            const isSocket = (value: unknown): value is Socket => {
-              if (!value || typeof value !== "object") return false
-              if (!("readyState" in value)) return false
-              if (!("send" in value) || typeof (value as { send?: unknown }).send !== "function") return false
-              if (!("close" in value) || typeof (value as { close?: unknown }).close !== "function") return false
-              return typeof (value as { readyState?: unknown }).readyState === "number"
-            }
-
-            const pending: string[] = []
-            let ready = false
-
-            return {
-              async onOpen(_event, ws) {
-                const socket = ws.raw
-                if (!isSocket(socket)) {
-                  ws.close()
-                  return
-                }
-                handler = await AppRuntime.runPromise(pty.connect(id, socket, cursor))
-                ready = true
-                for (const msg of pending) handler?.onMessage(msg)
-                pending.length = 0
-              },
-              onMessage(event) {
-                if (typeof event.data !== "string") return
-                if (!ready) {
-                  pending.push(event.data)
-                  return
-                }
-                handler?.onMessage(event.data)
-              },
-              onClose() {
-                handler?.onClose()
-              },
-              onError() {
-                handler?.onClose()
-              },
-            }
-          }),
-        )
+        const request = c.req as unknown as PtyConnectRequest
+        return runPtyRoute(connectPtySession(request))
       }),
     )
 }


### PR DESCRIPTION
## Summary

Names the remaining provider, MCP, and PTY instance route Effect boundaries while keeping the outer Hono handlers and public route behavior unchanged.

## Why

These route owners still had inline `AppRuntime.runPromise(Effect.gen(...))` bodies. Moving the route work into named `Effect.fn(...)` helpers makes this slice consistent with the recent #936 instance-route migrations and keeps the remaining runtime bridges explicit.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on behavior preservation for provider list/auth/recent routes, MCP auth error mapping, and PTY websocket ticket/session lifecycle.

## Risk Notes

No behavior, data, permission, dependency, or generated-file risk expected. The visible UI checklist item is left unticked because this PR does not change UI or copy.

## How To Verify

```text
Baseline focused tests before changes: 18 passed across provider-routes, provider-recent-route, mcp-routes, and pty-routes.
Focused tests after changes: 18 passed across provider-routes, provider-recent-route, mcp-routes, and pty-routes.
Typecheck: bun run typecheck passed from packages/opencode.
Diff check: git diff --check passed.
Inventory scan: only the three route-local run*Route bridges remain plus the intentional PTY websocket onOpen lifecycle bridge.
Fresh-eye review: no P0/P1/P2/P3 findings.
Claude read-only review: no bug, regression, or contract risk found; P3 notes were existing route-wrapper convention and intentional PTY websocket bridge behavior, both left unchanged.
```

## Screenshots or Recordings

N/A — no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated repeated logic across MCP, Provider, and PTY server route handlers into reusable helper functions and shared runtime adapters to reduce code duplication.
  * Improved internal code organization and maintainability while preserving all existing functionality and API stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->