### PR TITLE
refactor(opencode): add permission workspace HttpApi coverage

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
@@ -1,0 +1,88 @@
+import { PermissionID } from "@/permission/schema"
+import { MessageID, SessionID } from "@/session/schema"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+
+const root = "/permission"
+
+const PermissionRequest = Schema.Struct({
+  id: PermissionID,
+  sessionID: SessionID,
+  permission: Schema.String,
+  patterns: Schema.Array(Schema.String),
+  metadata: Schema.Record(Schema.String, Schema.Any),
+  always: Schema.Array(Schema.String),
+  tool: Schema.optional(
+    Schema.Struct({
+      messageID: MessageID,
+      callID: Schema.String,
+    }),
+  ),
+})
+
+const PermissionReplyPayload = Schema.Struct({
+  reply: Schema.Literals(["once", "always", "reject"]),
+  message: Schema.optional(Schema.String),
+})
+
+const PermissionReplyParam = Schema.Struct({
+  requestID: PermissionID,
+})
+
+const PermissionNotFoundError = Schema.Struct({
+  name: Schema.Literal("NotFoundError"),
+  data: Schema.Struct({
+    message: Schema.String,
+  }),
+}).pipe(
+  HttpApiSchema.status(404),
+  (schema) =>
+    schema.annotate({
+      identifier: "PermissionNotFoundError",
+      description: "Permission request not found",
+    }),
+)
+
+export const PermissionApi = HttpApi.make("permission")
+  .add(
+    HttpApiGroup.make("permission")
+      .add(
+        HttpApiEndpoint.get("list", root, {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Array(PermissionRequest),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "permission.list",
+            summary: "List pending permissions",
+            description: "Get all pending permission requests across all sessions.",
+          }),
+        ),
+        HttpApiEndpoint.post("reply", `${root}/:requestID/reply`, {
+          params: PermissionReplyParam,
+          query: WorkspaceRoutingQuery,
+          payload: PermissionReplyPayload,
+          success: Schema.Boolean,
+          error: [BadRequestError, PermissionNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "permission.reply",
+            summary: "Respond to permission request",
+            description: "Approve or deny a permission request from the AI assistant.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "permission",
+          description: "HttpApi permission routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode permission HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for the permission route group.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/workspace.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/workspace.ts
@@ -1,0 +1,104 @@
+import { WorkspaceID } from "@/control-plane/schema"
+import { ProjectID } from "@/project/schema"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+
+const root = "/experimental/workspace"
+
+const WorkspaceInfo = Schema.Struct({
+  id: WorkspaceID,
+  type: Schema.String,
+  branch: Schema.NullOr(Schema.String),
+  name: Schema.NullOr(Schema.String),
+  directory: Schema.NullOr(Schema.String),
+  extra: Schema.NullOr(Schema.Unknown),
+  projectID: ProjectID,
+})
+
+const WorkspaceConnectionStatus = Schema.Struct({
+  workspaceID: WorkspaceID,
+  status: Schema.Literals(["connected", "connecting", "disconnected", "error"]),
+  error: Schema.optional(Schema.String),
+})
+
+const WorkspaceCreatePayload = Schema.Struct({
+  id: Schema.optional(WorkspaceID),
+  type: Schema.String,
+  branch: Schema.NullOr(Schema.String),
+  extra: Schema.NullOr(Schema.Unknown),
+})
+
+const WorkspaceIDParam = Schema.Struct({
+  id: WorkspaceID,
+})
+
+export const WorkspacePaths = {
+  list: root,
+  status: `${root}/status`,
+  remove: `${root}/:id`,
+} as const
+
+export const WorkspaceApi = HttpApi.make("workspace")
+  .add(
+    HttpApiGroup.make("workspace")
+      .add(
+        HttpApiEndpoint.post("create", WorkspacePaths.list, {
+          query: WorkspaceRoutingQuery,
+          payload: WorkspaceCreatePayload,
+          success: WorkspaceInfo,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "experimental.workspace.create",
+            summary: "Create workspace",
+            description: "Create a workspace for the current project.",
+          }),
+        ),
+        HttpApiEndpoint.get("list", WorkspacePaths.list, {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Array(WorkspaceInfo),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "experimental.workspace.list",
+            summary: "List workspaces",
+            description: "List all workspaces.",
+          }),
+        ),
+        HttpApiEndpoint.get("status", WorkspacePaths.status, {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Array(WorkspaceConnectionStatus),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "experimental.workspace.status",
+            summary: "Workspace status",
+            description: "Get connection status for workspaces in the current project.",
+          }),
+        ),
+        HttpApiEndpoint.delete("remove", WorkspacePaths.remove, {
+          params: WorkspaceIDParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.UndefinedOr(WorkspaceInfo),
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "experimental.workspace.remove",
+            summary: "Remove workspace",
+            description: "Remove an existing workspace.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "workspace",
+          description: "HttpApi experimental workspace routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode workspace HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for the experimental workspace route group.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
@@ -1,0 +1,99 @@
+import { Permission } from "@/permission"
+import { PermissionID } from "@/permission/schema"
+import { SessionLiveness } from "@/session/liveness"
+import { NotFoundError } from "@/storage/db"
+import { NamedError } from "@opencode-ai/util/error"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { PermissionApi } from "../groups/permission"
+
+type PermissionReplyBody = {
+  reply: z.infer<typeof Permission.Reply>
+  message?: string
+}
+
+const PermissionReplyBody = z.object({
+  reply: Permission.Reply,
+  message: z.string().optional(),
+})
+
+function isJsonContentType(contentType: string | undefined) {
+  // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: z.ZodType<T>) {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+    return parsed.data
+  })
+}
+
+function permissionFailure(error: unknown) {
+  if (error instanceof NotFoundError) return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 404 }))
+  if (error instanceof NamedError) return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 500 }))
+  return Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
+      { status: 500 },
+    ),
+  )
+}
+
+export const permissionHandlers = HttpApiBuilder.group(PermissionApi, "permission", (handlers) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+
+    const list = Effect.fn("PermissionHttpApi.list")(function* () {
+      return yield* permission.list().pipe(
+        Effect.flatMap((items) =>
+          SessionLiveness.pruneDangling(items, (sessionID) => permission.clearSession(sessionID, "dangling_session")),
+        ),
+      )
+    })
+
+    const reply = Effect.fn("PermissionHttpApi.reply")(function* (requestID: PermissionID, json: PermissionReplyBody) {
+      yield* permission.reply({
+        requestID,
+        reply: json.reply,
+        message: json.message,
+      })
+      return true
+    })
+
+    return handlers
+      .handleRaw("list", () =>
+        list().pipe(
+          Effect.map((value) => HttpServerResponse.jsonUnsafe(value)),
+          Effect.catch(permissionFailure),
+          Effect.catchDefect(permissionFailure),
+        ),
+      )
+      .handleRaw("reply", (ctx) =>
+        Effect.gen(function* () {
+          const payload = yield* parseJsonBody(ctx.request, PermissionReplyBody)
+          if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+          const result = yield* reply(ctx.params.requestID, payload).pipe(
+            Effect.map((value) => HttpServerResponse.jsonUnsafe(value)),
+            Effect.catch(permissionFailure),
+            Effect.catchDefect(permissionFailure),
+          )
+          return result
+        }),
+      )
+  }),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/workspace.ts
@@ -1,0 +1,131 @@
+import { Workspace } from "@/control-plane/workspace"
+import { WorkspaceID } from "@/control-plane/schema"
+import { Instance } from "@/project/instance"
+import { NamedError } from "@opencode-ai/util/error"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { WorkspaceApi } from "../groups/workspace"
+
+const WorkspaceCreateBody = z.object({
+  id: WorkspaceID.zod.optional(),
+  type: z.string(),
+  branch: z.string().nullable(),
+  extra: z.unknown().nullable(),
+})
+
+type WorkspaceCreateBody = z.infer<typeof WorkspaceCreateBody>
+
+function preserveWorkspaceRouteError<A>(effect: Effect.Effect<A, Workspace.WorkspaceError>) {
+  return effect.pipe(
+    Effect.catch((error) => {
+      // Preserve facade-era errors so local HttpApi mirrors ErrorMiddleware's NamedError status mapping.
+      if (error.cause instanceof Error) return Effect.fail(error.cause)
+      return Effect.fail(error)
+    }),
+  )
+}
+
+function isJsonContentType(contentType: string | undefined) {
+  // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: z.ZodType<T>) {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+    return parsed.data
+  })
+}
+
+function workspaceFailure(error: unknown) {
+  if (error instanceof Workspace.WorkspaceError && error.cause instanceof Error) return workspaceFailure(error.cause)
+  if (error instanceof NamedError) {
+    const status = error.name.startsWith("Worktree") ? 400 : 500
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status }))
+  }
+  return Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
+      { status: 500 },
+    ),
+  )
+}
+
+export const workspaceHandlers = HttpApiBuilder.group(WorkspaceApi, "workspace", (handlers) =>
+  Effect.gen(function* () {
+    const workspace = yield* Workspace.Service
+
+    const create = Effect.fn("WorkspaceHttpApi.create")(function* (body: WorkspaceCreateBody) {
+      return yield* preserveWorkspaceRouteError(
+        workspace.create({
+          projectID: Instance.project.id,
+          ...body,
+        }),
+      )
+    })
+
+    const list = Effect.fn("WorkspaceHttpApi.list")(function* () {
+      return yield* preserveWorkspaceRouteError(workspace.list(Instance.project))
+    })
+
+    const status = Effect.fn("WorkspaceHttpApi.status")(function* () {
+      const workspaces = yield* preserveWorkspaceRouteError(workspace.list(Instance.project))
+      const ids = new Set(workspaces.map((item) => item.id))
+      const statuses = yield* preserveWorkspaceRouteError(workspace.status())
+      return statuses.filter((item) => ids.has(item.workspaceID))
+    })
+
+    const remove = Effect.fn("WorkspaceHttpApi.remove")(function* (id: WorkspaceID) {
+      return yield* preserveWorkspaceRouteError(workspace.remove(id))
+    })
+
+    return handlers
+      .handleRaw("create", (ctx) =>
+        Effect.gen(function* () {
+          const payload = yield* parseJsonBody(ctx.request, WorkspaceCreateBody)
+          if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+          const result = yield* create(payload).pipe(
+            Effect.map((value) => HttpServerResponse.jsonUnsafe(value)),
+            Effect.catch(workspaceFailure),
+            Effect.catchDefect(workspaceFailure),
+          )
+          return result
+        }),
+      )
+      .handleRaw("list", () =>
+        list().pipe(
+          Effect.map((value) => HttpServerResponse.jsonUnsafe(value)),
+          Effect.catch(workspaceFailure),
+          Effect.catchDefect(workspaceFailure),
+        ),
+      )
+      .handleRaw("status", () =>
+        status().pipe(
+          Effect.map((value) => HttpServerResponse.jsonUnsafe(value)),
+          Effect.catch(workspaceFailure),
+          Effect.catchDefect(workspaceFailure),
+        ),
+      )
+      .handleRaw("remove", (ctx) =>
+        remove(ctx.params.id).pipe(
+          Effect.map((value) => HttpServerResponse.jsonUnsafe(value)),
+          Effect.catch(workspaceFailure),
+          Effect.catchDefect(workspaceFailure),
+        ),
+      )
+  }),
+)

