### PR TITLE
refactor(opencode): add MCP HttpApi route coverage

### DIFF
--- a/packages/opencode/src/server/instance/mcp-actions.ts
+++ b/packages/opencode/src/server/instance/mcp-actions.ts
@@ -1,0 +1,49 @@
+import { Effect } from "effect"
+import { Config } from "../../config/config"
+import { MCP } from "../../mcp"
+
+export const getMcpStatus = Effect.fn("McpRoutes.status")(function* () {
+  const mcp = yield* MCP.Service
+  return yield* mcp.status()
+})
+
+export const addMcpServer = Effect.fn("McpRoutes.add")(function* (input: { name: string; config: Config.Mcp }) {
+  const mcp = yield* MCP.Service
+  return yield* mcp.add(input.name, input.config)
+})
+
+export const startMcpAuth = Effect.fn("McpRoutes.auth.start")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  const supportsOAuth = yield* mcp.supportsOAuth(name)
+  if (!supportsOAuth) return { type: "unsupported" as const }
+  const { authorizationUrl, oauthState } = yield* mcp.startAuth(name)
+  return { type: "started" as const, authorizationUrl, oauthState }
+})
+
+export const completeMcpAuth = Effect.fn("McpRoutes.auth.callback")(function* (input: { name: string; code: string }) {
+  const mcp = yield* MCP.Service
+  return yield* mcp.finishAuth(input.name, input.code)
+})
+
+export const authenticateMcp = Effect.fn("McpRoutes.auth.authenticate")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  const supportsOAuth = yield* mcp.supportsOAuth(name)
+  if (!supportsOAuth) return { type: "unsupported" as const }
+  const status = yield* mcp.authenticate(name)
+  return { type: "authenticated" as const, status }
+})
+
+export const removeMcpAuth = Effect.fn("McpRoutes.auth.remove")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  yield* mcp.removeAuth(name)
+})
+
+export const connectMcpServer = Effect.fn("McpRoutes.connect")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  yield* mcp.connect(name)
+})
+
+export const disconnectMcpServer = Effect.fn("McpRoutes.disconnect")(function* (name: string) {
+  const mcp = yield* MCP.Service
+  yield* mcp.disconnect(name)
+})

--- a/packages/opencode/src/server/instance/mcp.ts
+++ b/packages/opencode/src/server/instance/mcp.ts
@@ -1,60 +1,23 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
-import { Effect } from "effect"
 import z from "zod"
 import { MCP } from "../../mcp"
 import { Config } from "../../config/config"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { AppRuntime } from "../../effect/app-runtime"
+import {
+  addMcpServer,
+  authenticateMcp,
+  completeMcpAuth,
+  connectMcpServer,
+  disconnectMcpServer,
+  getMcpStatus,
+  removeMcpAuth,
+  startMcpAuth,
+} from "./mcp-actions"
 
 const runMcpRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
