### PR TITLE
feat(opencode): add automation HttpApi route coverage

### DIFF
--- a/packages/opencode/src/server/instance/automation-actions.ts
+++ b/packages/opencode/src/server/instance/automation-actions.ts
@@ -1,0 +1,187 @@
+import { Automation, AutomationID, ConflictError, ValidationError } from "@/automation"
+import { sessionPromptExecutor } from "@/automation/runner"
+import { AutomationScheduler } from "@/automation/scheduler"
+import { validateModelAndVariant } from "@/automation/validation"
+import { Provider } from "@/provider/provider"
+import { Effect } from "effect"
+import z from "zod"
+
+export const AutomationIDParam = z.object({ automationID: AutomationID.Definition.zod })
+export const AutomationRunsQuery = z.object({
+  limit: z.coerce.number().int().positive().max(100).optional(),
+  cursor: AutomationID.Run.zod.optional(),
+})
+
+export type AutomationIDParam = z.infer<typeof AutomationIDParam>
+export type AutomationRunsQuery = z.infer<typeof AutomationRunsQuery>
+
+export function validationError(error: ValidationError) {
+  return Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: error.details })
+}
+
+export function conflictError(error: ConflictError) {
+  return Automation.ConflictErrorResponse.parse({ error: "automation_conflict", message: error.message })
+}
+
+const settleAutomationScheduler = Effect.fn("AutomationRoutes.scheduler.settle")(function* (
+  scheduler: Pick<AutomationScheduler.Interface, "settleOwner"> = AutomationScheduler.current(),
+) {
+  yield* Effect.promise(() => scheduler.settleOwner())
+})
+
+function modelValidation(
+  model: Automation.Model,
+  variant?: string,
+): Effect.Effect<Automation.ValidationErrorDetail[], never, Provider.Service> {
+  if (process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION === "1") return Effect.succeed([])
+  return validateModelAndVariant(model, variant)
+}
+
+function validationIssuePath(issue: unknown) {
+  const path = typeof issue === "object" && issue !== null && "path" in issue ? issue.path : undefined
+  if (!Array.isArray(path)) return ""
+  return path.map((part) => String(part)).join(".")
+}
+
+export function validationDetailsFromIssues(
+  issues: readonly unknown[],
+  data: unknown,
+): Automation.ValidationErrorDetail[] {
+  const kind =
+    typeof data === "object" && data !== null && "kind" in data && typeof data.kind === "string" ? data.kind : undefined
+  return issues.flatMap((issue) => {
+    const path = validationIssuePath(issue)
+    if (typeof issue === "object" && issue !== null && "code" in issue && issue.code === "unrecognized_keys") {
+      const keys = "keys" in issue && Array.isArray(issue.keys) ? issue.keys : []
+      return keys.map((key) => {
+        const field = path ? `${path}.${String(key)}` : String(key)
+        if (kind === "oneshot" && (field === "rhythm" || field === "stop")) {
+          return { field, message: "unsupported_for_oneshot_automation" }
+        }
+        if (kind === "recurring" && field === "fireAt") {
+          return { field, message: "unsupported_for_recurring_automation" }
+        }
+        return { field, message: "unsupported_automation_field" }
+      })
+    }
+    const field = path
+    const message =
+      typeof issue === "object" && issue !== null && "message" in issue && typeof issue.message === "string"
+        ? issue.message
+        : "invalid_automation_field"
+    return [{ field, message }]
+  })
+}
+
+export const listAutomations = Effect.fn("AutomationRoutes.list")(function* () {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const items = yield* automation.list()
+  return { items }
+})
+
+export const createAutomation = Effect.fn("AutomationRoutes.create")(function* (input: Automation.CreateInput) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const modelDetails = yield* modelValidation(input.model, input.variant)
+  if (modelDetails.length) {
+    return yield* Effect.fail(new ValidationError(modelDetails))
+  }
+  const definition = yield* automation.create(input)
+  yield* automation.publishDefinitionUpdated(definition)
+  return definition
+})
+
+export const getAutomation = Effect.fn("AutomationRoutes.get")(function* (
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  return yield* automation.get(automationID)
+})
+
+export const updateAutomation = Effect.fn("AutomationRoutes.update")(function* (
+  automationID: AutomationIDParam["automationID"],
+  patch: Automation.UpdateInput,
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const previous = yield* automation.get(automationID)
+  if (patch.model !== undefined || patch.variant !== undefined) {
+    const effectiveModel = patch.model ?? previous.model
+    const effectiveVariant = patch.variant === null ? undefined : (patch.variant ?? previous.variant)
+    const modelDetails = yield* modelValidation(effectiveModel, effectiveVariant)
+    if (modelDetails.length) {
+      return yield* Effect.fail(new ValidationError(modelDetails))
+    }
+  }
+  const definition = yield* automation.update(automationID, patch)
+  if (definition.revision !== previous.revision) {
+    if (definition.where.projectID !== previous.where.projectID) {
+      yield* automation.publishDefinitionDeleted({ id: previous.id, deleted: true, revision: definition.revision })
+      yield* automation.publishDefinitionUpdatedForScope(definition, Automation.getScope(definition.id))
+    } else {
+      yield* automation.publishDefinitionUpdated(definition)
+    }
+  }
+  return definition
+})
+
+export const pauseAutomation = Effect.fn("AutomationRoutes.pause")(function* (
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const previous = yield* automation.get(automationID)
+  const definition = yield* automation.update(automationID, { paused: true })
+  if (definition.revision !== previous.revision) {
+    yield* automation.publishDefinitionUpdated(definition)
+  }
+  return definition
+})
+
+export const resumeAutomation = Effect.fn("AutomationRoutes.resume")(function* (
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const previous = yield* automation.get(automationID)
+  const definition = yield* automation.update(automationID, { paused: false })
+  if (definition.revision !== previous.revision) {
+    yield* automation.publishDefinitionUpdated(definition)
+  }
+  return definition
+})
+
+export const deleteAutomation = Effect.fn("AutomationRoutes.delete")(function* (
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  const scheduler = AutomationScheduler.current()
+  yield* settleAutomationScheduler(scheduler)
+  const removed = yield* automation.remove(automationID)
+  yield* Effect.sync(() => scheduler.cancel(removed.tombstone.id))
+  yield* automation.publishDefinitionDeleted(removed.tombstone)
+  return removed.tombstone
+})
+
+export const runAutomationNow = Effect.fn("AutomationRoutes.runNow")(function* (
+  automationID: AutomationIDParam["automationID"],
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  const run = yield* automation.runNowExecuting(automationID, {
+    executor: sessionPromptExecutor,
+  })
+  yield* automation.publishRunUpdated(run)
+  return run
+})
+
+export const listAutomationRuns = Effect.fn("AutomationRoutes.runs")(function* (
+  automationID: AutomationIDParam["automationID"],
+  query: AutomationRunsQuery,
+) {
+  const automation = yield* Automation.Service
+  yield* settleAutomationScheduler()
+  return yield* automation.runs({ automationID, ...query })
+})