--- a/packages/opencode/test/server/permission-routes.test.ts
+++ b/packages/opencode/test/server/permission-routes.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { Deferred } from "effect"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Deferred, Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Permission } from "../../src/permission"
@@ -7,6 +10,9 @@ import { PermissionID } from "../../src/permission/schema"
 import { Instance } from "../../src/project/instance"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { PermissionRoutes } from "../../src/server/instance/permission"
+import { PermissionApi } from "../../src/server/routes/instance/httpapi/groups/permission"
+import { permissionHandlers } from "../../src/server/routes/instance/httpapi/handlers/permission"
+import { Session } from "../../src/session"
 import { SessionRoutes } from "../../src/server/instance/session"
 import { SessionID } from "../../src/session/schema"
 import { tmpdir } from "../fixture/fixture"
@@ -22,24 +28,52 @@ describe("permission routes", () => {
     return instance
   }
 
+  function requestPermissionHttpApi(path: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(PermissionApi).pipe(
+              Layer.provide(permissionHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${path}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
   function sessionApp() {
     const instance = new Hono().route("/session", SessionRoutes())
     instance.onError(ErrorMiddleware)
     return instance
   }
 
+  test("declares the permission route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(PermissionApi) as any
+
+    expect(spec.paths).toHaveProperty("/permission")
+    expect(spec.paths).toHaveProperty("/permission/{requestID}/reply")
+    expect(spec.paths["/permission"]).toHaveProperty("get")
+    expect(spec.paths["/permission/{requestID}/reply"]).toHaveProperty("post")
+  })
+
   test("replies to a pending permission through the route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
+        const session = await AppRuntime.runPromise(Session.Service.use((service) => service.create({})))
         const requestID = PermissionID.ascending()
         const pending = await AppRuntime.runPromise(Deferred.make<void>())
         const asked = AppRuntime.runPromise(
           Permission.Service.use((permission) =>
             permission.ask({
               id: requestID,
-              sessionID: SessionID.descending(),
+              sessionID: session.id,
               permission: "bash",
               patterns: ["echo ok"],
               metadata: {},
@@ -61,6 +95,78 @@ describe("permission routes", () => {
         expect(response.status).toBe(200)
         expect(await response.json()).toBe(true)
         await expect(asked).resolves.toBeUndefined()
+      },
+    })
+  })
+
+  test("lists permissions and replies to pending permissions through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const listResponse = await requestPermissionHttpApi("/permission")
+        expect(listResponse.status).toBe(200)
+        expect(await listResponse.json()).toEqual([])
+
+        const session = await AppRuntime.runPromise(Session.Service.use((service) => service.create({})))
+        const requestID = PermissionID.ascending()
+        const pending = await AppRuntime.runPromise(Deferred.make<void>())
+        const asked = AppRuntime.runPromise(
+          Permission.Service.use((permission) =>
+            permission.ask({
+              id: requestID,
+              sessionID: session.id,
+              permission: "bash",
+              patterns: ["echo ok"],
+              metadata: {},
+              always: ["echo ok"],
+              ruleset: [{ permission: "bash", pattern: "echo ok", action: "ask" }],
+              onPending: () => Deferred.succeed(pending, undefined),
+            }),
+          ),
+        )
+
+        await AppRuntime.runPromise(Deferred.await(pending))
+
+        const pendingListResponse = await requestPermissionHttpApi("/permission")
+        expect(pendingListResponse.status).toBe(200)
+        expect(await pendingListResponse.json()).toMatchObject([
+          {
+            id: requestID,
+            sessionID: session.id,
+            permission: "bash",
+            patterns: ["echo ok"],
+            metadata: {},
+            always: ["echo ok"],
+          },
+        ])
+
+        const replyResponse = await requestPermissionHttpApi(`/permission/${requestID}/reply`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ reply: "once" }),
+        })
+
+        expect(replyResponse.status).toBe(200)
+        expect(await replyResponse.json()).toBe(true)
+        await expect(asked).resolves.toBeUndefined()
+      },
+    })
+  })
+
+  test("rejects malformed reply JSON through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestPermissionHttpApi(`/permission/${PermissionID.ascending()}/reply`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{",
+        })
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe("Malformed JSON in request body")
       },
     })
   })

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -68,6 +68,12 @@ describe("route inventory harness", () => {
       ["DELETE", "/mcp/:name/auth"],
       ["POST", "/mcp/:name/connect"],
       ["POST", "/mcp/:name/disconnect"],
+      ["GET", "/permission"],
+      ["POST", "/permission/:requestID/reply"],
+      ["POST", "/experimental/workspace"],
+      ["GET", "/experimental/workspace"],
+      ["GET", "/experimental/workspace/status"],
+      ["DELETE", "/experimental/workspace/:id"],
     ] as const) {
       expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
         hono: true,

--- a/packages/opencode/test/server/workspace-routes.test.ts
+++ b/packages/opencode/test/server/workspace-routes.test.ts
@@ -1,13 +1,20 @@
 import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
 import path from "path"
 import { pathToFileURL } from "url"
 import { Log } from "@opencode-ai/core/util/log"
 import { Workspace } from "../../src/control-plane/workspace"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { WorkspaceRoutes } from "../../src/server/instance/workspace"
+import { WorkspaceApi } from "../../src/server/routes/instance/httpapi/groups/workspace"
+import { workspaceHandlers } from "../../src/server/routes/instance/httpapi/handlers/workspace"
 import { resetDatabase } from "../fixture/db"
 import { tmpdir } from "../fixture/fixture"
 
@@ -28,6 +35,24 @@ afterAll(() => {
 
 function app() {
   return new Hono().onError(ErrorMiddleware).route("/workspace", WorkspaceRoutes())
+}
+
+function requestWorkspaceHttpApi(path: string, init?: RequestInit) {
+  return AppRuntime.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const router = yield* HttpRouter.toHttpEffect(
+          HttpApiBuilder.layer(WorkspaceApi).pipe(
+            Layer.provide(workspaceHandlers),
+            Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+          ),
+        )
+        const request = HttpServerRequest.fromWeb(new Request(`http://localhost${path}`, init))
+        const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+        return HttpServerResponse.toWeb(response)
+      }),
+    ) as Effect.Effect<Response>,
+  )
 }
 
 async function workspaceProject(label: string) {
@@ -85,6 +110,18 @@ async function createWorkspace(type: string) {
   })
 }
 
