### PR TITLE
feat(opencode): add provider HttpApi trial slice

### DIFF
--- a/packages/opencode/src/server/instance/provider-actions.ts
+++ b/packages/opencode/src/server/instance/provider-actions.ts
@@ -1,0 +1,63 @@
+import { Effect } from "effect"
+import { mapValues } from "remeda"
+import { Config } from "../../config/config"
+import { ModelState } from "../../provider/model-state"
+import { ModelsDev } from "../../provider/models"
+import { ProviderAuth } from "../../provider/auth"
+import { Provider } from "../../provider/provider"
+import { ModelID, ProviderID } from "../../provider/schema"
+
+export const listProviders = Effect.fn("ProviderRoutes.list")(function* () {
+  const config = yield* Config.Service
+  const provider = yield* Provider.Service
+  const [configInfo, allProviders, connected] = yield* Effect.all(
+    [config.get(), Effect.promise(() => ModelsDev.get()), provider.list()],
+    { concurrency: 3 },
+  )
+  const disabled = new Set(configInfo.disabled_providers ?? [])
+  const enabled = configInfo.enabled_providers ? new Set(configInfo.enabled_providers) : undefined
+
+  const filteredProviders: Record<string, (typeof allProviders)[string]> = {}
+  for (const [key, value] of Object.entries(allProviders)) {
+    if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
+      filteredProviders[key] = value
+    }
+  }
+
+  const providers = Object.assign(
+    mapValues(filteredProviders, (item) => Provider.fromModelsDevProvider(item)),
+    connected,
+  )
+  return {
+    all: Object.values(providers),
+    default: mapValues(providers, (item) => Provider.defaultModelID(item)),
+    connected: Object.keys(connected),
+  }
+})
+
+export const getAuthMethods = Effect.fn("ProviderRoutes.auth.methods")(function* () {
+  const auth = yield* ProviderAuth.Service
+  return yield* auth.methods()
+})
+
+export const authorizeProvider = Effect.fn("ProviderRoutes.oauth.authorize")(function* (input: {
+  providerID: ProviderID
+  method: number
+  inputs?: Record<string, string>
+}) {
+  const auth = yield* ProviderAuth.Service
+  return yield* auth.authorize(input)
+})
+
+export const completeProviderAuth = Effect.fn("ProviderRoutes.oauth.callback")(function* (input: {
+  providerID: ProviderID
+  method: number
+  code?: string
+}) {
+  const auth = yield* ProviderAuth.Service
+  yield* auth.callback(input)
+})
+
+export const recordRecentModel = Effect.fn("ProviderRoutes.recent.record")(function* (input: ModelState.ModelRef) {
+  yield* Effect.promise(() => ModelState.recordRecent(input))
+})

--- a/packages/opencode/src/server/instance/provider.ts
+++ b/packages/opencode/src/server/instance/provider.ts
@@ -1,77 +1,18 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
-import { Effect } from "effect"
 import z from "zod"
-import { Config } from "../../config/config"
 import { Provider } from "../../provider/provider"
-import { ModelsDev } from "../../provider/models"
 import { ProviderAuth } from "../../provider/auth"
-import { ModelState } from "../../provider/model-state"
 import { ProviderID, ModelID } from "../../provider/schema"
 import { AppRuntime } from "../../effect/app-runtime"
-import { mapValues } from "remeda"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { Log } from "@opencode-ai/core/util/log"
+import { authorizeProvider, completeProviderAuth, getAuthMethods, listProviders, recordRecentModel } from "./provider-actions"
 
 const log = Log.create({ service: "server" })
 
 const runProviderRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
