### PR TITLE
refactor(opencode): effectify config dependency installs

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -282,7 +282,7 @@ Some already-effectified areas still use raw `Filesystem.*` or `Process.spawn` i
 ### `Filesystem.*` → `AppFileSystem.Service` (yield in layer)
 
 - [ ] `file/index.ts` — 1 remaining `Filesystem.readText()` call in untracked diff handling
-- [ ] `config/config.ts` — 5 remaining `Filesystem.*` calls in `installDependencies()`
+- [x] `config/config.ts` — `installDependencies()` now lives on `Config.Service`, uses `AppFileSystem.Service` and `EffectFlock`, and the async facade delegates through `runPromise`
 - [ ] `provider/provider.ts` — 1 remaining `Filesystem.readJson()` call for recent model state
 
 ### `Process.spawn` → `ChildProcessSpawner` (yield in layer)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1179,10 +1179,10 @@ const rawLayer = Layer.effect(
           Effect.gen(function* () {
             const pkg = path.join(dir, "package.json")
             const target = configPluginDependencyTarget()
-            const json: Package = yield* fs.readFileString(pkg).pipe(
+            const parsed = yield* fs.readFileString(pkg).pipe(
               Effect.flatMap((text) =>
                 Effect.try({
-                  try: () => JSON.parse(text) as Package,
+                  try: () => JSON.parse(text) as unknown,
                   catch: () => undefined,
                 }),
               ),
@@ -1192,6 +1192,10 @@ const rawLayer = Layer.effect(
                 } satisfies Package),
               ),
             )
+            const json: Package =
+              parsed && typeof parsed === "object" && !Array.isArray(parsed)
+                ? (parsed as Package)
+                : ({ dependencies: {} } satisfies Package)
             const dependencies = json.dependencies ?? {}
             const required = {
               ...dependencies,
@@ -1235,7 +1239,14 @@ const rawLayer = Layer.effect(
           }),
           key,
         )
