### PR TITLE
fix(deps): clear undici audit advisory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -113,7 +113,7 @@
         "electron-window-state": "^5.0.3",
         "marked": "^15",
         "semver": "^7.6.0",
-        "undici": "7.24.7",
+        "undici": "7.28.0",
         "ws": "8.21.0",
       },
       "devDependencies": {
@@ -2950,7 +2950,7 @@
 
     "ulid": ["ulid@3.0.1", "", { "bin": { "ulid": "dist/cli.js" } }, "sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q=="],
 
-    "undici": ["undici@7.24.7", "", {}, "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
@@ -3160,7 +3160,7 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@effect/platform-node/undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
+    "@effect/platform-node/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -39,7 +39,7 @@
     "electron-window-state": "^5.0.3",
     "marked": "^15",
     "semver": "^7.6.0",
-    "undici": "7.24.7",
+    "undici": "7.28.0",
     "ws": "8.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Updates the `undici` resolutions that are tripping the required `dev-dep-audit` workflow:

- bumps the desktop Electron direct dependency from `undici@7.24.7` to `7.28.0`
- refreshes the `@effect/platform-node` transitive lock entry from `undici@8.3.0` to `8.5.0`

There is no tracked issue. This is a narrow CI/security follow-up for the newly reported `undici` high advisories.

## Why

`dev-dep-audit` runs `bun audit --audit-level=high` on every PR targeting `dev`. The current lockfile resolves vulnerable `undici` versions in the `7.x` and `8.x` ranges, so unrelated PRs are blocked before merge.

## Related Issue

None. CI/security maintenance.

## Human Review Status

Pending

## Review Focus

Please focus on the dependency boundary: this PR should only update the vulnerable `undici` resolutions needed for `bun audit --audit-level=high` to pass.

## Risk Notes

Dependency risk: `packages/desktop-electron` uses a patch-level `undici` bump within the same major line, and `@effect/platform-node` keeps its existing `^8.2.0` dependency range while the lockfile refreshes to `8.5.0`.

Skipped conditional checklist items:

- Visible UI/copy manual check: no UI or copy changed.
- Docs/release notes/permissions/credentials/deletion/generated content/local file behavior: none of those surfaces are part of this dependency audit fix.

## How To Verify

```text
RED: bun audit --audit-level=high -> failed on undici high advisories before the dependency update
Frozen install: bun install --frozen-lockfile -> accepted the updated lockfile
Audit: bun audit --audit-level=high -> passed
Desktop typecheck: bun run typecheck in packages/desktop-electron -> tsgo -b passed
Diff check: git diff --check -> no whitespace errors
```

## Screenshots or Recordings

Not applicable: no visible UI or copy changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
