### PR TITLE
ci: split Windows server tools advisory shard

### DIFF
--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -114,7 +114,7 @@ jobs:
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: windows-latest
     # Windows unit jobs are advisory, package-scoped or shard-scoped. Timeout
-    # budgets are explicit per matrix child; opencode has five parallel
+    # budgets are explicit per matrix child; opencode has seven parallel
     # shards, so a full stall can still consume multiple Windows runner slots.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
@@ -169,26 +169,50 @@ jobs:
               test/settings
               test/settings.test.ts
             report_path: packages/opencode/.artifacts/unit/junit-windows-config-project.xml
-          # Server tools carries the slow HTTP/server route suite and adjacent
-          # server support tests, so it gets a little more wall-clock budget.
+          # Server tools carries the slow HTTP/server route suite, so it gets
+          # the largest wall-clock budget plus a process-level attempt timeout.
           - package: opencode-server-tools
             uses_turbo: false
-            timeout_minutes: 25
+            timeout_minutes: 50
+            attempt_timeout_minutes: 20
             command: >-
               cd packages/opencode && bun test
               --timeout 30000
               --reporter=junit
               --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml
               test/server
-              test/snapshot
+            report_path: packages/opencode/.artifacts/unit/junit-windows-server-tools.xml
+          # Browser is isolated from server routes because a Windows process
+          # hang after browser tests can otherwise consume the whole job
+          # timeout before the retry wrapper sees an exit code.
+          - package: opencode-browser-agent
+            uses_turbo: false
+            timeout_minutes: 30
+            attempt_timeout_minutes: 10
+            command: >-
+              cd packages/opencode && bun test
+              --timeout 30000
+              --reporter=junit
+              --reporter-outfile=.artifacts/unit/junit-windows-browser-agent.xml
               test/browser
-              test/mcp
-              test/question
-              test/effect
               test/agent
+              test/question
+            report_path: packages/opencode/.artifacts/unit/junit-windows-browser-agent.xml
+          - package: opencode-server-support
+            uses_turbo: false
+            timeout_minutes: 30
+            attempt_timeout_minutes: 10
+            command: >-
+              cd packages/opencode && bun test
+              --timeout 30000
+              --reporter=junit
+              --reporter-outfile=.artifacts/unit/junit-windows-server-support.xml
+              test/snapshot
+              test/mcp
+              test/effect
               test/git/
               test/storage
-            report_path: packages/opencode/.artifacts/unit/junit-windows-server-tools.xml
+            report_path: packages/opencode/.artifacts/unit/junit-windows-server-support.xml
           - package: opencode-tool-runtime
             uses_turbo: false
             timeout_minutes: 20
@@ -295,11 +319,24 @@ jobs:
         run: |
           set +e
           attempts=2
+          attempt_timeout_minutes="${{ matrix.attempt_timeout_minutes }}"
           first_status=
+          if [ -n "$attempt_timeout_minutes" ] && ! command -v timeout >/dev/null 2>&1; then
+            echo "::error title=Missing GNU timeout::matrix package ${{ matrix.package }} needs process-level attempt timeout"
+            exit 127
+          fi
+
           for attempt in $(seq 1 "$attempts"); do
             echo "::group::Windows unit attempt $attempt of $attempts"
-            ( ${{ matrix.command }} )
+            if [ -n "$attempt_timeout_minutes" ]; then
+              timeout "${attempt_timeout_minutes}m" bash -lc '${{ matrix.command }}'
+            else
+              ( ${{ matrix.command }} )
+            fi
             status=$?
