### PR TITLE
refactor: finish low-tail tool Effect migration

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -267,11 +267,11 @@ Individual tools, ordered by value:
 - [x] `websearch.ts` — MEDIUM: MCP over HTTP → HttpClient
 - [x] `glob.ts` — LOW: simple async generator
 - [x] `lsp.ts` — LOW: dispatch switch over LSP operations
-- [ ] `question.ts` — LOW: prompt wrapper
+- [x] `question.ts` — LOW: prompt wrapper
 - [x] `skill.ts` — LOW: skill tool adapter
-- [ ] `todo.ts` — LOW: todo persistence wrapper
-- [ ] `invalid.ts` — LOW: invalid-tool fallback
-- [ ] `plan.ts` — LOW: plan file operations
+- [x] `todo.ts` — LOW: todo persistence wrapper
+- [x] `invalid.ts` — LOW: invalid-tool fallback
+- [x] `plan.ts` — LOW: plan file operations
 
 Stale entries removed 2026-06-19: the current tree has no `tool/batch.ts`, `tool/task.ts`, or `tool/ls.ts` files.
 
@@ -384,6 +384,7 @@ Decision table for the design:
 - `WriteTool` / `EditTool` / `LspTool` — checklist corrected 2026-06-15. Tool bodies already used named `Effect.fn(...execute)` boundaries and the shared `testEffect(...).live` harness; this follow-up verified the existing write/edit/lsp coverage and closed the stale checklist without code or test changes.
 - `ShellTool` / public `bash` tool — migrated 2026-06-15. The current tree exposes this tool from `tool/shell.ts` with public tool id `bash`; there is no standalone `bash.ts` file. The tool body already used named `Effect.fn(...)` boundaries, and this follow-up moved `shell.test.ts` off its local `ManagedRuntime` / `runtime.runPromise(...)` helper and onto an explicit `Effect.provide(testLayer)` runner that initializes and executes the tool inside the same Effect scope while preserving the shell behavior matrix.
 - `SkillTool` — migrated 2026-06-15. The tool body already used the named `Effect.fn("SkillTool.execute")` boundary; this follow-up moved the remaining `skill.test.ts` execute coverage off its local `ManagedRuntime` / `runtime.runPromise(...)` helper and onto an inline `Effect.scoped` + `Effect.provide(testLayer)` boundary, without changing skill discovery or ToolRegistry behavior.
