### PR TITLE
refactor(opencode): effectify provider model state writes

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -8,7 +8,7 @@ Use `InstanceState` (from `src/effect/instance-state.ts`) for services that need
 
 Use `makeRuntime` (from `src/effect/run-service.ts`) to create a per-service `ManagedRuntime` that lazily initializes and shares layers via a global `memoMap`. Returns `{ runPromise, runFork, runCallback }`.
 
-- Global services (no per-directory state): Account, Auth, AppFileSystem, Installation, Truncate, Worktree
+- Global services (no per-directory state): Account, Auth, AppFileSystem, Installation, ModelState, Truncate, Worktree
 - Instance-scoped (per-directory state via InstanceState): Agent, Bus, Command, Config, File, FileTime, FileWatcher, Format, LSP, MCP, Permission, Plugin, ProviderAuth, Pty, Question, SessionStatus, Skill, Snapshot, ToolRegistry, Vcs
 
 Rule of thumb: if two open directories should not share one copy of the service, it needs `InstanceState`.
@@ -196,6 +196,7 @@ Fully migrated (single namespace, InstanceState where needed, flattened facade):
 - [x] `LSP` — `lsp/index.ts`
 - [x] `MCP` — `mcp/index.ts`
 - [x] `McpAuth` — `mcp/auth.ts`
+- [x] `ModelState` — `provider/model-state.ts` (`recordRecent` write path; `Provider.defaultModel()` still owns the read path)
 - [x] `Permission` — `permission/index.ts`
 - [x] `Plugin` — `plugin/index.ts`
 - [x] `Project` — `project/project.ts`

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -14,6 +14,7 @@ import { FileWatcher } from "@/file/watcher"
 import { Storage } from "@/storage/storage"
 import { Snapshot } from "@/snapshot"
 import { Plugin } from "@/plugin"
+import { ModelState } from "@/provider/model-state"
 import { Provider } from "@/provider/provider"
 import { ProviderAuth } from "@/provider/auth"
 import { Agent } from "@/agent/agent"
@@ -68,6 +69,7 @@ export const AppLayer = Layer.mergeAll(
   Storage.defaultLayer,
   Snapshot.defaultLayer,
   Plugin.defaultLayer,
+  ModelState.defaultLayer,
   Provider.defaultLayer,
   ProviderAuth.defaultLayer,
   Agent.defaultLayer,

--- a/packages/opencode/src/provider/model-state.test.ts
+++ b/packages/opencode/src/provider/model-state.test.ts
@@ -2,6 +2,8 @@ import fs from "fs/promises"
 import path from "path"
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { Global } from "@opencode-ai/core/global"
+import { Effect } from "effect"
+import { testEffect } from "../../test/lib/effect"
 import { ModelState } from "./model-state"
 
 const model = { providerID: "deepseek", modelID: "deepseek-chat" }
@@ -79,4 +81,32 @@ describe("recordRecent", () => {
     await ModelState.recordRecent(model)
     expect(await fs.readFile(modelFile(), "utf8")).toBe("{ not valid json")
   })
+})
+
+describe("ModelState.Service.recordRecent", () => {
+  const modelFile = () => path.join(Global.Path.state, "model.json")
+  const run = testEffect(ModelState.defaultLayer)
+
+  beforeEach(async () => {
+    await fs.mkdir(Global.Path.state, { recursive: true })
+    await fs.rm(modelFile(), { force: true })
+  })
+  afterEach(async () => await fs.rm(modelFile(), { force: true }))
+
+  run.live(
+    "promotes the model through the Effect service while preserving sibling state",
+    Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        fs.writeFile(modelFile(), JSON.stringify({ recent: [other], favorite: ["x"], variant: { agent: "fast" } })),
+      )
+
+      const service = yield* ModelState.Service
+      yield* service.recordRecent(model)
+
+      const after = yield* Effect.promise(() => fs.readFile(modelFile(), "utf8").then(JSON.parse))
+      expect(after.recent[0]).toEqual(model)
+      expect(after.favorite).toEqual(["x"])
+      expect(after.variant).toEqual({ agent: "fast" })
+    }),
+  )
 })

--- a/packages/opencode/src/provider/model-state.ts
+++ b/packages/opencode/src/provider/model-state.ts
@@ -1,8 +1,9 @@
-import { rename, rm } from "fs/promises"
 import path from "path"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Global } from "@opencode-ai/core/global"