-
-const listProviders = Effect.fn("ProviderRoutes.list")(function* () {
-  const config = yield* Config.Service
-  const provider = yield* Provider.Service
-  const [configInfo, allProviders, connected] = yield* Effect.all(
-    [config.get(), Effect.promise(() => ModelsDev.get()), provider.list()],
-    { concurrency: 3 },
-  )
-  const disabled = new Set(configInfo.disabled_providers ?? [])
-  const enabled = configInfo.enabled_providers ? new Set(configInfo.enabled_providers) : undefined
-
-  const filteredProviders: Record<string, (typeof allProviders)[string]> = {}
-  for (const [key, value] of Object.entries(allProviders)) {
-    if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
-      filteredProviders[key] = value
-    }
-  }
-
-  const providers = Object.assign(
-    mapValues(filteredProviders, (item) => Provider.fromModelsDevProvider(item)),
-    connected,
-  )
-  return {
-    all: Object.values(providers),
-    default: mapValues(providers, (item) => Provider.defaultModelID(item)),
-    connected: Object.keys(connected),
-  }
-})
-
-const getAuthMethods = Effect.fn("ProviderRoutes.auth.methods")(function* () {
-  const auth = yield* ProviderAuth.Service
-  return yield* auth.methods()
-})
-
-const authorizeProvider = Effect.fn("ProviderRoutes.oauth.authorize")(function* (input: {
-  providerID: ProviderID
-  method: number
-  inputs?: Record<string, string>
-}) {
-  const auth = yield* ProviderAuth.Service
-  return yield* auth.authorize(input)
-})
-
-const completeProviderAuth = Effect.fn("ProviderRoutes.oauth.callback")(function* (input: {
-  providerID: ProviderID
-  method: number
-  code?: string
-}) {
-  const auth = yield* ProviderAuth.Service
-  yield* auth.callback(input)
-})
-
-const recordRecentModel = Effect.fn("ProviderRoutes.recent.record")(function* (input: ModelState.ModelRef) {
-  yield* Effect.promise(() => ModelState.recordRecent(input))
-})
 
 export const ProviderRoutes = lazy(() =>
   new Hono()

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/common.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/common.ts
@@ -1,0 +1,20 @@
+import { Schema } from "effect"
+import { HttpApiSchema } from "effect/unstable/httpapi"
+
+export const WorkspaceRoutingQuery = Schema.Struct({
+  directory: Schema.optionalKey(Schema.String),
+  workspace: Schema.optionalKey(Schema.String),
+})
+
+export const BadRequestError = Schema.Struct({
+  data: Schema.Any,
+  errors: Schema.Array(Schema.Record(Schema.String, Schema.Any)),
+  success: Schema.Literal(false),
+}).pipe(
+  HttpApiSchema.status(400),
+  (schema) =>
+    schema.annotate({
+      identifier: "BadRequestError",
+      description: "Bad request",
+    }),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
@@ -1,27 +1,9 @@
 import { Info as ConfigInfo } from "@/config/config"
 import { ConfigProvidersResult } from "@/provider/provider"
-import { Schema } from "effect"
-import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, WorkspaceRoutingQuery } from "./common"
 
 const root = "/config"
-
-export const WorkspaceRoutingQuery = Schema.Struct({
-  directory: Schema.optionalKey(Schema.String),
-  workspace: Schema.optionalKey(Schema.String),
-})
-
-export const BadRequestError = Schema.Struct({
-  data: Schema.Any,
-  errors: Schema.Array(Schema.Record(Schema.String, Schema.Any)),
-  success: Schema.Literal(false),
-}).pipe(
-  HttpApiSchema.status(400),
-  (schema) =>
-    schema.annotate({
-      identifier: "BadRequestError",
-      description: "Bad request",
-    }),
-)
 
 export const ConfigApi = HttpApi.make("config")
   .add(

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/provider.ts
@@ -1,0 +1,101 @@
+import {
+  Authorization as ProviderAuthAuthorization,
+  AuthorizeInput as ProviderAuthAuthorizeInput,
+  CallbackInput as ProviderAuthCallbackInput,
+  Methods as ProviderAuthMethods,
+} from "@/provider/auth"
+import { ListResult } from "@/provider/provider"
+import { ModelID, ProviderID } from "@/provider/schema"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+
+const root = "/provider"
+
+const ProviderParam = Schema.Struct({
+  providerID: ProviderID,
+})
+
+export const RecentModelInput = Schema.Struct({
+  providerID: ProviderID,
+  modelID: ModelID,
+})
+
+export const ProviderApi = HttpApi.make("provider")
+  .add(
+    HttpApiGroup.make("provider")
+      .add(
+        HttpApiEndpoint.get("list", root, {
+          query: WorkspaceRoutingQuery,
+          success: ListResult,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "provider.list",
+            summary: "List providers",
+            description: "Get a list of all available AI providers, including both available and connected ones.",
+          }),
+        ),
+        HttpApiEndpoint.get("auth", `${root}/auth`, {
+          query: WorkspaceRoutingQuery,
+          success: ProviderAuthMethods,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "provider.auth",
+            summary: "Get provider auth methods",
+            description: "Retrieve available authentication methods for all AI providers.",
+          }),
+        ),
+        HttpApiEndpoint.post("authorize", `${root}/:providerID/oauth/authorize`, {
+          params: ProviderParam,
+          query: WorkspaceRoutingQuery,
+          payload: ProviderAuthAuthorizeInput,
+          success: Schema.UndefinedOr(ProviderAuthAuthorization),
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "provider.oauth.authorize",
+            summary: "OAuth authorize",
+            description: "Initiate OAuth authorization for a specific AI provider to get an authorization URL.",
+          }),
+        ),
+        HttpApiEndpoint.post("callback", `${root}/:providerID/oauth/callback`, {
+          params: ProviderParam,
+          query: WorkspaceRoutingQuery,
+          payload: ProviderAuthCallbackInput,
+          success: Schema.Boolean,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "provider.oauth.callback",
+            summary: "OAuth callback",
+            description: "Handle the OAuth callback from a provider after user authorization.",
+          }),
+        ),
+        HttpApiEndpoint.post("recent", `${root}/recent`, {
+          query: WorkspaceRoutingQuery,
+          payload: RecentModelInput,
+          success: Schema.Boolean,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "provider.recordRecent",
+            summary: "Record recent model",
+            description:
+              "Persist the user's picked model as the recent default that model-less sessions (e.g. a Telegram /new) inherit. Called by the desktop model picker on an explicit pick.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "provider",
+          description: "HttpApi provider routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode provider HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for the provider route group.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
@@ -1,0 +1,110 @@
+import { authorizeProvider, completeProviderAuth, getAuthMethods, listProviders, recordRecentModel } from "@/server/instance/provider-actions"
+import { ProviderAuth } from "@/provider/auth"
+import { ModelID, ProviderID } from "@/provider/schema"
+import { NamedError } from "@opencode-ai/util/error"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { ProviderApi } from "../groups/provider"
+
+const RecentModelInput = z.object({
+  providerID: ProviderID.zod,
+  modelID: ModelID.zod,
+})
+
+function isJsonContentType(contentType: string | undefined) {
+  // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function isProviderAuthBadRequest(error: unknown): error is ProviderAuth.Error & { toObject: () => unknown } {
+  return (
+    error instanceof ProviderAuth.ValidationFailed ||
+    error instanceof ProviderAuth.OauthMissing ||
+    error instanceof ProviderAuth.OauthCodeMissing ||
+    error instanceof ProviderAuth.OauthCallbackFailed
+  )
+}
+
+function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: z.ZodType<T>) {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+    return parsed.data
+  })
+}
+
+function providerAuthFailure(error: ProviderAuth.Error) {
+  if (isProviderAuthBadRequest(error)) {
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 400 }))
+  }
+  return Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
+      { status: 500 },
+    ),
+  )
+}
+
+export const providerHandlers = HttpApiBuilder.group(ProviderApi, "provider", (handlers) =>
+  handlers
+    .handle("list", () =>
+      listProviders().pipe(
+        Effect.map((providers) => HttpServerResponse.jsonUnsafe(providers)),
+      ),
+    )
+    .handle("auth", () =>
+      getAuthMethods().pipe(
+        Effect.map((methods) => HttpServerResponse.jsonUnsafe(methods)),
+      ),
+    )
+    .handleRaw("authorize", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, ProviderAuth.AuthorizeInput)
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        const result = yield* authorizeProvider({
+          providerID: ctx.params.providerID,
+          method: payload.method,
+          inputs: payload.inputs,
+        }).pipe(Effect.catch(providerAuthFailure))
+        if (HttpServerResponse.isHttpServerResponse(result)) return result
+        return HttpServerResponse.jsonUnsafe(result)
+      }),
+    )
+    .handleRaw("callback", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, ProviderAuth.CallbackInput)
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        const result = yield* completeProviderAuth({
+          providerID: ctx.params.providerID,
+          method: payload.method,
+          code: payload.code,
+        }).pipe(
+          Effect.as(true),
+          Effect.catch(providerAuthFailure),
+        )
+        if (HttpServerResponse.isHttpServerResponse(result)) return result
+        return HttpServerResponse.jsonUnsafe(result)
+      }),
+    )
+    .handleRaw("recent", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, RecentModelInput)
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        yield* recordRecentModel(payload)
+        return HttpServerResponse.jsonUnsafe(true)
+      }),
+    ),
+)