+- Low-tail tools — migrated 2026-06-19. `QuestionTool`, `TodoWriteTool`, and `InvalidTool` already used `Tool.define(...)`, effectful init, and named `Effect.fn(...execute)` boundaries; this follow-up added shared Effect-harness execute coverage for submitted question answers, Todo.Service-backed persistence, and the invalid-tool fallback shape. `PlanExitTool` now wraps its `MessageV2.stream(...)` model lookup in a named Effect boundary and uses `Clock.currentTimeMillis` for the synthetic build-agent message timestamp, with coverage for the approved plan-exit handoff. No HTTP/server, remote, UI, or registry behavior changed.
 - Browser tool tests / `Tool.define` wrapper tests — migrated 2026-06-15. Browser tool bodies were already `Tool.define` + named `Effect.fn(...execute)` definitions, and `browser-shared.ts` already wrapped the CDP Promise boundary with `Effect.tryPromise`; this follow-up moved `browser-tools.test.ts` and `tool-define.test.ts` off their local `Effect.runPromise` / `ManagedRuntime` helpers and onto the shared `testEffect(...).live` harness while preserving fake CDP, permission, cancellation, and wrapper error-boundary assertions.
 - Light instance route handlers — migrated 2026-06-15. The `server/instance/permission.ts` e2e ask and list/prune handlers, `server/instance/session.ts` status and todo handlers, `server/instance/index.ts` raw/apply VCS handlers, and `server/instance/global.ts` upgrade handler now run their bodies through one `AppRuntime.runPromise(Effect.gen(...))` service injection path while preserving fire-and-forget logging, dangling-session pruning, VCS error mappings, and upgrade result handling. This does not claim full session, global, or heavy route migration.
 - MCP route handlers — migrated 2026-06-15. The current `server/instance/mcp.ts` operation handlers now run MCP service calls through `AppRuntime.runPromise(Effect.gen(...))` and `MCP.Service`, with route tests covering disabled local server add and non-OAuth auth 400 behavior. This does not change MCP service behavior, OAuth providers, or config schema.

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { Effect, Schema } from "effect"
+import { Clock, Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import type { DecodeResult } from "./tool"
 import { Question } from "../question"
@@ -10,12 +10,14 @@ import { Instance } from "../project/instance"
 import { type SessionID, MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 
-function getLastModel(sessionID: SessionID) {
-  for (const item of MessageV2.stream(sessionID)) {
-    if (item.info.role === "user" && item.info.model) return item.info.model
-  }
-  return undefined
-}
+const getLastModel = Effect.fn("PlanExitTool.getLastModel")((sessionID: SessionID) =>
+  Effect.sync(() => {
+    for (const item of MessageV2.stream(sessionID)) {
+      if (item.info.role === "user" && item.info.model) return item.info.model
+    }
+    return undefined
+  }),
+)
 
 export const Parameters = Schema.Struct({})
 
@@ -102,13 +104,14 @@ export const PlanExitTool = Tool.define(
           }
         }
 
-        const model = getLastModel(ctx.sessionID) ?? (yield* provider.defaultModel().pipe(Effect.orDie))
+        const model = (yield* getLastModel(ctx.sessionID)) ?? (yield* provider.defaultModel().pipe(Effect.orDie))
+        const now = yield* Clock.currentTimeMillis
 
         const msg: MessageV2.User = {
           id: MessageID.ascending(),
           sessionID: ctx.sessionID,
           role: "user",
-          time: { created: Date.now() },
+          time: { created: now },
           agent: "build",
           model,
         }

--- a/packages/opencode/test/tool/tool-tail-effect.test.ts
+++ b/packages/opencode/test/tool/tool-tail-effect.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Instance } from "../../src/project/instance"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { Session } from "../../src/session"
+import { Todo } from "../../src/session/todo"
+import { InvalidTool } from "../../src/tool/invalid"
+import { PlanExitTool } from "../../src/tool/plan"
+import { QuestionTool } from "../../src/tool/question"
+import { TodoWriteTool } from "../../src/tool/todo"
+import * as Tool from "../../src/tool/tool"
+import { Truncate } from "../../src/tool/truncate"
+import { ProviderTest } from "../fake/provider"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const providerID = ProviderID.make("tool-tail-provider")
+const modelID = ModelID.make("tool-tail-model")
+const provider = ProviderTest.fake({
+  model: ProviderTest.model({ providerID, id: modelID }),
+  defaultModel: Effect.fn("ToolTailTest.defaultModel")(() => Effect.die(new Error("defaultModel should not be used"))),
+})
+
+const it = testEffect(
+  Layer.mergeAll(
+    Truncate.defaultLayer,
+    Agent.defaultLayer,
+    Session.defaultLayer,
+    Todo.defaultLayer,
+    provider.layer,
+    CrossSpawnSpawner.defaultLayer,
+  ),
+)
+
+const baseCtx = (overrides: Partial<Tool.Context> = {}): Tool.Context => ({
+  sessionID: SessionID.make("ses_tool_tail"),
+  messageID: MessageID.ascending(),
+  agent: "build",
+  abort: new AbortController().signal,
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+  ...overrides,
+})
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("low-tail tool Effect migration", () => {
+  it.live("question tool initializes and resolves submitted external answers through its decoder", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const info = yield* QuestionTool
+        const tool = yield* info.init()
+        const params: Tool.InferParameters<typeof QuestionTool> = {
+          questions: [
+            {
+              question: "Pick one",
+              header: "Choice",
+              custom: false,
+              multiple: false,
+              options: [
+                { label: "Yes", description: "Proceed" },
+                { label: "No", description: "Stop" },
+              ],
+            },
+          ],
+        }
+
+        const result = yield* tool.execute(
+          params,
+          baseCtx({
+            externalResult: ({ inputSnapshot, decoder }) =>
+              Effect.sync(() => {
+                expect(inputSnapshot).toEqual(params)
+                const decoded = decoder?.({ answers: [[" Yes "]] }, inputSnapshot)
+                expect(decoded).toEqual({ ok: true, value: { answers: [["Yes"]] } })
+                if (!decoded?.ok) throw new Error("expected decoder success")
+                return { kind: "submitted", value: decoded.value }
+              }),
+          }),
+        )
+
+        expect(result.title).toBe("Asked 1 question")
+        expect(result.output).toContain('"Pick one"="Yes"')
+        expect(result.metadata).toMatchObject({ answers: [["Yes"]], dismissed: false })
+        expect((result.metadata as { truncated?: boolean }).truncated).toBe(false)
+      }),
+    ),
+  )
+
+  it.live("todowrite tool initializes with Todo.Service and persists revisioned todos", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const session = yield* Session.Service.use((svc) => svc.create({ title: "tool todo" }))
+        const info = yield* TodoWriteTool
+        const tool = yield* info.init()
+        const askCalls: unknown[] = []
+
+        const result = yield* tool.execute(
+          {
+            todos: [{ content: "Ship Effect tool tail", status: "pending", priority: "medium" }],
+          },
+          baseCtx({
+            sessionID: session.id,
+            ask: (input) =>
+              Effect.sync(() => {
+                askCalls.push(input)
+              }),
+          }),
+        )
+
+        const stored = yield* Todo.Service.use((svc) => svc.get(session.id))
+        expect(askCalls).toEqual([
+          { permission: "todowrite", patterns: ["*"], always: ["*"], metadata: {} },
+        ])
+        expect(result.title).toBe("1 todos")
+        expect(result.metadata.revision).toBe(1)
+        expect(result.metadata.todos[0].id).toStartWith("todo_")
+        expect(JSON.parse(result.output)).toEqual(result.metadata.todos)
+        expect(stored).toEqual({ revision: result.metadata.revision, todos: result.metadata.todos })
+      }),
+      { git: true },
+    ),
+  )
+
+  it.live("invalid tool initializes and returns the repair fallback shape", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const info = yield* InvalidTool
+        const tool = yield* info.init()
+
+        const result = yield* tool.execute({ tool: "missing_tool", error: "Unknown tool" }, baseCtx())
+
+        expect(result.title).toBe("Invalid Tool")
+        expect(result.output).toBe("The arguments provided to the tool are invalid: Unknown tool")
+        expect((result.metadata as { truncated?: boolean }).truncated).toBe(false)
+      }),
+    ),
+  )
+
+  it.effect("plan_exit tool writes the build-agent handoff using the Effect clock", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessionSvc = yield* Session.Service
+        const session = yield* sessionSvc.create({ title: "plan exit" })
+        yield* sessionSvc.updateMessage({
+          id: MessageID.ascending(),
+          sessionID: session.id,
+          role: "user",
+          time: { created: 1 },
+          agent: "plan",
+          model: { providerID, modelID },
+        } satisfies MessageV2.User)
+
+        const info = yield* PlanExitTool
+        const tool = yield* info.init()
+        const result = yield* tool.execute(
+          {},
+          baseCtx({
+            sessionID: session.id,
+            externalResult: ({ inputSnapshot, decoder }) =>
+              Effect.sync(() => {
+                const decoded = decoder?.({ answers: [["Yes"]] }, inputSnapshot)
+                expect(decoded).toEqual({ ok: true, value: { answers: [["Yes"]] } })
+                if (!decoded?.ok) throw new Error("expected decoder success")
+                return { kind: "submitted", value: decoded.value }
+              }),
+          }),
+        )
+
+        const messages = yield* sessionSvc.messages({ sessionID: session.id })
+        const build = messages.find(
+          (message): message is MessageV2.WithParts & { info: MessageV2.User } =>
+            message.info.role === "user" && message.info.agent === "build",
+        )
+        expect(result.title).toBe("Switching to build agent")
+        expect(result.output).toContain("User approved switching to build agent")
+        expect(build?.info.model).toEqual({ providerID, modelID })
+        expect(build?.info.time.created).toBe(0)
+        expect(build?.parts).toContainEqual(
+          expect.objectContaining({
+            type: "text",
+            text: expect.stringContaining("Execute the plan"),
+            synthetic: true,
+          } satisfies Partial<MessageV2.TextPart>),
+        )
+      }),
+      { git: true },
+    ),
+  )
+})


