### PR TITLE
fix(opencode): remove Bun globals from Node runtime paths

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -47,6 +47,7 @@ import { Automation } from "@/automation"
 import { Permission } from "../permission"
 import { Glob } from "../util/glob"
 import path from "path"
+import { readFile } from "node:fs/promises"
 import { pathToFileURL } from "url"
 import { Effect, Layer, Context, Schema } from "effect"
 import { ZodOverride } from "@/util/effect-zod"
@@ -254,7 +255,7 @@ export namespace ToolRegistry {
           const depsFailed = new Set<string>()
           for (const match of matches) {
             const namespace = path.basename(match, path.extname(match))
-            const text = yield* Effect.promise(() => Bun.file(match).text())
+            const text = yield* Effect.promise(() => readFile(match, "utf8"))
             const named = Array.from(
               text.matchAll(/export\s+(?:const|let|var|async function|function)\s+([A-Za-z_$][\w$]*)/g),
               (item) => `${namespace}_${item[1]}`,

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -205,10 +205,8 @@ export namespace Process {
     const pending = [pid]
     while (pending.length) {
       const parent = pending.pop()!
-      const out = await Bun.$`pgrep -P ${parent}`
-        .quiet()
-        .nothrow()
-        .text()
+      const out = await text(["pgrep", "-P", String(parent)], { nothrow: true })
+        .then((result) => result.text)
         .catch((error) => {
           log.debug("failed to enumerate child processes", { pid: parent, error: errorMessage(error) })
           return ""
@@ -250,7 +248,7 @@ export namespace Process {
   }) {
     const graceMs = input.graceMs ?? TERMINATION_GRACE_MS
     if (process.platform === "win32") {
-      await Bun.$`taskkill /pid ${input.pid} /f /t`.quiet().nothrow()
+      await run(["taskkill", "/pid", String(input.pid), "/f", "/t"], { nothrow: true })
       return
     }
 

--- a/packages/opencode/src/worktree/gitignore-guard.ts
+++ b/packages/opencode/src/worktree/gitignore-guard.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "fs"
 import path from "path"
 import { NamedError } from "@opencode-ai/util/error"
 import z from "zod"
+import { Process } from "../util/process"
 
 export const GitignoreGuardError = NamedError.create(
   "WorktreeGitignoreGuardError",
@@ -13,13 +14,12 @@ export const GitignoreGuardError = NamedError.create(
 const ENTRY = ".worktrees/"
 
 async function git(root: string, args: string[]) {
-  const proc = Bun.spawn(["git", ...args], { cwd: root, stdout: "pipe", stderr: "pipe" })
-  const [code, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ])
-  return { code, stdout, stderr }
+  const result = await Process.text(["git", ...args], { cwd: root, nothrow: true })
+  return {
+    code: result.code,
+    stdout: result.text,
+    stderr: result.stderr.toString(),
+  }
 }
 
 function hasWorktreesIgnore(text: string) {

--- a/packages/opencode/test/server/node-runtime-bun-boundary.test.ts
+++ b/packages/opencode/test/server/node-runtime-bun-boundary.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test"
+import fs from "node:fs/promises"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Process } from "../../src/util/process"
+import { tmpdir } from "../fixture/fixture"
+import { withEmbeddedServerArtifactLock } from "../shared/embedded-server-artifact-lock"
+import { expectModelsSnapshotUnchanged, writeCurrentModelsFixture } from "./models-snapshot-fixture"
+
+const root = path.join(import.meta.dir, "../..")
+const sourceRoot = path.join(root, "src")
+const distEntry = path.join(root, "dist", "node", "node.js")
+
+async function sourceFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const current = path.join(dir, entry.name)
+      if (entry.isDirectory()) return sourceFiles(current)
+      if (entry.isFile() && /\.(?:ts|tsx)$/.test(entry.name)) return [current]
+      return []
+    }),
+  )
+  return files.flat()
+}
+
+function normalizeRelative(file: string) {
+  return path.relative(sourceRoot, file).split(path.sep).join("/")
+}
+
+function isBunRuntimeBoundary(file: string) {
+  const relative = normalizeRelative(file)
+  if (relative.endsWith(".bun.ts")) return false
+  if (relative.startsWith("cli/")) return false
+  return true
+}
+
+describe("node runtime Bun boundary", () => {
+  test("keeps Node server source paths free of direct Bun globals", async () => {
+    const violations: string[] = []
+    for (const file of await sourceFiles(sourceRoot)) {
+      if (!isBunRuntimeBoundary(file)) continue
+
+      const relative = normalizeRelative(file)
+      const lines = (await fs.readFile(file, "utf8")).split(/\r?\n/)
+      lines.forEach((line, index) => {
+        if (!/\bBun\./.test(line)) return
+        if (line.includes("typeof Bun")) return
+        violations.push(`${relative}:${index + 1}: ${line.trim()}`)
+      })
+    }
+
+    expect(violations).toEqual([])
+  })
+
+  test("built Node server can create a worktree through the experimental route", async () => {
+    await withEmbeddedServerArtifactLock(async () => {
+      await using tmp = await tmpdir({ git: true })
+      const modelsFixture = writeCurrentModelsFixture(root, tmp.path)
+      const runtimeRoot = path.join(tmp.path, "runtime")
+      const runtimeHome = path.join(runtimeRoot, "home")
+      const isolatedEnv = {
+        ...process.env,
+        MODELS_DEV_API_JSON: modelsFixture.fixture,
+        HOME: runtimeHome,
+        USERPROFILE: runtimeHome,
+        XDG_DATA_HOME: path.join(runtimeRoot, "share"),
+        XDG_CACHE_HOME: path.join(runtimeRoot, "cache"),
+        XDG_CONFIG_HOME: path.join(runtimeRoot, "config"),
+        XDG_STATE_HOME: path.join(runtimeRoot, "state"),
+        OPENCODE_TEST_HOME: runtimeHome,
+        OPENCODE_TEST_MANAGED_CONFIG_DIR: path.join(runtimeRoot, "managed"),
+        OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+        OPENCODE_DB: ":memory:",
+      }
+
+      await Promise.all(
+        [
+          isolatedEnv.HOME,
+          isolatedEnv.XDG_DATA_HOME,
+          isolatedEnv.XDG_CACHE_HOME,
+          isolatedEnv.XDG_CONFIG_HOME,
+          isolatedEnv.XDG_STATE_HOME,
+          isolatedEnv.OPENCODE_TEST_MANAGED_CONFIG_DIR,
+        ].map((dir) => fs.mkdir(dir, { recursive: true })),
+      )
+
+      await Process.run([process.execPath, "run", "build:embedded-server"], {
+        cwd: root,
+        env: isolatedEnv,
+      })
+      expectModelsSnapshotUnchanged(modelsFixture)
+
+      const script = `
+        import { writeFileSync } from "node:fs"
+        import { request as httpRequest } from "node:http"
+        import { Server, Log } from ${JSON.stringify(pathToFileURL(distEntry).href)}
+
+        const password = process.env.OPENCODE_SERVER_PASSWORD
+        const directory = process.env.TEST_DIRECTORY
+        const outputFile = process.env.TEST_OUTPUT_FILE
+        if (!password) throw new Error("missing OPENCODE_SERVER_PASSWORD")
+        if (!directory) throw new Error("missing TEST_DIRECTORY")
+        if (!outputFile) throw new Error("missing TEST_OUTPUT_FILE")
+
+        await Log.init({ level: "DEBUG", print: false })
+        const listener = await Server.listen({ port: 0, hostname: "127.0.0.1" })
+        const auth = "Basic " + Buffer.from(\`opencode:\${password}\`).toString("base64")
+
+        const request = (pathname, init = {}) => new Promise((resolve, reject) => {
+          const url = new URL(pathname, listener.url)
+          url.searchParams.set("directory", directory)
+
+          const req = httpRequest(
+            url,
+            {
+              agent: false,
+              method: init.method ?? "GET",
+              headers: {
+                authorization: auth,
+                connection: "close",
+                ...(init.body ? { "content-type": "application/json" } : {}),
+              },
+            },
+            (response) => {
+              const chunks = []
+              response.on("data", (chunk) => chunks.push(chunk))
+              response.on("error", reject)
+              response.on("end", () => {
+                resolve({
+                  status: response.statusCode ?? 0,
+                  body: Buffer.concat(chunks).toString("utf8"),
+                })
+              })
+            },
+          )
+
+          req.on("error", reject)
+          if (init.body) req.write(init.body)
+          req.end()
+        })
+
+        try {
+          const result = await request("/experimental/worktree", {
+            method: "POST",
+            body: JSON.stringify({ name: "node-runtime-smoke" }),
+          })
+          writeFileSync(outputFile, JSON.stringify(result))
+        } finally {
+          await listener.stop(true)
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        process.exit(0)
+      `
+
+      const outputFile = path.join(tmp.path, "embedded-worktree-result.json")
+      const result = await Process.run(["node", "--input-type=module", "-e", script], {
+        cwd: root,
+        env: {
+          ...isolatedEnv,
+          OPENCODE_SERVER_USERNAME: "opencode",
+          OPENCODE_SERVER_PASSWORD: "testpass",
+          TEST_DIRECTORY: tmp.path,
+          TEST_OUTPUT_FILE: outputFile,
+        },
+      })
+
+      expect(result.stdout.toString()).toBe("")
+      const output = JSON.parse(await fs.readFile(outputFile, "utf8")) as {
+        status: number
+        body: string
+      }
+      const body = JSON.parse(output.body) as { name: string; directory: string }
+
+      expect(output.status).toBe(200)
+      expect(body.name).toBe("node-runtime-smoke")
+      expect(body.directory).toContain(`${path.sep}.worktrees${path.sep}`)
+      expect(path.basename(body.directory)).toBe("node-runtime-smoke")
+    })
+  }, 60_000)
+})

--- a/packages/opencode/test/server/node-runtime-bun-boundary.test.ts
+++ b/packages/opencode/test/server/node-runtime-bun-boundary.test.ts
@@ -84,6 +84,19 @@ describe("node runtime Bun boundary", () => {
           isolatedEnv.OPENCODE_TEST_MANAGED_CONFIG_DIR,
         ].map((dir) => fs.mkdir(dir, { recursive: true })),
       )
+      const toolDir = path.join(tmp.path, ".opencode", "tool")
+      await fs.mkdir(toolDir, { recursive: true })
+      await fs.writeFile(
+        path.join(toolDir, "hello.ts"),
+        [
+          "export default {",
+          "  description: 'hello tool',",
+          "  args: {},",
+          "  execute: async () => 'hello world',",
+          "}",
+          "",
+        ].join("\n"),
+      )
 
       await Process.run([process.execPath, "run", "build:embedded-server"], {
         cwd: root,
@@ -141,10 +154,13 @@ describe("node runtime Bun boundary", () => {
         })
 
         try {
-          const result = await request("/experimental/worktree", {
-            method: "POST",
-            body: JSON.stringify({ name: "node-runtime-smoke" }),
-          })
+          const result = {
+            toolIDs: await request("/experimental/tool/ids"),
+            worktree: await request("/experimental/worktree", {
+              method: "POST",
+              body: JSON.stringify({ name: "node-runtime-smoke" }),
+            }),
+          }
           writeFileSync(outputFile, JSON.stringify(result))
         } finally {
           await listener.stop(true)
@@ -168,15 +184,18 @@ describe("node runtime Bun boundary", () => {
 
       expect(result.stdout.toString()).toBe("")
       const output = JSON.parse(await fs.readFile(outputFile, "utf8")) as {
-        status: number
-        body: string
+        toolIDs: { status: number; body: string }
+        worktree: { status: number; body: string }
       }
-      const body = JSON.parse(output.body) as { name: string; directory: string }
+      const toolIDs = JSON.parse(output.toolIDs.body) as string[]
+      const worktree = JSON.parse(output.worktree.body) as { name: string; directory: string }
 
-      expect(output.status).toBe(200)
-      expect(body.name).toBe("node-runtime-smoke")
-      expect(body.directory).toContain(`${path.sep}.worktrees${path.sep}`)
-      expect(path.basename(body.directory)).toBe("node-runtime-smoke")
+      expect(output.toolIDs.status).toBe(200)
+      expect(toolIDs).toContain("hello")
+      expect(output.worktree.status).toBe(200)
+      expect(worktree.name).toBe("node-runtime-smoke")
+      expect(worktree.directory).toContain(`${path.sep}.worktrees${path.sep}`)
+      expect(path.basename(worktree.directory)).toBe("node-runtime-smoke")
     })
   }, 60_000)
 })


### PR DESCRIPTION
## Summary

Fixes a locally reproduced desktop `enter-worktree` crash where the embedded Node server hit `Bun is not defined`. This PR removes direct `Bun.*` usage from Node-reachable opencode runtime paths and adds regression tests for the boundary.

## Why

The desktop app runs the embedded opencode server under Node/Electron, not Bun. `enter-worktree` creates worktrees through `Worktree.createFromInfo`, which calls the gitignore guard. That guard used `Bun.spawn`, so the Node process crashed before the worktree could be created. The same runtime boundary also had direct Bun calls in local tool registry file reads and process tree cleanup.

## Related Issue

None. This came from a locally reproduced app session failure rather than a public GitHub issue.

## Human Review Status

Pending

## Review Focus

Please focus on whether the Node runtime boundary is scoped correctly: direct `Bun.*` remains allowed only in the Bun adapter, CLI-only code, and explicitly guarded fallback code, while server-reachable paths use Node-compatible APIs.

## Risk Notes

- The process cleanup path is platform-sensitive; the change keeps behavior on the existing `Process.run/text` wrapper and the focused `util.process` tests cover the Windows `taskkill` branch.
- Visible UI/copy check skipped: no visible UI or copy changed.
- Docs, release notes, dependency, permission, credential, deletion behavior, generated content, and local-file side-effect checks skipped: none of those surfaces changed.

## How To Verify

```text
bun test test/server/node-runtime-bun-boundary.test.ts
Result: 2 passed. The built Node server smoke reads a local .opencode/tool file through /experimental/tool/ids and creates a worktree through POST /experimental/worktree.

bun test test/worktree/gitignore-guard.test.ts test/project/worktree.test.ts test/tool/enter-worktree.test.ts test/tool/registry.test.ts test/util/process.test.ts test/server/node-runtime-bun-boundary.test.ts
Result: 85 passed across the affected worktree, registry, process, and Node boundary suites.

bun run typecheck
Result: tsgo --noEmit passed.

git diff --check
Result: no whitespace errors.
```

## Screenshots or Recordings

Not applicable; no visible UI or copy changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
