### PR TITLE
ci: split Windows opencode server tools advisory shard

### DIFF
--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -114,7 +114,7 @@ jobs:
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: windows-latest
     # Windows unit jobs are advisory, package-scoped or shard-scoped. Timeout
-    # budgets are explicit per matrix child; opencode has three parallel
+    # budgets are explicit per matrix child; opencode has five parallel
     # shards, so a full stall can still consume multiple Windows runner slots.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
@@ -169,11 +169,11 @@ jobs:
               test/settings
               test/settings.test.ts
             report_path: packages/opencode/.artifacts/unit/junit-windows-config-project.xml
-          # Server tools carries many smaller and faster directories, which is
-          # why it has more entries than the other two opencode shards.
+          # Server tools carries the slow HTTP/server route suite and adjacent
+          # server support tests, so it gets a little more wall-clock budget.
           - package: opencode-server-tools
             uses_turbo: false
-            timeout_minutes: 20
+            timeout_minutes: 25
             command: >-
               cd packages/opencode && bun test
               --timeout 30000
@@ -181,7 +181,6 @@ jobs:
               --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml
               test/server
               test/snapshot
-              test/tool
               test/browser
               test/mcp
               test/question
@@ -189,12 +188,31 @@ jobs:
               test/agent
               test/git/
               test/storage
+            report_path: packages/opencode/.artifacts/unit/junit-windows-server-tools.xml
+          - package: opencode-tool-runtime
+            uses_turbo: false
+            timeout_minutes: 20
+            command: >-
+              cd packages/opencode && bun test
+              --timeout 30000
+              --reporter=junit
+              --reporter-outfile=.artifacts/unit/junit-windows-tool-runtime.xml
+              test/tool
               test/provider
               test/pty
               test/share/
               test/script
               test/memory
               test/lsp
+            report_path: packages/opencode/.artifacts/unit/junit-windows-tool-runtime.xml
+          - package: opencode-platform
+            uses_turbo: false
+            timeout_minutes: 20
+            command: >-
+              cd packages/opencode && bun test
+              --timeout 30000
+              --reporter=junit
+              --reporter-outfile=.artifacts/unit/junit-windows-platform.xml
               test/fixture
               test/acp
               test/bus
@@ -210,7 +228,7 @@ jobs:
               test/installation
               test/auth
               test/automation
-            report_path: packages/opencode/.artifacts/unit/junit-windows-server-tools.xml
+            report_path: packages/opencode/.artifacts/unit/junit-windows-platform.xml
           - package: desktop
             uses_turbo: true
             timeout_minutes: 20

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -102,10 +102,26 @@ const windowsOpencodeShards = [
   {
     suffix: "opencode-server-tools",
     usesTurbo: false,
+    timeoutMinutes: 25,
+    command:
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/browser test/mcp test/question test/effect test/agent test/git/ test/storage",
+    reportPath: "packages/opencode/.artifacts/unit/junit-windows-server-tools.xml",
+  },
+  {
+    suffix: "opencode-tool-runtime",
+    usesTurbo: false,
     timeoutMinutes: 20,
     command:
-      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/tool test/browser test/mcp test/question test/effect test/agent test/git/ test/storage test/provider test/pty test/share/ test/script test/memory test/lsp test/fixture test/acp test/bus test/cli test/global test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth test/automation",
-    reportPath: "packages/opencode/.artifacts/unit/junit-windows-server-tools.xml",
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-tool-runtime.xml test/tool test/provider test/pty test/share/ test/script test/memory test/lsp",
+    reportPath: "packages/opencode/.artifacts/unit/junit-windows-tool-runtime.xml",
+  },
+  {
+    suffix: "opencode-platform",
+    usesTurbo: false,
+    timeoutMinutes: 20,
+    command:
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-platform.xml test/fixture test/acp test/bus test/cli test/global test/account test/sync test/filesystem test/patch test/shell test/control-plane test/ide test/installation test/auth test/automation",
+    reportPath: "packages/opencode/.artifacts/unit/junit-windows-platform.xml",
   },
 ] as const
 
@@ -687,6 +703,8 @@ describe("ci workflow", () => {
       "opencode-session",
       "opencode-config-project",
       "opencode-server-tools",
+      "opencode-tool-runtime",
+      "opencode-platform",
     ])
 
     for (const item of opencodeShards) {


### PR DESCRIPTION
## Summary

- Split the Windows advisory opencode server-tools shard into narrower server, tool-runtime, and platform shards.
- Keep the existing `opencode-server-tools` check name, but scope it to server/HTTP-adjacent tests and give it a 25 minute budget.
- Add workflow contract coverage so every opencode test file is still covered exactly once across Windows advisory shards.

## Why

#1386 is blocked by `windows-advisory / unit-windows-opencode-server-tools` being marked cancelled while the rest of CI is green. The latest cancelled run reached the `unit` step after setup/cache/install had already consumed several minutes, with no test failure in the job log. #1387 is running the same wide shard and can hit the same closeout blocker.

This PR keeps the advisory protection, but removes the oversized shard shape so #1386 and #1387 can close out without disabling real server/tool coverage.

## Related Issue

Related to #936

Also unblocks #1386 and #1387 CI closeout.

## Human Review Status

Pending

## Review Focus

Please focus on the Windows advisory shard boundaries, the timeout budget for `opencode-server-tools`, and the coverage contract that prevents missing or duplicated opencode tests.

## Risk Notes

Windows advisory now runs two additional opencode shard jobs. This increases advisory fan-out, but keeps the main Linux CI protection unchanged and avoids skipping real server/tool tests. No production code, UI, docs, dependencies, permissions, release notes, credentials, deletion behavior, generated content, or local file surfaces changed.

Skipped checklist items:

- Visible UI or copy check: not applicable; this is a workflow-only change.

## How To Verify

```text
RED: `bun test test/github/ci-workflow.test.ts` failed after updating the contract expectation, because windows-advisory.yml still had the old 3-shard matrix.
GREEN: `bun test test/github/ci-workflow.test.ts` -> 17 pass, 0 fail.
Workflow tests: `bun test test/github` -> 47 pass, 0 fail.
Typecheck: `bun run typecheck` in packages/opencode -> tsgo --noEmit passed.
Actionlint: `actionlint -color -shellcheck= .github/workflows/windows-advisory.yml` -> passed with no output.
Diff check: `git diff --check` -> passed with no output.
Local shard shape smoke: proposed server-tools group -> 721 pass, 1 skip; proposed tool-runtime group -> 1175 pass, 1 skip; proposed platform group -> 250 pass.
Limit: I cannot run the Windows GitHub runner locally; the PR CI windows-advisory jobs are the live proof.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
