### PR TITLE
refactor(opencode): add pty control HttpApi coverage

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/control.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/control.ts
@@ -1,0 +1,71 @@
+import { Auth } from "@/auth"
+import { ProviderID } from "@/provider/schema"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+
+const AuthParam = Schema.Struct({
+  providerID: ProviderID,
+})
+
+const LogPayload = Schema.Struct({
+  service: Schema.String,
+  level: Schema.Literals(["debug", "info", "error", "warn"]),
+  message: Schema.String,
+  extra: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
+})
+
+export const ControlApi = HttpApi.make("control")
+  .add(
+    HttpApiGroup.make("control")
+      .add(
+        HttpApiEndpoint.put("authSet", "/auth/:providerID", {
+          params: AuthParam,
+          payload: Auth.Info,
+          success: Schema.Boolean,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "auth.set",
+            summary: "Set auth credentials",
+            description: "Set authentication credentials",
+          }),
+        ),
+        HttpApiEndpoint.delete("authRemove", "/auth/:providerID", {
+          params: AuthParam,
+          success: Schema.Boolean,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "auth.remove",
+            summary: "Remove auth credentials",
+            description: "Remove authentication credentials",
+          }),
+        ),
+        HttpApiEndpoint.post("log", "/log", {
+          query: WorkspaceRoutingQuery,
+          payload: LogPayload,
+          success: Schema.Boolean,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "app.log",
+            summary: "Write log",
+            description: "Write a log entry to the server logs with specified level and metadata.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "control",
+          description: "HttpApi control-plane JSON routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode control HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for control-plane JSON routes.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/pty.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/pty.ts
@@ -1,0 +1,128 @@
+import { PtyID } from "@/pty/schema"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, NotFoundError } from "./common"
+
+const root = "/pty"
+
+const PtyParam = Schema.Struct({
+  ptyID: PtyID,
+})
+
+const PtyInfo = Schema.Struct({
+  id: PtyID,
+  title: Schema.String,
+  command: Schema.String,
+  args: Schema.Array(Schema.String),
+  cwd: Schema.String,
+  status: Schema.Literals(["running", "exited"]),
+  pid: Schema.Number,
+})
+
+const PtyCreateInput = Schema.Struct({
+  command: Schema.optional(Schema.String),
+  args: Schema.optional(Schema.Array(Schema.String)),
+  cwd: Schema.optional(Schema.String),
+  title: Schema.optional(Schema.String),
+  env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+})
+
+const PtyUpdateInput = Schema.Struct({
+  title: Schema.optional(Schema.String),
+  size: Schema.optional(
+    Schema.Struct({
+      rows: Schema.Number,
+      cols: Schema.Number,
+    }),
+  ),
+})
+
+const ConnectToken = Schema.Struct({
+  ticket: Schema.String,
+  expires_in: Schema.Number.check(Schema.isInt()).check(Schema.isGreaterThan(0)),
+})
+
+export const PtyApi = HttpApi.make("pty")
+  .add(
+    HttpApiGroup.make("pty")
+      .add(
+        HttpApiEndpoint.get("list", root, {
+          success: Schema.Array(PtyInfo),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "pty.list",
+            summary: "List PTY sessions",
+            description: "Get a list of all active pseudo-terminal (PTY) sessions managed by OpenCode.",
+          }),
+        ),
+        HttpApiEndpoint.post("create", root, {
+          payload: PtyCreateInput,
+          success: PtyInfo,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "pty.create",
+            summary: "Create PTY session",
+            description: "Create a new pseudo-terminal (PTY) session for running shell commands and processes.",
+          }),
+        ),
+        HttpApiEndpoint.get("get", `${root}/:ptyID`, {
+          params: PtyParam,
+          success: PtyInfo,
+          error: NotFoundError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "pty.get",
+            summary: "Get PTY session",
+            description: "Retrieve detailed information about a specific pseudo-terminal (PTY) session.",
+          }),
+        ),
+        HttpApiEndpoint.put("update", `${root}/:ptyID`, {
+          params: PtyParam,
+          payload: PtyUpdateInput,
+          success: PtyInfo,
+          error: [BadRequestError, NotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "pty.update",
+            summary: "Update PTY session",
+            description: "Update properties of an existing pseudo-terminal (PTY) session.",
+          }),
+        ),
+        HttpApiEndpoint.delete("remove", `${root}/:ptyID`, {
+          params: PtyParam,
+          success: Schema.Boolean,
+          error: NotFoundError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "pty.remove",
+            summary: "Remove PTY session",
+            description: "Remove and terminate a specific pseudo-terminal (PTY) session.",
+          }),
+        ),
+        HttpApiEndpoint.post("connectToken", `${root}/:ptyID/connect-token`, {
+          params: PtyParam,
+          success: ConnectToken,
+          error: NotFoundError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "pty.connectToken",
+            summary: "Create PTY WebSocket token",
+            description: "Create a short-lived ticket for opening a PTY WebSocket connection.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "pty",
+          description: "HttpApi PTY JSON and connect-token routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode pty HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for PTY JSON and connect-token routes.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/control.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/control.ts
@@ -1,0 +1,123 @@
+import { Auth } from "@/auth"
+import { ProviderID } from "@/provider/schema"
+import { Log } from "@opencode-ai/core/util/log"
+import { NamedError } from "@opencode-ai/util/error"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { ControlApi } from "../groups/control"
+
+const LogPayload = z.object({
+  service: z.string(),
+  level: z.enum(["debug", "info", "error", "warn"]),
+  message: z.string(),
+  extra: z.record(z.string(), z.any()).optional(),
+})
+
+type LogPayload = z.infer<typeof LogPayload>
+
+function isJsonContentType(contentType: string | undefined) {
+  // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: z.ZodType<T>) {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+    return parsed.data
+  })
+}
+
+function controlFailure(error: unknown) {
+  if (error instanceof NamedError) return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 500 }))
+  return Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
+      { status: 500 },
+    ),
+  )
+}
+
+function writeLog(payload: LogPayload) {
+  const logger = Log.create({ service: payload.service })
+
+  switch (payload.level) {
+    case "debug":
+      logger.debug(payload.message, payload.extra)
+      break
+    case "info":
+      logger.info(payload.message, payload.extra)
+      break
+    case "error":
+      logger.error(payload.message, payload.extra)
+      break
+    case "warn":
+      logger.warn(payload.message, payload.extra)
+      break
+  }
+}
+
+export const controlHandlers = HttpApiBuilder.group(ControlApi, "control", (handlers) =>
+  Effect.gen(function* () {
+    const auth = yield* Auth.Service
+
+    const authSet = Effect.fn("ControlHttpApi.authSet")(function* (providerID: ProviderID, info: Auth.Info) {
+      yield* auth.set(providerID, info)
+      return true
+    })
+
+    const authRemove = Effect.fn("ControlHttpApi.authRemove")(function* (providerID: ProviderID) {
+      yield* auth.remove(providerID)
+      return true
+    })
+
+    const log = Effect.fn("ControlHttpApi.log")(function* (payload: LogPayload) {
+      yield* Effect.sync(() => writeLog(payload))
+      return true
+    })
+
+    return handlers
+      .handleRaw("authSet", (ctx) =>
+        Effect.gen(function* () {
+          const payload = yield* parseJsonBody(ctx.request, Auth.Info.zod)
+          if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+          return yield* authSet(ctx.params.providerID, payload).pipe(
+            Effect.map((result) => HttpServerResponse.jsonUnsafe(result)),
+            Effect.catch(controlFailure),
+            Effect.catchDefect(controlFailure),
+          )
+        }),
+      )
+      .handleRaw("authRemove", (ctx) =>
+        authRemove(ctx.params.providerID).pipe(
+          Effect.map((result) => HttpServerResponse.jsonUnsafe(result)),
+          Effect.catch(controlFailure),
+          Effect.catchDefect(controlFailure),
+        ),
+      )
+      .handleRaw("log", (ctx) =>
+        Effect.gen(function* () {
+          const payload = yield* parseJsonBody(ctx.request, LogPayload)
+          if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+          return yield* log(payload).pipe(
+            Effect.map((result) => HttpServerResponse.jsonUnsafe(result)),
+            Effect.catch(controlFailure),
+            Effect.catchDefect(controlFailure),
+          )
+        }),
+      )
+  }),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts
@@ -1,0 +1,162 @@
+import { Pty } from "@/pty"
+import { PtyID } from "@/pty/schema"
+import { PtyTicket } from "@/pty/ticket"
+import { NotFoundError } from "@/storage/db"
+import { NamedError } from "@opencode-ai/util/error"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { PtyApi } from "../groups/pty"
+
+const PtyParam = z.object({ ptyID: PtyID.zod })
+
+function isJsonContentType(contentType: string | undefined) {
+  // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: z.ZodType<T>) {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return badRequestJson({ data: body, error: parsed.error.issues, success: false })
+    return parsed.data
+  })
+}
+
+function parseZod<T>(data: unknown, schema: z.ZodType<T>) {
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) return badRequestJson({ data, error: parsed.error.issues, success: false })
+  return parsed.data
+}
+
+function notFound(message: string) {
+  return new NotFoundError({ message })
+}
+
+function ptyFailure(error: unknown) {
+  if (error instanceof NotFoundError) return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 404 }))
+  if (error instanceof NamedError) return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 500 }))
+  return Effect.succeed(
+    HttpServerResponse.jsonUnsafe(
+      new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
+      { status: 500 },
+    ),
+  )
+}
+
+export const ptyHandlers = HttpApiBuilder.group(PtyApi, "pty", (handlers) =>
+  Effect.gen(function* () {
+    const pty = yield* Pty.Service
+
+    const list = Effect.fn("PtyHttpApi.list")(function* () {
+      return yield* pty.list()
+    })
+
+    const create = Effect.fn("PtyHttpApi.create")(function* (input: Pty.CreateInput) {
+      return yield* pty.create(input)
+    })
+
+    const get = Effect.fn("PtyHttpApi.get")(function* (id: PtyID) {
+      const info = yield* pty.get(id)
+      if (!info) return yield* Effect.fail(notFound("Session not found"))
+      return info
+    })
+
+    const update = Effect.fn("PtyHttpApi.update")(function* (id: PtyID, input: Pty.UpdateInput) {
+      const info = yield* pty.update(id, input)
+      if (!info) return yield* Effect.fail(notFound("Session not found"))
+      return info
+    })
+
+    const remove = Effect.fn("PtyHttpApi.remove")(function* (id: PtyID) {
+      const info = yield* pty.get(id)
+      if (!info) return yield* Effect.fail(notFound("Session not found"))
+      yield* pty.remove(id)
+      return true
+    })
+
+    const connectToken = Effect.fn("PtyHttpApi.connectToken")(function* (id: PtyID) {
+      const info = yield* pty.get(id)
+      if (!info) return yield* Effect.fail(notFound("PTY session not found"))
+      return PtyTicket.issue({ ptyID: id })
+    })
+
+    return handlers
+      .handleRaw("list", () =>
+        list().pipe(
+          Effect.map((sessions) => HttpServerResponse.jsonUnsafe(sessions)),
+          Effect.catch(ptyFailure),
+          Effect.catchDefect(ptyFailure),
+        ),
+      )
+      .handleRaw("create", (ctx) =>
+        Effect.gen(function* () {
+          const payload = yield* parseJsonBody(ctx.request, Pty.CreateInput)
+          if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+          return yield* create(payload).pipe(
+            Effect.map((info) => HttpServerResponse.jsonUnsafe(info)),
+            Effect.catch(ptyFailure),
+            Effect.catchDefect(ptyFailure),
+          )
+        }),
+      )
+      .handleRaw("get", (ctx) =>
+        Effect.gen(function* () {
+          const params = parseZod(ctx.params, PtyParam)
+          if (HttpServerResponse.isHttpServerResponse(params)) return params
+          return yield* get(params.ptyID).pipe(
+            Effect.map((info) => HttpServerResponse.jsonUnsafe(info)),
+            Effect.catch(ptyFailure),
+            Effect.catchDefect(ptyFailure),
+          )
+        }),
+      )
+      .handleRaw("update", (ctx) =>
+        Effect.gen(function* () {
+          const params = parseZod(ctx.params, PtyParam)
+          if (HttpServerResponse.isHttpServerResponse(params)) return params
+          const payload = yield* parseJsonBody(ctx.request, Pty.UpdateInput)
+          if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+          return yield* update(params.ptyID, payload).pipe(
+            Effect.map((info) => HttpServerResponse.jsonUnsafe(info)),
+            Effect.catch(ptyFailure),
+            Effect.catchDefect(ptyFailure),
+          )
+        }),
+      )
+      .handleRaw("remove", (ctx) =>
+        Effect.gen(function* () {
+          const params = parseZod(ctx.params, PtyParam)
+          if (HttpServerResponse.isHttpServerResponse(params)) return params
+          return yield* remove(params.ptyID).pipe(
+            Effect.map((removed) => HttpServerResponse.jsonUnsafe(removed)),
+            Effect.catch(ptyFailure),
+            Effect.catchDefect(ptyFailure),
+          )
+        }),
+      )
+      .handleRaw("connectToken", (ctx) =>
+        Effect.gen(function* () {
+          const params = parseZod(ctx.params, PtyParam)
+          if (HttpServerResponse.isHttpServerResponse(params)) return params
+          return yield* connectToken(params.ptyID).pipe(
+            Effect.map((token) => HttpServerResponse.jsonUnsafe(token)),
+            Effect.catch(ptyFailure),
+            Effect.catchDefect(ptyFailure),
+          )
+        }),
+      )
+  }),
+)

