### PR TITLE
feat: add small route HttpApi coverage

### DIFF
--- a/packages/opencode/src/server/instance/external-result.ts
+++ b/packages/opencode/src/server/instance/external-result.ts
@@ -80,7 +80,7 @@ const hydratePendingExternalResult = Effect.fn("ExternalResultRoutes.hydrate")(f
   return { session, message: pending.message.info, part: pending.part } satisfies z.infer<typeof PendingExternalResult>
 })
 
-const listPendingExternalResults = Effect.fn("ExternalResultRoutes.list")(function* () {
+export const listPendingExternalResults = Effect.fn("ExternalResultRoutes.list")(function* () {
   const sessions = yield* Session.Service
   const out: Array<z.infer<typeof PendingExternalResult>> = []
   for (const snap of ExternalResult.list()) {

--- a/packages/opencode/src/server/instance/file.ts
+++ b/packages/opencode/src/server/instance/file.ts
@@ -11,7 +11,7 @@ import { lazy } from "../../util/lazy"
 
 const runFileRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
 
-const findText = Effect.fn("FileRoutes.findText")(function* (pattern: string) {
+export const findText = Effect.fn("FileRoutes.findText")(function* (pattern: string) {
   const rg = yield* Ripgrep.Service
   return yield* rg.search({
     cwd: Instance.directory,
@@ -20,7 +20,7 @@ const findText = Effect.fn("FileRoutes.findText")(function* (pattern: string) {
   })
 })
 
-const findFiles = Effect.fn("FileRoutes.findFiles")(function* (input: {
+export const findFiles = Effect.fn("FileRoutes.findFiles")(function* (input: {
   query: string
   dirs?: "true" | "false"
   type?: "file" | "directory"
@@ -35,17 +35,17 @@ const findFiles = Effect.fn("FileRoutes.findFiles")(function* (input: {
   })
 })
 
-const listFiles = Effect.fn("FileRoutes.list")(function* (path: string) {
+export const listFiles = Effect.fn("FileRoutes.list")(function* (path: string) {
   const file = yield* File.Service
   return yield* file.list(path)
 })
 
-const readFileContent = Effect.fn("FileRoutes.read")(function* (path: string) {
+export const readFileContent = Effect.fn("FileRoutes.read")(function* (path: string) {
   const file = yield* File.Service
   return yield* file.read(path)
 })
 
-const getFileStatus = Effect.fn("FileRoutes.status")(function* () {
+export const getFileStatus = Effect.fn("FileRoutes.status")(function* () {
   const file = yield* File.Service
   return yield* file.status()
 })

--- a/packages/opencode/src/server/instance/memory.ts
+++ b/packages/opencode/src/server/instance/memory.ts
@@ -17,30 +17,30 @@ function createMemoryService() {
   return MemoryService.create({ workspacePath: Instance.directory })
 }
 
-const readMemory = Effect.fn("MemoryRoutes.read")(function* () {
+export const readMemory = Effect.fn("MemoryRoutes.read")(function* () {
   const memory = createMemoryService()
   return yield* Effect.promise(() => memory.read())
 })
 
-const updateRawMemory = Effect.fn("MemoryRoutes.updateRaw")(function* (content: string) {
+export const updateRawMemory = Effect.fn("MemoryRoutes.updateRaw")(function* (content: string) {
   const memory = createMemoryService()
   yield* Effect.promise(() => memory.saveRaw(content))
   return yield* Effect.promise(() => memory.read())
 })
 
-const resetMemory = Effect.fn("MemoryRoutes.reset")(function* () {
+export const resetMemory = Effect.fn("MemoryRoutes.reset")(function* () {
   const memory = createMemoryService()
   yield* Effect.promise(() => memory.resetToTemplate())
   return yield* Effect.promise(() => memory.read())
 })
 
-const setMemoryDisabled = Effect.fn("MemoryRoutes.disabled")(function* (disabled: boolean) {
+export const setMemoryDisabled = Effect.fn("MemoryRoutes.disabled")(function* (disabled: boolean) {
   const memory = createMemoryService()
   yield* Effect.promise(() => memory.setDisabled(disabled))
   return yield* Effect.promise(() => memory.read())
 })
 
-const deleteMemoryEntry = Effect.fn("MemoryRoutes.deleteEntry")(function* (id: string) {
+export const deleteMemoryEntry = Effect.fn("MemoryRoutes.deleteEntry")(function* (id: string) {
   const memory = createMemoryService()
   yield* Effect.promise(() => memory.deleteEntry(id))
   return yield* Effect.promise(() => memory.read())

--- a/packages/opencode/src/server/instance/project.ts
+++ b/packages/opencode/src/server/instance/project.ts
@@ -12,12 +12,12 @@ import { AppRuntime } from "../../effect/app-runtime"
 
 const runProjectRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
 
-const listProjects = Effect.fn("ProjectRoutes.list")(function* () {
+export const listProjects = Effect.fn("ProjectRoutes.list")(function* () {
   const project = yield* Project.Service
   return yield* project.list()
 })
 
-const initGit = Effect.fn("ProjectRoutes.git.init")(function* (input: { directory: string; project: Project.Info }) {
+export const initGit = Effect.fn("ProjectRoutes.git.init")(function* (input: { directory: string; project: Project.Info }) {
   const project = yield* Project.Service
   const next = yield* project.initGit(input)
   if (next.id === input.project.id && next.vcs === input.project.vcs && next.worktree === input.project.worktree)
@@ -32,7 +32,7 @@ const initGit = Effect.fn("ProjectRoutes.git.init")(function* (input: { director
   return next
 })
 
-const updateProject = Effect.fn("ProjectRoutes.update")(function* (input: Project.UpdateInput) {
+export const updateProject = Effect.fn("ProjectRoutes.update")(function* (input: Project.UpdateInput) {
   const project = yield* Project.Service
   return yield* project.update(input)
 })

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/common.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/common.ts
@@ -8,7 +8,7 @@ export const WorkspaceRoutingQuery = Schema.Struct({
 
 export const BadRequestError = Schema.Struct({
   data: Schema.Any,
-  errors: Schema.Array(Schema.Record(Schema.String, Schema.Any)),
+  error: Schema.Array(Schema.Record(Schema.String, Schema.Any)),
   success: Schema.Literal(false),
 }).pipe(
   HttpApiSchema.status(400),
@@ -16,5 +16,31 @@ export const BadRequestError = Schema.Struct({
     schema.annotate({
       identifier: "BadRequestError",
       description: "Bad request",
+    }),
+)
+
+export const InvalidMemoryFileError = Schema.Struct({
+  error: Schema.Literal("invalid_memory_file"),
+  reason: Schema.String,
+}).pipe(
+  HttpApiSchema.status(400),
+  (schema) =>
+    schema.annotate({
+      identifier: "InvalidMemoryFileError",
+      description: "Invalid PawWork memory file",
+    }),
+)
+
+export const NotFoundError = Schema.Struct({
+  name: Schema.Literal("NotFoundError"),
+  data: Schema.Struct({
+    message: Schema.String,
+  }),
+}).pipe(
+  HttpApiSchema.status(404),
+  (schema) =>
+    schema.annotate({
+      identifier: "NotFoundError",
+      description: "Not found",
     }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/external-result.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/external-result.ts
@@ -1,0 +1,40 @@
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { WorkspaceRoutingQuery } from "./common"
+
+const PendingExternalResult = Schema.Struct({
+  session: Schema.Any,
+  message: Schema.Any,
+  part: Schema.Any,
+})
+
+export const ExternalResultApi = HttpApi.make("externalResult")
+  .add(
+    HttpApiGroup.make("externalResult")
+      .add(
+        HttpApiEndpoint.get("list", "/external-result", {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Array(PendingExternalResult),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "externalResult.list",
+            summary: "List pending external-result tool calls",
+            description:
+              "Return the (session, message, part) trio for every external-result Deferred currently awaiting a user response.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "external-result",
+          description: "HttpApi external-result routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode external-result HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for external-result routes.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/file.ts
@@ -1,0 +1,141 @@
+import { Ripgrep } from "@/file/ripgrep"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { WorkspaceRoutingQuery } from "./common"
+
+const FileQuery = Schema.Struct({
+  ...WorkspaceRoutingQuery.fields,
+  path: Schema.String,
+})
+
+const FindTextQuery = Schema.Struct({
+  ...WorkspaceRoutingQuery.fields,
+  pattern: Schema.String,
+})
+
+const FindFileQuery = Schema.Struct({
+  ...WorkspaceRoutingQuery.fields,
+  query: Schema.String,
+  dirs: Schema.optionalKey(Schema.Literals(["true", "false"])),
+  type: Schema.optionalKey(Schema.Literals(["file", "directory"])),
+  limit: Schema.optionalKey(
+    Schema.NumberFromString.pipe(
+      Schema.check(Schema.isInt()),
+      Schema.check(Schema.isGreaterThanOrEqualTo(1)),
+      Schema.check(Schema.isLessThanOrEqualTo(200)),
+    ),
+  ),
+})
+
+const FindSymbolQuery = Schema.Struct({
+  ...WorkspaceRoutingQuery.fields,
+  query: Schema.String,
+})
+
+const FileNode = Schema.Struct({
+  name: Schema.String,
+  path: Schema.String,
+  absolute: Schema.String,
+  type: Schema.Literals(["file", "directory"]),
+  ignored: Schema.Boolean,
+})
+
+const FileContent = Schema.Struct({
+  type: Schema.Literals(["text", "binary"]),
+  content: Schema.String,
+  diff: Schema.optionalKey(Schema.String),
+  patch: Schema.optionalKey(Schema.Any),
+  encoding: Schema.optionalKey(Schema.Literal("base64")),
+  mimeType: Schema.optionalKey(Schema.String),
+})
+
+const FileStatus = Schema.Struct({
+  path: Schema.String,
+  added: Schema.Number,
+  removed: Schema.Number,
+  status: Schema.Literals(["added", "deleted", "modified"]),
+})
+
+export const FileApi = HttpApi.make("file")
+  .add(
+    HttpApiGroup.make("file")
+      .add(
+        HttpApiEndpoint.get("findText", "/find", {
+          query: FindTextQuery,
+          success: Schema.Struct({
+            items: Schema.Array(Ripgrep.SearchMatch),
+            partial: Schema.Boolean,
+            partialReason: Schema.optionalKey(Schema.Literals(["invalid_pattern", "partial_io"])),
+          }),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "find.text",
+            summary: "Find text",
+            description: "Search for text patterns across files in the project using ripgrep.",
+          }),
+        ),
+        HttpApiEndpoint.get("findFile", "/find/file", {
+          query: FindFileQuery,
+          success: Schema.Array(Schema.String),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "find.files",
+            summary: "Find files",
+            description: "Search for files or directories by name or pattern in the project directory.",
+          }),
+        ),
+        HttpApiEndpoint.get("findSymbol", "/find/symbol", {
+          query: FindSymbolQuery,
+          success: Schema.Array(Schema.Any),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "find.symbols",
+            summary: "Find symbols",
+            description: "Search for workspace symbols like functions, classes, and variables using LSP.",
+          }),
+        ),
+        HttpApiEndpoint.get("list", "/file", {
+          query: FileQuery,
+          success: Schema.Array(FileNode),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "file.list",
+            summary: "List files",
+            description: "List files and directories in a specified path.",
+          }),
+        ),
+        HttpApiEndpoint.get("content", "/file/content", {
+          query: FileQuery,
+          success: FileContent,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "file.read",
+            summary: "Read file",
+            description: "Read the content of a specified file.",
+          }),
+        ),
+        HttpApiEndpoint.get("status", "/file/status", {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Array(FileStatus),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "file.status",
+            summary: "Get file status",
+            description: "Get the git status of all files in the project.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "file",
+          description: "HttpApi file routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode file HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for file routes.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/memory.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/memory.ts
@@ -1,0 +1,85 @@
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+
+const MemoryRawPayload = Schema.Struct({
+  content: Schema.String,
+})
+
+const MemoryDisabledPayload = Schema.Struct({
+  disabled: Schema.Boolean,
+})
+
+const MemoryEntryParam = Schema.Struct({
+  id: Schema.String,
+})
+
+export const MemoryApi = HttpApi.make("memory")
+  .add(
+    HttpApiGroup.make("memory")
+      .add(
+        HttpApiEndpoint.get("get", "/memory", {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "memory.get",
+            summary: "Get PawWork memory",
+          }),
+        ),
+        HttpApiEndpoint.patch("update", "/memory", {
+          query: WorkspaceRoutingQuery,
+          payload: MemoryRawPayload,
+          success: Schema.Any,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "memory.update",
+            summary: "Update raw PawWork memory",
+          }),
+        ),
+        HttpApiEndpoint.post("reset", "/memory/reset", {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "memory.reset",
+            summary: "Reset PawWork memory",
+          }),
+        ),
+        HttpApiEndpoint.patch("disabled", "/memory/disabled", {
+          query: WorkspaceRoutingQuery,
+          payload: MemoryDisabledPayload,
+          success: Schema.Any,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "memory.disabled",
+            summary: "Disable or enable PawWork memory",
+          }),
+        ),
+        HttpApiEndpoint.delete("deleteEntry", "/memory/entry/:id", {
+          params: MemoryEntryParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "memory.deleteEntry",
+            summary: "Delete PawWork memory entry",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "memory",
+          description: "HttpApi PawWork memory routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode memory HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for PawWork memory routes.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/memory.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/memory.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+import { BadRequestError, InvalidMemoryFileError, WorkspaceRoutingQuery } from "./common"
 
 const MemoryRawPayload = Schema.Struct({
   content: Schema.String,
@@ -31,7 +31,7 @@ export const MemoryApi = HttpApi.make("memory")
           query: WorkspaceRoutingQuery,
           payload: MemoryRawPayload,
           success: Schema.Any,
-          error: BadRequestError,
+          error: [BadRequestError, InvalidMemoryFileError],
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "memory.update",

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/project.ts
@@ -1,0 +1,101 @@
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+
+const ProjectIDParam = Schema.Struct({
+  projectID: Schema.String,
+})
+
+const ProjectIcon = Schema.Struct({
+  url: Schema.optionalKey(Schema.String),
+  override: Schema.optionalKey(Schema.String),
+  color: Schema.optionalKey(Schema.String),
+})
+
+const ProjectCommands = Schema.Struct({
+  start: Schema.optionalKey(Schema.String),
+})
+
+const ProjectInfo = Schema.Struct({
+  id: Schema.String,
+  worktree: Schema.String,
+  vcs: Schema.optionalKey(Schema.Literal("git")),
+  name: Schema.optionalKey(Schema.String),
+  icon: Schema.optionalKey(ProjectIcon),
+  commands: Schema.optionalKey(ProjectCommands),
+  time: Schema.Struct({
+    created: Schema.Number,
+    updated: Schema.Number,
+    initialized: Schema.optionalKey(Schema.Number),
+  }),
+  sandboxes: Schema.Array(Schema.String),
+})
+
+const ProjectUpdatePayload = Schema.Struct({
+  name: Schema.optionalKey(Schema.String),
+  icon: Schema.optionalKey(ProjectIcon),
+  commands: Schema.optionalKey(ProjectCommands),
+})
+
+export const ProjectApi = HttpApi.make("project")
+  .add(
+    HttpApiGroup.make("project")
+      .add(
+        HttpApiEndpoint.get("list", "/project", {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Array(ProjectInfo),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "project.list",
+            summary: "List all projects",
+            description: "Get a list of projects that have been opened with OpenCode.",
+          }),
+        ),
+        HttpApiEndpoint.get("current", "/project/current", {
+          query: WorkspaceRoutingQuery,
+          success: ProjectInfo,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "project.current",
+            summary: "Get current project",
+            description: "Retrieve the currently active project that OpenCode is working with.",
+          }),
+        ),
+        HttpApiEndpoint.post("initGit", "/project/git/init", {
+          query: WorkspaceRoutingQuery,
+          success: ProjectInfo,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "project.initGit",
+            summary: "Initialize git repository",
+            description: "Create a git repository for the current project and return the refreshed project info.",
+          }),
+        ),
+        HttpApiEndpoint.patch("update", "/project/:projectID", {
+          params: ProjectIDParam,
+          query: WorkspaceRoutingQuery,
+          payload: ProjectUpdatePayload,
+          success: ProjectInfo,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "project.update",
+            summary: "Update project",
+            description: "Update project properties such as name, icon, and commands.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "project",
+          description: "HttpApi project routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode project HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for project routes.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/project.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+import { BadRequestError, NotFoundError, WorkspaceRoutingQuery } from "./common"
 
 const ProjectIDParam = Schema.Struct({
   projectID: Schema.String,
@@ -76,7 +76,7 @@ export const ProjectApi = HttpApi.make("project")
           query: WorkspaceRoutingQuery,
           payload: ProjectUpdatePayload,
           success: ProjectInfo,
-          error: BadRequestError,
+          error: [BadRequestError, NotFoundError],
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "project.update",

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/external-result.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/external-result.ts
@@ -1,0 +1,11 @@
+import { listPendingExternalResults } from "@/server/instance/external-result"
+import { Effect } from "effect"
+import { HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { ExternalResultApi } from "../groups/external-result"
+
+export const externalResultHandlers = HttpApiBuilder.group(ExternalResultApi, "externalResult", (handlers) =>
+  handlers.handleRaw("list", () =>
+    listPendingExternalResults().pipe(Effect.map((result) => HttpServerResponse.jsonUnsafe(result))),
+  ),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -1,0 +1,30 @@
+import { findFiles, findText, getFileStatus, listFiles, readFileContent } from "@/server/instance/file"
+import { Effect } from "effect"
+import { HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { FileApi } from "../groups/file"
+
+export const fileHandlers = HttpApiBuilder.group(FileApi, "file", (handlers) =>
+  handlers
+    .handleRaw("findText", (ctx) =>
+      findText(ctx.query.pattern).pipe(Effect.orDie, Effect.map((result) => HttpServerResponse.jsonUnsafe(result))),
+    )
+    .handleRaw("findFile", (ctx) =>
+      findFiles({
+        query: ctx.query.query,
+        dirs: ctx.query.dirs,
+        type: ctx.query.type,
+        limit: ctx.query.limit,
+      }).pipe(Effect.orDie, Effect.map((result) => HttpServerResponse.jsonUnsafe(result))),
+    )
+    .handleRaw("findSymbol", () => Effect.succeed(HttpServerResponse.jsonUnsafe([])))
+    .handleRaw("list", (ctx) =>
+      listFiles(ctx.query.path).pipe(Effect.orDie, Effect.map((result) => HttpServerResponse.jsonUnsafe(result))),
+    )
+    .handleRaw("content", (ctx) =>
+      readFileContent(ctx.query.path).pipe(Effect.orDie, Effect.map((result) => HttpServerResponse.jsonUnsafe(result))),
+    )
+    .handleRaw("status", () =>
+      getFileStatus().pipe(Effect.orDie, Effect.map((result) => HttpServerResponse.jsonUnsafe(result))),
+    ),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/memory.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/memory.ts
@@ -1,0 +1,70 @@
+import { deleteMemoryEntry, readMemory, resetMemory, setMemoryDisabled, updateRawMemory } from "@/server/instance/memory"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { MemoryApi } from "../groups/memory"
+
+const MemoryRawInput = z.object({ content: z.string() })
+const MemoryDisabledInput = z.object({ disabled: z.boolean() })
+
+function isJsonContentType(contentType: string | undefined) {
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: z.ZodType<T>) {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+    return parsed.data
+  })
+}
+
+function invalidMemoryFailure(error: unknown) {
+  return Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      { error: "invalid_memory_file", reason: error instanceof Error ? error.message : String(error) },
+      { status: 400 },
+    ),
+  )
+}
+
+export const memoryHandlers = HttpApiBuilder.group(MemoryApi, "memory", (handlers) =>
+  handlers
+    .handleRaw("get", () => readMemory().pipe(Effect.map((result) => HttpServerResponse.jsonUnsafe(result))))
+    .handleRaw("update", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, MemoryRawInput)
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        return yield* updateRawMemory(payload.content).pipe(
+          Effect.map((result) => HttpServerResponse.jsonUnsafe(result)),
+          Effect.catch(invalidMemoryFailure),
+          Effect.catchDefect(invalidMemoryFailure),
+        )
+      }),
+    )
+    .handleRaw("reset", () => resetMemory().pipe(Effect.map((result) => HttpServerResponse.jsonUnsafe(result))))
+    .handleRaw("disabled", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, MemoryDisabledInput)
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        return yield* setMemoryDisabled(payload.disabled).pipe(
+          Effect.map((result) => HttpServerResponse.jsonUnsafe(result)),
+        )
+      }),
+    )
+    .handleRaw("deleteEntry", (ctx) =>
+      deleteMemoryEntry(ctx.params.id).pipe(Effect.map((result) => HttpServerResponse.jsonUnsafe(result))),
+    ),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/project.ts
@@ -1,0 +1,70 @@
+import { Instance } from "@/project/instance"
+import { Project } from "@/project/project"
+import { ProjectID } from "@/project/schema"
+import { initGit, listProjects, updateProject } from "@/server/instance/project"
+import { NotFoundError } from "@/storage/db"
+import { NamedError } from "@opencode-ai/util/error"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { ProjectApi } from "../groups/project"
+
+function isJsonContentType(contentType: string | undefined) {
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: z.ZodType<T>) {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+    return parsed.data
+  })
+}
+
+function projectFailure(error: unknown) {
+  if (error instanceof NotFoundError || error instanceof NamedError) {
+    const status = error instanceof NotFoundError ? 404 : 500
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status }))
+  }
+  return Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
+      { status: 500 },
+    ),
+  )
+}
+
+export const projectHandlers = HttpApiBuilder.group(ProjectApi, "project", (handlers) =>
+  handlers
+    .handleRaw("list", () => listProjects().pipe(Effect.map((result) => HttpServerResponse.jsonUnsafe(result))))
+    .handleRaw("current", () => Effect.succeed(HttpServerResponse.jsonUnsafe(Instance.project)))
+    .handleRaw("initGit", () =>
+      initGit({ directory: Instance.directory, project: Instance.project }).pipe(
+        Effect.map((result) => HttpServerResponse.jsonUnsafe(result)),
+      ),
+    )
+    .handleRaw("update", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, Project.UpdateInput.omit({ projectID: true }))
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        const project = yield* updateProject({ ...payload, projectID: ProjectID.make(ctx.params.projectID) }).pipe(
+          Effect.catch(projectFailure),
+          Effect.catchDefect(projectFailure),
+        )
+        if (HttpServerResponse.isHttpServerResponse(project)) return project
+        return HttpServerResponse.jsonUnsafe(project)
+      }),
+    ),
+)

--- a/packages/opencode/test/server/external-result-routes.test.ts
+++ b/packages/opencode/test/server/external-result-routes.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { ExternalResultRoutes } from "../../src/server/instance/external-result"
+import { ExternalResultApi } from "../../src/server/routes/instance/httpapi/groups/external-result"
+import { externalResultHandlers } from "../../src/server/routes/instance/httpapi/handlers/external-result"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -19,6 +24,30 @@ describe("external-result routes", () => {
   function app() {
     return new Hono().route("/external-result", ExternalResultRoutes())
   }
+
+  function requestExternalResultHttpApi(routePath: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(ExternalResultApi).pipe(
+              Layer.provide(externalResultHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${routePath}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  test("declares the external-result route group as an HttpApi endpoint", () => {
+    const spec = OpenApi.fromApi(ExternalResultApi) as any
+
+    expect(spec.paths["/external-result"]).toHaveProperty("get")
+  })
 
   test("skips stale pending external-result entries through the route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
@@ -133,6 +162,29 @@ describe("external-result routes", () => {
             part: expect.objectContaining({ id: partID, callID }),
           }),
         ])
+      },
+    })
+  })
+
+  test("skips stale pending external-result entries through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    ExternalResult.__resetForTests()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Effect.runPromise(
+          ExternalResult.register({
+            sessionID: SessionID.descending(),
+            messageID: MessageID.ascending(),
+            callID: "call_stale_external_result_httpapi",
+            inputSnapshot: { questions: ["q1"] },
+          }),
+        )
+
+        const response = await requestExternalResultHttpApi("/external-result")
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual([])
       },
     })
   })

--- a/packages/opencode/test/server/file-routes.test.ts
+++ b/packages/opencode/test/server/file-routes.test.ts
@@ -1,11 +1,18 @@
 import { $ } from "bun"
 import { afterEach, describe, expect, test } from "bun:test"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import fs from "fs/promises"
 import path from "path"
 import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { FileRoutes } from "../../src/server/instance/file"
+import { FileApi } from "../../src/server/routes/instance/httpapi/groups/file"
+import { fileHandlers } from "../../src/server/routes/instance/httpapi/handlers/file"
 import { tmpdir } from "../fixture/fixture"
 
 void Log.init({ print: false })
@@ -18,6 +25,40 @@ describe("file routes", () => {
   function app() {
     return new Hono().route("/", FileRoutes())
   }
+
+  function requestFileHttpApi(routePath: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(FileApi).pipe(
+              Layer.provide(fileHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${routePath}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  test("declares the file route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(FileApi) as any
+
+    for (const [routePath, method] of [
+      ["/find", "get"],
+      ["/find/file", "get"],
+      ["/find/symbol", "get"],
+      ["/file", "get"],
+      ["/file/content", "get"],
+      ["/file/status", "get"],
+    ] as const) {
+      expect(spec.paths).toHaveProperty(routePath)
+      expect(spec.paths[routePath]).toHaveProperty(method)
+    }
+  })
 
   test("finds, lists, and reads files through the route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
@@ -54,6 +95,43 @@ describe("file routes", () => {
         const response = await app().request("/file/status")
         expect(response.status).toBe(200)
         expect(await response.json()).toEqual([{ path: "tracked.txt", added: 1, removed: 1, status: "modified" }])
+      },
+    })
+  })
+
+  test("finds, lists, reads, and reports status through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await fs.writeFile(path.join(tmp.path, "sample.txt"), "hello\n", "utf-8")
+    await $`git add sample.txt`.cwd(tmp.path).quiet()
+    await $`git commit --no-gpg-sign -m "add file"`.cwd(tmp.path).quiet()
+    await fs.writeFile(path.join(tmp.path, "sample.txt"), "hello changed\n", "utf-8")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const text = await requestFileHttpApi("/find?pattern=hello")
+        expect(text.status).toBe(200)
+        expect(await text.json()).toMatchObject({ partial: false })
+
+        const found = await requestFileHttpApi("/find/file?query=sample&dirs=false")
+        expect(found.status).toBe(200)
+        expect(await found.json()).toContain("sample.txt")
+
+        const symbols = await requestFileHttpApi("/find/symbol?query=sample")
+        expect(symbols.status).toBe(200)
+        expect(await symbols.json()).toEqual([])
+
+        const listed = await requestFileHttpApi("/file?path=.")
+        expect(listed.status).toBe(200)
+        expect((await listed.json()).map((item: { name: string }) => item.name)).toContain("sample.txt")
+
+        const read = await requestFileHttpApi("/file/content?path=sample.txt")
+        expect(read.status).toBe(200)
+        expect(await read.json()).toMatchObject({ type: "text", content: "hello changed" })
+
+        const status = await requestFileHttpApi("/file/status")
+        expect(status.status).toBe(200)
+        expect(await status.json()).toEqual([{ path: "sample.txt", added: 1, removed: 1, status: "modified" }])
       },
     })
   })

--- a/packages/opencode/test/server/memory-routes.test.ts
+++ b/packages/opencode/test/server/memory-routes.test.ts
@@ -53,6 +53,18 @@ describe("memory routes", () => {
     expect(spec.paths["/memory/reset"]).toHaveProperty("post")
     expect(spec.paths["/memory/disabled"]).toHaveProperty("patch")
     expect(spec.paths["/memory/entry/{id}"]).toHaveProperty("delete")
+    expect(spec.paths["/memory"]?.patch?.responses?.["400"]).toMatchObject({
+      content: {
+        "application/json": {
+          schema: {
+            anyOf: [
+              { $ref: "#/components/schemas/BadRequestError" },
+              { $ref: "#/components/schemas/InvalidMemoryFileError" },
+            ],
+          },
+        },
+      },
+    })
   })
 
   test("reads and updates memory through the route runtime", async () => {

--- a/packages/opencode/test/server/memory-routes.test.ts
+++ b/packages/opencode/test/server/memory-routes.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { MemoryRoutes } from "../../src/server/instance/memory"
+import { MemoryApi } from "../../src/server/routes/instance/httpapi/groups/memory"
+import { memoryHandlers } from "../../src/server/routes/instance/httpapi/handlers/memory"
 import { tmpdir } from "../fixture/fixture"
 
 void Log.init({ print: false })
@@ -19,6 +26,34 @@ describe("memory routes", () => {
   function app() {
     return new Hono().route("/memory", MemoryRoutes())
   }
+
+  function requestMemoryHttpApi(routePath: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(MemoryApi).pipe(
+              Layer.provide(memoryHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${routePath}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  test("declares the memory route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(MemoryApi) as any
+
+    expect(spec.paths["/memory"]).toHaveProperty("get")
+    expect(spec.paths["/memory"]).toHaveProperty("patch")
+    expect(spec.paths["/memory/reset"]).toHaveProperty("post")
+    expect(spec.paths["/memory/disabled"]).toHaveProperty("patch")
+    expect(spec.paths["/memory/entry/{id}"]).toHaveProperty("delete")
+  })
 
   test("reads and updates memory through the route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
@@ -75,6 +110,54 @@ describe("memory routes", () => {
         // The original error must surface cleanly through the Effect runtime,
         // not as a wrapped FiberFailure trace.
         expect(body).toMatchObject({ error: "invalid_memory_file", reason: "missing_profile" })
+      },
+    })
+  })
+
+  test("reads, updates, disables, deletes, and rejects invalid content through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await using home = await tmpdir()
+    process.env.PAWWORK_HOME = home.path
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const initial = await requestMemoryHttpApi("/memory")
+        expect(initial.status).toBe(200)
+        expect(await initial.json()).toMatchObject({ disabled: false, status: "ok" })
+
+        const content = "# PawWork Memory\n\n## Profile\n\n- PawWork Memory is enabled.\n\n## Archive\n\n### First id:first\n\nStored note.\n"
+        const updated = await requestMemoryHttpApi("/memory", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ content }),
+        })
+        expect(updated.status).toBe(200)
+        expect(await updated.json()).toMatchObject({ content })
+
+        const disabled = await requestMemoryHttpApi("/memory/disabled", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ disabled: true }),
+        })
+        expect(disabled.status).toBe(200)
+        expect(await disabled.json()).toMatchObject({ disabled: true })
+
+        const deleted = await requestMemoryHttpApi("/memory/entry/first", { method: "DELETE" })
+        expect(deleted.status).toBe(200)
+        expect((await deleted.json()).content).not.toContain("Stored note.")
+
+        const reset = await requestMemoryHttpApi("/memory/reset", { method: "POST" })
+        expect(reset.status).toBe(200)
+        expect(await reset.json()).toMatchObject({ content: expect.stringContaining("## Profile"), status: "ok" })
+
+        const invalid = await requestMemoryHttpApi("/memory", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ content: "garbage with no profile or archive sections" }),
+        })
+        expect(invalid.status).toBe(400)
+        expect(await invalid.json()).toMatchObject({ error: "invalid_memory_file", reason: "missing_profile" })
       },
     })
   })

--- a/packages/opencode/test/server/project-init-git.test.ts
+++ b/packages/opencode/test/server/project-init-git.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test"
-import { Effect } from "effect"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
 import path from "path"
 import { GlobalBus } from "../../src/bus/global"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Snapshot } from "../../src/snapshot"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
+import { ProjectApi } from "../../src/server/routes/instance/httpapi/groups/project"
+import { projectHandlers } from "../../src/server/routes/instance/httpapi/handlers/project"
 import { Filesystem } from "../../src/util/filesystem"
 import { Log } from "../../src/util"
 import { resetDatabase } from "../fixture/db"
@@ -17,6 +23,24 @@ afterEach(async () => {
 })
 
 describe("project.initGit endpoint", () => {
+  function requestProjectHttpApi(routePath: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(ProjectApi).pipe(
+              Layer.provide(projectHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${routePath}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
   test("lists and reads projects through the route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
     const app = Server.Default().app
@@ -87,6 +111,43 @@ describe("project.initGit endpoint", () => {
           ),
         ),
       ).toBeTruthy()
+    } finally {
+      await Instance.disposeAll()
+      reloadSpy.mockRestore()
+      GlobalBus.off("event", fn)
+    }
+  })
+
+  test("initializes git through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir()
+    const seen: { directory?: string; payload: { type: string } }[] = []
+    const fn = (evt: { directory?: string; payload: { type: string } }) => {
+      seen.push(evt)
+    }
+    const reload = Instance.reload
+    const reloadSpy = spyOn(Instance, "reload").mockImplementation((input) => reload(input))
+    GlobalBus.on("event", fn)
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const init = await requestProjectHttpApi("/project/git/init", { method: "POST" })
+          const body = await init.json()
+
+          expect(init.status).toBe(200)
+          expect(body).toMatchObject({
+            id: "global",
+            vcs: "git",
+            worktree: tmp.path,
+          })
+          expect(reloadSpy).toHaveBeenCalledTimes(1)
+          expect(seen.some((evt) => evt.directory === tmp.path && evt.payload.type === "server.instance.disposed")).toBe(
+            true,
+          )
+          expect(await Filesystem.exists(path.join(tmp.path, ".git", "opencode"))).toBe(false)
+        },
+      })
     } finally {
       await Instance.disposeAll()
       reloadSpy.mockRestore()

--- a/packages/opencode/test/server/project-routes.test.ts
+++ b/packages/opencode/test/server/project-routes.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { ProjectRoutes } from "../../src/server/instance/project"
+import { ProjectApi } from "../../src/server/routes/instance/httpapi/groups/project"
+import { projectHandlers } from "../../src/server/routes/instance/httpapi/handlers/project"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { tmpdir } from "../fixture/fixture"
 
@@ -17,6 +24,33 @@ describe("project routes", () => {
     return new Hono().route("/project", ProjectRoutes()).onError(ErrorMiddleware)
   }
 
+  function requestProjectHttpApi(routePath: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(ProjectApi).pipe(
+              Layer.provide(projectHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${routePath}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  test("declares the project route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(ProjectApi) as any
+
+    expect(spec.paths["/project"]).toHaveProperty("get")
+    expect(spec.paths["/project/current"]).toHaveProperty("get")
+    expect(spec.paths["/project/git/init"]).toHaveProperty("post")
+    expect(spec.paths["/project/{projectID}"]).toHaveProperty("patch")
+  })
+
   test("PATCH /:projectID returns documented 404 when the project does not exist", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
@@ -30,6 +64,33 @@ describe("project routes", () => {
         const body = await response.json()
 
         expect(response.status).toBe(404)
+        expect(body.name).toBe("NotFoundError")
+        expect(body.data.message).toContain("Project not found: nonexistent-project-id")
+      },
+    })
+  })
+
+  test("serves list, current, and PATCH 404 through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const list = await requestProjectHttpApi("/project")
+        expect(list.status).toBe(200)
+        expect(await list.json()).toBeArray()
+
+        const current = await requestProjectHttpApi("/project/current")
+        expect(current.status).toBe(200)
+        expect(await current.json()).toMatchObject({ vcs: "git", worktree: tmp.path })
+
+        const missing = await requestProjectHttpApi("/project/nonexistent-project-id", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "Should Fail" }),
+        })
+        const body = await missing.json()
+
+        expect(missing.status).toBe(404)
         expect(body.name).toBe("NotFoundError")
         expect(body.data.message).toContain("Project not found: nonexistent-project-id")
       },

--- a/packages/opencode/test/server/project-routes.test.ts
+++ b/packages/opencode/test/server/project-routes.test.ts
@@ -49,6 +49,10 @@ describe("project routes", () => {
     expect(spec.paths["/project/current"]).toHaveProperty("get")
     expect(spec.paths["/project/git/init"]).toHaveProperty("post")
     expect(spec.paths["/project/{projectID}"]).toHaveProperty("patch")
+    expect(spec.paths["/project/{projectID}"]?.patch?.responses?.["404"]).toMatchObject({
+      description: "Not found",
+      content: { "application/json": { schema: { $ref: "#/components/schemas/NotFoundError" } } },
+    })
   })
 
   test("PATCH /:projectID returns documented 404 when the project does not exist", async () => {

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -94,7 +94,39 @@ describe("route inventory harness", () => {
     })
     expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")).toMatchObject({
       hono: true,
-      localHttpApi: false,
+      localHttpApi: true,
+      classification: "pawwork-owned-sdk-v2-only",
+    })
+  })
+
+  test("tracks local HttpApi migration coverage for ordinary JSON file, project, memory, and external-result routes", async () => {
+    const inventory = await buildRouteInventory({ root, requireUpstream: false })
+
+    for (const [method, routePath] of [
+      ["GET", "/find"],
+      ["GET", "/find/file"],
+      ["GET", "/find/symbol"],
+      ["GET", "/file"],
+      ["GET", "/file/content"],
+      ["GET", "/file/status"],
+      ["GET", "/project"],
+      ["GET", "/project/current"],
+      ["POST", "/project/git/init"],
+      ["PATCH", "/project/:projectID"],
+      ["GET", "/memory"],
+      ["PATCH", "/memory"],
+      ["POST", "/memory/reset"],
+      ["PATCH", "/memory/disabled"],
+      ["DELETE", "/memory/entry/:id"],
+      ["GET", "/external-result"],
+    ] as const) {
+      expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
+        hono: true,
+        localHttpApi: true,
+      })
+    }
+
+    expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")).toMatchObject({
       classification: "pawwork-owned-sdk-v2-only",
     })
   })


### PR DESCRIPTION
## Summary

Add local Effect HttpApi declarations and handlers for ordinary JSON file, project, memory, and external-result routes.

## Why

Related to #936.

This gives the next Hono-to-HttpApi migration slice local coverage without switching the production server off Hono.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on Hono wire-behavior parity for JSON body parsing, project 404 handling, memory safe-mode errors, and route-inventory classification.

## Risk Notes

Production server routing is unchanged and remains on Hono in this PR. The new HttpApi schemas use broad `Schema.Any` only where the current route wire shape is Zod-owned or app-specific and preserving Hono behavior is more important than overstating OpenAPI precision.

Skipped checklist items: visible UI/copy check is not applicable; platform/packaging check is not applicable; docs/release/dependency/permission/generated-content checks are not applicable.

## How To Verify

```text
Baseline focused routes: 24 passed before changes
Focused route coverage: 34 passed after changes, 169 expect() calls
Typecheck: GOMAXPROCS=2 bun run typecheck passed
Diff check: git diff --check passed
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
