### PR TITLE
fix(opencode): enrich edit and write success output with path and line counts

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -197,12 +197,7 @@ export const EditTool = Tool.define(
           }),
         )
 
-        let additions = 0
-        let deletions = 0
-        for (const change of diffLines(contentOld, contentNew)) {
-          if (change.added) additions += change.count || 0
-          if (change.removed) deletions += change.count || 0
-        }
+        const { additions, deletions } = countLineChanges(contentOld, contentNew)
         const sensitive = isSensitiveTargetPath(filePath, Instance.worktree)
         const status = existedBefore ? "modified" : "added"
         const filediff: Snapshot.FileDiff = sensitive
@@ -682,6 +677,16 @@ export const ContextAwareReplacer: Replacer = function* (content, find) {
       }
     }
   }
+}
+
+export function countLineChanges(oldContent: string, newContent: string): { additions: number; deletions: number } {
+  let additions = 0
+  let deletions = 0
+  for (const change of diffLines(oldContent, newContent)) {
+    if (change.added) additions += change.count || 0
+    if (change.removed) deletions += change.count || 0
+  }
+  return { additions, deletions }
 }
 
 export function trimDiff(diff: string): string {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -230,7 +230,9 @@ export const EditTool = Tool.define(
           after: { exists: true, content: contentNew, bom: afterBom },
         })
 
-        let output = "Edit applied successfully."
+        let output = existedBefore
+          ? `Edited ${relativeFilePath} (+${additions} -${deletions} lines).`
+          : `Created ${relativeFilePath} (+${additions} lines).`
         yield* lsp.touchFile(filePath, true)
         const diagnostics = sensitive ? {} : yield* lsp.diagnostics()
         const normalizedFilePath = AppFileSystem.normalizePath(filePath)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { Effect } from "effect"
 import * as Tool from "./tool"
 import { LSP } from "../lsp"
-import { createTwoFilesPatch } from "diff"
+import { createTwoFilesPatch, diffLines } from "diff"
 import DESCRIPTION from "./write.txt"
 import { Bus } from "../bus"
 import { File } from "../file"
@@ -59,6 +59,12 @@ export const WriteTool = Tool.define(
 
         let diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, contentNew))
         const relativeFilepath = path.relative(Instance.worktree, filepath)
+        let additions = 0
+        let deletions = 0
+        for (const change of diffLines(contentOld, contentNew)) {
+          if (change.added) additions += change.count || 0
+          if (change.removed) deletions += change.count || 0
+        }
         const sensitive = isSensitiveTargetPath(filepath, Instance.worktree)
         const status = exists ? "modified" : "added"
         yield* ctx.ask({
@@ -88,7 +94,9 @@ export const WriteTool = Tool.define(
           event: exists ? "change" : "add",
         })
 
-        let output = "Wrote file successfully."
+        let output = exists
+          ? `Wrote ${relativeFilepath} (+${additions} -${deletions} lines).`
+          : `Created ${relativeFilepath} (+${additions} lines).`
         yield* lsp.touchFile(filepath, true)
         const diagnostics = sensitive ? {} : yield* lsp.diagnostics()
         const normalizedFilepath = AppFileSystem.normalizePath(filepath)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -3,14 +3,14 @@ import * as path from "path"
 import { Effect } from "effect"
 import * as Tool from "./tool"
 import { LSP } from "../lsp"
-import { createTwoFilesPatch, diffLines } from "diff"
+import { createTwoFilesPatch } from "diff"
 import DESCRIPTION from "./write.txt"
 import { Bus } from "../bus"
 import { File } from "../file"
 import { FileWatcher } from "../file/watcher"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Instance } from "../project/instance"
-import { trimDiff } from "./edit"
+import { trimDiff, countLineChanges } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import * as Bom from "@/util/bom"
 import { isSensitiveTargetPath, safeFilepathMetadata } from "./sensitive"