-import { Filesystem } from "../util/filesystem"
-import { Flock } from "../util/flock"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { Context, Effect, Layer } from "effect"
+import { makeRuntime } from "../effect/run-service"
 import { isRecord } from "../util/record"
 
 /**
@@ -14,6 +15,12 @@ export namespace ModelState {
     providerID: string
     modelID: string
   }
+
+  export interface Interface {
+    readonly recordRecent: (model: ModelRef) => Effect.Effect<void>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/ModelState") {}
 
   // Keep enough history that defaultModel() can fall through to an older choice
   // when the most-recent provider/model is no longer connected.
@@ -41,9 +48,47 @@ export namespace ModelState {
     return { ...base, recent }
   }
 
-  function isEnoent(err: unknown): boolean {
-    return typeof err === "object" && err !== null && (err as { code?: string }).code === "ENOENT"
+  function isMissingFile(err: unknown): boolean {
+    if (typeof err !== "object" || err === null) return false
+    return (err as { reason?: { _tag?: string } }).reason?._tag === "NotFound"
   }
+
+  export const layer = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const flock = yield* EffectFlock.Service
+
+      const recordRecent = Effect.fn("ModelState.recordRecent")(function* (model: ModelRef) {
+        const file = path.join(Global.Path.state, "model.json")
+        const tmp = `${file}.${process.pid}.tmp`
+
+        yield* flock.withLock(
+          Effect.gen(function* () {
+            const current = yield* fs.readJson(file).pipe(
+              Effect.catchIf(isMissingFile, () => Effect.succeed(undefined)),
+            )
+
+            yield* Effect.gen(function* () {
+              yield* fs.writeWithDirs(tmp, JSON.stringify(applyRecent(current, model), null, 2))
+              yield* fs.rename(tmp, file)
+            }).pipe(Effect.ensuring(fs.remove(tmp).pipe(Effect.ignore)))
+          }),
+          `model-state:${file}`,
+        ).pipe(
+          // Malformed JSON is a defect in AppFileSystem.readJson; recording
+          // recent stays best-effort for every read, lock, and write failure.
+          Effect.catchCause(() => Effect.void),
+        )
+      })
+
+      return Service.of({ recordRecent })
+    }),
+  )
+
+  export const defaultLayer = layer.pipe(Layer.provide(EffectFlock.defaultLayer), Layer.provide(AppFileSystem.defaultLayer))
+
+  const { runPromise } = makeRuntime(Service, defaultLayer)
 
   /**
    * Best-effort, locked read-modify-write. Only a missing file (ENOENT) starts
@@ -53,26 +98,6 @@ export namespace ModelState {
    * never reach the caller.
    */
   export async function recordRecent(model: ModelRef): Promise<void> {
-    const file = path.join(Global.Path.state, "model.json")
-    try {
-      await Flock.withLock(`model-state:${file}`, async () => {
-        let current: unknown
-        try {
-          current = await Filesystem.readJson<unknown>(file)
-        } catch (err) {
-          if (!isEnoent(err)) return
-          current = undefined
-        }
-        const tmp = `${file}.${process.pid}.tmp`
-        try {
-          await Filesystem.write(tmp, JSON.stringify(applyRecent(current, model), null, 2))
-          await rename(tmp, file)
-        } finally {
-          await rm(tmp, { force: true }).catch(() => {})
-        }
-      })
-    } catch {
-      // recording recent is best-effort — it must not surface to the caller
-    }
+    return runPromise((svc) => svc.recordRecent(model))
   }
 }

--- a/packages/opencode/src/server/instance/provider-actions.ts
+++ b/packages/opencode/src/server/instance/provider-actions.ts
@@ -59,5 +59,6 @@ export const completeProviderAuth = Effect.fn("ProviderRoutes.oauth.callback")(f
 })
 
 export const recordRecentModel = Effect.fn("ProviderRoutes.recent.record")(function* (input: ModelState.ModelRef) {
-  yield* Effect.promise(() => ModelState.recordRecent(input))
+  const modelState = yield* ModelState.Service
+  yield* modelState.recordRecent(input)
 })


### PR DESCRIPTION
## Summary

Effectify the provider recent-model state write path by moving `ModelState.recordRecent` behind `ModelState.Service` while preserving the async compatibility facade.

Related to #936

## Why

`POST /provider/recent` was already an Effect route action, but it still crossed back through `Effect.promise(() => ModelState.recordRecent(...))` and the model-state write implementation used raw filesystem utilities. This keeps the route path Effect-native and narrows the remaining compatibility surface to the exported async facade.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the `model.json` persistence invariants: ENOENT starts from empty, malformed or non-ENOENT read failures skip writes, sibling state is preserved, temp-file plus rename atomicity remains, temp cleanup is best-effort, and the route action stays inside Effect.

## Risk Notes

No UI, provider catalog, or provider loading changes. `Provider.defaultModel()` remains the read owner for `state/model.json`; this PR only migrates the recent-model write path.

Skipped conditional checklist items:
- Visible UI check: not applicable; no UI or copy changed.
- Platform/packaging check: not applicable; no platform, packaging, updater, signing, shell, permissions, or installer surface changed.
- Docs/release/dependency/security surface: only the existing Effect migration spec was updated with a factual checklist entry.

## How To Verify

```text
bun install --frozen-lockfile: installed dependencies in the isolated worktree.
Baseline before changes: model-state, provider-recent route, and defaultModel recent round-trip focused tests passed.
bun test src/provider/model-state.test.ts: 10 passed.
bun test test/server/provider-recent-route.test.ts: 2 passed.
bun test test/server/provider-routes.test.ts: 5 passed.
bun test test/provider/provider.test.ts -t "defaultModel returns a model seeded into recent via recordRecent": 1 passed.
git diff --check origin/dev...HEAD: no whitespace errors.
GOMAXPROCS=2 bun run typecheck: tsgo --noEmit passed.
Fresh-eye review: no P0/P1 and no concrete P2/P3 issues on the rebased diff.
Claude read-only review: no P0/P1; non-blocking P3 notes accepted or left as residual where appropriate.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