--- a/packages/opencode/src/server/instance/automation.ts
+++ b/packages/opencode/src/server/instance/automation.ts
@@ -2,45 +2,25 @@ import { Hono } from "hono"
 import type { Context } from "hono"
 import { describeRoute, resolver, validator } from "hono-openapi"
 import { Cause, Effect, Exit } from "effect"
-import z from "zod"
-import { Automation, AutomationID, ConflictError, ValidationError } from "@/automation"
-import { sessionPromptExecutor } from "@/automation/runner"
-import { AutomationScheduler } from "@/automation/scheduler"
-import { validateModelAndVariant } from "@/automation/validation"
-import { Provider } from "@/provider/provider"
+import { Automation, ConflictError, ValidationError } from "@/automation"
 import { AppRuntime, type AppServices } from "@/effect/app-runtime"
+import {
+  AutomationIDParam,
+  AutomationRunsQuery,
+  conflictError,
+  createAutomation,
+  deleteAutomation,
+  getAutomation,
+  listAutomationRuns,
+  listAutomations,
+  pauseAutomation,
+  resumeAutomation,
+  runAutomationNow,
+  updateAutomation,
+  validationDetailsFromIssues,
+  validationError,
+} from "./automation-actions"
 import { errors } from "../error"
-
-function validationError(error: ValidationError) {
-  return Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: error.details })
-}
-
-function conflictError(error: ConflictError) {
-  return Automation.ConflictErrorResponse.parse({ error: "automation_conflict", message: error.message })
-}
-
-const AutomationIDParam = z.object({ automationID: AutomationID.Definition.zod })
-const AutomationRunsQuery = z.object({
-  limit: z.coerce.number().int().positive().max(100).optional(),
-  cursor: AutomationID.Run.zod.optional(),
-})
-
-type AutomationIDParam = z.infer<typeof AutomationIDParam>
-type AutomationRunsQuery = z.infer<typeof AutomationRunsQuery>
-
-const settleAutomationScheduler = Effect.fn("AutomationRoutes.scheduler.settle")(function* (
-  scheduler: Pick<AutomationScheduler.Interface, "settleOwner"> = AutomationScheduler.current(),
-) {
-  yield* Effect.promise(() => scheduler.settleOwner())
-})
-
-function modelValidation(
-  model: Automation.Model,
-  variant?: string,
-): Effect.Effect<Automation.ValidationErrorDetail[], never, Provider.Service> {
-  if (process.env.OPENCODE_SKIP_AUTOMATION_MODEL_VALIDATION === "1") return Effect.succeed([])
-  return validateModelAndVariant(model, variant)
-}
 
 function runRoute(c: Context, effect: Effect.Effect<Response, unknown, AppServices>): Promise<Response> {
   return AppRuntime.runPromiseExit(effect).then((exit) => {
@@ -52,37 +32,8 @@ function runRoute(c: Context, effect: Effect.Effect<Response, unknown, AppServic
   })
 }
 
-function validationIssuePath(issue: unknown) {
-  const path = typeof issue === "object" && issue !== null && "path" in issue ? issue.path : undefined
-  if (!Array.isArray(path)) return ""
-  return path.map((part) => String(part)).join(".")
-}
-
-function validationDetailsFromIssues(issues: readonly unknown[], data: unknown): Automation.ValidationErrorDetail[] {
-  const kind =
-    typeof data === "object" && data !== null && "kind" in data && typeof data.kind === "string" ? data.kind : undefined
-  return issues.flatMap((issue) => {
-    const path = validationIssuePath(issue)
-    if (typeof issue === "object" && issue !== null && "code" in issue && issue.code === "unrecognized_keys") {
-      const keys = "keys" in issue && Array.isArray(issue.keys) ? issue.keys : []
-      return keys.map((key) => {
-        const field = path ? `${path}.${String(key)}` : String(key)
-        if (kind === "oneshot" && (field === "rhythm" || field === "stop")) {
-          return { field, message: "unsupported_for_oneshot_automation" }
-        }
-        if (kind === "recurring" && field === "fireAt") {
-          return { field, message: "unsupported_for_recurring_automation" }
-        }
-        return { field, message: "unsupported_automation_field" }
-      })
-    }
-    const field = path
-    const message =
-      typeof issue === "object" && issue !== null && "message" in issue && typeof issue.message === "string"
-        ? issue.message
-        : "invalid_automation_field"
-    return [{ field, message }]
-  })
+function runJsonRoute<A>(c: Context, effect: Effect.Effect<A, unknown, AppServices>): Promise<Response> {
+  return runRoute(c, effect.pipe(Effect.map((body) => c.json(body))))
 }
 
 function automationBodyValidationHook(
@@ -99,123 +50,6 @@ function automationBodyValidationHook(
   )
 }
 
-const listAutomations = Effect.fn("AutomationRoutes.list")(function* (c: Context) {
-  const automation = yield* Automation.Service
-  yield* settleAutomationScheduler()
-  const items = yield* automation.list()
-  return c.json({ items })
-})
-
-const createAutomation = Effect.fn("AutomationRoutes.create")(function* (c: Context, input: Automation.CreateInput) {
-  const automation = yield* Automation.Service
-  yield* settleAutomationScheduler()
-  const modelDetails = yield* modelValidation(input.model, input.variant)
-  if (modelDetails.length) {
-    return c.json(Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }), 422)
-  }
-  const definition = yield* automation.create(input)
-  yield* automation.publishDefinitionUpdated(definition)
-  return c.json(definition)
-})
-
-const getAutomation = Effect.fn("AutomationRoutes.get")(function* (c: Context, automationID: AutomationIDParam["automationID"]) {
-  const automation = yield* Automation.Service
-  yield* settleAutomationScheduler()
-  return c.json(yield* automation.get(automationID))
-})
-
-const updateAutomation = Effect.fn("AutomationRoutes.update")(function* (
-  c: Context,
-  automationID: AutomationIDParam["automationID"],
-  patch: Automation.UpdateInput,
-) {
-  const automation = yield* Automation.Service
-  yield* settleAutomationScheduler()
-  const previous = yield* automation.get(automationID)
-  if (patch.model !== undefined || patch.variant !== undefined) {
-    const effectiveModel = patch.model ?? previous.model
-    const effectiveVariant = patch.variant === null ? undefined : (patch.variant ?? previous.variant)
-    const modelDetails = yield* modelValidation(effectiveModel, effectiveVariant)
-    if (modelDetails.length) {
-      return c.json(Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details: modelDetails }), 422)
-    }
-  }
-  const definition = yield* automation.update(automationID, patch)
-  if (definition.revision !== previous.revision) {
-    if (definition.where.projectID !== previous.where.projectID) {
-      yield* automation.publishDefinitionDeleted({ id: previous.id, deleted: true, revision: definition.revision })
-      yield* automation.publishDefinitionUpdatedForScope(definition, Automation.getScope(definition.id))
-    } else {
-      yield* automation.publishDefinitionUpdated(definition)
-    }
-  }
-  return c.json(definition)
-})
-
-const pauseAutomation = Effect.fn("AutomationRoutes.pause")(function* (
-  c: Context,
-  automationID: AutomationIDParam["automationID"],
-) {
-  const automation = yield* Automation.Service
-  yield* settleAutomationScheduler()
-  const previous = yield* automation.get(automationID)
-  const definition = yield* automation.update(automationID, { paused: true })
-  if (definition.revision !== previous.revision) {
-    yield* automation.publishDefinitionUpdated(definition)
-  }
-  return c.json(definition)
-})
-
-const resumeAutomation = Effect.fn("AutomationRoutes.resume")(function* (
-  c: Context,
-  automationID: AutomationIDParam["automationID"],
-) {
-  const automation = yield* Automation.Service
-  yield* settleAutomationScheduler()
-  const previous = yield* automation.get(automationID)
-  const definition = yield* automation.update(automationID, { paused: false })
-  if (definition.revision !== previous.revision) {
-    yield* automation.publishDefinitionUpdated(definition)
-  }
-  return c.json(definition)
-})
-
-const deleteAutomation = Effect.fn("AutomationRoutes.delete")(function* (
-  c: Context,
-  automationID: AutomationIDParam["automationID"],
-) {
-  const automation = yield* Automation.Service
-  const scheduler = AutomationScheduler.current()
-  yield* settleAutomationScheduler(scheduler)
-  const removed = yield* automation.remove(automationID)
-  yield* Effect.sync(() => scheduler.cancel(removed.tombstone.id))
-  yield* automation.publishDefinitionDeleted(removed.tombstone)
-  return c.json(removed.tombstone)
-})
-
-const runAutomationNow = Effect.fn("AutomationRoutes.runNow")(function* (
-  c: Context,
-  automationID: AutomationIDParam["automationID"],
-) {
-  const automation = yield* Automation.Service
-  yield* settleAutomationScheduler()
-  const run = yield* automation.runNowExecuting(automationID, {
-    executor: sessionPromptExecutor,
-  })
-  yield* automation.publishRunUpdated(run)
-  return c.json(run)
-})
-
-const listAutomationRuns = Effect.fn("AutomationRoutes.runs")(function* (
-  c: Context,
-  automationID: AutomationIDParam["automationID"],
-  query: AutomationRunsQuery,
-) {
-  const automation = yield* Automation.Service
-  yield* settleAutomationScheduler()
-  return c.json(yield* automation.runs({ automationID, ...query }))
-})
-
 export const AutomationRoutes = (): Hono =>
   new Hono()
     .get(
@@ -231,7 +65,7 @@ export const AutomationRoutes = (): Hono =>
           },
         },
       }),
