### PR TITLE
feat: route production APIs through HttpApi dispatcher

### DIFF
--- a/packages/opencode/src/server/adapter.node.ts
+++ b/packages/opencode/src/server/adapter.node.ts
@@ -5,8 +5,8 @@ import type { Socket } from "node:net"
 import type { Adapter } from "./adapter"
 
 export const adapter: Adapter = {
-  create(app: Hono) {
-    const ws = createNodeWebSocket({ app })
+  create(app, websocketApp?: Hono) {
+    const ws = createNodeWebSocket({ app: websocketApp ?? (app as Hono) })
     return {
       upgradeWebSocket: ws.upgradeWebSocket,
       async listen(opts) {

--- a/packages/opencode/src/server/adapter.ts
+++ b/packages/opencode/src/server/adapter.ts
@@ -16,6 +16,10 @@ export interface Runtime {
   listen(opts: Opts): Promise<Listener>
 }
 
+export type FetchApp = {
+  fetch: (request: Request, env?: unknown) => Response | Promise<Response>
+}
+
 export interface Adapter {
-  create(app: Hono): Runtime
+  create(app: Hono | FetchApp, websocketApp?: Hono): Runtime
 }

--- a/packages/opencode/src/server/compatibility.ts
+++ b/packages/opencode/src/server/compatibility.ts
@@ -1,0 +1,22 @@
+import { Hono } from "hono"
+import type { UpgradeWebSocket } from "hono/ws"
+import { AuthMiddleware, CompressionMiddleware, CorsMiddleware, ErrorMiddleware, LoggerMiddleware } from "./middleware"
+import { EventRoutes } from "./instance/event"
+import { createGlobalCompatibilityRoutes } from "./instance/global"
+import { PtyConnectCompatibilityRoutes } from "./instance/pty"
+import { WorkspaceWebSocketCompatibilityRoutes } from "./proxy"
+import { UIRoutes } from "./routes/ui"
+
+export function createCompatibilityApp(input: { cors?: string[]; upgradeWebSocket: UpgradeWebSocket }) {
+  return new Hono()
+    .onError(ErrorMiddleware)
+    .use(CorsMiddleware(input))
+    .use(LoggerMiddleware)
+    .use(AuthMiddleware)
+    .use(CompressionMiddleware)
+    .route("/global", createGlobalCompatibilityRoutes())
+    .route("/", EventRoutes())
+    .route("/", WorkspaceWebSocketCompatibilityRoutes(input.upgradeWebSocket))
+    .route("/pty", PtyConnectCompatibilityRoutes(input.upgradeWebSocket))
+    .route("/", UIRoutes())
+}

--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -550,4 +550,79 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
     )
 }
 
+export function createGlobalCompatibilityRoutes(options: GlobalRoutesOptions = {}) {
+  const replayBridge = options.replayBridge ?? globalEventReplay
+  const heartbeatMs = normalizeHeartbeatMs(options.heartbeatMs)
+  const syncSubscribe =
+    options.syncSubscribe ??
+    ((q: AsyncQueue<string | null>) => {
+      return SyncEvent.subscribeAll(({ def, event }) => {
+        // TODO: don't pass def, just pass the type (and it should
+        // be versioned)
+        q.push(
+          JSON.stringify({
+            payload: {
+              ...event,
+              type: SyncEvent.versionedType(def.type, def.version),
+            },
+          }),
+        )
+      })
+    })
+
+  return new Hono()
+    .use((c, next) => withRequestContext(requestContextFromHono(c, {}), () => next()))
+    .get(
+      "/event",
+      describeRoute({
+        summary: "Get global events",
+        description: "Subscribe to global events from the OpenCode system using server-sent events.",
+        operationId: "global.event",
+        responses: {
+          200: {
+            description: "Event stream",
+            content: {
+              "text/event-stream": {
+                schema: resolver(globalEventOpenApiSchema()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        log.info("global event connected")
+        c.header("Cache-Control", "no-cache, no-transform")
+        c.header("X-Accel-Buffering", "no")
+        c.header("X-Content-Type-Options", "nosniff")
+
+        return streamGlobalEvents(c, replayBridge, heartbeatMs)
+      },
+    )
+    .get(
+      "/sync-event",
+      describeRoute({
+        summary: "Subscribe to global sync events",
+        description: "Get global sync events",
+        operationId: "global.sync-event.subscribe",
+        responses: {
+          200: {
+            description: "Event stream",
+            content: {
+              "text/event-stream": {
+                schema: resolver(globalSyncEventOpenApiSchema()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        log.info("global sync event connected")
+        c.header("Cache-Control", "no-cache, no-transform")
+        c.header("X-Accel-Buffering", "no")
+        c.header("X-Content-Type-Options", "nosniff")
+        return streamEvents(c, syncSubscribe, heartbeatMs)
+      },
+    )
+}
+
 export const GlobalRoutes = lazy(() => createGlobalRoutes())

--- a/packages/opencode/src/server/instance/pty.ts
+++ b/packages/opencode/src/server/instance/pty.ts
@@ -318,3 +318,31 @@ export function PtyRoutes(upgradeWebSocket: UpgradeWebSocket) {
       }),
     )
 }
+
+export function PtyConnectCompatibilityRoutes(upgradeWebSocket: UpgradeWebSocket) {
+  return new Hono().get(
+    "/:ptyID/connect",
+    describeRoute({
+      summary: "Connect to PTY session",
+      description: "Establish a WebSocket connection to interact with a pseudo-terminal (PTY) session in real-time.",
+      operationId: "pty.connect",
+      responses: {
+        200: {
+          description: "Connected session",
+          content: {
+            "application/json": {
+              schema: resolver(z.boolean()),
+            },
+          },
+        },
+        ...errors(404),
+      },
+    }),
+    validator("param", z.object({ ptyID: PtyID.zod })),
+    validator("query", PtyConnectQuery),
+    upgradeWebSocket(async (c) => {
+      const request = c.req as unknown as PtyConnectRequest
+      return runPtyRoute(connectPtySession(request))
+    }),
+  )
+}

--- a/packages/opencode/src/server/openapi.ts
+++ b/packages/opencode/src/server/openapi.ts
@@ -1,0 +1,30 @@
+import { Hono } from "hono"
+import { generateSpecs } from "hono-openapi"
+import { adapter } from "#hono"
+import { ControlPlaneRoutes } from "./routes/control"
+import { GlobalRoutes } from "./routes/global"
+import { InstanceRoutes } from "./routes/instance"
+import { InstanceMiddleware } from "./routes/instance/middleware"
+import { WorkspaceRoutes } from "./routes/control/workspace"
+
+export async function serverOpenApi() {
+  // Spec-generation compatibility only. Production requests are dispatched by
+  // the native server app in server.ts, not this Hono documentation tree.
+  const app = new Hono().route("/global", GlobalRoutes())
+  const runtime = adapter.create(app)
+  const documented = app
+    .route("/", ControlPlaneRoutes())
+    .route("/experimental/workspace", new Hono().use(InstanceMiddleware()).route("/", WorkspaceRoutes()))
+    .route("/", new Hono().use(InstanceMiddleware()).route("/", InstanceRoutes(runtime.upgradeWebSocket)))
+
+  return generateSpecs(documented, {
+    documentation: {
+      info: {
+        title: "opencode",
+        version: "1.0.0",
+        description: "opencode api",
+      },
+      openapi: "3.1.1",
+    },
+  })
+}

--- a/packages/opencode/src/server/production-httpapi.ts
+++ b/packages/opencode/src/server/production-httpapi.ts
@@ -1,0 +1,395 @@
+import { mkdirSync } from "fs"
+import os from "os"
+import path from "path"
+import type { UpgradeWebSocket } from "hono/ws"
+import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { Runtime } from "@opencode-ai/core/runtime"
+import { Context, Effect, Layer } from "effect"
+import { Etag, HttpEffect, HttpServerRequest, HttpServerResponse, HttpRouter } from "effect/unstable/http"
+import { HttpApi, HttpApiBuilder } from "effect/unstable/httpapi"
+import { WorkspaceContext } from "@/control-plane/workspace-context"
+import type { WorkspaceID } from "@/control-plane/schema"
+import { AppRuntime } from "@/effect/app-runtime"
+import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
+import { Global } from "@/global"
+import { Instance, type InstanceContext } from "@/project/instance"
+import { Filesystem } from "@/util/filesystem"
+import * as Fence from "./fence"
+import { resolveWorkspaceRoute } from "./instance/workspace-routing"
+import { ServerProxy } from "./proxy"
+import { requestContextFromRequest, withRequestContext } from "./request-context"
+import { automationHandlers } from "./routes/instance/httpapi/handlers/automation"
+import { configHandlers } from "./routes/instance/httpapi/handlers/config"
+import { controlHandlers } from "./routes/instance/httpapi/handlers/control"
+import { experimentalHandlers } from "./routes/instance/httpapi/handlers/experimental"
+import { externalResultHandlers } from "./routes/instance/httpapi/handlers/external-result"
+import { fileHandlers } from "./routes/instance/httpapi/handlers/file"
+import { globalHandlers } from "./routes/instance/httpapi/handlers/global"
+import { mcpHandlers } from "./routes/instance/httpapi/handlers/mcp"
+import { memoryHandlers } from "./routes/instance/httpapi/handlers/memory"
+import { permissionHandlers } from "./routes/instance/httpapi/handlers/permission"
+import { projectHandlers } from "./routes/instance/httpapi/handlers/project"
+import { providerHandlers } from "./routes/instance/httpapi/handlers/provider"
+import { ptyHandlers } from "./routes/instance/httpapi/handlers/pty"
+import { rootHandlers } from "./routes/instance/httpapi/handlers/root"
+import { sessionHandlers } from "./routes/instance/httpapi/handlers/session"
+import { workspaceHandlers } from "./routes/instance/httpapi/handlers/workspace"
+import { AutomationApi } from "./routes/instance/httpapi/groups/automation"
+import { ConfigApi } from "./routes/instance/httpapi/groups/config"
+import { ControlApi } from "./routes/instance/httpapi/groups/control"
+import { ExperimentalApi } from "./routes/instance/httpapi/groups/experimental"
+import { ExternalResultApi } from "./routes/instance/httpapi/groups/external-result"
+import { FileApi } from "./routes/instance/httpapi/groups/file"
+import { GlobalApi } from "./routes/instance/httpapi/groups/global"
+import { McpApi } from "./routes/instance/httpapi/groups/mcp"
+import { MemoryApi } from "./routes/instance/httpapi/groups/memory"
+import { PermissionApi } from "./routes/instance/httpapi/groups/permission"
+import { ProjectApi } from "./routes/instance/httpapi/groups/project"
+import { ProviderApi } from "./routes/instance/httpapi/groups/provider"
+import { PtyApi } from "./routes/instance/httpapi/groups/pty"
+import { RootApi } from "./routes/instance/httpapi/groups/root"
+import { SessionApi } from "./routes/instance/httpapi/groups/session"
+import { WorkspaceApi } from "./routes/instance/httpapi/groups/workspace"
+
+const ProductionApi = HttpApi.make("production")
+  .addHttpApi(ControlApi)
+  .addHttpApi(GlobalApi)
+  .addHttpApi(WorkspaceApi)
+  .addHttpApi(RootApi)
+  .addHttpApi(ProjectApi)
+  .addHttpApi(PtyApi)
+  .addHttpApi(ConfigApi)
+  .addHttpApi(ExperimentalApi)
+  .addHttpApi(SessionApi)
+  .addHttpApi(PermissionApi)
+  .addHttpApi(ExternalResultApi)
+  .addHttpApi(ProviderApi)
+  .addHttpApi(MemoryApi)
+  .addHttpApi(AutomationApi)
+  .addHttpApi(FileApi)
+  .addHttpApi(McpApi)
+
+const productionHandlers = Layer.mergeAll(
+  controlHandlers,
+  globalHandlers,
+  workspaceHandlers,
+  rootHandlers,
+  projectHandlers,
+  ptyHandlers,
+  configHandlers,
+  experimentalHandlers,
+  sessionHandlers,
+  permissionHandlers,
+  externalResultHandlers,
+  providerHandlers,
+  memoryHandlers,
+  automationHandlers,
+  fileHandlers,
+  mcpHandlers,
+)
+
+const productionRouterLayer = HttpApiBuilder.layer(ProductionApi).pipe(
+  Layer.provide(productionHandlers),
+  Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodeHttpPlatform.layer, NodePath.layer, Etag.layer)),
+)
+
+const apiPrefixes = [
+  "/auth/",
+  "/global/",
+  "/experimental/",
+  "/session",
+  "/permission",
+  "/external-result",
+  "/provider",
+  "/memory",
+  "/automation",
+  "/mcp",
+  "/project",
+  "/pty",
+  "/config",
+  "/find",
+  "/file",
+]
+
+const apiExactPaths = new Set([
+  "/doc",
+  "/log",
+  "/instance/dispose",
+  "/path",
+  "/vcs",
+  "/vcs/status",
+  "/vcs/diff",
+  "/vcs/diff/raw",
+  "/vcs/apply",
+  "/command",
+  "/agent",
+  "/skill",
+  "/lsp",
+])
+
+function pathnameOf(request: Request) {
+  return new URL(request.url).pathname
+}
+
+function isWebSocketUpgrade(request: Request) {
+  return request.headers.get("upgrade")?.toLowerCase() === "websocket"
+}
+
+export function isProductionHttpApiRequest(request: Request) {
+  const pathname = pathnameOf(request)
+  if (request.method === "GET" && (pathname === "/global/event" || pathname === "/global/sync-event")) {
+    return false
+  }
+  if (request.method === "GET" && pathname === "/event") return true
+  if (request.method === "GET" && pathname === "/__workspace_ws") return false
+  if (request.method === "GET" && /^\/pty\/[^/]+\/connect$/.test(pathname)) return true
+  if (apiExactPaths.has(pathname)) return true
+  return apiPrefixes.some((prefix) => pathname === prefix.slice(0, -1) || pathname.startsWith(prefix))
+}
+
+function isGlobalApi(pathname: string) {
+  return pathname.startsWith("/global/")
+}
+
+function isWorkspaceApi(pathname: string) {
+  return pathname === "/experimental/workspace" || pathname.startsWith("/experimental/workspace/")
+}
+
+function isControlPlaneApi(pathname: string) {
+  return pathname === "/doc" || pathname === "/log" || pathname.startsWith("/auth/")
+}
+
+function isInstanceCompatibilityApi(pathname: string) {
+  return pathname === "/event" || /^\/pty\/[^/]+\/connect$/.test(pathname)
+}
+
+function resolveDirectory(request: Request) {
+  const url = new URL(request.url)
+  const pawworkDefault = path.join(os.homedir(), "PawWork")
+  const raw = url.searchParams.get("directory") || request.headers.get("x-opencode-directory") || pawworkDefault
+  const directory = Filesystem.resolve(
+    (() => {
+      try {
+        return decodeURIComponent(raw)
+      } catch {
+        return raw
+      }
+    })(),
+  )
+
+  if (!url.searchParams.has("directory") && !request.headers.has("x-opencode-directory")) {
+    try {
+      mkdirSync(pawworkDefault, { recursive: true })
+    } catch {
+      // Ignore: home may be unwritable or path may be a regular file.
+    }
+  }
+
+  return directory
+}
+
+type EffectRequestRefs = {
+  instance: InstanceContext
+  workspaceID?: WorkspaceID
+}
+
+function effectRequestContext(refs?: EffectRequestRefs) {
+  if (!refs) return undefined
+  const context = Context.add(Context.empty(), InstanceRef, refs.instance)
+  if (!refs.workspaceID) return context
+  return Context.add(context, WorkspaceRef, refs.workspaceID)
+}
+
+function provideInstanceContext(input: {
+  directory: string
+  request: Request
+  workspaceID?: WorkspaceID
+  fn: (refs: EffectRequestRefs) => Promise<Response>
+}) {
+  const snapshot = requestContextFromRequest(input.request, {
+    directory: input.directory,
+    workspaceID: input.workspaceID,
+  })
+
+  const runInstance = () =>
+    withRequestContext(snapshot, () =>
+      Instance.provide({
+        directory: input.directory,
+        fn: () =>
+          input.fn({
+            instance: Instance.current,
+            workspaceID: input.workspaceID,
+          }),
+      }),
+    )
+
+  if (!input.workspaceID) return runInstance()
+
+  return WorkspaceContext.provide({
+    workspaceID: input.workspaceID,
+    fn: runInstance,
+  })
+}
+
+async function runWithFence(request: Request, next: () => Promise<Response>) {
+  if (request.method === "GET" || request.method === "HEAD" || request.method === "OPTIONS") return next()
+
+  const prev = Fence.load()
+  const response = await next()
+  const current = Fence.diff(prev, Fence.load())
+  if (Object.keys(current).length === 0) return response
+
+  const headers = new Headers(response.headers)
+  headers.set("x-opencode-sync", JSON.stringify(current))
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+type ProductionHttpApiDispatcherOptions = {
+  handler?: (request: Request) => Promise<Response>
+  compatibilityHandler?: (request: Request, env?: unknown) => Promise<Response>
+}
+
+function createProductionWebHandler() {
+  const resolveSymbol = Symbol.for("@effect/platform/HttpApp/resolve")
+
+  return {
+    dispose: async () => {},
+    async handler(request: Request, context?: Context.Context<never>) {
+      const handler = (await AppRuntime.runPromise(
+        Effect.scoped(HttpRouter.toHttpEffect(productionRouterLayer as never)) as never,
+      )) as Effect.Effect<HttpServerResponse.HttpServerResponse, unknown, HttpServerRequest.HttpServerRequest>
+      const response = await new Promise<Response>((resolve) => {
+        const httpServerRequest = HttpServerRequest.fromWeb(request)
+        ;(httpServerRequest as any)[resolveSymbol] = resolve
+        const requestContext = Context.add(context ?? Context.empty(), HttpServerRequest.HttpServerRequest, httpServerRequest)
+        const responseHandler = HttpEffect.toHandled(handler, (request, response) => {
+          response = HttpEffect.scopeTransferToStream(response)
+          ;(request as any)[resolveSymbol](
+            HttpServerResponse.toWeb(response, { withoutBody: request.method === "HEAD", context: requestContext }),
+          )
+          return Effect.void
+        })
+        const instance = context ? Context.getReferenceUnsafe(context, InstanceRef) : undefined
+        const workspaceID = context ? Context.getReferenceUnsafe(context, WorkspaceRef) : undefined
+        let effect = responseHandler.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, httpServerRequest))
+        if (instance) effect = effect.pipe(Effect.provideService(InstanceRef, instance))
+        if (workspaceID) effect = effect.pipe(Effect.provideService(WorkspaceRef, workspaceID))
+        const fiber = AppRuntime.runFork(effect as never)
+        request.signal?.addEventListener(
+          "abort",
+          () => {
+            fiber.interruptUnsafe(undefined as never)
+          },
+          { once: true },
+        )
+      })
+      return response
+    },
+  }
+}
+
+export function createProductionHttpApiDispatcher(
+  upgradeWebSocket: UpgradeWebSocket,
+  options: ProductionHttpApiDispatcherOptions = {},
+) {
+  const web = options.handler
+    ? {
+        handler: options.handler,
+        dispose: async () => {},
+      }
+    : createProductionWebHandler()
+
+  const dispatchLocal = (request: Request, refs?: EffectRequestRefs) => {
+    const context = effectRequestContext(refs)
+    if (!context) return web.handler(request)
+    return web.handler(request, context as never)
+  }
+  const dispatchLocalCompatibility = (request: Request, env: unknown) => {
+    if (!options.compatibilityHandler) return dispatchLocal(request)
+    return options.compatibilityHandler(request, env)
+  }
+
+  const dispatchInstance = (request: Request, env: unknown) =>
+    runWithFence(request, async () => {
+      const url = new URL(request.url)
+      const directory = resolveDirectory(request)
+      const workspaceID = url.searchParams.get("workspace") || request.headers.get("x-opencode-workspace")
+      const resolution = await AppRuntime.runPromise(
+        resolveWorkspaceRoute({
+          method: request.method,
+          pathname: url.pathname,
+          directory,
+          workspaceID,
+          ensureConfig: url.searchParams.get("ensureConfig") === "true",
+          isPawWork: Runtime.isPawWork(),
+          isWebSocketUpgrade: isWebSocketUpgrade(request),
+        }),
+      )
+
+      if (resolution.action === "provide-local-context") {
+        if (resolution.createLegacyConfig) mkdirSync(Global.Path.config, { recursive: true })
+        return provideInstanceContext({
+          directory: resolution.directory,
+          workspaceID: resolution.workspaceID,
+          request,
+          fn: (refs) =>
+            isProductionHttpApiRequest(request) && !isInstanceCompatibilityApi(url.pathname)
+              ? dispatchLocal(request, refs)
+              : dispatchLocalCompatibility(request, env),
+        })
+      }
+
+      if (resolution.action === "serve-local-cache" || resolution.action === "pass-missing-session-delete") {
+        return dispatchLocal(request)
+      }
+
+      if (resolution.action === "missing-workspace-error") {
+        return new Response(`Workspace not found: ${resolution.workspaceID}`, {
+          status: 500,
+          headers: {
+            "content-type": "text/plain; charset=utf-8",
+          },
+        })
+      }
+
+      if (resolution.action === "proxy-websocket") {
+        return ServerProxy.websocket(upgradeWebSocket, resolution.target, request, env)
+      }
+
+      const headers = new Headers(request.headers)
+      headers.delete("x-opencode-workspace")
+      return ServerProxy.http(
+        resolution.target.url,
+        resolution.target.headers,
+        new Request(request, {
+          headers,
+        }),
+        resolution.workspaceID,
+      )
+    })
+
+  return {
+    async handle(request: Request, env?: unknown) {
+      const pathname = pathnameOf(request)
+      if (isControlPlaneApi(pathname)) return dispatchLocal(request)
+      if (isGlobalApi(pathname)) {
+        const snapshot = requestContextFromRequest(request, {})
+        return withRequestContext(snapshot, () => dispatchLocal(request))
+      }
+      if (isWorkspaceApi(pathname)) {
+        const directory = resolveDirectory(request)
+        return provideInstanceContext({
+          directory,
+          request,
+          fn: (refs) => dispatchLocal(request, refs),
+        })
+      }
+      return dispatchInstance(request, env)
+    },
+    dispose: web.dispose,
+  }
+}

--- a/packages/opencode/src/server/proxy.ts
+++ b/packages/opencode/src/server/proxy.ts
@@ -123,7 +123,7 @@ export function createWorkspaceProxyPeer({
   }
 }
 
-const app = (upgrade: UpgradeWebSocket) =>
+export const WorkspaceWebSocketCompatibilityRoutes = (upgrade: UpgradeWebSocket) =>
   new Hono().get(
     "/__workspace_ws",
     upgrade((c) => {
@@ -274,7 +274,7 @@ export function websocket(
     request: redactProxyURL(req.url),
     target: redactProxyURL(target),
   })
-  return app(upgrade).fetch(
+  return WorkspaceWebSocketCompatibilityRoutes(upgrade).fetch(
     new Request(proxy, {
       method: req.method,
       headers: next,

--- a/packages/opencode/src/server/request-context.ts
+++ b/packages/opencode/src/server/request-context.ts
@@ -41,6 +41,33 @@ export function requestContextFromHono(
   }
 }
 
+export function requestContextFromRequest(
+  request: Request,
+  input: { directory?: string; workspaceID?: string },
+): RequestContextSnapshot {
+  const url = new URL(request.url)
+  const clientActionID = safeHeaderToken(request.headers.get("x-pawwork-client-action-id") ?? undefined)
+  const clientActionKind = safeHeaderToken(request.headers.get("x-pawwork-client-action-kind") ?? undefined)
+  const routeSessionID = safeHeaderToken(request.headers.get("x-pawwork-route-session-id") ?? undefined)
+  const visibleSessionID = safeHeaderToken(request.headers.get("x-pawwork-visible-session-id") ?? undefined)
+  const client_action = clientActionID
+    ? {
+        id: clientActionID,
+        kind: clientActionKind ?? "unknown",
+        route_session_id: routeSessionID,
+        visible_session_id: visibleSessionID,
+      }
+    : undefined
+  return {
+    method: request.method,
+    path: url.pathname,
+    source: client_action ? "renderer" : "local_api",
+    directory_key: input.directory ? directoryKey(input.directory) : undefined,
+    workspace_id: input.workspaceID,
+    client_action,
+  }
+}
+
 function safeHeaderToken(value: string | undefined): string | undefined {
   if (!value) return undefined
   const trimmed = value.trim()

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -39,12 +39,12 @@ const SessionListQuery = Schema.Struct({
 
 const SessionAbortQuery = Schema.Struct({
   ...WorkspaceRoutingQuery.fields,
-  source: Schema.optionalKey(Schema.String.check(Schema.isPattern(/^[A-Za-z0-9._-]{1,80}$/))),
+  source: Schema.optionalKey(Schema.String),
 })
 
 const SessionDiffQuery = Schema.Struct({
   ...WorkspaceRoutingQuery.fields,
-  messageID: MessageID,
+  messageID: Schema.optionalKey(MessageID),
 })
 
 const SessionMessagesQuery = Schema.Struct({

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -65,6 +65,7 @@ const SummarizeBody = z.object({
 
 const PermissionBody = z.object({ response: Permission.Reply })
 const OptionalForceBody = z.object({ force: z.boolean().optional() }).optional()
+const AbortSource = z.string().regex(/^[A-Za-z0-9._-]{1,80}$/)
 
 function isJsonContentType(contentType: string | undefined) {
   // Mirrors hono/validator's jsonRegex, reached through hono-openapi's validator("json").
@@ -357,12 +358,22 @@ export const sessionHandlers = HttpApiBuilder.group(SessionApi, "session", (hand
       }).pipe(Effect.catch(sessionFailure), Effect.catchDefect(sessionFailure)),
     )
     .handleRaw("abort", (ctx) =>
-      jsonResponse(
-        SessionRouteEffects.abortSession({
-          sessionID: ctx.params.sessionID,
-          source: ctx.query.source,
-        }),
-      ),
+      Effect.gen(function* () {
+        const source = new URL(ctx.request.url, "http://localhost").searchParams.get("source") ?? undefined
+        if (source !== undefined && !AbortSource.safeParse(source).success) {
+          return badRequestJson({
+            data: { ...ctx.query, source },
+            error: [{ path: ["source"], message: "Invalid token source" }],
+            success: false,
+          })
+        }
+        return yield* jsonResponse(
+          SessionRouteEffects.abortSession({
+            sessionID: ctx.params.sessionID,
+            source,
+          }),
+        )
+      }),
     )
     .handleRaw("command", (ctx) =>
       Effect.gen(function* () {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,19 +1,21 @@
-import { generateSpecs } from "hono-openapi"
-import { Hono } from "hono"
 import { adapter } from "#hono"
-import { AutomationScheduler } from "@/automation/scheduler"
+import { Hono } from "hono"
+import { HTTPException } from "hono/http-exception"
+import { Option, Redacted } from "effect"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { lazy } from "@/util/lazy"
 import { Log } from "@/util"
+import { Provider } from "@/provider"
+import { Session } from "@/session"
+import { NotFoundError } from "@/storage/db"
+import { NamedError } from "@opencode-ai/util/error"
+import { AutomationScheduler } from "@/automation/scheduler"
 import { MDNS } from "./mdns"
-import { AuthMiddleware, CompressionMiddleware, CorsMiddleware, ErrorMiddleware, LoggerMiddleware } from "./middleware"
-import { FenceMiddleware } from "./fence"
+import { ServerAuth } from "./auth"
+import { createCompatibilityApp } from "./compatibility"
 import { initProjectors } from "./projectors"
-import { InstanceRoutes } from "./routes/instance"
-import { ControlPlaneRoutes } from "./routes/control"
-import { UIRoutes } from "./routes/ui"
-import { GlobalRoutes } from "./routes/global"
-import { InstanceMiddleware } from "./routes/instance/middleware"
-import { WorkspaceRoutes } from "./routes/control/workspace"
+import { createProductionHttpApiDispatcher, isProductionHttpApiRequest } from "./production-httpapi"
+import { serverOpenApi } from "./openapi"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -21,6 +23,13 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 initProjectors()
 
 const log = Log.create({ service: "server" })
+const PTY_CONNECT_PATH = /^\/pty\/[^/]+\/connect$/
+const PROVIDER_AUTH_BAD_REQUEST = new Set([
+  "ProviderAuthValidationFailed",
+  "ProviderAuthOauthMissing",
+  "ProviderAuthOauthCodeMissing",
+  "ProviderAuthOauthCallbackFailed",
+])
 
 export type Listener = {
   hostname: string
@@ -29,46 +38,183 @@ export type Listener = {
   stop: (close?: boolean) => Promise<void>
 }
 
+type ServerApp = {
+  fetch: (request: Request, env?: unknown) => Promise<Response>
+  request: (input: string | Request, init?: RequestInit) => Promise<Response>
+}
+
 export const Default = lazy(() => create({}))
 
-function create(opts: { cors?: string[] }) {
-  const app = new Hono()
-    .onError(ErrorMiddleware)
-    .use(CorsMiddleware(opts))
-    .use(LoggerMiddleware)
-    .use(AuthMiddleware)
-    .use(CompressionMiddleware)
-    .route("/global", GlobalRoutes())
+function corsOrigin(origin: string | null, opts: { cors?: string[] }) {
+  if (!origin) return
+  if (origin.startsWith("http://localhost:")) return origin
+  if (origin.startsWith("http://127.0.0.1:")) return origin
+  if (/^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/.test(origin)) return origin
+  if (opts.cors?.includes(origin)) return origin
+}
 
-  const runtime = adapter.create(app)
+function applyCors(request: Request, response: Response, opts: { cors?: string[] }) {
+  const origin = corsOrigin(request.headers.get("origin"), opts)
+  if (!origin) return response
+
+  const headers = new Headers(response.headers)
+  headers.set("access-control-allow-origin", origin)
+  headers.append("vary", "Origin")
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+function corsPreflight(request: Request, opts: { cors?: string[] }) {
+  const origin = corsOrigin(request.headers.get("origin"), opts)
+  const headers = new Headers()
+  if (origin) {
+    headers.set("access-control-allow-origin", origin)
+    headers.set("access-control-allow-methods", "GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS")
+    const requestedHeaders = request.headers.get("access-control-request-headers")
+    if (requestedHeaders) headers.set("access-control-allow-headers", requestedHeaders)
+    headers.set("access-control-max-age", "86400")
+    headers.append("vary", "Origin")
+  }
+  return new Response(null, { status: 204, headers })
+}
+
+function unauthorized() {
+  return new Response("Unauthorized", {
+    status: 401,
+    headers: {
+      "www-authenticate": 'Basic realm="opencode"',
+      "content-type": "text/plain; charset=UTF-8",
+    },
+  })
+}
+
+function authorize(request: Request) {
+  if (request.method === "OPTIONS") return
+
+  const password = Flag.OPENCODE_SERVER_PASSWORD
+  if (!password) return
+
+  const url = new URL(request.url)
+  if (request.method === "GET" && PTY_CONNECT_PATH.test(url.pathname) && url.searchParams.get("ticket")) return
+
+  const queryToken = url.searchParams.get("auth_token")
+  const authHeader = request.headers.get("authorization")
+  const header = queryToken ? "Basic " + queryToken : authHeader
+  const match = header?.match(/^Basic\s+(.+)$/i)
+  if (!match) return unauthorized()
+
+  const decoded = Buffer.from(match[1], "base64").toString("utf8")
+  const separator = decoded.indexOf(":")
+  if (separator === -1) return unauthorized()
+
+  const config = {
+    password: Option.some(password),
+    username: Flag.OPENCODE_SERVER_USERNAME ?? "opencode",
+  }
+  const credentials = {
+    username: decoded.slice(0, separator),
+    password: Redacted.make(decoded.slice(separator + 1)),
+  }
+  if (!ServerAuth.authorized(credentials, config)) return unauthorized()
+}
+
+function errorResponse(error: unknown) {
+  if (error instanceof NamedError) {
+    const status =
+      error instanceof NotFoundError
+        ? 404
+        : error instanceof Provider.ModelNotFoundError ||
+            PROVIDER_AUTH_BAD_REQUEST.has(error.name) ||
+            error.name.startsWith("Worktree")
+          ? 400
+          : 500
+    if (!(error instanceof NotFoundError)) log.error("failed", { error })
+    return Response.json(error.toObject(), { status })
+  }
+  log.error("failed", { error })
+  if (error instanceof Session.BusyError) {
+    return Response.json(new NamedError.Unknown({ message: error.message }).toObject(), { status: 409 })
+  }
+  if (error instanceof HTTPException) return error.getResponse()
+  return Response.json(new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(), {
+    status: 500,
+  })
+}
+
+async function maybeCompress(request: Request, response: Response) {
+  const url = new URL(request.url)
+  if (!request.headers.get("accept-encoding")?.includes("gzip")) return response
+  if (response.headers.has("content-encoding")) return response
+  if (url.pathname === "/event" || url.pathname === "/global/event") return response
+  if (request.method === "POST" && /\/session\/[^/]+\/(message|prompt_async)$/.test(url.pathname)) return response
+  if (!response.body || !("CompressionStream" in globalThis)) return response
+
+  const headers = new Headers(response.headers)
+  headers.set("content-encoding", "gzip")
+  headers.delete("content-length")
+  return new Response(response.body.pipeThrough(new CompressionStream("gzip")), {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+function create(opts: { cors?: string[] }) {
+  const websocketApp = new Hono()
+  let app: ServerApp
+  const runtime = adapter.create(
+    {
+      fetch(request: Request, env?: unknown) {
+        return app.fetch(request, env)
+      },
+    },
+    websocketApp,
+  )
+  const compatibility = createCompatibilityApp({ ...opts, upgradeWebSocket: runtime.upgradeWebSocket })
+  const dispatcher = createProductionHttpApiDispatcher(runtime.upgradeWebSocket, {
+    compatibilityHandler: (request, env) => Promise.resolve(compatibility.fetch(request, (env ?? {}) as never)),
+  })
+  websocketApp.route("/", compatibility)
+
+  app = {
+    async fetch(request, env) {
+      if (!isProductionHttpApiRequest(request)) {
+        return Promise.resolve(compatibility.fetch(request, (env ?? {}) as never))
+      }
+
+      const pathname = new URL(request.url).pathname
+      const skip = pathname === "/log"
+      if (!skip) log.info("request", { method: request.method, path: pathname })
+      const timer = log.time("request", { method: request.method, path: pathname })
+      try {
+        const response =
+          request.method === "OPTIONS" ? corsPreflight(request, opts) : (authorize(request) ?? (await dispatcher.handle(request, env)))
+        return await maybeCompress(request, applyCors(request, response, opts))
+      } catch (error) {
+        return applyCors(request, errorResponse(error), opts)
+      } finally {
+        if (!skip) timer.stop()
+      }
+    },
+    request(input, init) {
+      const request =
+        input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init)
+      return this.fetch(request)
+    },
+  }
 
   return {
-    app: app
-      .route("/", ControlPlaneRoutes())
-      .route("/experimental/workspace", new Hono().use(InstanceMiddleware()).route("/", WorkspaceRoutes()))
-      .route("/", new Hono().use(FenceMiddleware).route("/", InstanceRoutes(runtime.upgradeWebSocket)))
-      .route("/", UIRoutes()),
+    app,
     runtime,
+    dispose: dispatcher.dispose,
   }
 }
 
 export async function openapi() {
-  // Build a fresh app with all routes registered directly so
-  // hono-openapi can see describeRoute metadata (`.route()` wraps
-  // handlers when the sub-app has a custom errorHandler, which
-  // strips the metadata symbol).
-  const { app } = create({})
-  const result = await generateSpecs(app, {
-    documentation: {
-      info: {
-        title: "opencode",
-        version: "1.0.0",
-        description: "opencode api",
-      },
-      openapi: "3.1.1",
-    },
-  })
-  return result
+  return serverOpenApi()
 }
 
 export let url: URL
@@ -89,6 +235,7 @@ export async function listen(opts: {
     AutomationScheduler.stopProcess({ stopRuns: false })
     try {
       await server.stop(true)
+      await built.dispose()
     } catch (stopError) {
       log.error("server cleanup after scheduler settle failure failed", { error: stopError })
     }
@@ -122,6 +269,7 @@ export async function listen(opts: {
         if (mdns) MDNS.unpublish()
         AutomationScheduler.stopProcess({ stopRuns: false })
         await server.stop(close)
+        await built.dispose()
       })()
       return closing
     },

--- a/packages/opencode/test/server/production-boundary.test.ts
+++ b/packages/opencode/test/server/production-boundary.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { Instance } from "../../src/project/instance"
+import { PtyID } from "../../src/pty/schema"
+import { PtyTicket } from "../../src/pty/ticket"
+import { Server } from "../../src/server/server"
+import { tmpdir } from "../fixture/fixture"
+
+describe("production server boundary", () => {
+  test("serves ordinary JSON API requests through the production app", async () => {
+    const response = await Server.Default().app.request("/global/health")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("application/json")
+    expect(await response.json()).toEqual({ healthy: true, version: "local" })
+  })
+
+  test("serves the OpenAPI document through the production API path", async () => {
+    const response = await Server.Default().app.request("/doc")
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("application/json")
+    expect(body.openapi).toBe("3.1.1")
+    expect(body.paths).toHaveProperty("/global/health")
+  })
+
+  test("keeps control-plane routes out of workspace routing", async () => {
+    const doc = await Server.Default().app.request("/doc?workspace=wrk_missing")
+    const docBody = await doc.json()
+
+    expect(doc.status).toBe(200)
+    expect(docBody.paths).toHaveProperty("/global/health")
+
+    const auth = await Server.Default().app.request("/auth/provider_missing", {
+      method: "DELETE",
+      headers: {
+        "x-opencode-workspace": "wrk_missing",
+      },
+    })
+
+    expect(auth.status).not.toBe(500)
+    expect(await auth.text()).not.toContain("Workspace not found")
+  })
+
+  test("serves local PTY websocket compatibility with production instance context", async () => {
+    if (process.platform === "win32") return
+
+    await using tmp = await tmpdir({ git: true })
+    const ptyID = PtyID.ascending()
+    const issued = PtyTicket.issue({ ptyID })
+    const response = await Server.Default().app.request(
+      `/pty/${ptyID}/connect?directory=${encodeURIComponent(tmp.path)}&ticket=${encodeURIComponent(issued.ticket)}`,
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body.name).toBe("NotFoundError")
+  })
+
+  test("serves instance SSE compatibility with production instance context", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const response = await Server.Default().app.request(`/event?directory=${encodeURIComponent(tmp.path)}`)
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error("Expected SSE body")
+
+    try {
+      const first = await reader.read()
+      const text = new TextDecoder().decode(first.value)
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get("content-type")).toContain("text/event-stream")
+      expect(text).toContain("server.connected")
+    } finally {
+      await reader.cancel()
+    }
+  })
+
+  test("does not mount ordinary API route trees through Hono in production", async () => {
+    const server = await readFile(path.join(import.meta.dir, "../../src/server/server.ts"), "utf8")
+
+    expect(server).not.toContain("InstanceRoutes")
+    expect(server).not.toContain("ControlPlaneRoutes")
+    expect(server).not.toContain("GlobalRoutes")
+  })
+
+  test("keeps legacy route tree usage isolated to spec generation", async () => {
+    const openapi = await readFile(path.join(import.meta.dir, "../../src/server/openapi.ts"), "utf8")
+
+    expect(openapi).toContain("serverOpenApi")
+    expect(openapi).toContain("generateSpecs")
+    expect(openapi).toContain("InstanceRoutes")
+    expect(openapi).toContain("ControlPlaneRoutes")
+    expect(openapi).toContain("GlobalRoutes")
+  })
+})

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -471,6 +471,7 @@ describe("workspace router", () => {
     await Instance.disposeAll()
 
     const ensureSync = disableWorkspaceSync()
+    const proxyHttp = spyOn(ServerProxy, "http")
 
     try {
       const app = Server.Default().app
@@ -486,8 +487,14 @@ describe("workspace router", () => {
       expect(response.status).toBe(200)
       expect(await response.json()).toEqual({ routed: "session-workspace" })
       expect(remoteHits).toBe(1)
+      expect(proxyHttp).toHaveBeenCalledTimes(1)
+      const call = proxyHttp.mock.calls[0] as unknown as [URL | string, HeadersInit | undefined, Request, unknown]
+      expect(call[0].toString()).toBe(remote.url.origin)
+      expect(call[3]).toBe(remoteWorkspace.id)
+      expect(call[2].headers.has("x-opencode-workspace")).toBe(false)
     } finally {
       ensureSync.mockRestore()
+      proxyHttp.mockRestore()
     }
   })
 


### PR DESCRIPTION
## Summary
- move the production ordinary JSON/API request path from the Hono route tree to the local Effect HttpApi dispatcher
- keep Hono only inside explicit compatibility owners for UI static/proxy, workspace websocket proxy, SSE event streams, and PTY websocket connect
- keep `/doc` behavior compatible while isolating legacy Hono route tree usage to OpenAPI spec generation, not production request routing
- add runtime and source guardrails proving production API requests work through `Server.Default().app.request(...)` without mounting ordinary Hono route trees

Related to #936

## Verification
- `bun install --frozen-lockfile`
- `bun test test/server/route-inventory-harness.test.ts test/server/production-boundary.test.ts test/server/control-routes.test.ts test/server/instance-root-routes.test.ts test/server/global-config-routes.test.ts test/server/cors-middleware.test.ts test/server/auth.test.ts test/server/middleware.test.ts test/server/default-directory.test.ts test/server/workspace-router.test.ts test/server/pty-routes.test.ts test/server/server-listen.test.ts test/server/adapter-node-shutdown.test.ts test/server/event-stream-routes.test.ts test/server/global-event-replay.test.ts test/server/proxy.test.ts test/server/workspace-routing-decision.test.ts test/server/session-runtime-routes.test.ts test/server/session-actions.test.ts`
- `git diff --check`
- `GOMAXPROCS=2 bun run typecheck`
- `bun test test/server`