-        .pipe(Effect.orDie)
+        .pipe(
+          Effect.catch((error) =>
+            Effect.sync(() => {
+              log.warn("dependency install failed", { dir, error: String(error) })
+              return false
+            }),
+          ),
+        )
     })
 
     const update = Effect.fn("Config.update")(function* (config: Info) {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -14,7 +14,7 @@ import { Auth } from "../auth"
 import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
 import { Instance, type InstanceContext } from "../project/instance"
-import { constants, existsSync, statSync } from "fs"
+import { existsSync, statSync } from "fs"
 import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
 import { Account } from "@/account"
@@ -109,15 +109,6 @@ function shouldGenerateInDirectory(dir: string) {
 
 type Package = {
   dependencies?: Record<string, string>
-}
-
-async function isWritable(dir: string) {
-  try {
-    await fsNode.access(dir, constants.W_OK)
-    return true
-  } catch {
-    return false
-  }
 }
 
 function configPluginDependencyTarget() {
@@ -390,6 +381,7 @@ export interface Interface {
   readonly invalidate: (wait?: boolean) => Effect.Effect<void>
   readonly directories: () => Effect.Effect<string[]>
   readonly waitForDependencies: () => Effect.Effect<void>
+  readonly installDependencies: (dir: string) => Effect.Effect<boolean>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Config") {}
@@ -731,6 +723,7 @@ const rawLayer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* AppFileSystem.Service
+    const flock = yield* EffectFlock.Service
     const authSvc = yield* Auth.Service
     const accountSvc = yield* Account.Service
     const env = yield* Env.Service
@@ -988,13 +981,15 @@ const rawLayer = Layer.effect(
           if (shouldGenerateInDirectory(dir)) {
             yield* ensureGitignore(dir).pipe(Effect.orDie)
 
-            const dep = yield* Effect.promise(async () => {
-              try {
-                await installDependencies(dir)
-              } catch (error) {
-                log.warn("background dependency install failed", { dir, error: String(error) })
-              }
-            }).pipe(Effect.forkDetach)
+            const dep = yield* installDependencies(dir).pipe(
+              Effect.asVoid,
+              Effect.catchDefect((defect) =>
+                Effect.sync(() => {
+                  log.warn("background dependency install failed", { dir, error: String(defect) })
+                }),
+              ),
+              Effect.forkDetach,
+            )
             deps.push(dep)
           }
 
@@ -1168,6 +1163,81 @@ const rawLayer = Layer.effect(
       )
     })
 
+    const installDependencies: Interface["installDependencies"] = Effect.fn("Config.installDependencies")(function* (
+      dir,
+    ) {
+      const canWrite = yield* fs.access(dir, { writable: true }).pipe(
+        Effect.as(true),
+        Effect.orElseSucceed(() => false),
+      )
+      if (!canWrite) return false
+
+      const key = process.platform === "win32" ? "config-install:win32" : `config-install:${AppFileSystem.resolve(dir)}`
+
+      return yield* flock
+        .withLock(
+          Effect.gen(function* () {
+            const pkg = path.join(dir, "package.json")
+            const target = configPluginDependencyTarget()
+            const json: Package = yield* fs.readFileString(pkg).pipe(
+              Effect.flatMap((text) =>
+                Effect.try({
+                  try: () => JSON.parse(text) as Package,
+                  catch: () => undefined,
+                }),
+              ),
+              Effect.catch(() =>
+                Effect.succeed({
+                  dependencies: {},
+                } satisfies Package),
+              ),
+            )
+            const dependencies = json.dependencies ?? {}
+            const required = {
+              ...dependencies,
+              "@opencode-ai/plugin": target,
+            }
+            const hasDep = dependencies["@opencode-ai/plugin"] === target
+            json.dependencies = required
+
+            const gitignore = path.join(dir, ".gitignore")
+            const ignore = yield* fs.existsSafe(gitignore)
+            const installed = yield* Effect.all(
+              Object.keys(required).map((pkg) =>
+                fs.existsSafe(path.join(dir, "node_modules", ...pkg.split("/"), "package.json")),
+              ),
+              { concurrency: "unbounded" },
+            )
+
+            if (!hasDep) {
+              yield* fs.writeJson(pkg, json)
+            }
+            if (!ignore) {
+              yield* fs.writeFileString(
+                gitignore,
+                ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
+              )
+            }
+            if (hasDep && ignore && installed.every(Boolean)) return true
+            const installedDependencies = yield* Effect.tryPromise({
+              try: () => Npm.install(dir),
+              catch: (error) => error,
+            }).pipe(
+              Effect.as(true),
+              Effect.catch((error) =>
+                Effect.sync(() => {
+                  log.warn("dependency install failed", { dir, error: String(error) })
+                  return false
+                }),
+              ),
+            )
+            return installedDependencies
+          }),
+          key,
+        )
+        .pipe(Effect.orDie)
+    })
+
     const update = Effect.fn("Config.update")(function* (config: Info) {
       const dir = yield* InstanceState.directory
       const file = projectConfigFile(dir)
@@ -1293,6 +1363,7 @@ const rawLayer = Layer.effect(
       invalidate,
       directories,
       waitForDependencies,
+      installDependencies,
     })
   }),
 )
@@ -1345,50 +1416,7 @@ export async function waitForDependencies() {
 }
 
 export async function installDependencies(dir: string) {
-  if (!(await isWritable(dir))) return false
-  const key = process.platform === "win32" ? "config-install:win32" : `config-install:${Filesystem.resolve(dir)}`
-  await using _ = await Flock.acquire(key)
-
-  const pkg = path.join(dir, "package.json")
-  const target = configPluginDependencyTarget()
-  const json = await Filesystem.readJson<Package>(pkg).catch(
-    (): Package => ({
-      dependencies: {},
-    }),
-  )
-  const dependencies = json.dependencies ?? {}
-  const required = {
-    ...dependencies,
-    "@opencode-ai/plugin": target,
-  }
-  const hasDep = dependencies["@opencode-ai/plugin"] === target
-  json.dependencies = required
-
-  const gitignore = path.join(dir, ".gitignore")
-  const ignore = await Filesystem.exists(gitignore)
-  const installed = await Promise.all(
-    Object.keys(required).map((pkg) =>
-      Filesystem.exists(path.join(dir, "node_modules", ...pkg.split("/"), "package.json")),
-    ),
-  )
-
-  if (!hasDep) {
-    await Filesystem.writeJson(pkg, json)
-  }
-  if (!ignore) {
-    await Filesystem.write(
-      gitignore,
-      ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
-    )
-  }
-  if (hasDep && ignore && installed.every(Boolean)) return true
-  try {
-    await Npm.install(dir)
-    return true
-  } catch (error) {
-    log.warn("dependency install failed", { dir, error: String(error) })
-    return false
-  }
+  return runPromise((svc) => svc.installDependencies(dir))
 }
 
 const ConfigInfo = Info

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -274,17 +274,17 @@ export namespace ToolRegistry {
               const needsDeps = yield* Effect.promise(() => needsConfigDependencies(match, configDir))
               yield* config.waitForDependencies()
               if (needsDeps) {
-                const installed = yield* Effect.promise(async () => {
-                  try {
-                    return await Config.installDependencies(configDir)
-                  } catch (error) {
-                    log.warn("failed to install config dependencies for local tool", {
-                      dir: configDir,
-                      error: String(error),
-                    })
-                    return false
-                  }
-                })
+                const installed = yield* config.installDependencies(configDir).pipe(
+                  Effect.catchDefect((defect) =>
+                    Effect.sync(() => {
+                      log.warn("failed to install config dependencies for local tool", {
+                        dir: configDir,
+                        error: String(defect),
+                      })
+                      return false
+                    }),
+                  ),
+                )
                 if (!installed) {
                   depsFailed.add(configDir)
                   continue

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -13,6 +13,7 @@ import { Auth } from "../../src/auth"
 import { Account } from "../../src/account"
 import { AccessToken, AccountID, OrgID } from "../../src/account/schema"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { tmpdir } from "../fixture/fixture"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
@@ -47,6 +48,7 @@ const emptyAuth = Layer.mock(Auth.Service)({
 })
 
 const layer = Config.layer.pipe(
+  Layer.provide(EffectFlock.defaultLayer),
   Layer.provide(AppFileSystem.defaultLayer),
   Layer.provide(emptyAuth),
   Layer.provide(emptyAccount),
@@ -64,6 +66,8 @@ const listDirs = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.directories()).pipe(Effect.scoped, Effect.provide(layer)))
 const ready = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.waitForDependencies()).pipe(Effect.scoped, Effect.provide(layer)))
+const installDeps = (dir: string) =>
+  Effect.runPromise(Config.Service.use((svc) => svc.installDependencies(dir)).pipe(Effect.scoped, Effect.provide(layer)))
 
 async function withPawWorkRuntime(fn: () => Promise<void>) {
   const previous = process.env.PAWWORK_RUNTIME_NAMESPACE
@@ -743,6 +747,7 @@ test("resolves env templates in account config with account token", async () => 
   })
 
   const layer = Config.layer.pipe(
+    Layer.provide(EffectFlock.defaultLayer),
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(emptyAuth),
     Layer.provide(fakeAccount),
@@ -1442,6 +1447,7 @@ it.live(
     const install = spyOn(Npm, "install").mockResolvedValue(undefined)
 
     const testLayer = Config.layer.pipe(
+      Layer.provide(EffectFlock.defaultLayer),
       Layer.provide(AppFileSystem.defaultLayer),
       Layer.provide(emptyAuth),
       Layer.provide(emptyAccount),
@@ -1499,6 +1505,55 @@ test("installDependencies bootstraps the config plugin package metadata", async 
     expect(pkg.dependencies?.["@opencode-ai/plugin"]).toBe(target)
     expect(await Filesystem.readText(path.join(tmp.path, ".gitignore"))).toContain("package-lock.json")
     expect(install).toHaveBeenCalledWith(tmp.path)
+  } finally {
+    install.mockRestore()
+  }
+})
+
+test("service installDependencies bootstraps the config plugin package metadata", async () => {
+  await using tmp = await tmpdir()
+  const install = spyOn(Npm, "install").mockResolvedValue(undefined)
+
+  try {
+    await installDeps(tmp.path)
+
+    const pkg = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(path.join(tmp.path, "package.json"))
+    const target = Installation.isLocal() ? "*" : Installation.VERSION
+
+    expect(pkg.dependencies?.["@opencode-ai/plugin"]).toBe(target)
+    expect(await Filesystem.readText(path.join(tmp.path, ".gitignore"))).toContain("package-lock.json")
+    expect(install).toHaveBeenCalledWith(tmp.path)
+  } finally {
+    install.mockRestore()
+  }
+})
+
+test("service installDependencies treats malformed package metadata as missing", async () => {
+  await using tmp = await tmpdir()
+  await Filesystem.write(path.join(tmp.path, "package.json"), "{")
+  const install = spyOn(Npm, "install").mockResolvedValue(undefined)
+
+  try {
+    await installDeps(tmp.path)
+
+    const pkg = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(path.join(tmp.path, "package.json"))
+    const target = Installation.isLocal() ? "*" : Installation.VERSION
+
+    expect(pkg.dependencies?.["@opencode-ai/plugin"]).toBe(target)
+    expect(install).toHaveBeenCalledWith(tmp.path)
+  } finally {
+    install.mockRestore()
+  }
+})
+
+test("service installDependencies returns false when dependency install fails", async () => {
+  await using tmp = await tmpdir()
+  const install = spyOn(Npm, "install").mockImplementation(async () => {
+    throw new Error("install failed")
+  })
+
+  try {
+    await expect(installDeps(tmp.path)).resolves.toBe(false)
   } finally {
     install.mockRestore()
   }
@@ -2539,6 +2594,7 @@ test("project config overrides remote well-known config", async () => {
   })
 
   const layer = Config.layer.pipe(
+    Layer.provide(EffectFlock.defaultLayer),
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(fakeAuth),
     Layer.provide(emptyAccount),
@@ -2594,6 +2650,7 @@ test("wellknown URL with trailing slash is normalized", async () => {
   })
 
   const layer = Config.layer.pipe(
+    Layer.provide(EffectFlock.defaultLayer),
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(fakeAuth),
     Layer.provide(emptyAccount),
@@ -2639,6 +2696,7 @@ test("wellknown HTML response surfaces remote auth recovery error", async () => 
   })
 
   const layer = Config.layer.pipe(
+    Layer.provide(EffectFlock.defaultLayer),
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(fakeAuth),
     Layer.provide(emptyAccount),
@@ -2686,6 +2744,7 @@ test("wellknown non-json response surfaces remote auth recovery error", async ()
   })
 
   const layer = Config.layer.pipe(
+    Layer.provide(EffectFlock.defaultLayer),
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(fakeAuth),
     Layer.provide(emptyAccount),
@@ -2727,6 +2786,7 @@ test("wellknown unauthorized response surfaces remote auth recovery error", asyn
   })
 
   const layer = Config.layer.pipe(
+    Layer.provide(EffectFlock.defaultLayer),
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(fakeAuth),
     Layer.provide(emptyAccount),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -66,8 +66,25 @@ const listDirs = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.directories()).pipe(Effect.scoped, Effect.provide(layer)))
 const ready = () =>
   Effect.runPromise(Config.Service.use((svc) => svc.waitForDependencies()).pipe(Effect.scoped, Effect.provide(layer)))
-const installDeps = (dir: string) =>
-  Effect.runPromise(Config.Service.use((svc) => svc.installDependencies(dir)).pipe(Effect.scoped, Effect.provide(layer)))
+const installDepsWithLayer = (dir: string, targetLayer = layer) =>
+  Effect.runPromise(
+    Config.Service.use((svc) => svc.installDependencies(dir)).pipe(Effect.scoped, Effect.provide(targetLayer)),
+  )
+const installDeps = (dir: string) => installDepsWithLayer(dir)
+
+const lockFailureLayer = Config.layer.pipe(
+  Layer.provide(
+    Layer.mock(EffectFlock.Service)({
+      acquire: () => Effect.fail(new EffectFlock.LockTimeoutError({ key: "config-install:test" })),
+      withLock: ((body: Effect.Effect<unknown>, key?: string) =>
+        Effect.fail(new EffectFlock.LockTimeoutError({ key: key ?? "config-install:test" }))) as never,
+    }),
+  ),
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(emptyAuth),
+  Layer.provide(emptyAccount),
+  Layer.provideMerge(infra),
+)
 
 async function withPawWorkRuntime(fn: () => Promise<void>) {
   const previous = process.env.PAWWORK_RUNTIME_NAMESPACE
@@ -1546,6 +1563,24 @@ test("service installDependencies treats malformed package metadata as missing",
   }
 })
 
+test("service installDependencies treats non-object package metadata as missing", async () => {
+  await using tmp = await tmpdir()
+  await Filesystem.write(path.join(tmp.path, "package.json"), "null")
+  const install = spyOn(Npm, "install").mockResolvedValue(undefined)
+
+  try {
+    await installDeps(tmp.path)
+
+    const pkg = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(path.join(tmp.path, "package.json"))
+    const target = Installation.isLocal() ? "*" : Installation.VERSION
+
+    expect(pkg.dependencies?.["@opencode-ai/plugin"]).toBe(target)
+    expect(install).toHaveBeenCalledWith(tmp.path)
+  } finally {
+    install.mockRestore()
+  }
+})
+
 test("service installDependencies returns false when dependency install fails", async () => {
   await using tmp = await tmpdir()
   const install = spyOn(Npm, "install").mockImplementation(async () => {
@@ -1557,6 +1592,12 @@ test("service installDependencies returns false when dependency install fails", 
   } finally {
     install.mockRestore()
   }
+})
+
+test("service installDependencies returns false when config install lock fails", async () => {
+  await using tmp = await tmpdir()
+
+  await expect(installDepsWithLayer(tmp.path, lockFailureLayer)).resolves.toBe(false)
 })
 
 test("installDependencies does not pin config plugin metadata to a packaged app build version", async () => {

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -11,6 +11,7 @@ import { ConfigPlugin } from "../../src/config/plugin"
 import { ConfigPaths } from "../../src/config/paths"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
@@ -32,6 +33,7 @@ const emptyAuth = Layer.mock(Auth.Service)({
 })
 
 const layer = Config.layer.pipe(
+  Layer.provide(EffectFlock.defaultLayer),
   Layer.provide(AppFileSystem.defaultLayer),
   Layer.provide(emptyAuth),
   Layer.provide(emptyAccount),

--- a/packages/opencode/test/server/config-routes.test.ts
+++ b/packages/opencode/test/server/config-routes.test.ts
@@ -319,6 +319,7 @@ describe("config routes", () => {
           invalidate: () => Effect.void,
           directories: () => Effect.succeed([]),
           waitForDependencies: () => Effect.void,
+          installDependencies: () => Effect.succeed(true),
         },
         provider: unusedProvider(),
       },


### PR DESCRIPTION
## Summary

Move config-scoped dependency installation onto `Config.Service.installDependencies(dir)` while keeping the existing async facade for compatibility.

## Why

The local tool registry was already inside an Effect flow, but still called the async `Config.installDependencies(...)` facade. This keeps the dependency-install boundary inside the Config service and lets Effect-native callers use the injected service directly.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please review the behavior-preserving migration around writable checks, config-install lock keys, package metadata writes, `.gitignore` creation, malformed `package.json` fallback, failed `Npm.install(...)` returning `false`, and local tool registry dependency-loading behavior.

## Risk Notes

No visible UI or copy changed, so the manual UI check item is not applicable.

Platform impact was considered: the Windows single lock key is preserved, path resolution now uses the same `AppFileSystem.resolve` implementation that `Filesystem.resolve` re-exported, and focused config/tool-registry checks plus package typecheck passed.

## How To Verify

```text
Focused config install tests: 5 passed via bun test test/config/config.test.ts -t installDependencies
Focused tool registry dependency tests: 5 passed via bun test test/tool/registry.test.ts -t "config-scoped dependencies|config dependency install|external dependencies" --timeout 30000
Diff check: git diff --check passed
Typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode
Fresh-eye review: No P0/P1 blockers; no P2/P3 findings on the final diff
Claude read-only review: No P0/P1 blockers; only optional P3 notes on preserved/pre-existing edges
Base sync: branch rebased cleanly onto origin/dev e441480174d3bc16c50d776c82049f0d6c14a32a after #1371 and #1366 merged
``` 

## Screenshots or Recordings

Not applicable. This PR has no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dependency installation now uses a coordinated service layer to prevent conflicts and improve reliability during project configuration and setup.
  * Enhanced automatic management of required plugin dependencies with improved `package.json` and `.gitignore` file handling and validation.

* **Bug Fixes**
  * Improved error reporting and warning logs when dependency installation encounters issues or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->