-      async (c) => runRoute(c, listAutomations(c)),
+      async (c) => runJsonRoute(c, listAutomations()),
     )
     .post(
       "/",
@@ -252,7 +86,7 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("json", Automation.CreateInput, automationBodyValidationHook),
-      async (c) => runRoute(c, createAutomation(c, c.req.valid("json"))),
+      async (c) => runJsonRoute(c, createAutomation(c.req.valid("json"))),
     )
     .get(
       "/:automationID",
@@ -269,7 +103,7 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", AutomationIDParam),
-      async (c) => runRoute(c, getAutomation(c, c.req.valid("param").automationID)),
+      async (c) => runJsonRoute(c, getAutomation(c.req.valid("param").automationID)),
     )
     .put(
       "/:automationID",
@@ -295,7 +129,7 @@ export const AutomationRoutes = (): Hono =>
       }),
       validator("param", AutomationIDParam),
       validator("json", Automation.UpdateInput, automationBodyValidationHook),
-      async (c) => runRoute(c, updateAutomation(c, c.req.valid("param").automationID, c.req.valid("json"))),
+      async (c) => runJsonRoute(c, updateAutomation(c.req.valid("param").automationID, c.req.valid("json"))),
     )
     .post(
       "/:automationID/pause",
@@ -316,7 +150,7 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", AutomationIDParam),
-      async (c) => runRoute(c, pauseAutomation(c, c.req.valid("param").automationID)),
+      async (c) => runJsonRoute(c, pauseAutomation(c.req.valid("param").automationID)),
     )
     .post(
       "/:automationID/resume",
@@ -337,7 +171,7 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", AutomationIDParam),
-      async (c) => runRoute(c, resumeAutomation(c, c.req.valid("param").automationID)),
+      async (c) => runJsonRoute(c, resumeAutomation(c.req.valid("param").automationID)),
     )
     .delete(
       "/:automationID",
@@ -355,7 +189,7 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", AutomationIDParam),
-      async (c) => runRoute(c, deleteAutomation(c, c.req.valid("param").automationID)),
+      async (c) => runJsonRoute(c, deleteAutomation(c.req.valid("param").automationID)),
     )
     .post(
       "/:automationID/run",
@@ -372,7 +206,7 @@ export const AutomationRoutes = (): Hono =>
         },
       }),
       validator("param", AutomationIDParam),
