### PR TITLE
feat(opencode): add config HttpApi trial slice

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -18,6 +18,7 @@ export type RouteRow = {
   openapi: boolean
   legacySdk: boolean
   v2Sdk: boolean
+  localHttpApi: boolean
   upstreamHttpApi: boolean
   classification: string
   specialSurface: string
@@ -33,12 +34,14 @@ export type RouteInventory = {
     openapi: number
     legacySdk: number
     v2Sdk: number
+    localHttpApi: number
     upstreamHttpApi: number
   }
   hono: { routes: Route[] }
   openapi: { routes: Route[] }
   legacySdk: { routes: Route[] }
   v2Sdk: { routes: Route[] }
+  localHttpApi: { routes: Route[] }
   upstreamHttpApi: { routes: Route[] }
   rows: RouteRow[]
 }
@@ -355,7 +358,7 @@ export function parseHttpApiRoutesFromText(text: string, source: string): Route[
     if (literal) routePath = resolveTemplatePath(literal[2]!, constants)
     else {
       const key = pathExpr.split(".").pop()
-      routePath = pathValues.get(pathExpr) ?? (key ? pathValues.get(key) : undefined)
+      routePath = pathValues.get(pathExpr) ?? constants.get(pathExpr) ?? (key ? pathValues.get(key) : undefined)
     }
     if (routePath) routes.push({ method, path: normalizePath(routePath), source })
   }
@@ -395,6 +398,15 @@ async function readUpstreamHttpApiRoutes(root: string, ref: string, required: bo
   return unique
 }
 
+async function readLocalHttpApiRoutes(root: string): Promise<Route[]> {
+  const files = await listTypeScriptFiles(root, "packages/opencode/src/server/routes/instance/httpapi")
+  const routes: Route[] = []
+  for (const file of files) {
+    routes.push(...parseHttpApiRoutesFromText(await readText(path.join(root, file)), file))
+  }
+  return uniqueRoutes(routes)
+}
+
 function specialSurfaceFor(method: string, routePath: string) {
   const key = `${method} ${routePath}`
   return specialSurfaces.find(([pattern]) => pattern.test(key) || pattern.test(routePath))?.[1] ?? "-"
@@ -432,11 +444,12 @@ export async function buildRouteInventory(options: BuildOptions = {}): Promise<R
   if (sourceCoverage.missing.length > 0) {
     throw new Error(`Hono route inventory source list is missing: ${sourceCoverage.missing.join(", ")}`)
   }
-  const [hono, openapi, legacySdk, v2Sdk, upstreamHttpApi] = await Promise.all([
+  const [hono, openapi, legacySdk, v2Sdk, localHttpApi, upstreamHttpApi] = await Promise.all([
     discoverHonoRoutes(root),
     readOpenApiRoutes(root),
     readSdkRoutes(root, "packages/sdk/js/src/gen/sdk.gen.ts"),
     readSdkRoutes(root, "packages/sdk/js/src/v2/gen/sdk.gen.ts"),
+    readLocalHttpApiRoutes(root),
     readUpstreamHttpApiRoutes(root, upstreamRef, requireUpstream),
   ])
 
@@ -445,6 +458,7 @@ export async function buildRouteInventory(options: BuildOptions = {}): Promise<R
     openapi: new Set(openapi.map(routeKey)),
     legacySdk: new Set(legacySdk.map(routeKey)),
     v2Sdk: new Set(v2Sdk.map(routeKey)),
+    localHttpApi: new Set(localHttpApi.map(routeKey)),
     upstreamHttpApi: new Set(upstreamHttpApi.map(routeKey)),
   }
 
@@ -463,6 +477,7 @@ export async function buildRouteInventory(options: BuildOptions = {}): Promise<R
         openapi: sets.openapi.has(key),
         legacySdk: sets.legacySdk.has(key),
         v2Sdk: sets.v2Sdk.has(key),
+        localHttpApi: sets.localHttpApi.has(key),
         upstreamHttpApi: sets.upstreamHttpApi.has(key),
       }
       return {
@@ -496,12 +511,14 @@ export async function buildRouteInventory(options: BuildOptions = {}): Promise<R
       openapi: openapi.length,
       legacySdk: legacySdk.length,
       v2Sdk: v2Sdk.length,
+      localHttpApi: localHttpApi.length,
       upstreamHttpApi: upstreamHttpApi.length,
     },
     hono: { routes: hono },
     openapi: { routes: openapi },
     legacySdk: { routes: legacySdk },
     v2Sdk: { routes: v2Sdk },
+    localHttpApi: { routes: localHttpApi },
     upstreamHttpApi: { routes: upstreamHttpApi },
     rows,
   }