--- a/packages/opencode/test/server/control-routes.test.ts
+++ b/packages/opencode/test/server/control-routes.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Log } from "@opencode-ai/core/util/log"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
+import { Auth } from "../../src/auth"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { ControlApi } from "../../src/server/routes/instance/httpapi/groups/control"
+import { controlHandlers } from "../../src/server/routes/instance/httpapi/handlers/control"
+
+const testProviderID = "httpapi-control-provider"
+
+afterEach(async () => {
+  await Auth.remove(testProviderID).catch(() => {})
+})
+
+describe("control routes", () => {
+  function requestControlHttpApi(path: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(ControlApi).pipe(
+              Layer.provide(controlHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${path}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  test("declares auth and log control routes as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(ControlApi) as any
+
+    expect(spec.paths).toHaveProperty("/auth/{providerID}")
+    expect(spec.paths).toHaveProperty("/log")
+    expect(spec.paths).not.toHaveProperty("/doc")
+    expect(spec.paths["/auth/{providerID}"]).toHaveProperty("put")
+    expect(spec.paths["/auth/{providerID}"]).toHaveProperty("delete")
+    expect(spec.paths["/log"]).toHaveProperty("post")
+  })
+
+  test("sets and removes auth credentials through the HttpApi handlers", async () => {
+    const setResponse = await requestControlHttpApi(`/auth/${testProviderID}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "api", key: "sk-httpapi-control" }),
+    })
+
+    expect(setResponse.status).toBe(200)
+    expect(await setResponse.json()).toBe(true)
+    expect(await Auth.get(testProviderID)).toEqual({ type: "api", key: "sk-httpapi-control" })
+
+    const removeResponse = await requestControlHttpApi(`/auth/${testProviderID}`, { method: "DELETE" })
+
+    expect(removeResponse.status).toBe(200)
+    expect(await removeResponse.json()).toBe(true)
+    expect(await Auth.get(testProviderID)).toBeUndefined()
+  })
+
+  test("writes log entries through the HttpApi handlers", async () => {
+    const logger = Log.create({ service: "httpapi-control-test" })
+    const original = {
+      debug: logger.debug,
+      info: logger.info,
+      error: logger.error,
+      warn: logger.warn,
+    }
+    const calls: Array<{ level: string; message: unknown; extra: unknown }> = []
+    logger.debug = (message, extra) => {
+      calls.push({ level: "debug", message, extra })
+    }
+    logger.info = (message, extra) => {
+      calls.push({ level: "info", message, extra })
+    }
+    logger.error = (message, extra) => {
+      calls.push({ level: "error", message, extra })
+    }
+    logger.warn = (message, extra) => {
+      calls.push({ level: "warn", message, extra })
+    }
+
+    try {
+      for (const level of ["debug", "info", "error", "warn"] as const) {
+        const response = await requestControlHttpApi("/log", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            service: "httpapi-control-test",
+            level,
+            message: `control ${level}`,
+            extra: { source: "httpapi" },
+          }),
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toBe(true)
+      }
+      expect(calls).toEqual([
+        { level: "debug", message: "control debug", extra: { source: "httpapi" } },
+        { level: "info", message: "control info", extra: { source: "httpapi" } },
+        { level: "error", message: "control error", extra: { source: "httpapi" } },
+        { level: "warn", message: "control warn", extra: { source: "httpapi" } },
+      ])
+    } finally {
+      logger.debug = original.debug
+      logger.info = original.info
+      logger.error = original.error
+      logger.warn = original.warn
+    }
+  })
+
+  test("rejects invalid log JSON through the HttpApi handlers", async () => {
+    const response = await requestControlHttpApi("/log", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        service: "httpapi-control-test",
+        level: "verbose",
+        message: "control verbose",
+      }),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body).toMatchObject({
+      data: {
+        service: "httpapi-control-test",
+        level: "verbose",
+        message: "control verbose",
+      },
+      success: false,
+    })
+    expect(body.error).toBeArray()
+  })
+
+  test("rejects malformed log JSON through the HttpApi handlers", async () => {
+    const response = await requestControlHttpApi("/log", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe("Malformed JSON in request body")
+  })
+})

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
 import type { UpgradeWebSocket } from "hono/ws"
 import { Log } from "@opencode-ai/core/util/log"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { assertPtyConnectTarget, PtyRoutes } from "../../src/server/instance/pty"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { NotFoundError } from "../../src/storage/db"
@@ -9,6 +14,8 @@ import { Pty } from "../../src/pty"
 import { PtyID } from "../../src/pty/schema"
 import { PtyTicket } from "../../src/pty/ticket"
 import { Instance } from "../../src/project/instance"
+import { PtyApi } from "../../src/server/routes/instance/httpapi/groups/pty"
+import { ptyHandlers } from "../../src/server/routes/instance/httpapi/handlers/pty"
 import { Server } from "../../src/server/server"
 import { tmpdir } from "../fixture/fixture"
 
@@ -26,6 +33,188 @@ const testUpgradeWebSocket = ((createEvents: (c: unknown) => unknown | Promise<u
 }) as unknown as UpgradeWebSocket
 
 describe("pty routes", () => {
+  function requestPtyHttpApi(path: string, init?: RequestInit) {
+    return AppRuntime.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const router = yield* HttpRouter.toHttpEffect(
+            HttpApiBuilder.layer(PtyApi).pipe(
+              Layer.provide(ptyHandlers),
+              Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+            ),
+          )
+          const request = HttpServerRequest.fromWeb(new Request(`http://localhost${path}`, init))
+          const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+          return HttpServerResponse.toWeb(response)
+        }),
+      ) as Effect.Effect<Response>,
+    )
+  }
+
+  test("declares the PTY JSON route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(PtyApi) as any
+
+    expect(spec.paths).toHaveProperty("/pty")
+    expect(spec.paths).toHaveProperty("/pty/{ptyID}")
+    expect(spec.paths).toHaveProperty("/pty/{ptyID}/connect-token")
+    expect(spec.paths).not.toHaveProperty("/pty/{ptyID}/connect")
+    expect(spec.paths["/pty"]).toHaveProperty("get")
+    expect(spec.paths["/pty"]).toHaveProperty("post")
+    expect(spec.paths["/pty/{ptyID}"]).toHaveProperty("get")
+    expect(spec.paths["/pty/{ptyID}"]).toHaveProperty("put")
+    expect(spec.paths["/pty/{ptyID}"]).toHaveProperty("delete")
+    expect(spec.paths["/pty/{ptyID}/connect-token"]).toHaveProperty("post")
+
+    const connectTokenSchema =
+      spec.paths["/pty/{ptyID}/connect-token"].post.responses["200"].content["application/json"].schema.properties
+        .expires_in
+    expect(connectTokenSchema.type).toBe("integer")
+    expect(connectTokenSchema.allOf).toContainEqual({ exclusiveMinimum: 0 })
+  })
+
+  test("serves PTY list, create, get, update, connect-token, and remove through the HttpApi handlers", async () => {
+    if (process.platform === "win32") return
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const initial = await requestPtyHttpApi("/pty")
+        expect(initial.status).toBe(200)
+        expect(await initial.json()).toEqual([])
+
+        const createdResponse = await requestPtyHttpApi("/pty", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            command: "/bin/sh",
+            args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+            title: "httpapi-pty",
+          }),
+        })
+        expect(createdResponse.status).toBe(200)
+        const created = (await createdResponse.json()) as Pty.Info
+        expect(created.title).toBe("httpapi-pty")
+
+        try {
+          const getResponse = await requestPtyHttpApi(`/pty/${created.id}`)
+          expect(getResponse.status).toBe(200)
+          expect(await getResponse.json()).toMatchObject({ id: created.id, title: "httpapi-pty" })
+
+          const updateResponse = await requestPtyHttpApi(`/pty/${created.id}`, {
+            method: "PUT",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ title: "renamed-httpapi-pty" }),
+          })
+          expect(updateResponse.status).toBe(200)
+          expect(await updateResponse.json()).toMatchObject({ id: created.id, title: "renamed-httpapi-pty" })
+
+          const tokenResponse = await requestPtyHttpApi(`/pty/${created.id}/connect-token`, { method: "POST" })
+          expect(tokenResponse.status).toBe(200)
+          const token = await tokenResponse.json()
+          expect(token.ticket).toBeString()
+          expect(token.expires_in).toBe(60)
+
+          const removeResponse = await requestPtyHttpApi(`/pty/${created.id}`, { method: "DELETE" })
+          expect(removeResponse.status).toBe(200)
+          expect(await removeResponse.json()).toBe(true)
+        } finally {
+          await Pty.remove(created.id)
+        }
+      },
+    })
+  })
+
+  test("maps missing PTY HttpApi targets as not found", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const id = PtyID.ascending()
+
+        for (const [path, init, message] of [
+          [`/pty/${id}`, undefined, "Session not found"],
+          [
+            `/pty/${id}`,
+            {
+              method: "PUT",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ title: "gone" }),
+            },
+            "Session not found",
+          ],
+          [`/pty/${id}`, { method: "DELETE" }, "Session not found"],
+          [`/pty/${id}/connect-token`, { method: "POST" }, "PTY session not found"],
+        ] as const) {
+          const response = await requestPtyHttpApi(path, init)
+          const body = await response.json()
+
+          expect(response.status).toBe(404)
+          expect(body).toEqual({
+            name: "NotFoundError",
+            data: { message },
+          })
+        }
+      },
+    })
+  })
+
+  test("rejects malformed PTY ids through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestPtyHttpApi("/pty/not-a-pty")
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body).toMatchObject({
+          data: { ptyID: "not-a-pty" },
+          success: false,
+        })
+        expect(body.error).toBeArray()
+      },
+    })
+  })
+
+  test("rejects invalid PTY create JSON through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestPtyHttpApi("/pty", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ args: "not-an-array" }),
+        })
+        const body = await response.json()
+
+        expect(response.status).toBe(400)
+        expect(body).toMatchObject({
+          data: { args: "not-an-array" },
+          success: false,
+        })
+        expect(body.error).toBeArray()
+      },
+    })
+  })
+
+  test("rejects malformed PTY create JSON through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestPtyHttpApi("/pty", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{",
+        })
+
+        expect(response.status).toBe(400)
+        expect(await response.text()).toBe("Malformed JSON in request body")
+      },
+    })
+  })
+
   test("reports missing websocket connect targets as not found", () => {
     expect(() => assertPtyConnectTarget(undefined)).toThrow(NotFoundError)
   })

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -187,6 +187,44 @@ describe("route inventory harness", () => {
     }
   })
 