-      async (c) => runRoute(c, runAutomationNow(c, c.req.valid("param").automationID)),
+      async (c) => runJsonRoute(c, runAutomationNow(c.req.valid("param").automationID)),
     )
     .get(
       "/:automationID/runs",
@@ -390,5 +224,5 @@ export const AutomationRoutes = (): Hono =>
       }),
       validator("param", AutomationIDParam),
       validator("query", AutomationRunsQuery),
-      async (c) => runRoute(c, listAutomationRuns(c, c.req.valid("param").automationID, c.req.valid("query"))),
+      async (c) => runJsonRoute(c, listAutomationRuns(c.req.valid("param").automationID, c.req.valid("query"))),
     )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/automation.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/automation.ts
@@ -4,15 +4,40 @@ import { BadRequestError, NotFoundError, WorkspaceRoutingQuery } from "./common"
 
 const root = "/automation"
 
-const AutomationParam = Schema.Struct({
-  automationID: Schema.String,
+const AutomationDefinitionID = Schema.String.check(Schema.isPattern(/^automation_(?!run_)/))
+const AutomationRunID = Schema.String.check(Schema.isPattern(/^automation_run_/))
+const AutomationRunsLimit = Schema.NumberFromString.pipe(
+  Schema.check(Schema.isInt()),
+  Schema.check(Schema.isGreaterThan(0)),
+  Schema.check(Schema.isLessThanOrEqualTo(100)),
+)
+
+export const AutomationParam = Schema.Struct({
+  automationID: AutomationDefinitionID,
 })
 
-const AutomationRunsQuery = Schema.Struct({
+export const AutomationRunsQuery = Schema.Struct({
   ...WorkspaceRoutingQuery.fields,
-  limit: Schema.optionalKey(Schema.NumberFromString),
-  cursor: Schema.optionalKey(Schema.String),
+  limit: Schema.optionalKey(AutomationRunsLimit),
+  cursor: Schema.optionalKey(AutomationRunID),
 })
+
+function constrainAutomationOpenApi(spec: Record<string, any>) {
+  const parameters = spec.paths?.["/automation/{automationID}/runs"]?.get?.parameters
+  if (!Array.isArray(parameters)) return spec
+
+  const limit = parameters.find((parameter) => parameter.name === "limit")
+  if (limit?.schema && typeof limit.schema === "object") {
+    limit.schema = {
+      ...limit.schema,
+      type: "integer",
+      exclusiveMinimum: 0,
+      maximum: 100,
+    }
+  }
+
+  return spec
+}
 
 const AutomationValidationError = Schema.Struct({
   error: Schema.Literal("invalid_automation"),
@@ -169,5 +194,6 @@ export const AutomationApi = HttpApi.make("automation")
       title: "opencode automation HttpApi",
       version: "0.0.1",
       description: "HttpApi surface for ordinary automation JSON routes.",
+      transform: constrainAutomationOpenApi,
     }),
   )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/automation.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/automation.ts
@@ -1,0 +1,173 @@
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+import { BadRequestError, NotFoundError, WorkspaceRoutingQuery } from "./common"
+
+const root = "/automation"
+
+const AutomationParam = Schema.Struct({
+  automationID: Schema.String,
+})
+
+const AutomationRunsQuery = Schema.Struct({
+  ...WorkspaceRoutingQuery.fields,
+  limit: Schema.optionalKey(Schema.NumberFromString),
+  cursor: Schema.optionalKey(Schema.String),
+})
+
+const AutomationValidationError = Schema.Struct({
+  error: Schema.Literal("invalid_automation"),
+  details: Schema.Array(
+    Schema.Struct({
+      field: Schema.String,
+      message: Schema.String,
+    }),
+  ),
+}).pipe(
+  HttpApiSchema.status(422),
+  (schema) =>
+    schema.annotate({
+      identifier: "AutomationValidationError",
+      description: "Automation validation failed",
+    }),
+)
+
+const AutomationConflictError = Schema.Struct({
+  error: Schema.Literal("automation_conflict"),
+  message: Schema.String,
+}).pipe(
+  HttpApiSchema.status(409),
+  (schema) =>
+    schema.annotate({
+      identifier: "AutomationConflictError",
+      description: "Automation update conflict",
+    }),
+)
+
+export const AutomationApi = HttpApi.make("automation")
+  .add(
+    HttpApiGroup.make("automation")
+      .add(
+        HttpApiEndpoint.get("list", root, {
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.list",
+            summary: "List automations",
+            description: "List automation definitions for the current project.",
+          }),
+        ),
+        HttpApiEndpoint.post("create", root, {
+          query: WorkspaceRoutingQuery,
+          payload: Schema.Any,
+          success: Schema.Any,
+          error: [BadRequestError, AutomationValidationError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.create",
+            summary: "Create automation",
+            description: "Create an automation definition without executing it.",
+          }),
+        ),
+        HttpApiEndpoint.get("get", `${root}/:automationID`, {
+          params: AutomationParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+          error: [BadRequestError, NotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.get",
+            summary: "Get automation",
+            description: "Get one automation definition.",
+          }),
+        ),
+        HttpApiEndpoint.put("update", `${root}/:automationID`, {
+          params: AutomationParam,
+          query: WorkspaceRoutingQuery,
+          payload: Schema.Any,
+          success: Schema.Any,
+          error: [BadRequestError, NotFoundError, AutomationValidationError, AutomationConflictError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.update",
+            summary: "Update automation",
+            description: "Update an automation definition.",
+          }),
+        ),
+        HttpApiEndpoint.delete("delete", `${root}/:automationID`, {
+          params: AutomationParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+          error: [BadRequestError, NotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.delete",
+            summary: "Delete automation",
+            description:
+              "Delete an automation definition, cancel future scheduling, and return a tombstone. Already-started runs continue to completion.",
+          }),
+        ),
+        HttpApiEndpoint.get("runs", `${root}/:automationID/runs`, {
+          params: AutomationParam,
+          query: AutomationRunsQuery,
+          success: Schema.Any,
+          error: [BadRequestError, NotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.runs",
+            summary: "List automation runs",
+            description: "List automation runs newest first.",
+          }),
+        ),
+        HttpApiEndpoint.post("runNow", `${root}/:automationID/run`, {
+          params: AutomationParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+          error: [BadRequestError, NotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.runNow",
+            summary: "Run automation now",
+            description:
+              "Create a queued automation run, start execution in the background, and return the queued run immediately.",
+          }),
+        ),
+        HttpApiEndpoint.post("pause", `${root}/:automationID/pause`, {
+          params: AutomationParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+          error: [BadRequestError, NotFoundError, AutomationConflictError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.pause",
+            summary: "Pause automation",
+            description: "Pause an automation definition.",
+          }),
+        ),
+        HttpApiEndpoint.post("resume", `${root}/:automationID/resume`, {
+          params: AutomationParam,
+          query: WorkspaceRoutingQuery,
+          success: Schema.Any,
+          error: [BadRequestError, NotFoundError, AutomationConflictError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "automation.resume",
+            summary: "Resume automation",
+            description: "Resume a paused automation definition.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "automation",
+          description: "HttpApi automation routes.",
+        }),
+      ),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode automation HttpApi",
+      version: "0.0.1",
+      description: "HttpApi surface for ordinary automation JSON routes.",
+    }),
+  )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/automation.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/automation.ts
@@ -1,0 +1,148 @@
+import { Automation, ConflictError, ValidationError } from "@/automation"
+import {
+  AutomationIDParam,
+  AutomationRunsQuery,
+  conflictError,
+  createAutomation,
+  deleteAutomation,
+  getAutomation,
+  listAutomationRuns,
+  listAutomations,
+  pauseAutomation,
+  resumeAutomation,
+  runAutomationNow,
+  updateAutomation,
+  validationDetailsFromIssues,
+  validationError,
+} from "@/server/instance/automation-actions"
+import { NotFoundError } from "@/storage/db"
+import { NamedError } from "@opencode-ai/util/error"
+import { Effect } from "effect"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import z from "zod"
+import { AutomationApi } from "../groups/automation"
+
+type AutomationHttpResponse = HttpServerResponse.HttpServerResponse
+type AutomationRouteParams = z.infer<typeof AutomationIDParam>
+type AutomationRunsQueryInput = z.infer<typeof AutomationRunsQuery>
+
+function isJsonContentType(contentType: string | undefined) {
+  // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
+  return /^application\/([a-z-.]+\+)?json(?:;\s*[a-zA-Z0-9-]+=([^;]+))*$/.test(contentType ?? "")
+}
+
+function badRequestJson(body: unknown) {
+  return HttpServerResponse.jsonUnsafe(body, { status: 400 })
+}
+
+function invalidAutomationJson(details: Automation.ValidationErrorDetail[]): AutomationHttpResponse {
+  return HttpServerResponse.jsonUnsafe(
+    Automation.ValidationErrorResponse.parse({ error: "invalid_automation", details }),
+    { status: 422 },
+  )
+}
+
+function parseJsonBody<T>(
+  request: HttpServerRequest.HttpServerRequest,
+  schema: z.ZodType<T>,
+): Effect.Effect<T | AutomationHttpResponse> {
+  return Effect.gen(function* () {
+    const body = isJsonContentType(request.headers["content-type"])
+      ? yield* request.json.pipe(
+          Effect.catch(() => Effect.succeed(HttpServerResponse.raw("Malformed JSON in request body", { status: 400 }))),
+        )
+      : {}
+    if (HttpServerResponse.isHttpServerResponse(body)) return body
+
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) return invalidAutomationJson(validationDetailsFromIssues(parsed.error.issues, body))
+    return parsed.data
+  })
+}
+
+function parseRouteParams(raw: unknown): AutomationRouteParams | AutomationHttpResponse {
+  const parsed = AutomationIDParam.safeParse(raw)
+  if (!parsed.success) return badRequestJson({ data: raw, error: parsed.error.issues, success: false })
+  return parsed.data
+}
+
+function parseRunsQuery(raw: unknown): AutomationRunsQueryInput | AutomationHttpResponse {
+  const parsed = AutomationRunsQuery.safeParse(raw)
+  if (!parsed.success) return badRequestJson({ data: raw, error: parsed.error.issues, success: false })
+  return parsed.data
+}
+
+function unknownError(message = "Unexpected server error. Check server logs for details.") {
+  return new NamedError.Unknown({ message }).toObject()
+}
+
+function automationFailure(error: unknown): Effect.Effect<AutomationHttpResponse> {
+  if (error instanceof ValidationError) {
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(validationError(error), { status: 422 }))
+  }
+  if (error instanceof ConflictError) {
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(conflictError(error), { status: 409 }))
+  }
+  if (error instanceof NotFoundError) {
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 404 }))
+  }
+  if (error instanceof NamedError) {
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 500 }))
+  }
+  return Effect.succeed(HttpServerResponse.jsonUnsafe(unknownError(), { status: 500 }))
+}
+
+function jsonResponse<A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<AutomationHttpResponse, never, R> {
+  return effect.pipe(
+    Effect.map((value) => HttpServerResponse.jsonUnsafe(value)),
+    Effect.catch(automationFailure),
+    Effect.catchDefect(automationFailure),
+  )
+}
+
+function withParams<R>(
+  raw: unknown,
+  fn: (params: AutomationRouteParams) => Effect.Effect<AutomationHttpResponse, never, R>,
+): Effect.Effect<AutomationHttpResponse, never, R> {
+  return Effect.gen(function* () {
+    const params = parseRouteParams(raw)
+    if (HttpServerResponse.isHttpServerResponse(params)) return params
+    return yield* fn(params)
+  })
+}
+
+export const automationHandlers = HttpApiBuilder.group(AutomationApi, "automation", (handlers) =>
+  handlers
+    .handleRaw("list", () => jsonResponse(listAutomations()))
+    .handleRaw("create", (ctx) =>
+      Effect.gen(function* () {
+        const payload = yield* parseJsonBody(ctx.request, Automation.CreateInput)
+        if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+        return yield* jsonResponse(createAutomation(payload))
+      }),
+    )
+    .handleRaw("get", (ctx) => withParams(ctx.params, (params) => jsonResponse(getAutomation(params.automationID))))
+    .handleRaw("update", (ctx) =>
+      withParams(ctx.params, (params) =>
+        Effect.gen(function* () {
+          const payload = yield* parseJsonBody(ctx.request, Automation.UpdateInput)
+          if (HttpServerResponse.isHttpServerResponse(payload)) return payload
+          return yield* jsonResponse(updateAutomation(params.automationID, payload))
+        }),
+      ),
+    )
+    .handleRaw("delete", (ctx) => withParams(ctx.params, (params) => jsonResponse(deleteAutomation(params.automationID))))
+    .handleRaw("runs", (ctx) =>
+      withParams(ctx.params, (params) =>
+        Effect.gen(function* () {
+          const query = parseRunsQuery(ctx.query)
+          if (HttpServerResponse.isHttpServerResponse(query)) return query
+          return yield* jsonResponse(listAutomationRuns(params.automationID, query))
+        }),
+      ),
+    )
+    .handleRaw("runNow", (ctx) => withParams(ctx.params, (params) => jsonResponse(runAutomationNow(params.automationID))))
+    .handleRaw("pause", (ctx) => withParams(ctx.params, (params) => jsonResponse(pauseAutomation(params.automationID))))
+    .handleRaw("resume", (ctx) => withParams(ctx.params, (params) => jsonResponse(resumeAutomation(params.automationID)))),
+)

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test"
 import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