@@ -528,17 +545,18 @@ export function renderRouteInventoryReport(inventory: RouteInventory) {
     `- Checked-in OpenAPI method routes: ${inventory.counts.openapi}`,
     `- Legacy generated SDK route calls: ${inventory.counts.legacySdk}`,
     `- v2 generated SDK route calls: ${inventory.counts.v2Sdk}`,
+    `- Local HttpApi method routes: ${inventory.counts.localHttpApi}`,
     `- Upstream parsed HttpApi method routes: ${inventory.counts.upstreamHttpApi}`,
     "",
     "## Main Table",
     "",
-    "| Path | Method | Hono | OpenAPI | Legacy SDK | v2 SDK | Upstream HttpApi | Classification | Special surface |",
-    "|---|---:|---:|---:|---:|---:|---:|---|---|",
+    "| Path | Method | Hono | OpenAPI | Legacy SDK | v2 SDK | Local HttpApi | Upstream HttpApi | Classification | Special surface |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
   ]
 
   for (const row of inventory.rows) {
     lines.push(
-      `| \`${row.path}\` | \`${row.method}\` | ${mark(row.hono)} | ${mark(row.openapi)} | ${mark(row.legacySdk)} | ${mark(row.v2Sdk)} | ${mark(row.upstreamHttpApi)} | \`${row.classification}\` | ${row.specialSurface} |`,
+      `| \`${row.path}\` | \`${row.method}\` | ${mark(row.hono)} | ${mark(row.openapi)} | ${mark(row.legacySdk)} | ${mark(row.v2Sdk)} | ${mark(row.localHttpApi)} | ${mark(row.upstreamHttpApi)} | \`${row.classification}\` | ${row.specialSurface} |`,
     )
   }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