+  test("tracks local HttpApi migration coverage for PTY JSON and control-plane routes", async () => {
+    const inventory = await buildRouteInventory({ root, requireUpstream: false })
+
+    for (const [method, routePath] of [
+      ["GET", "/pty"],
+      ["POST", "/pty"],
+      ["GET", "/pty/:ptyID"],
+      ["PUT", "/pty/:ptyID"],
+      ["DELETE", "/pty/:ptyID"],
+      ["POST", "/pty/:ptyID/connect-token"],
+      ["PUT", "/auth/:providerID"],
+      ["DELETE", "/auth/:providerID"],
+      ["POST", "/log"],
+    ] as const) {
+      expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
+        hono: true,
+        localHttpApi: true,
+      })
+    }
+
+    expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/pty/:ptyID/connect")).toMatchObject({
+      hono: true,
+      localHttpApi: false,
+      specialSurface: "PTY websocket",
+    })
+    expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/doc")).toMatchObject({
+      hono: true,
+      localHttpApi: false,
+      specialSurface: "OpenAPI source",
+    })
+    expect(
+      inventory.rows.find((row) => row.method === "POST" && row.path === "/permission/__e2e/ask"),
+    ).toMatchObject({
+      hono: true,
+      localHttpApi: false,
+    })
+  })
+
   test("parses upstream HttpApi route declarations without requiring a live upstream ref", () => {
     const routes = parseHttpApiRoutesFromText(
       `
@@ -288,6 +326,7 @@ describe("route inventory harness", () => {
       hono: true,
       openapi: true,
       v2Sdk: true,
+      localHttpApi: true,
       classification: "openapi-v2-sdk",
       specialSurface: "PTY websocket",
     })


### PR DESCRIPTION
## Summary

Adds local Effect HttpApi coverage for the remaining PTY JSON/control routes and the small control-plane auth/log routes:

- PTY list, create, get, update, remove, and connect-token endpoints.
- Control-plane auth set/remove and log endpoints.
- Route inventory assertions that mark these endpoints as `localHttpApi: true`.

## Why

This continues the #936 HttpApi coverage migration while keeping the production server on Hono. The PR intentionally leaves `/doc`, PTY WebSocket connect, permission e2e ask, automation, session, SSE, workspace WebSocket, and static UI routes outside this slice.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the new local HttpApi handlers preserve the existing Hono wire behavior for JSON parsing, 400/404 bodies, PTY missing targets, auth credential writes/removes, and log level dispatch.

## Risk Notes

No production server switch. The local HttpApi coverage mirrors existing Hono behavior and keeps the WebSocket/OpenAPI-source/test-only routes Hono-only. No visible UI or copy changed, so the UI screenshot checklist item is not applicable.

## How To Verify

```text
bun install --frozen-lockfile: ok
Baseline before changes: bun test test/server/route-inventory-harness.test.ts test/server/pty-routes.test.ts test/server/auth.test.ts: 39 pass
Focused tests: bun test test/server/route-inventory-harness.test.ts test/server/pty-routes.test.ts test/server/control-routes.test.ts test/server/auth.test.ts: 51 pass
Typecheck: GOMAXPROCS=2 bun run typecheck: ok
Diff check: git diff --check origin/dev..HEAD: ok
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