@@ -59,12 +59,7 @@ export const WriteTool = Tool.define(
 
         let diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, contentNew))
         const relativeFilepath = path.relative(Instance.worktree, filepath)
-        let additions = 0
-        let deletions = 0
-        for (const change of diffLines(contentOld, contentNew)) {
-          if (change.added) additions += change.count || 0
-          if (change.removed) deletions += change.count || 0
-        }
+        const { additions, deletions } = countLineChanges(contentOld, contentNew)
         const sensitive = isSensitiveTargetPath(filepath, Instance.worktree)
         const status = exists ? "modified" : "added"
         yield* ctx.ask({

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -184,7 +184,7 @@ describe("tool.edit", () => {
             newString: "new content",
           })
 
-          expect(result.output).toContain("Edit applied successfully")
+          expect(result.output).toMatch(/^Edited .+ \(\+\d+ -\d+ lines\)\.$/)
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("new content here")
@@ -204,7 +204,7 @@ describe("tool.edit", () => {
             newString: "new content",
           })
 
-          expect(result.output).toContain("Edit applied successfully")
+          expect(result.output).toMatch(/^Edited .+ \(\+\d+ -\d+ lines\)\.$/)
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("new content here")

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -125,6 +125,7 @@ describe("tool.edit", () => {
           })
 
           expect(result.metadata.diff).toContain("new content")
+          expect(result.output).toContain("newfile.txt (+1 lines).")
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("new content")
@@ -184,7 +185,7 @@ describe("tool.edit", () => {
             newString: "new content",
           })
 
-          expect(result.output).toMatch(/^Edited .+ \(\+\d+ -\d+ lines\)\.$/)
+          expect(result.output).toContain("existing-no-read.txt (+1 -1 lines).")
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("new content here")
@@ -204,7 +205,7 @@ describe("tool.edit", () => {
             newString: "new content",
           })
 
-          expect(result.output).toMatch(/^Edited .+ \(\+\d+ -\d+ lines\)\.$/)
+          expect(result.output).toContain("existing.txt (+1 -1 lines).")
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("new content here")
@@ -612,11 +613,13 @@ describe("tool.edit", () => {
           const filepath = path.join(dir, "file.txt")
           yield* Effect.promise(() => fs.writeFile(filepath, "line1\nline2\nline3", "utf-8"))
 
-          yield* run({
+          const result = yield* run({
             filePath: filepath,
             oldString: "line2",
             newString: "new line 2\nextra line",
           })
+
+          expect(result.output).toContain("file.txt (+2 -1 lines).")
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
           expect(content).toBe("line1\nnew line 2\nextra line\nline3")

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -78,7 +78,7 @@ describe("tool.write", () => {
           const filepath = path.join(dir, "newfile.txt")
           const result = yield* run({ filePath: filepath, content: "Hello, World!" })
 
-          expect(result.output).toContain("Wrote file successfully")
+          expect(result.output).toMatch(/^Created .+ \(\+\d+ lines\)\.$/)
           expect(result.metadata.exists).toBe(false)
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
@@ -120,7 +120,7 @@ describe("tool.write", () => {
 
           const result = yield* run({ filePath: filepath, content: "new content" })
 
-          expect(result.output).toContain("Wrote file successfully")
+          expect(result.output).toMatch(/^Wrote .+ \(\+\d+ -\d+ lines\)\.$/)
           expect(result.metadata.exists).toBe(true)
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
@@ -137,7 +137,7 @@ describe("tool.write", () => {
 
           const result = yield* run({ filePath: filepath, content: "new content" })
 
-          expect(result.output).toContain("Wrote file successfully")
+          expect(result.output).toMatch(/^Wrote .+ \(\+\d+ -\d+ lines\)\.$/)
           expect(result.metadata.exists).toBe(true)
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -78,7 +78,7 @@ describe("tool.write", () => {
           const filepath = path.join(dir, "newfile.txt")
           const result = yield* run({ filePath: filepath, content: "Hello, World!" })
 
-          expect(result.output).toMatch(/^Created .+ \(\+\d+ lines\)\.$/)
+          expect(result.output).toContain("newfile.txt (+1 lines).")
           expect(result.metadata.exists).toBe(false)
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
@@ -120,7 +120,7 @@ describe("tool.write", () => {
 
           const result = yield* run({ filePath: filepath, content: "new content" })
 
-          expect(result.output).toMatch(/^Wrote .+ \(\+\d+ -\d+ lines\)\.$/)
+          expect(result.output).toContain("existing-no-read.txt (+1 -1 lines).")
           expect(result.metadata.exists).toBe(true)
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
@@ -137,7 +137,7 @@ describe("tool.write", () => {
 
           const result = yield* run({ filePath: filepath, content: "new content" })
 
-          expect(result.output).toMatch(/^Wrote .+ \(\+\d+ -\d+ lines\)\.$/)
+          expect(result.output).toContain("existing.txt (+1 -1 lines).")
           expect(result.metadata.exists).toBe(true)
 
           const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))


### PR DESCRIPTION
## Summary

- Enrich the model-visible success output of the `edit` and `write` tools to include the relative file path and `+N -M` line counts, replacing the fixed 3-word confirmation that caused weak models to repeat edits.
- `edit`: `Edited {path} (+N -M lines).` / `Created {path} (+N lines).`
- `write`: `Wrote {path} (+N -M lines).` / `Created {path} (+N lines).`
- `apply_patch` is intentionally unchanged — it already returns a Codex-style `A`/`M`/`D` file list.

## Root cause

`edit` and `write` returned `"Edit applied successfully."` / `"Wrote file successfully."` as `state.output`. Rich metadata (diff, additions/deletions, diagnostics) was computed and stored in `result.metadata`, but `message-v2.ts` only serializes `state.output` + `state.input` into model context — `metadata` never reaches the model. After a successful edit the model saw only its own input echoed back plus 3 words, with no indication of what landed where. Weak models (glm-5.2 class) could not tell whether an edit had landed, and repeated edits to the same file produced duplicate content.

## Change boundary

- `packages/opencode/src/tool/edit.ts` — output construction (~3 lines)
- `packages/opencode/src/tool/write.ts` — add `diffLines` import + additions/deletions calculation (mirrors edit.ts:200-205) + output construction
- `packages/opencode/test/tool/edit.test.ts` — 2 assertions updated to regex match new format
- `packages/opencode/test/tool/write.test.ts` — 3 assertions updated to regex match new format

## Design rationale

Researched 6 industry tools (Pi, Codex CLI, Claude Code, Gemini CLI, Cline, Aider) and consulted Codex + Claude for second opinions. Key findings that shaped this:

1. **Path is industry consensus** — Pi/Codex/Claude Code/Gemini/Cline all include it; PawWork was the only one that didn't.
2. **`+N -M` line counts** use git `--stat` vocabulary that models see constantly in training — zero learning cost, and each edit produces a distinct fingerprint the model can match against its own `newString`.
3. **`Created` vs `Edited`/`Wrote`** uses the existing `existedBefore`/`exists` flag — accurate semantics for new files at near-zero cost.
4. **Did not use a convergence hint** (e.g. Claude Code's "no need to re-read") — the real bug is repeated *Edit*, not repeated *Read*; a convergence hint targets the wrong failure mode. Line counts give a verifiable magnitude fingerprint instead.

Sensitive files: `sanitizeSensitiveToolPart` only scrubs output on the share/export path, not the model-context path. The model already knows the path and change from its own input, so surfacing path + line counts in `output` is not a new leak.

## Verification

- `bun test test/tool/edit.test.ts test/tool/write.test.ts` — 51 pass, 0 fail
- `tsc --noEmit` — no new errors in changed files (pre-existing errors in unrelated files unchanged)

Closes #1368