### PR DESCRIPTION
## Summary

Finish the low-priority tool tail in the #936 Effect migration checklist: `question.ts`, `todo.ts`, `invalid.ts`, and `plan.ts`.

Changes:
- Added shared Effect-harness execute coverage for `QuestionTool`, `TodoWriteTool`, `InvalidTool`, and `PlanExitTool`.
- Moved `PlanExitTool`'s last-model scan behind a named Effect boundary and switched its synthetic build-agent timestamp to `Clock.currentTimeMillis`.
- Updated `packages/opencode/specs/effect-migration.md` to mark the four tool checklist items complete.

## Why

The tool bodies were already mostly Effect-native, but the checklist still had four low-tail items open and there was no single focused test proving their init/execute paths through the current Effect tool framework. This closes that tail without touching HTTP/server, remote, UI, desktop, or registry behavior.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the new `tool-tail-effect.test.ts` coverage is the smallest useful public-interface proof for these tools, and whether the `PlanExitTool` `Clock.currentTimeMillis` change preserves the existing handoff behavior.

## Risk Notes

Runtime risk is low: the only production code change is `plan_exit` moving a synchronous model-history scan into `Effect.sync` and reading the timestamp from the Effect clock. The migration spec update is factual for this PR only.

Skipped checklist items:
- Visible UI/manual check: not applicable; no visible UI or user-facing copy changed.
- Platform/packaging check: not applicable; no platform, packaging, updater, signing, path, shell, or permission surface changed.

## How To Verify

```text
bun install --frozen-lockfile: passed
bun test test/tool/question-decoder.test.ts test/tool/external-result.test.ts test/tool/external-result-registry.test.ts test/tool/tool-define.test.ts test/tool/registry.test.ts test/session/todo.test.ts: baseline passed, 94 tests
bun test test/tool/tool-tail-effect.test.ts: RED on plan_exit Date.now vs Effect clock, then passed after the Clock.currentTimeMillis change, 4 tests
bun test test/tool/tool-tail-effect.test.ts test/tool/question-decoder.test.ts test/tool/external-result.test.ts test/tool/external-result-registry.test.ts test/tool/tool-define.test.ts test/tool/registry.test.ts test/session/todo.test.ts: passed, 98 tests
GOMAXPROCS=2 bun run typecheck: passed
git diff --check: passed
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