-
-const getMcpStatus = Effect.fn("McpRoutes.status")(function* () {
-  const mcp = yield* MCP.Service
-  return yield* mcp.status()
-})
-
-const addMcpServer = Effect.fn("McpRoutes.add")(function* (input: { name: string; config: Config.Mcp }) {
-  const mcp = yield* MCP.Service
-  return yield* mcp.add(input.name, input.config)
-})
-
-const startMcpAuth = Effect.fn("McpRoutes.auth.start")(function* (name: string) {
-  const mcp = yield* MCP.Service
-  const supportsOAuth = yield* mcp.supportsOAuth(name)
-  if (!supportsOAuth) return { type: "unsupported" as const }
-  const { authorizationUrl, oauthState } = yield* mcp.startAuth(name)
-  return { type: "started" as const, authorizationUrl, oauthState }
-})
-
-const completeMcpAuth = Effect.fn("McpRoutes.auth.callback")(function* (input: { name: string; code: string }) {
-  const mcp = yield* MCP.Service
-  return yield* mcp.finishAuth(input.name, input.code)
-})
-
-const authenticateMcp = Effect.fn("McpRoutes.auth.authenticate")(function* (name: string) {
-  const mcp = yield* MCP.Service
-  const supportsOAuth = yield* mcp.supportsOAuth(name)
-  if (!supportsOAuth) return { type: "unsupported" as const }
-  const status = yield* mcp.authenticate(name)
-  return { type: "authenticated" as const, status }
-})
-
-const removeMcpAuth = Effect.fn("McpRoutes.auth.remove")(function* (name: string) {
-  const mcp = yield* MCP.Service
-  yield* mcp.removeAuth(name)
-})
-
-const connectMcpServer = Effect.fn("McpRoutes.connect")(function* (name: string) {
-  const mcp = yield* MCP.Service
-  yield* mcp.connect(name)
-})
-
-const disconnectMcpServer = Effect.fn("McpRoutes.disconnect")(function* (name: string) {
-  const mcp = yield* MCP.Service
-  yield* mcp.disconnect(name)
-})
 
 export const McpRoutes = lazy(() =>
   new Hono()

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/mcp.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/mcp.ts
@@ -1,0 +1,160 @@
+import { ConfigMCP } from "@/config"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+
+const root = "/mcp"
+
+const McpNameParam = Schema.Struct({
+  name: Schema.String,
+})
+
+export const AddMcpPayload = Schema.Struct({
+  name: Schema.String,
+  config: ConfigMCP.Info,
+})
+
+const McpStatus = Schema.Union([
+  Schema.Struct({ status: Schema.Literal("connected") }),
+  Schema.Struct({ status: Schema.Literal("disabled") }),
+  Schema.Struct({ status: Schema.Literal("failed"), error: Schema.String }),
+  Schema.Struct({ status: Schema.Literal("needs_auth") }),
+  Schema.Struct({ status: Schema.Literal("needs_client_registration"), error: Schema.String }),
+])
+
+export const McpStatusMap = Schema.Record(Schema.String, McpStatus)
+
+export const McpAuthStartResponse = Schema.Struct({
+  authorizationUrl: Schema.String,
+  oauthState: Schema.String,
+})
+
+export const McpAuthCallbackPayload = Schema.Struct({
+  code: Schema.String,
+})
+
+export const McpAuthRemoveResponse = Schema.Struct({
+  success: Schema.Literal(true),
+})
+
+export const McpUnsupportedOAuthError = Schema.Struct({
+  error: Schema.String,
+}).pipe(
+  HttpApiSchema.status(400),
+  (schema) =>
+    schema.annotate({
+      identifier: "McpUnsupportedOAuthError",
+      description: "MCP server does not support OAuth",
+    }),
+)
+
+export const McpApi = HttpApi.make("mcp")
+  .add(
+    HttpApiGroup.make("mcp")
+      .add(
+        HttpApiEndpoint.get("status", root, {
+          query: WorkspaceRoutingQuery,
+          success: McpStatusMap,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.status",
+            summary: "Get MCP status",
+            description: "Get the status of all Model Context Protocol (MCP) servers.",
+          }),
+        ),
+        HttpApiEndpoint.post("add", root, {
+          query: WorkspaceRoutingQuery,
+          payload: AddMcpPayload,
+          success: McpStatusMap,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.add",
+            summary: "Add MCP server",
+            description: "Dynamically add a new Model Context Protocol (MCP) server to the system.",
+          }),
+        ),
+        HttpApiEndpoint.post("authStart", `${root}/:name/auth`, {
+          params: McpNameParam,
+          query: WorkspaceRoutingQuery,
+          success: McpAuthStartResponse,
+          error: McpUnsupportedOAuthError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.auth.start",
+            summary: "Start MCP OAuth",
+            description: "Start OAuth authentication flow for a Model Context Protocol (MCP) server.",
+          }),
+        ),
+        HttpApiEndpoint.post("authCallback", `${root}/:name/auth/callback`, {
+          params: McpNameParam,
+          query: WorkspaceRoutingQuery,
+          payload: McpAuthCallbackPayload,
+          success: McpStatus,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.auth.callback",
+            summary: "Complete MCP OAuth",
+            description:
+              "Complete OAuth authentication for a Model Context Protocol (MCP) server using the authorization code.",
+          }),
+        ),
+        HttpApiEndpoint.post("authAuthenticate", `${root}/:name/auth/authenticate`, {
+          params: McpNameParam,
+          query: WorkspaceRoutingQuery,
+          success: McpStatus,
+          error: McpUnsupportedOAuthError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.auth.authenticate",
+            summary: "Authenticate MCP OAuth",
+            description: "Start OAuth flow and wait for callback (opens browser)",
+          }),
+        ),
+        HttpApiEndpoint.delete("authRemove", `${root}/:name/auth`, {
+          params: McpNameParam,
+          query: WorkspaceRoutingQuery,
+          success: McpAuthRemoveResponse,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.auth.remove",
+            summary: "Remove MCP OAuth",
+            description: "Remove OAuth credentials for an MCP server",
+          }),
+        ),
+        HttpApiEndpoint.post("connect", `${root}/:name/connect`, {
+          params: McpNameParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.Boolean,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.connect",
+            description: "Connect an MCP server",
+          }),
+        ),
+        HttpApiEndpoint.post("disconnect", `${root}/:name/disconnect`, {
+          params: McpNameParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.Boolean,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.disconnect",
+            description: "Disconnect an MCP server",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "mcp",
+          description: "HttpApi MCP routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode mcp HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for the MCP route group.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/mcp.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/mcp.ts
@@ -1,0 +1,138 @@
+import { Config } from "@/config/config"
+import {
+  addMcpServer,
+  authenticateMcp,
+  completeMcpAuth,
+  connectMcpServer,
+  disconnectMcpServer,
+  getMcpStatus,
+  removeMcpAuth,
+  startMcpAuth,
+} from "@/server/instance/mcp-actions"
+import { NotFoundError } from "@/storage/db"
+import { NamedError } from "@opencode-ai/util/error"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { McpApi } from "../groups/mcp"
+
+const AddMcpInput = z.object({
+  name: z.string(),
+  config: Config.Mcp,
+})
+
+const AuthCallbackInput = z.object({
+  code: z.string(),
+})
+
+function isJsonContentType(contentType: string | undefined) {
+  // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: z.ZodType<T>) {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+    return parsed.data
+  })
+}
+
+function mcpFailure(error: unknown) {
+  if (error instanceof NotFoundError) {
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 404 }))
+  }
+  if (error instanceof NamedError) {
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 500 }))
+  }
+  return Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
+      { status: 500 },
+    ),
+  )
+}
+
+function asMcpResponse<A>(effect: Effect.Effect<A, unknown, unknown>) {
+  return effect.pipe(
+    Effect.map((body) => HttpServerResponse.jsonUnsafe(body)),
+    Effect.catch(mcpFailure),
+    Effect.catchDefect(mcpFailure),
+  )
+}
+
+function unsupportedOAuth(name: string) {
+  return HttpServerResponse.jsonUnsafe({ error: `MCP server ${name} does not support OAuth` }, { status: 400 })
+}
+
+export const mcpHandlers = HttpApiBuilder.group(McpApi, "mcp", (handlers) =>
+  handlers
+    .handleRaw("status", () => asMcpResponse(getMcpStatus()))
+    .handleRaw("add", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, AddMcpInput)
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        const result = yield* addMcpServer(payload)
+        return HttpServerResponse.jsonUnsafe(result.status)
+      }).pipe(Effect.catch(mcpFailure), Effect.catchDefect(mcpFailure)),
+    )
+    .handleRaw("authStart", (ctx) =>
+      Effect.gen(function* () {
+        const result = yield* startMcpAuth(ctx.params.name)
+        if (result.type === "unsupported") {
+          return unsupportedOAuth(ctx.params.name)
+        }
+        return HttpServerResponse.jsonUnsafe({
+          authorizationUrl: result.authorizationUrl,
+          oauthState: result.oauthState,
+        })
+      }).pipe(Effect.catch(mcpFailure), Effect.catchDefect(mcpFailure)),
+    )
+    .handleRaw("authCallback", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, AuthCallbackInput)
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        const status = yield* completeMcpAuth({ name: ctx.params.name, code: payload.code })
+        return HttpServerResponse.jsonUnsafe(status)
+      }).pipe(Effect.catch(mcpFailure), Effect.catchDefect(mcpFailure)),
+    )
+    .handleRaw("authAuthenticate", (ctx) =>
+      Effect.gen(function* () {
+        const result = yield* authenticateMcp(ctx.params.name)
+        if (result.type === "unsupported") {
+          return unsupportedOAuth(ctx.params.name)
+        }
+        return HttpServerResponse.jsonUnsafe(result.status)
+      }).pipe(Effect.catch(mcpFailure), Effect.catchDefect(mcpFailure)),
+    )
+    .handleRaw("authRemove", (ctx) =>
+      Effect.gen(function* () {
+        yield* removeMcpAuth(ctx.params.name)
+        return HttpServerResponse.jsonUnsafe({ success: true as const })
+      }).pipe(Effect.catch(mcpFailure), Effect.catchDefect(mcpFailure)),
+    )
+    .handleRaw("connect", (ctx) =>
+      Effect.gen(function* () {
+        yield* connectMcpServer(ctx.params.name)
+        return HttpServerResponse.jsonUnsafe(true)
+      }).pipe(Effect.catch(mcpFailure), Effect.catchDefect(mcpFailure)),
+    )
+    .handleRaw("disconnect", (ctx) =>
+      Effect.gen(function* () {
+        yield* disconnectMcpServer(ctx.params.name)
+        return HttpServerResponse.jsonUnsafe(true)
+      }).pipe(Effect.catch(mcpFailure), Effect.catchDefect(mcpFailure)),
+    ),
+)