+async function createWorkspaceHttpApi(type: string) {
+  return requestWorkspaceHttpApi("/experimental/workspace", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      type,
+      branch: null,
+      extra: null,
+    }),
+  })
+}
+
 async function waitForStatus(workspaceID: string) {
   for (let attempt = 0; attempt < 20; attempt++) {
     const status = Workspace.status()
@@ -95,6 +132,18 @@ async function waitForStatus(workspaceID: string) {
 }
 
 describe("workspace routes", () => {
+  test("declares the experimental workspace route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(WorkspaceApi) as any
+
+    expect(spec.paths).toHaveProperty("/experimental/workspace")
+    expect(spec.paths).toHaveProperty("/experimental/workspace/status")
+    expect(spec.paths).toHaveProperty("/experimental/workspace/{id}")
+    expect(spec.paths["/experimental/workspace"]).toHaveProperty("post")
+    expect(spec.paths["/experimental/workspace"]).toHaveProperty("get")
+    expect(spec.paths["/experimental/workspace/status"]).toHaveProperty("get")
+    expect(spec.paths["/experimental/workspace/{id}"]).toHaveProperty("delete")
+  })
+
   test("creates, lists, reports status, and removes workspaces through the route runtime", async () => {
     await using current = await workspaceProject("current")
     await using other = await workspaceProject("other")
@@ -158,6 +207,42 @@ describe("workspace routes", () => {
     })
   })
 
+  test("creates, lists, reports status, and removes workspaces through the HttpApi handlers", async () => {
+    await using current = await workspaceProject("current-httpapi")
+
+    await Instance.provide({
+      directory: current.path,
+      fn: async () => {
+        await Plugin.init()
+
+        const createdResponse = await createWorkspaceHttpApi(current.extra.type)
+        expect(createdResponse.status).toBe(200)
+        const created = (await createdResponse.json()) as Workspace.Info
+        expect(created).toMatchObject({
+          type: current.extra.type,
+          name: "current-httpapi",
+          branch: "route/main",
+          directory: current.path,
+          projectID: Instance.project.id,
+        })
+
+        const listResponse = await requestWorkspaceHttpApi("/experimental/workspace")
+        expect(listResponse.status).toBe(200)
+        expect(await listResponse.json()).toEqual([created])
+
+        await waitForStatus(created.id)
+        const statusResponse = await requestWorkspaceHttpApi("/experimental/workspace/status")
+        expect(statusResponse.status).toBe(200)
+        const status = (await statusResponse.json()) as Workspace.ConnectionStatus[]
+        expect(status.map((item) => item.workspaceID)).toContain(created.id)
+
+        const deleteResponse = await requestWorkspaceHttpApi(`/experimental/workspace/${created.id}`, { method: "DELETE" })
+        expect(deleteResponse.status).toBe(200)
+        expect(await deleteResponse.json()).toEqual(created)
+      },
+    })
+  })
+
   test("keeps worktree create failures as bad requests", async () => {
     await using tmp = await tmpdir()
 
@@ -165,6 +250,24 @@ describe("workspace routes", () => {
       directory: tmp.path,
       fn: async () => {
         const response = await createWorkspace("worktree")
+        expect(response.status).toBe(400)
+        expect(await response.json()).toMatchObject({
+          name: "WorktreeNotGitError",
+          data: {
+            message: "Worktrees are only supported for git projects",
+          },
+        })
+      },
+    })
+  })
+
+  test("keeps worktree create failures as bad requests through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await createWorkspaceHttpApi("worktree")
         expect(response.status).toBe(400)
         expect(await response.json()).toMatchObject({
           name: "WorktreeNotGitError",


### PR DESCRIPTION
## Summary

Add local Effect HttpApi declarations and handlers for the permission and experimental workspace JSON routes covered by this #936 slice. The production server remains on the existing Hono routes.

## Why

This moves another small ordinary-JSON route group into the local HttpApi migration inventory while preserving the current Hono wire behavior and avoiding unrelated server-switching work.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the local HttpApi handlers preserve the existing Hono behavior for permission reply/list and experimental workspace create/list/status/remove, including malformed JSON and bad-request mapping.

## Risk Notes

No production server switch is included. `POST /permission/__e2e/ask` remains Hono-only because it is test-only and env-gated; the existing route inventory assertion keeps it classified separately. No visible UI/copy, platform/packaging, docs, release notes, dependencies, credentials, deletion-policy, generated-content, or local-file surfaces changed.

## How To Verify

```text
Baseline focused tests before changes: 46 passed across permission, workspace, workspace-router, workspace-routing-decision, and route-inventory harness.
Focused tests after changes: 52 passed across permission, workspace, workspace-router, workspace-routing-decision, and route-inventory harness.
Diff check: git diff --check passed.
Typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP API endpoints for permission management, enabling users to list permission requests and reply to specific requests.
  * Added HTTP API endpoints for workspace operations, allowing users to create, list, check connection status, and delete workspaces.

* **Tests**
  * Added comprehensive test coverage for new permission and workspace HTTP API endpoints, including validation of request/response handling and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->