@@ -16,7 +16,11 @@ import { AutomationRoutes } from "../../src/server/instance/automation"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { PermissionID } from "../../src/permission/schema"
 import { SessionID } from "../../src/session/schema"
-import { AutomationApi } from "../../src/server/routes/instance/httpapi/groups/automation"
+import {
+  AutomationApi,
+  AutomationParam,
+  AutomationRunsQuery,
+} from "../../src/server/routes/instance/httpapi/groups/automation"
 import { automationHandlers } from "../../src/server/routes/instance/httpapi/handlers/automation"
 import { Database, eq } from "../../src/storage/db"
 import { Flock } from "../../src/util/flock"
@@ -241,6 +245,40 @@ describe("automation routes", () => {
     expect(spec.paths["/automation/{automationID}/pause"]).toHaveProperty("post")
     expect(spec.paths["/automation/{automationID}/resume"]).toHaveProperty("post")
     expect(spec.paths["/automation/{automationID}"]?.delete?.description).toContain("Already-started runs continue")
+  })
+
+  test("declares automation run query constraints matching runtime validators", () => {
+    const spec = OpenApi.fromApi(AutomationApi) as any
+    const parameters = spec.paths["/automation/{automationID}/runs"]?.get?.parameters as any[]
+    const parameter = (name: string) => parameters.find((item) => item.name === name)
+    const schemaClauses = (schema: any) => [schema, ...(schema?.allOf ?? [])]
+
+    expect(schemaClauses(parameter("automationID")?.schema)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ pattern: "^automation_(?!run_)" })]),
+    )
+    expect(parameter("limit")?.schema).toMatchObject({
+      type: "integer",
+      exclusiveMinimum: 0,
+      maximum: 100,
+    })
+    expect(schemaClauses(parameter("cursor")?.schema)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ pattern: "^automation_run_" })]),
+    )
+  })
+
+  test("validates automation run params and query through HttpApi schemas", () => {
+    const decodeParam = Schema.decodeUnknownSync(AutomationParam)
+    const decodeQuery = Schema.decodeUnknownSync(AutomationRunsQuery)
+    const automationID = AutomationID.Definition.ascending()
+    const runID = AutomationID.Run.ascending()
+
+    expect(decodeParam({ automationID })).toEqual({ automationID })
+    expect(() => decodeParam({ automationID: runID })).toThrow()
+    expect(decodeQuery({ limit: "100", cursor: runID })).toMatchObject({ limit: 100, cursor: runID })
+    expect(() => decodeQuery({ limit: "0" })).toThrow()
+    expect(() => decodeQuery({ limit: "101" })).toThrow()
+    expect(() => decodeQuery({ limit: "1.5" })).toThrow()
+    expect(() => decodeQuery({ cursor: automationID })).toThrow()
   })
 
   test("serves ordinary automation lifecycle routes through the HttpApi handlers", async () => {

--- a/packages/opencode/test/server/automation-routes.test.ts
+++ b/packages/opencode/test/server/automation-routes.test.ts
@@ -1,4 +1,8 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
 import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
 import { Automation, AutomationID } from "../../src/automation"
@@ -9,8 +13,11 @@ import { Instance } from "../../src/project/instance"
 import { ProjectID } from "../../src/project/schema"
 import { ErrorMiddleware } from "../../src/server/middleware"
 import { AutomationRoutes } from "../../src/server/instance/automation"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { PermissionID } from "../../src/permission/schema"
 import { SessionID } from "../../src/session/schema"
+import { AutomationApi } from "../../src/server/routes/instance/httpapi/groups/automation"
+import { automationHandlers } from "../../src/server/routes/instance/httpapi/handlers/automation"
 import { Database, eq } from "../../src/storage/db"
 import { Flock } from "../../src/util/flock"
 import { tmpdir } from "../fixture/fixture"
@@ -51,6 +58,24 @@ async function withAutomationApp<T>(
 async function json(app: Hono, input: string, init?: RequestInit) {
   const response = await app.request(input, init)
   return response.json()
+}
+
+function requestAutomationHttpApi(pathname: string, init?: RequestInit) {
+  return AppRuntime.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const router = yield* HttpRouter.toHttpEffect(
+          HttpApiBuilder.layer(AutomationApi).pipe(
+            Layer.provide(automationHandlers),
+            Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+          ),
+        )
+        const request = HttpServerRequest.fromWeb(new Request(`http://localhost${pathname}`, init))
+        const response = yield* router.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request), Effect.orDie)
+        return HttpServerResponse.toWeb(response)
+      }),
+    ) as Effect.Effect<Response>,
+  )
 }
 
 async function waitForRunState(automationID: string, state: Automation.Run["state"]) {
@@ -191,6 +216,126 @@ describe("automation route 422 wiring with provider validation enabled", () => {
 })
 
 describe("automation routes", () => {
+  test("keeps the automation local HttpApi handler importable", async () => {
+    const mod = await import("../../src/server/routes/instance/httpapi/handlers/automation")
+
+    expect(mod.automationHandlers).toBeDefined()
+  })
+
+  test("declares the automation route group as HttpApi endpoints", () => {
+    const spec = OpenApi.fromApi(AutomationApi) as any
+
+    expect(spec.paths).toHaveProperty("/automation")
+    expect(spec.paths).toHaveProperty("/automation/{automationID}")
+    expect(spec.paths).toHaveProperty("/automation/{automationID}/runs")
+    expect(spec.paths).toHaveProperty("/automation/{automationID}/run")
+    expect(spec.paths).toHaveProperty("/automation/{automationID}/pause")
+    expect(spec.paths).toHaveProperty("/automation/{automationID}/resume")
+    expect(spec.paths["/automation"]).toHaveProperty("get")
+    expect(spec.paths["/automation"]).toHaveProperty("post")
+    expect(spec.paths["/automation/{automationID}"]).toHaveProperty("get")
+    expect(spec.paths["/automation/{automationID}"]).toHaveProperty("put")
+    expect(spec.paths["/automation/{automationID}"]).toHaveProperty("delete")
+    expect(spec.paths["/automation/{automationID}/runs"]).toHaveProperty("get")
+    expect(spec.paths["/automation/{automationID}/run"]).toHaveProperty("post")
+    expect(spec.paths["/automation/{automationID}/pause"]).toHaveProperty("post")
+    expect(spec.paths["/automation/{automationID}/resume"]).toHaveProperty("post")
+    expect(spec.paths["/automation/{automationID}"]?.delete?.description).toContain("Already-started runs continue")
+  })
+
+  test("serves ordinary automation lifecycle routes through the HttpApi handlers", async () => {
+    await withAutomationApp(async ({ projectID }) => {
+      const create = await requestAutomationHttpApi("/automation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(recurringInput(projectID)),
+      })
+      const created = await create.json()
+
+      expect(create.status).toBe(200)
+      expect(created).toMatchObject({ title: "Daily repo brief", paused: false, revision: 1 })
+
+      const list = await requestAutomationHttpApi("/automation")
+      expect(list.status).toBe(200)
+      expect(await list.json()).toMatchObject({ items: [expect.objectContaining({ id: created.id })] })
+
+      const get = await requestAutomationHttpApi(`/automation/${created.id}`)
+      expect(get.status).toBe(200)
+      expect(await get.json()).toMatchObject({ id: created.id })
+
+      const update = await requestAutomationHttpApi(`/automation/${created.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "Updated repo brief" }),
+      })
+      expect(update.status).toBe(200)
+      expect(await update.json()).toMatchObject({ id: created.id, title: "Updated repo brief", revision: 2 })
+
+      const paused = await requestAutomationHttpApi(`/automation/${created.id}/pause`, { method: "POST" })
+      expect(paused.status).toBe(200)
+      expect(await paused.json()).toMatchObject({ id: created.id, paused: true, revision: 3 })
+
+      const resumed = await requestAutomationHttpApi(`/automation/${created.id}/resume`, { method: "POST" })
+      expect(resumed.status).toBe(200)
+      expect(await resumed.json()).toMatchObject({ id: created.id, paused: false, revision: 4 })
+
+      const runResponse = await requestAutomationHttpApi(`/automation/${created.id}/run`, { method: "POST" })
+      const runBody = await runResponse.json()
+      expect(runResponse.status).toBe(200)
+      expect(runBody).toMatchObject({ automationID: created.id, state: "scheduled", definitionRevision: 4 })
+
+      const runs = await requestAutomationHttpApi(`/automation/${created.id}/runs?limit=1`)
+      expect(runs.status).toBe(200)
+      expect(await runs.json()).toMatchObject({ items: [expect.objectContaining({ id: runBody.id })] })
+
+      const deleted = await requestAutomationHttpApi(`/automation/${created.id}`, { method: "DELETE" })
+      expect(deleted.status).toBe(200)
+      expect(await deleted.json()).toEqual({ id: created.id, deleted: true, revision: 5 })
+    })
+  })
+
+  test("HttpApi delete keeps already-started run history alive", async () => {
+    await withAutomationApp(async ({ projectID }) => {
+      const create = await requestAutomationHttpApi("/automation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(recurringInput(projectID)),
+      })
+      const created = await create.json()
+      const active = Automation.runNow(created.id, { now: 200 })
+      await using _lease = await Flock.acquire(`automation-run:${Instance.directory}:${active.id}`)
+
+      const deleted = await requestAutomationHttpApi(`/automation/${created.id}`, { method: "DELETE" })
+
+      expect(deleted.status).toBe(200)
+      expect(await deleted.json()).toEqual({ id: created.id, deleted: true, revision: 2 })
+      expect(() => Automation.get(created.id)).toThrow()
+      const row = Database.use((db) => db.select().from(AutomationRunTable).where(eq(AutomationRunTable.id, active.id)).get())
+      expect(row?.data).toMatchObject({ id: active.id, state: "scheduled", automationID: created.id })
+    })
+  })
+
+  test("maps automation validation and not-found failures through the HttpApi handlers", async () => {
+    await withAutomationApp(async ({ projectID }) => {
+      const invalid = await requestAutomationHttpApi("/automation", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...recurringInput(projectID), retryPolicy: { attempts: 2 } }),
+      })
+      expect(invalid.status).toBe(422)
+      expect(await invalid.json()).toEqual({
+        error: "invalid_automation",
+        details: [{ field: "retryPolicy", message: "unsupported_automation_field" }],
+      })
+
+      const missing = await requestAutomationHttpApi(`/automation/${AutomationID.Definition.ascending()}`, {
+        method: "DELETE",
+      })
+      expect(missing.status).toBe(404)
+      expect(await missing.json()).toMatchObject({ name: "NotFoundError" })
+    })
+  })
+
   test("reloads definitions and runs from durable storage after instance restart", async () => {
     await using tmp = await tmpdir({ git: true })
     let automationID: string | undefined

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -187,6 +187,27 @@ describe("route inventory harness", () => {
     }
   })
 
+  test("tracks local HttpApi migration coverage for ordinary automation routes", async () => {
+    const inventory = await buildRouteInventory({ root, requireUpstream: false })
+
+    for (const [method, routePath] of [
+      ["GET", "/automation"],
+      ["POST", "/automation"],
+      ["GET", "/automation/:automationID"],
+      ["PUT", "/automation/:automationID"],
+      ["DELETE", "/automation/:automationID"],
+      ["GET", "/automation/:automationID/runs"],
+      ["POST", "/automation/:automationID/run"],
+      ["POST", "/automation/:automationID/pause"],
+      ["POST", "/automation/:automationID/resume"],
+    ] as const) {
+      expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
+        hono: true,
+        localHttpApi: true,
+      })
+    }
+  })
+
   test("tracks local HttpApi migration coverage for PTY JSON and control-plane routes", async () => {
     const inventory = await buildRouteInventory({ root, requireUpstream: false })
 


### PR DESCRIPTION
## Summary

Add local Effect HttpApi coverage for the ordinary automation HTTP route group while keeping the existing Hono routes as the compatibility entry point.

## Why

Automation routes were still Hono-only in the #936 migration inventory. This PR adds the local HttpApi declarations and handlers for the ordinary JSON automation routes without switching production routing.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on behavior parity between the existing Hono routes and the new local HttpApi handlers, especially delete semantics, scheduler settling, run ledger preservation, validation status codes, pause/resume revision behavior, route inventory classification, and HttpApi schema parity for automation run query constraints.

## Risk Notes

Deletion behavior is intentionally preserved: deleting an automation cancels future scheduling and publishes a tombstone, but already-started run history remains durable. No visible UI or copy changed, so the UI screenshot checklist item is not applicable. No platform, packaging, updater, signing, shell, or filesystem platform surface was touched, so the platform checklist item is not applicable.

## How To Verify

```text
Dependency install: bun install --frozen-lockfile succeeded in the isolated worktree.
Baseline focused tests before changes: bun test test/server/automation-routes.test.ts test/server/automation-runner.test.ts test/tool/automate-manage.test.ts test/server/route-inventory-harness.test.ts passed, 111 tests.
Review-fix RED: the automation OpenAPI contract test failed before tightening automationID, limit, and cursor schemas.
Focused tests after final changes: bun test test/server/automation-routes.test.ts test/server/automation-runner.test.ts test/tool/automate-manage.test.ts test/server/route-inventory-harness.test.ts passed, 119 tests.
Typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode.
Diff check: git diff --check origin/dev...HEAD passed.
Final fresh-eye review: PASS under P0/P1 gate; no P0/P1/P2/P3 findings.
Pre-push base check: rebased onto origin/dev 81b46e5ca618e834ba9cd71975b29eeb0a70e495 after #1388 merged.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