@@ -1,0 +1,77 @@
+import { Info as ConfigInfo } from "@/config/config"
+import { ConfigProvidersResult } from "@/provider/provider"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+
+const root = "/config"
+
+export const WorkspaceRoutingQuery = Schema.Struct({
+  directory: Schema.optionalKey(Schema.String),
+  workspace: Schema.optionalKey(Schema.String),
+})
+
+export const BadRequestError = Schema.Struct({
+  data: Schema.Any,
+  errors: Schema.Array(Schema.Record(Schema.String, Schema.Any)),
+  success: Schema.Literal(false),
+}).pipe(
+  HttpApiSchema.status(400),
+  (schema) =>
+    schema.annotate({
+      identifier: "BadRequestError",
+      description: "Bad request",
+    }),
+)
+
+export const ConfigApi = HttpApi.make("config")
+  .add(
+    HttpApiGroup.make("config")
+      .add(
+        HttpApiEndpoint.get("get", root, {
+          query: WorkspaceRoutingQuery,
+          success: ConfigInfo,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "config.get",
+            summary: "Get configuration",
+            description: "Retrieve the current OpenCode configuration settings and preferences.",
+          }),
+        ),
+        HttpApiEndpoint.patch("update", root, {
+          query: WorkspaceRoutingQuery,
+          // Declaration only in this trial; the handler mirrors Hono's validator("json", Config.Info.zod).
+          payload: ConfigInfo,
+          success: ConfigInfo,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "config.update",
+            summary: "Update configuration",
+            description: "Update OpenCode configuration settings and preferences.",
+          }),
+        ),
+        HttpApiEndpoint.get("providers", `${root}/providers`, {
+          query: WorkspaceRoutingQuery,
+          success: ConfigProvidersResult,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "config.providers",
+            summary: "List config providers",
+            description: "Get a list of all configured AI providers and their default models.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "config",
+          description: "HttpApi config routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode config HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for the config route group.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -1,0 +1,54 @@
+import { Config } from "@/config/config"
+import { Provider } from "@/provider/provider"
+import { Effect } from "effect"
+import { HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { mapValues } from "remeda"
+import { ConfigApi } from "../groups/config"
+
+const getWith = Effect.fn("ConfigHttpApi.get")(function* (config: Config.Interface) {
+  return HttpServerResponse.jsonUnsafe(yield* config.get())
+})
+
+const providersWith = Effect.fn("ConfigHttpApi.providers")(function* (provider: Provider.Interface) {
+  const providers = yield* provider.list()
+  return HttpServerResponse.jsonUnsafe({
+    providers: Object.values(providers),
+    default: mapValues(providers, (item) => Provider.defaultModelID(item)),
+  })
+})
+
+function isJsonContentType(contentType: string | undefined) {
+  // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+export const configHandlers = HttpApiBuilder.group(ConfigApi, "config", (handlers) =>
+  Effect.gen(function* () {
+    const config = yield* Config.Service
+    const provider = yield* Provider.Service
+
+    return handlers
+      .handle("get", () => getWith(config))
+      .handleRaw("update", (ctx) =>
+        Effect.gen(function* () {
+          // Use Hono's strict Config.Info.zod contract instead of HttpApi payload decoding, which strips excess fields.
+          const body = isJsonContentType(ctx.request.headers["content-type"])
+            ? yield* ctx.request.json.pipe(
+                Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+              )
+            : {}
+          if (HttpServerResponse.isHttpServerResponse(body)) return body
+          const parsed = Config.Info.zod.safeParse(body)
+          if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+          yield* config.update(parsed.data)
+          return HttpServerResponse.jsonUnsafe(parsed.data)
+        }),
+      )
+      .handle("providers", () => providersWith(provider))
+  }),
+)

--- a/packages/opencode/test/server/config-routes.test.ts
+++ b/packages/opencode/test/server/config-routes.test.ts
@@ -1,8 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Hono } from "hono"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, HttpApiTest, OpenApi } from "effect/unstable/httpapi"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
 import { Log } from "@opencode-ai/core/util/log"
+import { Config } from "../../src/config/config"
 import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { ConfigRoutes } from "../../src/server/instance/config"
+import { ConfigApi } from "../../src/server/routes/instance/httpapi/groups/config"
+import { configHandlers } from "../../src/server/routes/instance/httpapi/handlers/config"
 import { tmpdir } from "../fixture/fixture"
 
 void Log.init({ print: false })
@@ -15,6 +24,113 @@ describe("config routes", () => {
   function app() {
     return new Hono().route("/config", ConfigRoutes())
   }
+
+  type ConfigClient = {
+    config: {
+      get: (input?: { query?: { directory?: string; workspace?: string } }) => Effect.Effect<unknown, unknown, unknown>
+      update: (input: {
+        query?: { directory?: string; workspace?: string }
+        payload: { username: string; unexpected?: unknown }
+      }) => Effect.Effect<unknown, unknown, unknown>
+      providers: (input?: {
+        query?: { directory?: string; workspace?: string }
+      }) => Effect.Effect<{ providers: ReadonlyArray<unknown>; default: Readonly<Record<string, string>> }, unknown, unknown>
+    }
+  }
+
+  function withConfigClient<A>(fn: (client: ConfigClient) => Effect.Effect<A, unknown, unknown>) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const client = yield* HttpApiTest.groups(ConfigApi, ["config"])
+          return yield* fn(client as unknown as ConfigClient)
+        }).pipe(
+          Effect.provide(configHandlers),
+          Effect.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+        ),
+      ) as Effect.Effect<A>,
+    )
+  }
+
+  function requestConfigHttpApi(
+    path: string,
+    options: {
+      init?: RequestInit
+      services?: {
+        config: Config.Interface
+        provider: Provider.Interface
+      }
+    } = {},
+  ) {
+    const serviceLayer = options.services
+      ? Layer.mergeAll(
+          Layer.succeed(Config.Service, options.services.config),
+          Layer.succeed(Provider.Service, options.services.provider),
+        )
+      : Layer.empty
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(ConfigApi).pipe(
+              Layer.provide(configHandlers),
+              Layer.provide(
+                Layer.mergeAll(serviceLayer, NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer),
+              ),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${path}`, options.init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  function unusedProvider(): Provider.Interface {
+    const unused = () => Effect.die(new Error("unused provider method"))
+    return {
+      list: () => Effect.succeed({}),
+      getProvider: unused,
+      getModel: unused,
+      getLanguage: unused,
+      closest: unused,
+      getSmallModel: unused,
+      defaultModel: unused,
+    } as Provider.Interface
+  }
+
+  test("declares the config route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(ConfigApi) as any
+
+    expect(spec.paths).toHaveProperty("/config")
+    expect(spec.paths).toHaveProperty("/config/providers")
+    expect(spec.paths["/config"]).toHaveProperty("get")
+    expect(spec.paths["/config"]).toHaveProperty("patch")
+    expect(spec.paths["/config/providers"]).toHaveProperty("get")
+
+    for (const operation of [
+      spec.paths["/config"]?.get,
+      spec.paths["/config"]?.patch,
+      spec.paths["/config/providers"]?.get,
+    ]) {
+      expect(operation?.parameters).toEqual([
+        { name: "directory", in: "query", required: false, schema: { type: "string" } },
+        { name: "workspace", in: "query", required: false, schema: { type: "string" } },
+      ])
+    }
+
+    expect(spec.paths["/config"]?.patch?.requestBody).toMatchObject({
+      content: { "application/json": { schema: { $ref: "#/components/schemas/Config" } } },
+    })
+    expect(spec.paths["/config"]?.patch?.responses?.["200"]).toMatchObject({
+      content: { "application/json": { schema: { $ref: "#/components/schemas/Config" } } },
+    })
+    expect(spec.paths["/config"]?.patch?.responses?.["400"]).toMatchObject({
+      description: "Bad request",
+      content: { "application/json": { schema: { $ref: "#/components/schemas/BadRequestError" } } },
+    })
+  })
 
   test("reads config through the route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
@@ -62,6 +178,263 @@ describe("config routes", () => {
         const reread = await app().request("/config")
         expect(reread.status).toBe(200)
         expect(await reread.json()).toMatchObject({ username: "route-runtime-tester" })
+      },
+    })
+  })
+
+  test("rejects unknown config fields through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/config", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ username: "route-runtime-tester", unexpected: true }),
+        })
+
+        expect(response.status).toBe(400)
+        expect(await response.json()).toEqual({
+          data: { username: "route-runtime-tester", unexpected: true },
+          error: [
+            {
+              code: "unrecognized_keys",
+              keys: ["unexpected"],
+              path: [],
+              message: 'Unrecognized key: "unexpected"',
+            },
+          ],
+          success: false,
+        })
+      },
+    })
+  })
+
+  test("ignores patch bodies without a json content type through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/config", {
+          method: "PATCH",
+          headers: { "content-type": "text/plain" },
+          body: JSON.stringify({ username: "route-runtime-text-body" }),
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toEqual({})
+      },
+    })
+  })
+
+  test("accepts vendor json patch bodies through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/config", {
+          method: "PATCH",
+          headers: { "content-type": "application/vnd.opencode.config+json" },
+          body: JSON.stringify({ username: "route-runtime-vendor-json" }),
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toMatchObject({ username: "route-runtime-vendor-json" })
+      },
+    })
+  })
+
+  test("accepts json patch bodies with content type parameters through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/config", {
+          method: "PATCH",
+          headers: { "content-type": "application/json; charset=utf-8" },
+          body: JSON.stringify({ username: "route-runtime-json-params" }),
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toMatchObject({ username: "route-runtime-json-params" })
+      },
+    })
+  })
+
+  test("rejects malformed json patch bodies through the route runtime", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await app().request("/config", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: "{",
+        })
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe("Malformed JSON in request body")
+      },
+    })
+  })
+
+  test("serves get, update, and providers through the HttpApi config handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await withConfigClient((client) =>
+          Effect.gen(function* () {
+            expect(yield* client.config.get({ query: {} })).toBeObject()
+            expect(
+              yield* client.config.update({ query: {}, payload: { username: "httpapi-route-runtime-tester" } }),
+            ).toMatchObject({
+              username: "httpapi-route-runtime-tester",
+            })
+            expect(yield* client.config.get({ query: {} })).toMatchObject({ username: "httpapi-route-runtime-tester" })
+
+            const providers = yield* client.config.providers({ query: {} })
+            expect(providers.providers).toBeArray()
+            expect(providers.default).toBeObject()
+          }),
+        )
+      },
+    })
+  })
+
+  test("preserves derived config fields through the HttpApi get handler", async () => {
+    const config = {
+      username: "httpapi-derived-field-tester",
+      plugin_origins: [{ spec: "local-plugin@1.0.0", source: "/tmp/opencode.json", scope: "local" }],
+    } satisfies Config.Info
+    const response = await requestConfigHttpApi("/config", {
+      services: {
+        config: {
+          get: () => Effect.succeed(config),
+          getGlobal: () => Effect.succeed({}),
+          getConsoleState: () => Effect.succeed({} as never),
+          update: () => Effect.void,
+          updateGlobal: (next) => Effect.succeed(next),
+          invalidate: () => Effect.void,
+          directories: () => Effect.succeed([]),
+          waitForDependencies: () => Effect.void,
+        },
+        provider: unusedProvider(),
+      },
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      username: "httpapi-derived-field-tester",
+      plugin_origins: [{ spec: "local-plugin@1.0.0", source: "/tmp/opencode.json", scope: "local" }],
+    })
+  })
+
+  test("rejects unknown config fields through the HttpApi config handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestConfigHttpApi("/config", {
+          init: {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ username: "httpapi-route-runtime-tester", unexpected: true }),
+          },
+        })
+
+        expect(response.status).toBe(400)
+        expect(await response.json()).toEqual({
+          data: { username: "httpapi-route-runtime-tester", unexpected: true },
+          error: [
+            {
+              code: "unrecognized_keys",
+              keys: ["unexpected"],
+              path: [],
+              message: 'Unrecognized key: "unexpected"',
+            },
+          ],
+          success: false,
+        })
+      },
+    })
+  })
+
+  test("ignores patch bodies without a json content type through the HttpApi config handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestConfigHttpApi("/config", {
+          init: {
+            method: "PATCH",
+            headers: { "content-type": "text/plain" },
+            body: JSON.stringify({ username: "httpapi-route-runtime-text-body" }),
+          },
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toEqual({})
+      },
+    })
+  })
+
+  test("accepts vendor json patch bodies through the HttpApi config handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestConfigHttpApi("/config", {
+          init: {
+            method: "PATCH",
+            headers: { "content-type": "application/vnd.opencode.config+json" },
+            body: JSON.stringify({ username: "httpapi-route-runtime-vendor-json" }),
+          },
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toMatchObject({ username: "httpapi-route-runtime-vendor-json" })
+      },
+    })
+  })
+
+  test("accepts json patch bodies with content type parameters through the HttpApi config handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestConfigHttpApi("/config", {
+          init: {
+            method: "PATCH",
+            headers: { "content-type": "application/json; charset=utf-8" },
+            body: JSON.stringify({ username: "httpapi-route-runtime-json-params" }),
+          },
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toMatchObject({ username: "httpapi-route-runtime-json-params" })
+      },
+    })
+  })
+
+  test("rejects malformed json patch bodies through the HttpApi config handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestConfigHttpApi("/config", {
+          init: {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: "{",
+          },
+        })
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe("Malformed JSON in request body")
       },
     })
   })

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -51,6 +51,34 @@ describe("route inventory harness", () => {
     expect(inventory.counts.v2Sdk).toBeGreaterThanOrEqual(100)
   })
 
+  test("tracks local HttpApi migration coverage separately from upstream parity", async () => {
+    const inventory = await buildRouteInventory({ root, requireUpstream: false })
+
+    expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/config")).toMatchObject({
+      hono: true,
+      openapi: true,
+      localHttpApi: true,
+      classification: "all-public-surfaces",
+    })
+    expect(inventory.rows.find((row) => row.method === "PATCH" && row.path === "/config")).toMatchObject({
+      hono: true,
+      openapi: true,
+      localHttpApi: true,
+      classification: "all-public-surfaces",
+    })
+    expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/config/providers")).toMatchObject({
+      hono: true,
+      openapi: true,
+      localHttpApi: true,
+      classification: "all-public-surfaces",
+    })
+    expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")).toMatchObject({
+      hono: true,
+      localHttpApi: false,
+      classification: "pawwork-owned-sdk-v2-only",
+    })
+  })
+
   test("parses upstream HttpApi route declarations without requiring a live upstream ref", () => {
     const routes = parseHttpApiRoutesFromText(
       `
@@ -74,6 +102,26 @@ describe("route inventory harness", () => {
       path: "/session/:sessionID/message/:messageID",
       source: "fixture.ts",
     })
+  })
+
+  test("parses upstream HttpApi route declarations when one add call registers multiple endpoints", () => {
+    const routes = parseHttpApiRoutesFromText(
+      `
+      const root = "/config"
+
+      HttpApiGroup.make("config")
+        .add(
+          HttpApiEndpoint.get("get", root, {}),
+          HttpApiEndpoint.patch("update", root, {}),
+          HttpApiEndpoint.get("providers", \`\${root}/providers\`, {}),
+        )
+      `,
+      "fixture.ts",
+    )
+
+    expect(routes).toContainEqual({ method: "GET", path: "/config", source: "fixture.ts" })
+    expect(routes).toContainEqual({ method: "PATCH", path: "/config", source: "fixture.ts" })
+    expect(routes).toContainEqual({ method: "GET", path: "/config/providers", source: "fixture.ts" })
   })
 
   test("qualifies upstream HttpApi path object keys when names collide", () => {
@@ -148,7 +196,13 @@ describe("route inventory harness", () => {
   })
 
   test("fails when the upstream ref does not contain the HttpApi route tree", async () => {
-    await expect(buildRouteInventory({ root, upstreamRef: "HEAD", requireUpstream: true })).rejects.toThrow(
+    await expect(
+      buildRouteInventory({
+        root,
+        upstreamRef: "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+        requireUpstream: true,
+      }),
+    ).rejects.toThrow(
       /Unable to read upstream HttpApi route tree/,
     )
   })


### PR DESCRIPTION
## Summary

Add the first config-route HttpApi trial slice for the #936 migration:

- declare a local `ConfigApi` group for `GET /config`, `PATCH /config`, and `GET /config/providers`
- add unmounted HttpApi handlers that mirror the current Hono config runtime behavior
- extend the route inventory with a `localHttpApi` surface and focused config coverage checks
- strengthen config route tests across Hono and HttpApi for strict validation, content-type handling, malformed JSON, derived fields, and provider payloads

## Why

This is the first small Hono to Effect HttpApi pilot. The slice proves that a single low-risk route group can be represented and tested through HttpApi without replacing the production Hono route yet.

Related to #936

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on:

- whether the config HttpApi handlers preserve the current Hono runtime contract
- whether route inventory now protects local HttpApi migration coverage without weakening PawWork-owned/Hono-only/special route classifications
- whether the intentionally unmounted trial boundary is clear and reversible

## Risk Notes

The config HttpApi group is intentionally not mounted into the production server in this PR. Production `/config` continues to use the Hono route.

Accepted non-blocking review items:

- Complete `OpenApi.fromApi(ConfigApi)` component schema parity is deferred. Checked-in `packages/sdk/openapi.json` and generated SDK files are unchanged; a future HttpApi OpenAPI cutover should solve component parity through a generic adapter/generator rather than a config-local normalizer.
- The current Hono surface documents `BadRequestError.errors` while runtime validation returns `error`. This PR mirrors Hono runtime behavior in the handler and leaves the checked OpenAPI/SDK contract unchanged.

Skipped checklist items:

- Visible UI check: not applicable, no UI or copy changed.
- Platform manual check: not applicable, this is server route harness/test work and does not touch packaging, updater, signing, shell, paths, or permissions.
- Docs/release/dependency/generated-content check: no docs, dependencies, generated files, permissions, credentials, deletion behavior, or local file surfaces were changed.

## How To Verify

```text
Install: bun install --frozen-lockfile completed in this worktree.
Focused tests: bun test test/server/config-routes.test.ts test/server/route-inventory-harness.test.ts test/server/no-tui-routes.test.ts -> 31 pass, 82 expect() calls.
Typecheck: bun run typecheck from packages/opencode -> pass.
Diff check: git diff --check -> no whitespace errors.
Generated SDK/OpenAPI check: git diff --exit-code -- packages/sdk/openapi.json packages/sdk/js/src/gen packages/sdk/js/src/v2/gen -> no generated changes.
Route inventory probe: upstream 62c746f2e8b4bf325fbdf67bdb3246f043609850; counts hono 128, openapi 100, legacySdk 64, v2Sdk 124, localHttpApi 3, upstreamHttpApi 126; all three config methods aligned across Hono/OpenAPI/legacy SDK/v2 SDK/local HttpApi/upstream HttpApi.
Fresh-eye review: PASS under the P0/P1 gate; no P0/P1, one accepted P3 on existing BadRequestError schema/runtime naming mismatch.
Claude review: PASS under the P0/P1 gate; no P0/P1, accepted non-blocking note on the same existing BadRequestError schema/runtime mismatch.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

