### PR TITLE
feat(opencode): cover special HTTP boundaries

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -20,6 +20,7 @@ export type RouteRow = {
   v2Sdk: boolean
   localHttpApi: boolean
   upstreamHttpApi: boolean
+  compatibilityBoundary: boolean
   classification: string
   specialSurface: string
 }
@@ -103,6 +104,15 @@ const specialSurfaces: Array<[RegExp, string]> = [
   [/\/auth\b|\/oauth\//, "auth"],
   [/^\/experimental\/workspace\b/, "workspace"],
 ]
+
+const compatibilityBoundaryRoutes = new Set([
+  "GET /event",
+  "GET /global/event",
+  "GET /global/sync-event",
+  "GET /pty/:ptyID/connect",
+  "GET /__workspace_ws",
+  "ALL /*",
+])
 
 const pawworkOwned = new Set([
   "GET /global/sync-event",
@@ -412,6 +422,10 @@ function specialSurfaceFor(method: string, routePath: string) {
   return specialSurfaces.find(([pattern]) => pattern.test(key) || pattern.test(routePath))?.[1] ?? "-"
 }
 
+function isCompatibilityBoundary(method: string, routePath: string) {
+  return compatibilityBoundaryRoutes.has(`${method} ${routePath}`)
+}
+
 function classify(input: {
   method: string
   path: string
@@ -419,9 +433,13 @@ function classify(input: {
   openapi: boolean
   legacySdk: boolean
   v2Sdk: boolean
+  localHttpApi: boolean
   upstreamHttpApi: boolean
 }) {
   const key = `${input.method} ${input.path}`
+  if (isCompatibilityBoundary(input.method, input.path) && input.hono && !input.localHttpApi) {
+    return "compatibility-boundary"
+  }
   if (explicitlyDeferred.some((pattern) => pattern.test(key) || pattern.test(input.path))) return "explicitly-deferred"
   if (pawworkOwned.has(key) && input.hono && !input.openapi && !input.legacySdk && input.v2Sdk) {
     return "pawwork-owned-sdk-v2-only"
@@ -482,6 +500,7 @@ export async function buildRouteInventory(options: BuildOptions = {}): Promise<R
       }
       return {
         ...flags,
+        compatibilityBoundary: isCompatibilityBoundary(flags.method, flags.path),
         classification: classify(flags),
         specialSurface: specialSurfaceFor(flags.method, flags.path),
       }
@@ -550,13 +569,13 @@ export function renderRouteInventoryReport(inventory: RouteInventory) {
     "",
     "## Main Table",
     "",
-    "| Path | Method | Hono | OpenAPI | Legacy SDK | v2 SDK | Local HttpApi | Upstream HttpApi | Classification | Special surface |",
-    "|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
+    "| Path | Method | Hono | OpenAPI | Legacy SDK | v2 SDK | Local HttpApi | Upstream HttpApi | Compatibility Boundary | Classification | Special surface |",
+    "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
   ]
 
   for (const row of inventory.rows) {
     lines.push(
-      `| \`${row.path}\` | \`${row.method}\` | ${mark(row.hono)} | ${mark(row.openapi)} | ${mark(row.legacySdk)} | ${mark(row.v2Sdk)} | ${mark(row.localHttpApi)} | ${mark(row.upstreamHttpApi)} | \`${row.classification}\` | ${row.specialSurface} |`,
+      `| \`${row.path}\` | \`${row.method}\` | ${mark(row.hono)} | ${mark(row.openapi)} | ${mark(row.legacySdk)} | ${mark(row.v2Sdk)} | ${mark(row.localHttpApi)} | ${mark(row.upstreamHttpApi)} | ${mark(row.compatibilityBoundary)} | \`${row.classification}\` | ${row.specialSurface} |`,
     )
   }
 
@@ -564,7 +583,8 @@ export function renderRouteInventoryReport(inventory: RouteInventory) {
     "",
     "## Special Surfaces",
     "",
-    "- `/doc`, UI static routing, workspace proxy WebSocket, SSE/event streams, and PTY WebSocket are compatibility boundaries rather than ordinary JSON route parity.",
+    "- UI static routing, workspace proxy WebSocket, SSE/event streams, and PTY WebSocket are compatibility boundaries rather than ordinary JSON route parity.",
+    "- `/doc` is tracked as an OpenAPI-source HttpApi route, not a compatibility boundary.",
     "- PawWork-owned routes must be preserved during future HttpApi migration even when they are absent upstream or absent from the checked-in OpenAPI file.",
     "- v2 SDK coverage is tracked separately from the legacy SDK because PawWork-owned app/runtime routes currently appear in the v2 generated SDK surface.",
     "",

--- a/packages/opencode/src/server/error.ts
+++ b/packages/opencode/src/server/error.ts
@@ -3,22 +3,22 @@ import z from "zod"
 import { NamedError } from "@opencode-ai/util/error"
 import { NotFoundError } from "../storage/db"
 
+export const BadRequestErrorSchema = z
+  .object({
+    data: z.any(),
+    errors: z.array(z.record(z.string(), z.any())),
+    success: z.literal(false),
+  })
+  .meta({
+    ref: "BadRequestError",
+  })
+
 export const ERRORS = {
   400: {
     description: "Bad request",
     content: {
       "application/json": {
-        schema: resolver(
-          z
-            .object({
-              data: z.any(),
-              errors: z.array(z.record(z.string(), z.any())),
-              success: z.literal(false),
-            })
-            .meta({
-              ref: "BadRequestError",
-            }),
-        ),
+        schema: resolver(BadRequestErrorSchema),
       },
     },
   },

--- a/packages/opencode/src/server/error.ts
+++ b/packages/opencode/src/server/error.ts
@@ -6,7 +6,7 @@ import { NotFoundError } from "../storage/db"
 export const BadRequestErrorSchema = z
   .object({
     data: z.any(),
-    errors: z.array(z.record(z.string(), z.any())),
+    error: z.array(z.record(z.string(), z.any())),
     success: z.literal(false),
   })
   .meta({

--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -27,6 +27,29 @@ const LifecycleCloseResult = z.object({
   affectedDirectoryKeys: z.array(z.string()),
 })
 
+export function globalEventOpenApiSchema() {
+  return z
+    .object({
+      directory: z.string(),
+      project: z.string().optional(),
+      workspace: z.string().optional(),
+      payload: BusEvent.payloads(),
+    })
+    .meta({
+      ref: "GlobalEvent",
+    })
+}
+
+export function globalSyncEventOpenApiSchema() {
+  return z
+    .object({
+      payload: SyncEvent.payloads(),
+    })
+    .meta({
+      ref: "SyncEvent",
+    })
+}
+
 function emitGlobalDisposed() {
   GlobalBus.emit("event", {
     directory: "global",
@@ -364,18 +387,7 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
             description: "Event stream",
             content: {
               "text/event-stream": {
-                schema: resolver(
-                  z
-                    .object({
-                      directory: z.string(),
-                      project: z.string().optional(),
-                      workspace: z.string().optional(),
-                      payload: BusEvent.payloads(),
-                    })
-                    .meta({
-                      ref: "GlobalEvent",
-                    }),
-                ),
+                schema: resolver(globalEventOpenApiSchema()),
               },
             },
           },
@@ -401,15 +413,7 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
             description: "Event stream",
             content: {
               "text/event-stream": {
-                schema: resolver(
-                  z
-                    .object({
-                      payload: SyncEvent.payloads(),
-                    })
-                    .meta({
-                      ref: "SyncEvent",
-                    }),
-                ),
+                schema: resolver(globalSyncEventOpenApiSchema()),
               },
             },
           },

--- a/packages/opencode/src/server/instance/permission.ts
+++ b/packages/opencode/src/server/instance/permission.ts
@@ -13,10 +13,11 @@ import { SessionLiveness } from "@/session/liveness"
 import { Effect } from "effect"
 
 const log = Log.create({ service: "server" })
-const e2ePermissionRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
+export const e2ePermissionRoutesEnabled = () =>
+  Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
 const runPermissionRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
 
-const E2EPermissionAskBody = z.object({
+export const E2EPermissionAskBody = z.object({
   sessionID: SessionID.zod,
   permission: z.string().min(1),
   patterns: z.array(z.string()).min(1),
@@ -24,13 +25,13 @@ const E2EPermissionAskBody = z.object({
   always: z.array(z.string()).optional(),
 })
 
-type E2EPermissionAskBody = z.infer<typeof E2EPermissionAskBody>
+export type E2EPermissionAskBody = z.infer<typeof E2EPermissionAskBody>
 type PermissionReplyBody = {
   reply: z.infer<typeof Permission.Reply>
   message?: string
 }
 
-const seedE2EPermissionAsk = Effect.fn("PermissionRoutes.e2e.ask")(function* (json: E2EPermissionAskBody) {
+export const seedE2EPermissionAsk = Effect.fn("PermissionRoutes.e2e.ask")(function* (json: E2EPermissionAskBody) {
   const permission = yield* Permission.Service
   yield* permission.ask({
     sessionID: json.sessionID,

--- a/packages/opencode/src/server/proxy.ts
+++ b/packages/opencode/src/server/proxy.ts
@@ -21,6 +21,27 @@ const hop = new Set([
 ])
 
 type Msg = string | ArrayBuffer | Uint8Array
+type ProxySocket = {
+  binaryType?: BinaryType
+  readyState: number
+  send(data: Msg): void
+  close(code?: number, reason?: string): void
+  onopen: (() => void) | null
+  onmessage: ((event: { data: unknown }) => void) | null
+  onerror: (() => void) | null
+  onclose: ((event: { code: number; reason: string }) => void) | null
+}
+
+type LocalSocket = {
+  send(data: Msg): void
+  close(code?: number, reason?: string): void
+}
+
+type WorkspaceProxyPeerOptions = {
+  targetUrl?: string
+  protocols?: string[]
+  socketFactory?: (url: string, protocols: string[]) => ProxySocket
+}
 
 function headers(req: Request, extra?: HeadersInit) {
   const out = new Headers(req.headers)
@@ -35,7 +56,7 @@ function headers(req: Request, extra?: HeadersInit) {
   return out
 }
 
-function protocols(req: Request) {
+export function protocols(req: Request) {
   const value = req.headers.get("sec-websocket-protocol")
   if (!value) return []
   return value
@@ -58,46 +79,67 @@ function send(ws: { send(data: string | ArrayBuffer | Uint8Array): void }, data:
   return ws.send(data)
 }
 
+export function createWorkspaceProxyPeer({
+  targetUrl,
+  protocols = [],
+  socketFactory = (url, protocols) => new WebSocket(url, protocols) as ProxySocket,
+}: WorkspaceProxyPeerOptions) {
+  const queue: Msg[] = []
+  let remote: ProxySocket | undefined
+
+  return {
+    onOpen(ws: LocalSocket) {
+      if (!targetUrl) {
+        ws.close(1011, "missing proxy target")
+        return
+      }
+      remote = socketFactory(targetUrl, protocols)
+      remote.binaryType = "arraybuffer"
+      remote.onopen = () => {
+        for (const item of queue) remote?.send(item)
+        queue.length = 0
+      }
+      remote.onmessage = (event) => {
+        void send(ws, event.data)
+      }
+      remote.onerror = () => {
+        ws.close(1011, "proxy error")
+      }
+      remote.onclose = (event) => {
+        ws.close(event.code, event.reason)
+      }
+    },
+    onMessage(data: unknown) {
+      if (typeof data !== "string" && !(data instanceof Uint8Array) && !(data instanceof ArrayBuffer)) return
+      if (remote?.readyState === WebSocket.OPEN) {
+        remote.send(data)
+        return
+      }
+      queue.push(data)
+    },
+    onClose(code?: number, reason?: string) {
+      remote?.close(code, reason)
+    },
+  }
+}
+
 const app = (upgrade: UpgradeWebSocket) =>
   new Hono().get(
     "/__workspace_ws",
     upgrade((c) => {
-      const url = c.req.header("x-opencode-proxy-url")
-      const queue: Msg[] = []
-      let remote: WebSocket | undefined
+      const peer = createWorkspaceProxyPeer({
+        targetUrl: c.req.header("x-opencode-proxy-url"),
+        protocols: protocols(c.req.raw),
+      })
       return {
         onOpen(_, ws) {
-          if (!url) {
-            ws.close(1011, "missing proxy target")
-            return
-          }
-          remote = new WebSocket(url, protocols(c.req.raw))
-          remote.binaryType = "arraybuffer"
-          remote.onopen = () => {
-            for (const item of queue) remote?.send(item)
-            queue.length = 0
-          }
-          remote.onmessage = (event) => {
-            void send(ws, event.data)
-          }
-          remote.onerror = () => {
-            ws.close(1011, "proxy error")
-          }
-          remote.onclose = (event) => {
-            ws.close(event.code, event.reason)
-          }
+          peer.onOpen(ws)
         },
         onMessage(event) {
-          const data = event.data
-          if (typeof data !== "string" && !(data instanceof Uint8Array) && !(data instanceof ArrayBuffer)) return
-          if (remote?.readyState === WebSocket.OPEN) {
-            remote.send(data)
-            return
-          }
-          queue.push(data)
+          peer.onMessage(event.data)
         },
         onClose(event) {
-          remote?.close(event.code, event.reason)
+          peer.onClose(event.code, event.reason)
         },
       }
     }),

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/control.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/control.ts
@@ -54,6 +54,15 @@ export const ControlApi = HttpApi.make("control")
             description: "Write a log entry to the server logs with specified level and metadata.",
           }),
         ),
+        HttpApiEndpoint.get("doc", "/doc", {
+          success: Schema.Any,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "doc",
+            summary: "Get OpenAPI document",
+            description: "Return the server OpenAPI document.",
+          }),
+        ),
       )
       .annotateMerge(
         OpenApi.annotations({

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
@@ -1,8 +1,8 @@
 import { PermissionID } from "@/permission/schema"
 import { MessageID, SessionID } from "@/session/schema"
 import { Schema } from "effect"
-import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
-import { BadRequestError, WorkspaceRoutingQuery } from "./common"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, NotFoundError, WorkspaceRoutingQuery } from "./common"
 
 const root = "/permission"
 
@@ -30,19 +30,13 @@ const PermissionReplyParam = Schema.Struct({
   requestID: PermissionID,
 })
 
-const PermissionNotFoundError = Schema.Struct({
-  name: Schema.Literal("NotFoundError"),
-  data: Schema.Struct({
-    message: Schema.String,
-  }),
-}).pipe(
-  HttpApiSchema.status(404),
-  (schema) =>
-    schema.annotate({
-      identifier: "PermissionNotFoundError",
-      description: "Permission request not found",
-    }),
-)
+const E2EPermissionAskPayload = Schema.Struct({
+  sessionID: SessionID,
+  permission: Schema.String,
+  patterns: Schema.Array(Schema.String),
+  metadata: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
+  always: Schema.optional(Schema.Array(Schema.String)),
+})
 
 export const PermissionApi = HttpApi.make("permission")
   .add(
@@ -63,12 +57,23 @@ export const PermissionApi = HttpApi.make("permission")
           query: WorkspaceRoutingQuery,
           payload: PermissionReplyPayload,
           success: Schema.Boolean,
-          error: [BadRequestError, PermissionNotFoundError],
+          error: [BadRequestError, NotFoundError],
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "permission.reply",
             summary: "Respond to permission request",
             description: "Approve or deny a permission request from the AI assistant.",
+          }),
+        ),
+        HttpApiEndpoint.post("e2eAsk", `${root}/__e2e/ask`, {
+          payload: E2EPermissionAskPayload,
+          success: Schema.Void,
+          error: BadRequestError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "permission.e2e.ask",
+            summary: "Seed an e2e permission request",
+            description: "Test-only route gated by the OPENCODE_E2E_ENABLED and OPENCODE_E2E_LLM_URL environment flags.",
           }),
         ),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/control.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/control.ts
@@ -6,6 +6,7 @@ import { Effect } from "effect"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import z from "zod"
+import { ControlPlaneRoutes } from "@/server/control"
 import { ControlApi } from "../groups/control"
 
 const LogPayload = z.object({
@@ -70,6 +71,11 @@ function writeLog(payload: LogPayload) {
   }
 }
 
+async function controlOpenApiDocument() {
+  const response = await ControlPlaneRoutes().request("/doc")
+  return response.json()
+}
+
 export const controlHandlers = HttpApiBuilder.group(ControlApi, "control", (handlers) =>
   Effect.gen(function* () {
     const auth = yield* Auth.Service
@@ -118,6 +124,9 @@ export const controlHandlers = HttpApiBuilder.group(ControlApi, "control", (hand
             Effect.catchDefect(controlFailure),
           )
         }),
+      )
+      .handleRaw("doc", () =>
+        Effect.promise(() => controlOpenApiDocument()).pipe(Effect.map((document) => HttpServerResponse.jsonUnsafe(document))),
       )
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/control.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/control.ts
@@ -5,9 +5,19 @@ import { NamedError } from "@opencode-ai/util/error"
 import { Effect } from "effect"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { resolver } from "hono-openapi"
 import z from "zod"
 import { ControlPlaneRoutes } from "@/server/control"
+import { BadRequestErrorSchema } from "@/server/error"
+import { globalEventOpenApiSchema, globalSyncEventOpenApiSchema } from "@/server/instance/global"
 import { ControlApi } from "../groups/control"
+
+type OpenApiDocument = {
+  paths?: unknown
+  components?: {
+    schemas?: Record<string, unknown>
+  }
+}
 
 const LogPayload = z.object({
   service: z.string(),
@@ -71,9 +81,53 @@ function writeLog(payload: LogPayload) {
   }
 }
 
+function collectSchemaRefs(value: unknown, refs = new Set<string>()) {
+  if (!value || typeof value !== "object") return refs
+  if (Array.isArray(value)) {
+    for (const item of value) collectSchemaRefs(item, refs)
+    return refs
+  }
+
+  const record = value as Record<string, unknown>
+  if (typeof record.$ref === "string" && record.$ref.startsWith("#/components/schemas/")) refs.add(record.$ref)
+  for (const item of Object.values(record)) collectSchemaRefs(item, refs)
+  return refs
+}
+
+function mergeSchemas(document: OpenApiDocument, schemas: Record<string, unknown>) {
+  document.components ??= {}
+  document.components.schemas = {
+    ...schemas,
+    ...document.components.schemas,
+  }
+}
+
+async function ensureReferencedControlDocSchemas(document: OpenApiDocument) {
+  const refs = collectSchemaRefs(document.paths)
+  const schemas = document.components?.schemas ?? {}
+  const missingGlobalEvent = refs.has("#/components/schemas/GlobalEvent") && !schemas.GlobalEvent
+  const missingSyncEvent = refs.has("#/components/schemas/SyncEvent") && !schemas.SyncEvent
+  const missingBadRequestError = refs.has("#/components/schemas/BadRequestError") && !schemas.BadRequestError
+
+  if (missingGlobalEvent) {
+    const generated = await resolver(globalEventOpenApiSchema()).toOpenAPISchema()
+    mergeSchemas(document, generated.components?.schemas ?? {})
+  }
+  if (missingSyncEvent) {
+    const generated = await resolver(globalSyncEventOpenApiSchema()).toOpenAPISchema()
+    mergeSchemas(document, generated.components?.schemas ?? {})
+  }
+  if (missingBadRequestError) {
+    const generated = await resolver(BadRequestErrorSchema).toOpenAPISchema()
+    mergeSchemas(document, generated.components?.schemas ?? {})
+  }
+}
+
 async function controlOpenApiDocument() {
   const response = await ControlPlaneRoutes().request("/doc")
-  return response.json()
+  const document = await response.json()
+  await ensureReferencedControlDocSchemas(document)
+  return document
 }
 
 export const controlHandlers = HttpApiBuilder.group(ControlApi, "control", (handlers) =>

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
@@ -1,13 +1,18 @@
 import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
+import { e2ePermissionRoutesEnabled, E2EPermissionAskBody, seedE2EPermissionAsk } from "@/server/instance/permission"
 import { SessionLiveness } from "@/session/liveness"
 import { NotFoundError } from "@/storage/db"
+import { AppRuntime } from "@/effect/app-runtime"
+import { Log } from "@opencode-ai/core/util/log"
 import { NamedError } from "@opencode-ai/util/error"
 import { Effect } from "effect"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import z from "zod"
 import { PermissionApi } from "../groups/permission"
+
+const log = Log.create({ service: "server" })
 
 type PermissionReplyBody = {
   reply: z.infer<typeof Permission.Reply>
@@ -75,6 +80,17 @@ export const permissionHandlers = HttpApiBuilder.group(PermissionApi, "permissio
       return true
     })
 
+    const e2eAsk = Effect.fn("PermissionHttpApi.e2eAsk")(function* (json: E2EPermissionAskBody) {
+      if (!e2ePermissionRoutesEnabled()) return HttpServerResponse.empty({ status: 404 })
+
+      return yield* Effect.sync(() => {
+        void AppRuntime.runPromise(seedE2EPermissionAsk(json)).catch((error) => {
+          log.error("e2e permission seed failed", { sessionID: json.sessionID, error })
+        })
+        return HttpServerResponse.empty()
+      })
+    })
+
     return handlers
       .handleRaw("list", () =>
         list().pipe(
@@ -93,6 +109,13 @@ export const permissionHandlers = HttpApiBuilder.group(PermissionApi, "permissio
             Effect.catchDefect(permissionFailure),
           )
           return result
+        }),
+      )
+      .handleRaw("e2eAsk", (ctx) =>
+        Effect.gen(function* () {
+          const payload = yield* parseJsonBody(ctx.request, E2EPermissionAskBody)
+          if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+          return yield* e2eAsk(payload)
         }),
       )
   }),

--- a/packages/opencode/test/server/control-routes.test.ts
+++ b/packages/opencode/test/server/control-routes.test.ts
@@ -87,6 +87,8 @@ describe("control routes", () => {
     for (const ref of collectSchemaRefs(spec.paths)) {
       expect(schemas).toHaveProperty(ref.replace("#/components/schemas/", ""))
     }
+    expect(schemas.BadRequestError?.properties).toHaveProperty("error")
+    expect(schemas.BadRequestError?.properties).not.toHaveProperty("errors")
   })
 
   test("sets and removes auth credentials through the HttpApi handlers", async () => {

--- a/packages/opencode/test/server/control-routes.test.ts
+++ b/packages/opencode/test/server/control-routes.test.ts
@@ -16,6 +16,21 @@ afterEach(async () => {
 })
 
 describe("control routes", () => {
+  function collectSchemaRefs(value: unknown, refs = new Set<string>()) {
+    if (!value || typeof value !== "object") return refs
+    if (Array.isArray(value)) {
+      for (const item of value) collectSchemaRefs(item, refs)
+      return refs
+    }
+
+    const record = value as Record<string, unknown>
+    if (typeof record.$ref === "string" && record.$ref.startsWith("#/components/schemas/")) {
+      refs.add(record.$ref)
+    }
+    for (const item of Object.values(record)) collectSchemaRefs(item, refs)
+    return refs
+  }
+
   function requestControlHttpApi(path: string, init?: RequestInit) {
     return AppRuntime.runPromise(
       Effect.scoped(
@@ -39,10 +54,36 @@ describe("control routes", () => {
 
     expect(spec.paths).toHaveProperty("/auth/{providerID}")
     expect(spec.paths).toHaveProperty("/log")
-    expect(spec.paths).not.toHaveProperty("/doc")
+    expect(spec.paths).toHaveProperty("/doc")
     expect(spec.paths["/auth/{providerID}"]).toHaveProperty("put")
     expect(spec.paths["/auth/{providerID}"]).toHaveProperty("delete")
     expect(spec.paths["/log"]).toHaveProperty("post")
+    expect(spec.paths["/doc"]).toHaveProperty("get")
+  })
+
+  test("serves the generated OpenAPI document through the HttpApi handlers", async () => {
+    const response = await requestControlHttpApi("/doc")
+    const spec = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(spec).toMatchObject({
+      info: {
+        title: "opencode",
+        version: "0.0.3",
+        description: "opencode api",
+      },
+      openapi: "3.1.1",
+    })
+    expect(spec.paths).toHaveProperty("/auth/{providerID}")
+    expect(spec.paths).toHaveProperty("/global/health")
+    expect(spec.paths).toHaveProperty("/global/event")
+    expect(spec.paths).toHaveProperty("/global/sync-event")
+    expect(spec.paths).not.toHaveProperty("/doc")
+
+    const schemas = spec.components?.schemas ?? {}
+    for (const ref of collectSchemaRefs(spec.paths)) {
+      expect(schemas).toHaveProperty(ref.replace("#/components/schemas/", ""))
+    }
   })
 
   test("sets and removes auth credentials through the HttpApi handlers", async () => {

--- a/packages/opencode/test/server/control-routes.test.ts
+++ b/packages/opencode/test/server/control-routes.test.ts
@@ -8,6 +8,7 @@ import { Auth } from "../../src/auth"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { ControlApi } from "../../src/server/routes/instance/httpapi/groups/control"
 import { controlHandlers } from "../../src/server/routes/instance/httpapi/handlers/control"
+import { Server } from "../../src/server/server"
 
 const testProviderID = "httpapi-control-provider"
 
@@ -62,6 +63,8 @@ describe("control routes", () => {
   })
 
   test("serves the generated OpenAPI document through the HttpApi handlers", async () => {
+    await Server.openapi()
+
     const response = await requestControlHttpApi("/doc")
     const spec = await response.json()
 

--- a/packages/opencode/test/server/permission-routes.test.ts
+++ b/packages/opencode/test/server/permission-routes.test.ts
@@ -57,8 +57,10 @@ describe("permission routes", () => {
 
     expect(spec.paths).toHaveProperty("/permission")
     expect(spec.paths).toHaveProperty("/permission/{requestID}/reply")
+    expect(spec.paths).toHaveProperty("/permission/__e2e/ask")
     expect(spec.paths["/permission"]).toHaveProperty("get")
     expect(spec.paths["/permission/{requestID}/reply"]).toHaveProperty("post")
+    expect(spec.paths["/permission/__e2e/ask"]).toHaveProperty("post")
   })
 
   test("replies to a pending permission through the route runtime", async () => {
@@ -150,6 +152,26 @@ describe("permission routes", () => {
         expect(replyResponse.status).toBe(200)
         expect(await replyResponse.json()).toBe(true)
         await expect(asked).resolves.toBeUndefined()
+      },
+    })
+  })
+
+  test("keeps the e2e permission ask gate closed through the HttpApi handlers", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestPermissionHttpApi("/permission/__e2e/ask", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            sessionID: SessionID.descending(),
+            permission: "bash",
+            patterns: ["echo ok"],
+          }),
+        })
+
+        expect(response.status).toBe(404)
       },
     })
   })

--- a/packages/opencode/test/server/proxy.test.ts
+++ b/packages/opencode/test/server/proxy.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, test } from "bun:test"
-import { redactProxyURL } from "../../src/server/proxy"
+import { createWorkspaceProxyPeer, protocols, redactProxyURL } from "../../src/server/proxy"
+
+class FakeRemoteSocket {
+  static readonly OPEN = WebSocket.OPEN
+  binaryType: BinaryType = "blob"
+  readyState = 0
+  sent: unknown[] = []
+  closed: Array<{ code?: number; reason?: string }> = []
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: ((event: { code: number; reason: string }) => void) | null = null
+
+  send(data: unknown) {
+    this.sent.push(data)
+  }
+
+  close(code?: number, reason?: string) {
+    this.closed.push({ code, reason })
+  }
+}
 
 describe("server proxy logging", () => {
   test("redacts sensitive websocket query credentials", () => {
@@ -20,5 +40,56 @@ describe("server proxy logging", () => {
     expect(request).not.toContain("basic-token")
     expect(target).not.toContain("remote-ticket")
     expect(target).not.toContain("remote-token")
+  })
+})
+
+describe("workspace websocket proxy boundary", () => {
+  test("parses requested websocket subprotocols", () => {
+    const request = new Request("http://localhost", {
+      headers: { "sec-websocket-protocol": "pawwork, remote-sync , ," },
+    })
+
+    expect(protocols(request)).toEqual(["pawwork", "remote-sync"])
+  })
+
+  test("closes the local socket when the proxy target is missing", () => {
+    const closed: Array<{ code?: number; reason?: string }> = []
+    const peer = createWorkspaceProxyPeer({})
+
+    peer.onOpen({ send: () => {}, close: (code, reason) => closed.push({ code, reason }) })
+
+    expect(closed).toEqual([{ code: 1011, reason: "missing proxy target" }])
+  })
+
+  test("queues local messages until the remote websocket opens", () => {
+    let remote: FakeRemoteSocket | undefined
+    const localSent: unknown[] = []
+    const localClosed: Array<{ code?: number; reason?: string }> = []
+    const peer = createWorkspaceProxyPeer({
+      targetUrl: "ws://remote.example/session",
+      protocols: ["pawwork"],
+      socketFactory: () => {
+        remote = new FakeRemoteSocket()
+        return remote as any
+      },
+    })
+
+    peer.onMessage("queued-before-open")
+    peer.onOpen({
+      send: (data) => localSent.push(data),
+      close: (code, reason) => localClosed.push({ code, reason }),
+    })
+    expect(remote?.binaryType).toBe("arraybuffer")
+    expect(remote?.sent).toEqual([])
+
+    remote!.readyState = WebSocket.OPEN
+    remote!.onopen?.()
+    peer.onMessage("after-open")
+    remote!.onmessage?.({ data: "from-remote" })
+    remote!.onclose?.({ code: 1000, reason: "done" })
+
+    expect(remote?.sent).toEqual(["queued-before-open", "after-open"])
+    expect(localSent).toEqual(["from-remote"])
+    expect(localClosed).toEqual([{ code: 1000, reason: "done" }])
   })
 })

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -211,17 +211,18 @@ describe("route inventory harness", () => {
       hono: true,
       localHttpApi: false,
       specialSurface: "PTY websocket",
+      compatibilityBoundary: true,
     })
     expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/doc")).toMatchObject({
       hono: true,
-      localHttpApi: false,
+      localHttpApi: true,
       specialSurface: "OpenAPI source",
     })
     expect(
       inventory.rows.find((row) => row.method === "POST" && row.path === "/permission/__e2e/ask"),
     ).toMatchObject({
       hono: true,
-      localHttpApi: false,
+      localHttpApi: true,
     })
   })
 
@@ -380,7 +381,28 @@ describe("route inventory harness", () => {
 
     expect(
       inventory.rows.find((row) => row.method === "POST" && row.path === "/permission/__e2e/ask"),
-    ).toMatchObject({ hono: true, openapi: false, v2Sdk: true, classification: "hono-v2-sdk" })
+    ).toMatchObject({ hono: true, openapi: false, v2Sdk: true, localHttpApi: true, classification: "hono-v2-sdk" })
+  })
+
+  test("tracks explicit compatibility boundary coverage for non-JSON HTTP surfaces", async () => {
+    const inventory = await buildRouteInventory({ root, requireUpstream: false })
+
+    for (const [method, routePath, specialSurface] of [
+      ["GET", "/event", "SSE/event"],
+      ["GET", "/global/event", "SSE/event"],
+      ["GET", "/global/sync-event", "SSE/event"],
+      ["GET", "/pty/:ptyID/connect", "PTY websocket"],
+      ["GET", "/__workspace_ws", "workspace websocket proxy"],
+      ["ALL", "/*", "UI static route"],
+    ] as const) {
+      expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
+        hono: true,
+        localHttpApi: false,
+        compatibilityBoundary: true,
+        classification: "compatibility-boundary",
+        specialSurface,
+      })
+    }
   })
 
   test("keeps the PTY connect-token route in the public OpenAPI and v2 SDK surfaces", async () => {


### PR DESCRIPTION
## Summary
- add local HttpApi coverage for the control-plane `/doc` route and the gated permission e2e ask route
- track SSE, WebSocket, and UI static routes as explicit compatibility boundaries instead of forgotten Hono-only routes
- extract the workspace WebSocket proxy peer lifecycle into a direct test seam while preserving the Hono upgrade adapter

Related to #936

## Verification
- `bun test test/server/control-routes.test.ts test/server/route-inventory-harness.test.ts test/server/permission-routes.test.ts test/server/event-stream-routes.test.ts test/server/pty-routes.test.ts test/server/proxy.test.ts`
- `GOMAXPROCS=2 bun run typecheck`
- `git diff --check origin/dev...HEAD`
- Fresh-eye review: no P0/P1 and no concrete P2 in the final pass