--- a/packages/opencode/test/server/mcp-routes.test.ts
+++ b/packages/opencode/test/server/mcp-routes.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { McpRoutes } from "../../src/server/instance/mcp"
+import { McpApi } from "../../src/server/routes/instance/httpapi/groups/mcp"
+import { mcpHandlers } from "../../src/server/routes/instance/httpapi/handlers/mcp"
 import { tmpdir } from "../fixture/fixture"
 
 afterEach(async () => {
@@ -28,12 +35,76 @@ describe("MCP routes", () => {
     })
   }
 
+  function requestMcpHttpApi(path: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(McpApi).pipe(
+              Layer.provide(mcpHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${path}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  async function addDisabledLocalServerHttpApi(name: string) {
+    return requestMcpHttpApi("/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name,
+        config: {
+          type: "local",
+          command: ["echo", "test"],
+          enabled: false,
+        },
+      }),
+    })
+  }
+
+  test("declares the MCP route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(McpApi) as any
+
+    expect(spec.paths).toHaveProperty("/mcp")
+    expect(spec.paths).toHaveProperty("/mcp/{name}/auth")
+    expect(spec.paths).toHaveProperty("/mcp/{name}/auth/callback")
+    expect(spec.paths).toHaveProperty("/mcp/{name}/auth/authenticate")
+    expect(spec.paths).toHaveProperty("/mcp/{name}/connect")
+    expect(spec.paths).toHaveProperty("/mcp/{name}/disconnect")
+    expect(spec.paths["/mcp"]).toHaveProperty("get")
+    expect(spec.paths["/mcp"]).toHaveProperty("post")
+    expect(spec.paths["/mcp/{name}/auth"]).toHaveProperty("post")
+    expect(spec.paths["/mcp/{name}/auth"]).toHaveProperty("delete")
+    expect(spec.paths["/mcp/{name}/auth/callback"]).toHaveProperty("post")
+    expect(spec.paths["/mcp/{name}/auth/authenticate"]).toHaveProperty("post")
+    expect(spec.paths["/mcp/{name}/connect"]).toHaveProperty("post")
+    expect(spec.paths["/mcp/{name}/disconnect"]).toHaveProperty("post")
+  })
+
   test("returns MCP status through the route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
         const response = await app().request("/mcp")
+        expect(response.status).toBe(200)
+        expect(await response.json()).toBeObject()
+      },
+    })
+  })
+
+  test("returns MCP status through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestMcpHttpApi("/mcp")
         expect(response.status).toBe(200)
         expect(await response.json()).toBeObject()
       },