--- a/packages/opencode/test/server/provider-routes.test.ts
+++ b/packages/opencode/test/server/provider-routes.test.ts
@@ -1,19 +1,192 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import fs from "fs/promises"
+import { Global } from "@opencode-ai/core/global"
 import { Hono } from "hono"
 import path from "path"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, HttpApiTest, OpenApi } from "effect/unstable/httpapi"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { ProviderRoutes } from "../../src/server/instance/provider"
+import { ProviderApi } from "../../src/server/routes/instance/httpapi/groups/provider"
+import { providerHandlers } from "../../src/server/routes/instance/httpapi/handlers/provider"
 import { tmpdir } from "../fixture/fixture"
+
+const modelFile = () => path.join(Global.Path.state, "model.json")
 
 afterEach(async () => {
   await Instance.disposeAll()
+  await fs.rm(modelFile(), { force: true })
 })
 
 describe("provider routes", () => {
   function app() {
     return new Hono().route("/provider", ProviderRoutes())
   }
+
+  type ProviderClient = {
+    provider: {
+      list: (input?: { query?: { directory?: string; workspace?: string } }) => Effect.Effect<
+        { all: ReadonlyArray<unknown>; default: Readonly<Record<string, string>>; connected: ReadonlyArray<string> },
+        unknown,
+        unknown
+      >
+      auth: (input?: { query?: { directory?: string; workspace?: string } }) => Effect.Effect<
+        Record<string, ReadonlyArray<{ label: string }>>,
+        unknown,
+        unknown
+      >
+      authorize: (input: {
+        params: { providerID: string }
+        query?: { directory?: string; workspace?: string }
+        payload: { method: number; inputs?: Record<string, string> }
+      }) => Effect.Effect<{ url: string; method: "auto" | "code"; instructions: string } | undefined, unknown, unknown>
+      callback: (input: {
+        params: { providerID: string }
+        query?: { directory?: string; workspace?: string }
+        payload: { method: number; code?: string }
+      }) => Effect.Effect<boolean, unknown, unknown>
+      recent: (input: {
+        query?: { directory?: string; workspace?: string }
+        payload: { providerID: string; modelID: string }
+      }) => Effect.Effect<boolean, unknown, unknown>
+    }
+  }
+
+  function withProviderClient<A>(fn: (client: ProviderClient) => Effect.Effect<A, unknown, unknown>) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const client = yield* HttpApiTest.groups(ProviderApi, ["provider"])
+          return yield* fn(client as unknown as ProviderClient)
+        }).pipe(
+          Effect.provide(providerHandlers),
+          Effect.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+        ),
+      ) as Effect.Effect<A>,
+    )
+  }
+
+  function requestProviderHttpApi(pathname: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(ProviderApi).pipe(
+              Layer.provide(providerHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${pathname}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  async function writeRouteAuthPlugin(dir: string) {
+    const pluginDir = path.join(dir, ".opencode", "plugin")
+    await fs.mkdir(pluginDir, { recursive: true })
+    await Bun.write(
+      path.join(pluginDir, "route-auth.ts"),
+      [
+        "export default {",
+        '  id: "test.route-auth",',
+        "  server: async () => ({",
+        "    auth: {",
+        '      provider: "route-auth",',
+        "      methods: [",
+        "        {",
+        '          type: "oauth",',
+        '          label: "Route OAuth",',
+        "          authorize: async () => ({",
+        '            url: "https://example.com/oauth",',
+        '            method: "code",',
+        '            instructions: "Enter code",',
+        "            callback: async (code) =>",
+        "              code === 'ok'",
+        "                ? { type: 'success', key: 'route-key' }",
+        "                : { type: 'failure' },",
+        "          }),",
+        "        },",
+        "      ],",
+        "    },",
+        "  }),",
+        "}",
+        "",
+      ].join("\n"),
+    )
+  }
+
+  test("declares the provider route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(ProviderApi) as any
+
+    expect(spec.paths).toHaveProperty("/provider")
+    expect(spec.paths).toHaveProperty("/provider/auth")
+    expect(spec.paths).toHaveProperty("/provider/{providerID}/oauth/authorize")
+    expect(spec.paths).toHaveProperty("/provider/{providerID}/oauth/callback")
+    expect(spec.paths).toHaveProperty("/provider/recent")
+    expect(spec.paths["/provider"]).toHaveProperty("get")
+    expect(spec.paths["/provider/auth"]).toHaveProperty("get")
+    expect(spec.paths["/provider/{providerID}/oauth/authorize"]).toHaveProperty("post")
+    expect(spec.paths["/provider/{providerID}/oauth/callback"]).toHaveProperty("post")
+    expect(spec.paths["/provider/recent"]).toHaveProperty("post")
+
+    expect(spec.paths["/provider/{providerID}/oauth/authorize"]?.post?.parameters).toContainEqual({
+      name: "providerID",
+      in: "path",
+      required: true,
+      schema: { type: "string" },
+    })
+    expect(spec.paths["/provider/{providerID}/oauth/authorize"]?.post?.requestBody).toMatchObject({
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["method"],
+            properties: {
+              method: expect.any(Object),
+              inputs: expect.any(Object),
+            },
+          },
+        },
+      },
+    })
+    expect(spec.paths["/provider/{providerID}/oauth/callback"]?.post?.requestBody).toMatchObject({
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["method"],
+            properties: {
+              method: expect.any(Object),
+              code: expect.any(Object),
+            },
+          },
+        },
+      },
+    })
+    expect(spec.paths["/provider/recent"]?.post?.requestBody).toMatchObject({
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["providerID", "modelID"],
+            properties: {
+              providerID: { type: "string" },
+              modelID: { type: "string" },
+            },
+          },
+        },
+      },
+    })
+  })
 
   test("lists providers through the route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
@@ -34,39 +207,7 @@ describe("provider routes", () => {
   test("runs provider auth routes through the route runtime", async () => {
     await using tmp = await tmpdir({
       git: true,
-      init: async (dir) => {
-        const pluginDir = path.join(dir, ".opencode", "plugin")
-        await fs.mkdir(pluginDir, { recursive: true })
-        await Bun.write(
-          path.join(pluginDir, "route-auth.ts"),
-          [
-            "export default {",
-            '  id: "test.route-auth",',
-            "  server: async () => ({",
-            "    auth: {",
-            '      provider: "route-auth",',
-            "      methods: [",
-            "        {",
-            '          type: "oauth",',
-            '          label: "Route OAuth",',
-            "          authorize: async () => ({",
-            '            url: "https://example.com/oauth",',
-            '            method: "code",',
-            '            instructions: "Enter code",',
-            "            callback: async (code) =>",
-            "              code === 'ok'",
-            "                ? { type: 'success', key: 'route-key' }",
-            "                : { type: 'failure' },",
-            "          }),",
-            "        },",
-            "      ],",
-            "    },",
-            "  }),",
-            "}",
-            "",
-          ].join("\n"),
-        )
-      },
+      init: writeRouteAuthPlugin,
     })
     await Instance.provide({
       directory: tmp.path,
@@ -92,6 +233,70 @@ describe("provider routes", () => {
         expect(authorizeBody.url).toBe("https://example.com/oauth")
         expect(callback.status).toBe(200)
         expect(callbackBody).toBe(true)
+      },
+    })
+  }, 30000)
+
+  test("serves provider list, auth, oauth, and recent through the HttpApi handlers", async () => {
+    await fs.mkdir(Global.Path.state, { recursive: true })
+    await using tmp = await tmpdir({ git: true, init: writeRouteAuthPlugin })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await withProviderClient((client) =>
+          Effect.gen(function* () {
+            const providers = yield* client.provider.list({ query: {} })
+            expect(providers.all).toBeArray()
+            expect(providers.default).toBeObject()
+            expect(providers.connected).toBeArray()
+
+            const methods = yield* client.provider.auth({ query: {} })
+            expect(methods["route-auth"][0].label).toBe("Route OAuth")
+
+            const authorization = yield* client.provider.authorize({
+              params: { providerID: "route-auth" },
+              query: {},
+              payload: { method: 0 },
+            })
+            expect(authorization?.url).toBe("https://example.com/oauth")
+
+            expect(
+              yield* client.provider.callback({
+                params: { providerID: "route-auth" },
+                query: {},
+                payload: { method: 0, code: "ok" },
+              }),
+            ).toBe(true)
+
+            expect(
+              yield* client.provider.recent({
+                query: {},
+                payload: { providerID: "deepseek", modelID: "deepseek-chat" },
+              }),
+            ).toBe(true)
+          }),
+        )
+
+        const recent = JSON.parse(await fs.readFile(modelFile(), "utf-8")).recent
+        expect(recent[0]).toEqual({ providerID: "deepseek", modelID: "deepseek-chat" })
+      },
+    })
+  }, 30000)
+
+  test("maps provider auth failures to 400 through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true, init: writeRouteAuthPlugin })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestProviderHttpApi("/provider/route-auth/oauth/callback", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ method: 0, code: "ok" }),
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body.name).toBe("ProviderAuthOauthMissing")
       },
     })
   }, 30000)

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -54,6 +54,18 @@ describe("route inventory harness", () => {
   test("tracks local HttpApi migration coverage separately from upstream parity", async () => {
     const inventory = await buildRouteInventory({ root, requireUpstream: false })
 
+    for (const [method, routePath] of [
+      ["GET", "/provider"],
+      ["GET", "/provider/auth"],
+      ["POST", "/provider/:providerID/oauth/authorize"],
+      ["POST", "/provider/:providerID/oauth/callback"],
+      ["POST", "/provider/recent"],
+    ] as const) {
+      expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
+        hono: true,
+        localHttpApi: true,
+      })
+    }
     expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/config")).toMatchObject({
       hono: true,
       openapi: true,


### PR DESCRIPTION
## Summary

Add a local provider HttpApi trial slice for the provider route group:

- declare HttpApi endpoints for provider list, auth, OAuth authorize/callback, and recent model recording
- extract shared provider route actions so Hono and HttpApi handlers use the same Effect boundaries
- add handler coverage for provider list/auth/OAuth/recent behavior and route inventory coverage for the five provider routes

## Why

This is the second Hono to Effect HttpApi vertical slice after the config scaffolding. It keeps production Hono routing intact while making the provider group available in local HttpApi parity coverage.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the provider HttpApi handlers preserve Hono response shapes, OAuth error status mapping, and `ModelState.recordRecent` behavior without switching production routing.

## Risk Notes

This is a parity/scaffolding slice only; production server routing remains Hono. Fresh-eye and Claude found no P0/P1. Non-blocking residuals: the provider HttpApi error schemas are still trial/OpenAPI declarations and inherit the existing Hono 400 schema mismatch for runtime validation and OAuth NamedError bodies; full invalid-body matrix coverage can be tightened before HttpApi is wired as production routing. Skipped conditional checklist items: no visible UI or copy changed, no platform/packaging surface changed, and no docs/release/dependency/permission/generated surfaces changed.

## How To Verify

```text
Install: bun install --frozen-lockfile completed in the new worktree.
Baseline focused tests: 34 passed before changes across provider-routes, provider-recent-route, config-routes, and route-inventory-harness.
Initial focused tests: 37 passed after changes across provider-routes, provider-recent-route, config-routes, and route-inventory-harness.
Initial route inventory probe: localHttpApi count is 8; GET /provider, GET /provider/auth, POST /provider/:providerID/oauth/authorize, POST /provider/:providerID/oauth/callback, and POST /provider/recent all report localHttpApi=true; /provider/recent remains hono-v2-sdk and upstreamHttpApi=false.
Initial typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode.
Initial diff check: git diff --check passed.
Rebase: cleanly rebased onto origin/dev 6310080ec400ee83ed62cd61960a8a337c38a35a after PR #1370 merged.
Post-rebase focused tests: 37 passed across provider-routes, provider-recent-route, config-routes, and route-inventory-harness.
Post-rebase route inventory probe: after fetching opencode/dev, localHttpApi count is 8 and the same five provider routes report localHttpApi=true; /provider/recent remains hono-v2-sdk and upstreamHttpApi=false.
Post-rebase typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode.
Post-rebase diff check: git diff --check origin/dev...HEAD passed.
Fresh-eye review: no P0/P1; P2/P3 recorded in Risk Notes as non-blocking residuals.
Claude read-only review: no P0/P1; P2/P3 recorded in Risk Notes as non-blocking residuals.
```

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
