### PR TITLE
fix(ci): avoid e2e install-deps apt timeout

### DIFF
--- a/.github/workflows/e2e-artifacts.yml
+++ b/.github/workflows/e2e-artifacts.yml
@@ -25,9 +25,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
-
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -142,23 +139,14 @@ jobs:
           restore-keys: |
             bun-${{ runner.os }}-
 
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/.playwright-browsers
-          key: playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}
-          restore-keys: |-
-            playwright-${{ runner.os }}-
-
       - run: bun install --frozen-lockfile
 
-      # Avoid Playwright's browser download path here; on this runner it can
-      # hang after reaching 100%. Use the GitHub-hosted Chrome install instead.
-      - name: Install Playwright system dependencies
-        timeout-minutes: 10
-        working-directory: packages/app
-        run: |
-          bunx playwright install-deps chromium
-          google-chrome --version
+      # This workflow runs Playwright against GitHub-hosted Chrome. Do not call
+      # `playwright install-deps chromium` here: on Ubuntu 24.04 it installs
+      # extra apt font packages and can time out before e2e starts.
+      - name: Verify GitHub-hosted Chrome
+        timeout-minutes: 2
+        run: google-chrome --version
 
       - name: Run e2e
         id: run_e2e

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -15,6 +15,8 @@ describe("e2e artifacts workflow", () => {
     const changesSteps = changes?.steps ?? []
     const steps = job?.steps ?? []
     const checkSteps = checkJob?.steps ?? []
+    const runCommands = steps.flatMap((step) => (typeof step.run === "string" ? [step.run] : []))
+    const runCommandText = runCommands.join("\n")
     const docsPathsStep = changesSteps.find((step) => step.id === "docs-paths")
     const codePathsStep = changesSteps.find((step) => step.id === "code-paths")
     const filterStep = changesSteps.find((step) => step.id === "filter")
@@ -75,8 +77,8 @@ describe("e2e artifacts workflow", () => {
     expect(chromeStep?.["timeout-minutes"]).toBe(2)
     expect(chromeStep?.run).toBe("google-chrome --version")
     expect(workflow).not.toContain("PLAYWRIGHT_BROWSERS_PATH")
-    expect(workflow).not.toContain("bunx playwright install")
-    expect(workflow).not.toContain("run: playwright install")
+    expect(runCommandText).not.toContain("playwright install")
+    expect(runCommandText).not.toContain("playwright install-deps")
     expect(runStep?.env?.PLAYWRIGHT_BROWSER_CHANNEL).toBe("chrome")
     expect(runStep?.env?.PLAYWRIGHT_VIDEO).toBe("off")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")

--- a/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
+++ b/packages/opencode/test/config/e2e-artifacts-workflow.test.ts
@@ -23,7 +23,7 @@ describe("e2e artifacts workflow", () => {
     const playwrightCacheStep = steps.find(
       (step) => step.uses?.startsWith("actions/cache@") && step.with?.path === "${{ github.workspace }}/.playwright-browsers",
     )
-    const installBrowsersStep = steps.find((step) => step.name === "Install Playwright system dependencies")
+    const chromeStep = steps.find((step) => step.name === "Verify GitHub-hosted Chrome")
     const runStep = steps.find((step) => step.name === "Run e2e")
     const warnStep = steps.find((step) => step.name === "Warn on E2E failure")
     const uploadStep = steps.find((step) => step.name === "Upload e2e artifacts")
@@ -71,13 +71,12 @@ describe("e2e artifacts workflow", () => {
     expect(checkoutStep?.uses).toBe("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd")
     expect(checkoutStep?.with).toEqual({ "persist-credentials": false })
     expect(bunStep?.uses).toBe("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6")
-    expect(playwrightCacheStep?.with?.key).toBe(
-      "playwright-${{ runner.os }}-${{ hashFiles('packages/app/package.json', 'bun.lock') }}",
-    )
-    expect(playwrightCacheStep?.with?.["restore-keys"]).toBe("playwright-${{ runner.os }}-")
-    expect(installBrowsersStep?.["timeout-minutes"]).toBe(10)
-    expect(installBrowsersStep?.run).toContain("bunx playwright install-deps chromium")
-    expect(installBrowsersStep?.run).not.toContain("playwright install chromium")
+    expect(playwrightCacheStep).toBeUndefined()
+    expect(chromeStep?.["timeout-minutes"]).toBe(2)
+    expect(chromeStep?.run).toBe("google-chrome --version")
+    expect(workflow).not.toContain("PLAYWRIGHT_BROWSERS_PATH")
+    expect(workflow).not.toContain("bunx playwright install")
+    expect(workflow).not.toContain("run: playwright install")
     expect(runStep?.env?.PLAYWRIGHT_BROWSER_CHANNEL).toBe("chrome")
     expect(runStep?.env?.PLAYWRIGHT_VIDEO).toBe("off")
     expect(runStep?.run).toContain("bun --cwd packages/app test:e2e:local:smoke")


### PR DESCRIPTION
## Summary

Stop the PR `e2e-artifacts` workflow from calling Playwright's apt dependency helper before running Chrome-channel e2e tests.

The workflow now verifies the GitHub-hosted Chrome binary directly, keeps the real `Run e2e` step unchanged, and keeps the warning, artifact upload, and aggregate check behavior intact.

## Why

`Related to #1378`
`Related to #1380`

PR #1378 and PR #1380 both had green code-related checks but `e2e-artifacts` failed before the test suite started. The failing Ubuntu 24.04 hosted runners timed out in `bunx playwright install-deps chromium` while downloading extra apt font packages from `azure.archive.ubuntu.com`; `Run e2e` was skipped.

This workflow already runs Playwright with `PLAYWRIGHT_BROWSER_CHANNEL=chrome`, so the Playwright-managed Chromium browser cache and `install-deps` apt path are not needed for the PR smoke suite. Avoiding that apt path unblocks install-deps timeouts while still failing the workflow when the actual e2e run fails.

## Related Issue

Related to #1378 and #1380.

## Human Review Status

Pending

## Review Focus

Please check that the workflow still reports real e2e failures and uploads artifacts, while no longer depending on the slow Playwright apt dependency install step.

## Risk Notes

Residual risk: if the GitHub-hosted Ubuntu image stops including `google-chrome`, this workflow will fail fast at `Verify GitHub-hosted Chrome` instead of timing out in apt. That is intentional and easier to diagnose than a 10-minute apt timeout.

Skipped conditional checklist items:

- Visible UI/copy check: not applicable; this changes only GitHub Actions workflow behavior.
- macOS/Windows platform check: not applicable; this changes only the Ubuntu PR e2e workflow.
- Docs/release/dependency/permission/generated-content check: not applicable; no docs, dependency files, credentials, or generated outputs changed.

Out of scope: `perf-probe-baseline.yml` still has its own `bunx playwright install-deps chromium` contract. It is a separate performance workflow, not the PR `e2e-artifacts` blocker for #1378/#1380.

## How To Verify

```text
RED contract check: bun test test/config/e2e-artifacts-workflow.test.ts (packages/opencode) failed before the workflow change because the old Playwright browser cache/install-deps path was still present.
Focused workflow contract: bun test test/config/e2e-artifacts-workflow.test.ts (packages/opencode) passed, 1 test / 62 assertions.
Typecheck: bun run typecheck (packages/opencode) passed.
Workflow syntax: actionlint .github/workflows/e2e-artifacts.yml passed.
Diff hygiene: git diff --check passed.
Live PR CI: e2e-artifacts on #1381 reached Verify GitHub-hosted Chrome successfully and entered the real Run e2e step on the new workflow, proving the previous apt/install-deps layer is bypassed.
Review gate: fresh-eye review reported no P0/P1/P2/P3; Claude review reported no P0/P1 and one non-blocking P2 about the separate perf workflow retaining the same pattern.
```

## Screenshots or Recordings

Not applicable; this is a CI workflow-only change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