@@ -54,6 +125,37 @@ describe("MCP routes", () => {
     })
   })
 
+  test("adds a disabled local MCP server through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await addDisabledLocalServerHttpApi("httpapi-disabled")
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+          "httpapi-disabled": { status: "disabled" },
+        })
+      },
+    })
+  })
+
+  test("rejects malformed add JSON through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestMcpHttpApi("/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{",
+        })
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe("Malformed JSON in request body")
+      },
+    })
+  })
+
   test("keeps the non-OAuth auth start response at 400", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
@@ -67,6 +169,38 @@ describe("MCP routes", () => {
         expect(await response.json()).toEqual({
           error: "MCP server route-disabled does not support OAuth",
         })
+      },
+    })
+  })
+
+  test("keeps the non-OAuth auth start response at 400 through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const added = await addDisabledLocalServerHttpApi("httpapi-disabled")
+        expect(added.status).toBe(200)
+
+        const response = await requestMcpHttpApi("/mcp/httpapi-disabled/auth", { method: "POST" })
+        expect(response.status).toBe(400)
+        expect(await response.json()).toEqual({
+          error: "MCP server httpapi-disabled does not support OAuth",
+        })
+      },
+    })
+  })
+
+  test("returns true when disconnecting through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const added = await addDisabledLocalServerHttpApi("httpapi-disabled")
+        expect(added.status).toBe(200)
+
+        const response = await requestMcpHttpApi("/mcp/httpapi-disabled/disconnect", { method: "POST" })
+        expect(response.status).toBe(200)
+        expect(await response.json()).toBe(true)
       },
     })
   })

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -60,6 +60,14 @@ describe("route inventory harness", () => {
       ["POST", "/provider/:providerID/oauth/authorize"],
       ["POST", "/provider/:providerID/oauth/callback"],
       ["POST", "/provider/recent"],
+      ["GET", "/mcp"],
+      ["POST", "/mcp"],
+      ["POST", "/mcp/:name/auth"],
+      ["POST", "/mcp/:name/auth/callback"],
+      ["POST", "/mcp/:name/auth/authenticate"],
+      ["DELETE", "/mcp/:name/auth"],
+      ["POST", "/mcp/:name/connect"],
+      ["POST", "/mcp/:name/disconnect"],
     ] as const) {
       expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
         hono: true,


### PR DESCRIPTION
## Summary

Adds local Effect HttpApi coverage for the MCP route group while keeping the existing Hono routes as the production surface.

## Why

This advances the #936 route-boundary migration with one review-sized vertical slice for `/mcp`, without switching the production server fully to HttpApi.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the new HttpApi MCP group and raw handlers preserve the existing Hono response shapes for status, add, auth unsupported errors, JSON parse failures, and disconnect success responses.

## Risk Notes

- The production Hono route remains in place; this PR adds local HttpApi coverage and tests only.
- The MCP route actions are shared between Hono and HttpApi handlers to reduce drift.
- No visible UI or copy changed, so the visible UI checklist item is not applicable.
- No docs, release notes, dependencies, credentials, deletion behavior, generated content, or local-only files changed.

## How To Verify

```text
Baseline before changes: bun test test/server/mcp-routes.test.ts -> 3 passed
Baseline before changes: bun test test/server/route-inventory-harness.test.ts -> 14 passed
Focused tests after changes: bun test test/server/mcp-routes.test.ts test/server/route-inventory-harness.test.ts -> 23 passed
Diff check: git diff --check -> no whitespace errors
Typecheck: GOMAXPROCS=2 bun run typecheck -> tsgo --noEmit passed
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP API endpoints for MCP server management, including status retrieval, server addition, OAuth authentication flows, and connection/disconnection operations.
  * Implemented request validation with proper error handling for malformed inputs.

* **Tests**
  * Expanded test coverage for MCP routes through HTTP API handlers.
  * Added validation tests for request format and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->