+            if [ -n "$attempt_timeout_minutes" ] && [ "$status" -eq 124 ]; then
+              echo "Windows unit attempt timed out after ${attempt_timeout_minutes}m"
+            fi
             echo "::endgroup::"
 
             if [ "$attempt" -eq 1 ]; then

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -102,10 +102,29 @@ const windowsOpencodeShards = [
   {
     suffix: "opencode-server-tools",
     usesTurbo: false,
-    timeoutMinutes: 25,
+    timeoutMinutes: 50,
+    attemptTimeoutMinutes: 20,
     command:
-      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server test/snapshot test/browser test/mcp test/question test/effect test/agent test/git/ test/storage",
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-tools.xml test/server",
     reportPath: "packages/opencode/.artifacts/unit/junit-windows-server-tools.xml",
+  },
+  {
+    suffix: "opencode-browser-agent",
+    usesTurbo: false,
+    timeoutMinutes: 30,
+    attemptTimeoutMinutes: 10,
+    command:
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-browser-agent.xml test/browser test/agent test/question",
+    reportPath: "packages/opencode/.artifacts/unit/junit-windows-browser-agent.xml",
+  },
+  {
+    suffix: "opencode-server-support",
+    usesTurbo: false,
+    timeoutMinutes: 30,
+    attemptTimeoutMinutes: 10,
+    command:
+      "cd packages/opencode && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit-windows-server-support.xml test/snapshot test/mcp test/effect test/git/ test/storage",
+    reportPath: "packages/opencode/.artifacts/unit/junit-windows-server-support.xml",
   },
   {
     suffix: "opencode-tool-runtime",
@@ -642,9 +661,11 @@ describe("ci workflow", () => {
     // Retry budget: exactly one extra attempt (max_attempts=2).
     expect(unitRun).toContain("attempts=2")
 
-    // Each attempt runs in a subshell so `cd packages/...` in matrix.command
-    // does not leak working directory across attempts.
-    expect(unitRun).toContain("( ${{ matrix.command }} )")
+    // Each time-boxed attempt runs in a fresh shell so `cd packages/...` in
+    // matrix.command does not leak working directory across attempts.
+    expect(unitRun).toContain('attempt_timeout_minutes="${{ matrix.attempt_timeout_minutes }}"')
+    expect(unitRun).toContain('timeout "${attempt_timeout_minutes}m" bash -lc')
+    expect(unitRun).toContain("Windows unit attempt timed out")
 
     // First-attempt exit code must be exported so downstream steps and humans
     // can tell a recovered run apart from a clean-first-pass run.
@@ -672,13 +693,19 @@ describe("ci workflow", () => {
     const matrixIncludes = job?.strategy?.matrix?.include ?? []
 
     expect(matrixIncludes).toEqual(
-      windowsUnitJobs.map(({ jobName, usesTurbo, timeoutMinutes, command, reportPath }) => ({
-        package: jobName.replace("unit-windows-", ""),
-        uses_turbo: usesTurbo,
-        timeout_minutes: timeoutMinutes,
-        command,
-        report_path: reportPath,
-      })),
+      windowsUnitJobs.map((pkg) => {
+        const matrixItem: Record<string, string | number | boolean> = {
+          package: pkg.jobName.replace("unit-windows-", ""),
+          uses_turbo: pkg.usesTurbo,
+          timeout_minutes: pkg.timeoutMinutes,
+          command: pkg.command,
+          report_path: pkg.reportPath,
+        }
+        if ("attemptTimeoutMinutes" in pkg) {
+          matrixItem.attempt_timeout_minutes = pkg.attemptTimeoutMinutes
+        }
+        return matrixItem
+      }),
     )
 
     for (const { jobName, artifactName } of windowsUnitJobs) {
@@ -703,6 +730,8 @@ describe("ci workflow", () => {
       "opencode-session",
       "opencode-config-project",
       "opencode-server-tools",
+      "opencode-browser-agent",
+      "opencode-server-support",
       "opencode-tool-runtime",
       "opencode-platform",
     ])
@@ -749,6 +778,38 @@ describe("ci workflow", () => {
       extra: [],
       missing: [],
     })
+  })
+
+  test("time-boxes server-derived Windows opencode shards below the job budget", () => {
+    const parsed = parseWorkflow(windowsAdvisoryWorkflowPath)
+    const matrixIncludes = parsed.jobs?.[windowsUnitJobName]?.strategy?.matrix?.include ?? []
+    const serverDerivedShards = matrixIncludes.filter((item) =>
+      ["opencode-server-tools", "opencode-browser-agent", "opencode-server-support"].includes(String(item.package)),
+    )
+
+    expect(
+      serverDerivedShards.map((item) => ({
+        package: item.package,
+        timeout_minutes: item.timeout_minutes,
+        attempt_timeout_minutes: item.attempt_timeout_minutes,
+      })),
+    ).toEqual([
+      { package: "opencode-server-tools", timeout_minutes: 50, attempt_timeout_minutes: 20 },
+      { package: "opencode-browser-agent", timeout_minutes: 30, attempt_timeout_minutes: 10 },
+      { package: "opencode-server-support", timeout_minutes: 30, attempt_timeout_minutes: 10 },
+    ])
+
+    for (const item of serverDerivedShards) {
+      const timeoutMinutes = item.timeout_minutes
+      const attemptTimeoutMinutes = item.attempt_timeout_minutes
+
+      expect(typeof timeoutMinutes).toBe("number")
+      expect(typeof attemptTimeoutMinutes).toBe("number")
+      if (typeof timeoutMinutes !== "number" || typeof attemptTimeoutMinutes !== "number") {
+        throw new Error(`Invalid timeout shape for ${String(item.package)}`)
+      }
+      expect(timeoutMinutes).toBeGreaterThanOrEqual(attemptTimeoutMinutes * 2 + 10)
+    }
   })
 
   test("keeps Windows opencode shard paths from prefix-matching sibling test directories", () => {


### PR DESCRIPTION
## Summary

Split the Windows advisory `opencode-server-tools` shard into smaller server-derived shards and add process-level attempt timeouts for the shards that previously could hang until the job timeout cancelled the run.

## Why

The latest `dev` push for #1387 cancelled `windows-advisory` run 27802484637 because `unit-windows-opencode-server-tools` job 82275434554 reached its job timeout while `bun test` was still running. The log showed no assertion failure: setup succeeded, other Windows shards passed, and the unit process stopped producing output after `test/browser/session.test.ts` before GitHub cancelled the operation.

This PR keeps the Windows advisory coverage but prevents one broad shard or one hung Bun process from consuming the entire job budget before the retry wrapper can observe an exit code. It unblocks #1387 post-merge closeout and future #936 migration closeout.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

Please check that the new shard boundaries preserve all existing opencode Windows advisory test coverage exactly once, and that the per-attempt timeout budget is large enough for normal runs while still firing before the job-level timeout.

## Risk Notes

Windows-only runtime behavior cannot be fully proven on this macOS worktree; the PR CI Windows advisory jobs are the authoritative verification. No UI, copy, docs, dependency, credential, deletion, release, or generated-content surface changed.

## How To Verify

```text
Read failing GitHub Actions evidence: run 27802484637 / job 82275434554 showed setup succeeded, other Windows shards passed, and the unit step was cancelled by job timeout with no test assertion failure.
RED: bun test test/github/ci-workflow.test.ts failed before the workflow update because the expected split shards and attempt timeout contract were missing.
Focused workflow contract: bun test test/github/ci-workflow.test.ts passed, 18 passed.
Workflow tests: bun test test/github passed, 48 passed.
Typecheck: bun run typecheck passed in packages/opencode.
Actionlint: actionlint -color -shellcheck= .github/workflows/windows-advisory.yml passed.
Diff whitespace: git diff --check passed.
Local shard smoke: server-tools, browser-agent, and server-support shard commands passed locally with JUnit reporter output after the workflow artifact directory was prepared.
Limitation: local macOS environment does not provide GNU timeout, so the timeout wrapper itself is left to GitHub Actions Windows CI.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow test execution by rebalancing parallel test shards and introducing per-attempt timeout handling to improve reliability and execution efficiency.

* **Tests**
  * Updated test expectations to reflect changes in workflow shard organization and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->