### PR TITLE
refactor(opencode): add Effect-native process wrapper

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -308,7 +308,9 @@ Current raw fs users that will convert during tool migration:
 - [ ] `util/flock.ts` — `packages/core/src/util/effect-flock.ts` is the Effect-native implementation; Effect/service callers should use `EffectFlock.Service`, while legacy Promise callers still use the `packages/opencode/src/util/flock.ts` facade
   - Converted in this slice: `Config.updateGlobal` now uses `EffectFlock.Service.withLock`
   - Retained Promise boundary: provider models, plugin config patching/meta reads, automation run leases/scheduler ownership, and direct flock compatibility tests
-- [ ] `util/process.ts` — child process spawn wrapper → return Effect instead of Promise
+- [x] `util/process.ts` — `Process.Service` and Effect-native `run/text/lines/stop/descendants/terminateTree` now own execution and cleanup; the async facade delegates through `runPromise`
+  - Retained compatibility boundary: `Process.spawn` still returns the Node child facade because CLI pager/auth flows, long-lived LSP launch, Windows cmd script spawning, and stream ownership still depend on that shape
+  - Converted in this slice: `session/prompt.ts` inline shell expansion, `pty/index.ts` teardown cleanup, and `tool/shell.ts` abort/timeout cleanup use `Process.*Effect` directly
 - [ ] `util/lazy.ts` — sync-only route factories, shell selection, native module loading, and zod recursion stay on `lazy`; async Effect code should use `Effect.cached`
   - Converted in this slice: `tool/shell.ts` parser initialization now uses `Effect.cached` inside the tool's Effect definition
   - Retained async legacy boundary: provider models catalog cache and control-plane built-in adaptor import still expose Promise facades
@@ -318,6 +320,8 @@ Current raw fs users that will convert during tool migration:
 Every service currently exports async facade functions at the bottom of its namespace — `export async function read(...) { return runPromise(...) }` — backed by a per-service `makeRuntime`. These exist because cyclic imports used to force each service to build its own independent runtime. Now that the layer DAG is acyclic and `AppRuntime` (`src/effect/app-runtime.ts`) composes everything into one `ManagedRuntime`, we're removing them.
 
 ### Process
+
+Process execution is now effect-native at the utility boundary. Keep the Node child `spawn` facade until long-lived process owners no longer need direct `stdin`/`stdout` streams and `exited` promises, then delete it as a separate compatibility cleanup.
 
 For each service, the migration is roughly:
 

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -169,13 +169,11 @@ export namespace Pty {
           return yield* Effect.promise(() => exited)
         }
 
-        yield* Effect.promise(() =>
-          Process.terminateTree({
-            pid: session.process.pid,
-            signalRoot: (signal) => session.process.kill(signal),
-            waitForExit: exited,
-          }),
-        )
+        yield* Process.terminateTreeEffect({
+          pid: session.process.pid,
+          signalRoot: (signal) => session.process.kill(signal),
+          waitForExit: exited,
+        }).pipe(Effect.orDie)
         if (hasExited(session)) return session.exitCode
         return yield* Effect.promise(() => exited)
       })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1495,10 +1495,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const shellMatches = ConfigMarkdown.shell(template)
       if (shellMatches.length > 0) {
         const sh = Shell.preferred()
-        const results = yield* Effect.promise(() =>
-          Promise.all(
-            shellMatches.map(async ([, shellCmd]) => (await Process.text([shellCmd], { shell: sh, nothrow: true })).text),
+        const results = yield* Effect.all(
+          shellMatches.map(([, shellCmd]) =>
+            Process.textEffect([shellCmd], { shell: sh, nothrow: true }).pipe(
+              Effect.map((result) => result.text),
+              Effect.orDie,
+            ),
           ),
+          { concurrency: "unbounded" },
         )
         let index = 0
         template = template.replace(bashRegex, () => results[index++])

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -607,15 +607,15 @@ export const ShellTool = Tool.define(
 
           if (exit.kind === "abort") {
             aborted = true
-            yield* Effect.promise(() =>
-              Process.terminateTree({ pid: handle.pid, waitForExit: Effect.runPromise(handle.exitCode) }),
-            ).pipe(Effect.orDie)
+            yield* Process.terminateTreeEffect({ pid: handle.pid, waitForExit: Effect.runPromise(handle.exitCode) }).pipe(
+              Effect.orDie,
+            )
           }
           if (exit.kind === "timeout") {
             expired = true
-            yield* Effect.promise(() =>
-              Process.terminateTree({ pid: handle.pid, waitForExit: Effect.runPromise(handle.exitCode) }),
-            ).pipe(Effect.orDie)
+            yield* Process.terminateTreeEffect({ pid: handle.pid, waitForExit: Effect.runPromise(handle.exitCode) }).pipe(
+              Effect.orDie,
+            )
           }
 
           // Drain any chunks the consumer hasn't processed yet, then push the

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess } from "child_process"
 import launch from "cross-spawn"
+import { Context, Effect, Layer, ManagedRuntime } from "effect"
 import { buffer } from "node:stream/consumers"
 import { setTimeout as sleep } from "node:timers/promises"
 import { errorMessage } from "./error"
@@ -62,7 +63,27 @@ export namespace Process {
 
   export type Child = ChildProcess & { exited: Promise<number> }
 
-  export function spawn(cmd: string[], opts: Options = {}): Child {
+  export interface Interface {
+    readonly spawn: (cmd: string[], opts?: Options) => Effect.Effect<Child, unknown>
+    readonly run: (cmd: string[], opts?: RunOptions) => Effect.Effect<Result, unknown>
+    readonly text: (cmd: string[], opts?: RunOptions) => Effect.Effect<TextResult, unknown>
+    readonly lines: (cmd: string[], opts?: RunOptions) => Effect.Effect<string[], unknown>
+    readonly stop: (proc: ChildProcess) => Effect.Effect<void, unknown>
+    readonly descendants: (pid: number) => Effect.Effect<number[]>
+    readonly terminateTree: (input: TerminateTreeInput) => Effect.Effect<void, unknown>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/Process") {}
+
+  export interface TerminateTreeInput {
+    pid: number
+    graceMs?: number
+    signalRoot?: (signal: NodeJS.Signals) => void
+    waitForExit?: Promise<unknown>
+    findDescendants?: (pid: number) => Promise<number[]>
+  }
+
+  function spawnNode(cmd: string[], opts: Options = {}): Child {
     if (cmd.length === 0) throw new Error("Command is required")
     opts.abort?.throwIfAborted()
 
@@ -130,8 +151,16 @@ export namespace Process {
     return child
   }
 
-  export async function run(cmd: string[], opts: RunOptions = {}): Promise<Result> {
-    const proc = spawn(cmd, {
+  export function spawn(cmd: string[], opts: Options = {}): Child {
+    return spawnNode(cmd, opts)
+  }
+
+  export const spawnEffect = Effect.fn("Process.spawn")(function* (cmd: string[], opts: Options = {}) {
+    return yield* Effect.sync(() => spawnNode(cmd, opts))
+  })
+
+  export const runEffect = Effect.fn("Process.run")(function* (cmd: string[], opts: RunOptions = {}) {
+    const proc = yield* spawnEffect(cmd, {
       cwd: opts.cwd,
       env: opts.env,
       stdin: opts.stdin,
@@ -143,29 +172,31 @@ export namespace Process {
       stderr: "pipe",
     })
 
-    if (!proc.stdout || !proc.stderr) throw new Error("Process output not available")
+    if (!proc.stdout || !proc.stderr) return yield* Effect.fail(new Error("Process output not available"))
 
-    const out = await Promise.all([proc.exited, buffer(proc.stdout), buffer(proc.stderr)])
-      .then(([code, stdout, stderr]) => ({
+    const out = yield* Effect.tryPromise(() =>
+      Promise.all([proc.exited, buffer(proc.stdout!), buffer(proc.stderr!)]).then(([code, stdout, stderr]) => ({
         code,
         stdout,
         stderr,
-      }))
-      .catch((err: unknown) => {
-        if (!opts.nothrow) throw err
-        return {
+      })),
+    ).pipe(
+      Effect.catch((err: unknown) => {
+        if (!opts.nothrow) return Effect.fail(err)
+        return Effect.succeed({
           code: 1,
           stdout: Buffer.alloc(0),
           stderr: Buffer.from(errorMessage(err)),
-        }
-      })
+        })
+      }),
+    )
     if (out.code === 0 || opts.nothrow) return out
-    throw new RunFailedError(cmd, out.code, out.stdout, out.stderr)
-  }
+    return yield* Effect.fail(new RunFailedError(cmd, out.code, out.stdout, out.stderr))
+  })
 
   // The SDK keeps a sync stop variant because it cannot import opencode without
   // creating a cycle. Keep platform behavior aligned when changing this path.
-  export async function stop(proc: ChildProcess) {
+  export const stopEffect = Effect.fn("Process.stop")(function* (proc: ChildProcess) {
     if (proc.exitCode !== null || proc.signalCode !== null) return
 
     if (!proc.pid) {
@@ -183,12 +214,12 @@ export namespace Process {
       proc.once("error", done)
     })
 
-    await terminateTree({
+    yield* terminateTreeEffect({
       pid: proc.pid,
       signalRoot: (signal) => proc.kill(signal),
       waitForExit,
     })
-  }
+  })
 
   export function exists(pid: number) {
     try {
@@ -199,18 +230,19 @@ export namespace Process {
     }
   }
 
-  export async function descendants(pid: number): Promise<number[]> {
+  export const descendantsEffect = Effect.fn("Process.descendants")(function* (pid: number) {
     if (process.platform === "win32") return []
     const seen = new Set<number>()
     const pending = [pid]
     while (pending.length) {
       const parent = pending.pop()!
-      const out = await text(["pgrep", "-P", String(parent)], { nothrow: true })
-        .then((result) => result.text)
-        .catch((error) => {
+      const out = yield* textEffect(["pgrep", "-P", String(parent)], { nothrow: true }).pipe(
+        Effect.map((result) => result.text),
+        Effect.catch((error) => {
           log.debug("failed to enumerate child processes", { pid: parent, error: errorMessage(error) })
-          return ""
-        })
+          return Effect.succeed("")
+        }),
+      )
       for (const line of out.split(/\s+/)) {
         const child = Number(line)
         if (!Number.isInteger(child) || child <= 0 || seen.has(child)) continue
@@ -219,7 +251,7 @@ export namespace Process {
       }
     }
     return Array.from(seen)
-  }
+  })
 
   function signalPid(pid: number, signal: NodeJS.Signals) {
     try {
@@ -239,25 +271,25 @@ export namespace Process {
     }
   }
 
-  export async function terminateTree(input: {
-    pid: number
-    graceMs?: number
-    signalRoot?: (signal: NodeJS.Signals) => void
-    waitForExit?: Promise<unknown>
-    findDescendants?: (pid: number) => Promise<number[]>
-  }) {
+  export const terminateTreeEffect = Effect.fn("Process.terminateTree")(function* (input: TerminateTreeInput) {
     const graceMs = input.graceMs ?? TERMINATION_GRACE_MS
     if (process.platform === "win32") {
-      await run(["taskkill", "/pid", String(input.pid), "/f", "/t"], { nothrow: true })
+      yield* runEffect(["taskkill", "/pid", String(input.pid), "/f", "/t"], { nothrow: true })
       return
     }
 
     // Descendants are a best-effort snapshot for normal child processes. A
     // daemonized double-fork can intentionally leave this tree before cleanup.
-    const children = await (input.findDescendants ?? descendants)(input.pid).catch((error) => {
-      log.debug("failed to enumerate process tree", { pid: input.pid, error: errorMessage(error) })
-      return []
-    })
+    const children = yield* (
+      input.findDescendants
+        ? Effect.tryPromise(() => input.findDescendants!(input.pid))
+        : descendantsEffect(input.pid)
+    ).pipe(
+      Effect.catch((error) => {
+        log.debug("failed to enumerate process tree", { pid: input.pid, error: errorMessage(error) })
+        return Effect.succeed([])
+      }),
+    )
     const signalRoot = (signal: NodeJS.Signals) => {
       if (input.signalRoot && exists(input.pid)) {
         try {
@@ -277,9 +309,11 @@ export namespace Process {
 
     // With waitForExit, worst case is one grace period before SIGKILL and one
     // bounded wait after SIGKILL so callers can observe the final exit.
-    const rootExited = await (input.waitForExit
-      ? Promise.race([input.waitForExit.then(() => true, () => true), sleep(graceMs).then(() => false)])
-      : sleep(graceMs).then(() => false))
+    const rootExited = yield* Effect.promise(() =>
+      input.waitForExit
+        ? Promise.race([input.waitForExit.then(() => true, () => true), sleep(graceMs).then(() => false)])
+        : sleep(graceMs).then(() => false),
+    )
 
     if (!exists(input.pid) && children.every((child) => !exists(child))) return
     if (groupSignaled && !rootExited && exists(input.pid)) {
@@ -290,18 +324,59 @@ export namespace Process {
     }
     for (const child of children) signalPid(child, "SIGKILL")
     log.debug("sent process tree kill signals", { pid: input.pid, groupSignaled, descendantCount: children.length })
-    if (input.waitForExit) await Promise.race([input.waitForExit.catch(() => undefined), sleep(graceMs)])
-  }
+    if (input.waitForExit) yield* Effect.promise(() => Promise.race([input.waitForExit!.catch(() => undefined), sleep(graceMs)]))
+  })
 
-  export async function text(cmd: string[], opts: RunOptions = {}): Promise<TextResult> {
-    const out = await run(cmd, opts)
+  export const textEffect = Effect.fn("Process.text")(function* (cmd: string[], opts: RunOptions = {}) {
+    const out = yield* runEffect(cmd, opts)
     return {
       ...out,
       text: out.stdout.toString(),
     }
+  })
+
+  export const linesEffect = Effect.fn("Process.lines")(function* (cmd: string[], opts: RunOptions = {}) {
+    return (yield* textEffect(cmd, opts)).text.split(/\r?\n/).filter(Boolean)
+  })
+
+  export const layer = Layer.succeed(
+    Service,
+    Service.of({
+      spawn: spawnEffect,
+      run: runEffect,
+      text: textEffect,
+      lines: linesEffect,
+      stop: stopEffect,
+      descendants: descendantsEffect,
+      terminateTree: terminateTreeEffect,
+    }),
+  )
+  export const defaultLayer = layer
+
+  const runtime = ManagedRuntime.make(defaultLayer)
+  const runPromise = <A, E>(fn: (process: Interface) => Effect.Effect<A, E>) => runtime.runPromise(Service.use(fn))
+
+  export async function run(cmd: string[], opts: RunOptions = {}): Promise<Result> {
+    return runPromise((process) => process.run(cmd, opts))
+  }
+
+  export async function stop(proc: ChildProcess) {
+    return runPromise((process) => process.stop(proc))
+  }
+
+  export async function descendants(pid: number): Promise<number[]> {
+    return runPromise((process) => process.descendants(pid))
+  }
+
+  export async function terminateTree(input: TerminateTreeInput) {
+    return runPromise((process) => process.terminateTree(input))
+  }
+
+  export async function text(cmd: string[], opts: RunOptions = {}): Promise<TextResult> {
+    return runPromise((process) => process.text(cmd, opts))
   }
 
   export async function lines(cmd: string[], opts: RunOptions = {}): Promise<string[]> {
-    return (await text(cmd, opts)).text.split(/\r?\n/).filter(Boolean)
+    return runPromise((process) => process.lines(cmd, opts))
   }
 }

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -64,7 +64,6 @@ export namespace Process {
   export type Child = ChildProcess & { exited: Promise<number> }
 
   export interface Interface {
-    readonly spawn: (cmd: string[], opts?: Options) => Effect.Effect<Child, unknown>
     readonly run: (cmd: string[], opts?: RunOptions) => Effect.Effect<Result, unknown>
     readonly text: (cmd: string[], opts?: RunOptions) => Effect.Effect<TextResult, unknown>
     readonly lines: (cmd: string[], opts?: RunOptions) => Effect.Effect<string[], unknown>
@@ -83,7 +82,7 @@ export namespace Process {
     findDescendants?: (pid: number) => Promise<number[]>
   }
 
-  function spawnNode(cmd: string[], opts: Options = {}): Child {
+  export function spawn(cmd: string[], opts: Options = {}): Child {
     if (cmd.length === 0) throw new Error("Command is required")
     opts.abort?.throwIfAborted()
 
@@ -151,12 +150,8 @@ export namespace Process {
     return child
   }
 
-  export function spawn(cmd: string[], opts: Options = {}): Child {
-    return spawnNode(cmd, opts)
-  }
-
   export const spawnEffect = Effect.fn("Process.spawn")(function* (cmd: string[], opts: Options = {}) {
-    return yield* Effect.sync(() => spawnNode(cmd, opts))
+    return yield* Effect.sync(() => spawn(cmd, opts))
   })
 
   export const runEffect = Effect.fn("Process.run")(function* (cmd: string[], opts: RunOptions = {}) {
@@ -342,7 +337,6 @@ export namespace Process {
   export const layer = Layer.succeed(
     Service,
     Service.of({
-      spawn: spawnEffect,
       run: runEffect,
       text: textEffect,
       lines: linesEffect,

--- a/packages/opencode/test/util/process.test.ts
+++ b/packages/opencode/test/util/process.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
 import fs from "fs/promises"
 import path from "path"
 import { Process } from "../../src/util/process"
@@ -18,6 +19,13 @@ async function waitForFile(file: string) {
 }
 
 describe("util.process", () => {
+  test("captures stdout and stderr through the Effect path", async () => {
+    const out = await Effect.runPromise(Process.runEffect(node('process.stdout.write("out");process.stderr.write("err")')))
+    expect(out.code).toBe(0)
+    expect(out.stdout.toString()).toBe("out")
+    expect(out.stderr.toString()).toBe("err")
+  })
+
   test("captures stdout and stderr", async () => {
     const out = await Process.run(node('process.stdout.write("out");process.stderr.write("err")'))
     expect(out.code).toBe(0)


### PR DESCRIPTION
## Summary

Move `packages/opencode/src/util/process.ts` to an Effect-native implementation while keeping the legacy async compatibility facade.

Closed process boundaries:

- `Process.runEffect`, `textEffect`, `linesEffect`, `stopEffect`, `descendantsEffect`, and `terminateTreeEffect` now own execution and cleanup.
- The async `run/text/lines/stop/descendants/terminateTree` facade now delegates through the Process service runtime.
- Effect graph callers in `session/prompt.ts`, `pty/index.ts`, and `tool/shell.ts` now yield the Effect-native process APIs directly.

Retained process boundaries:

- `Process.spawn` still returns the Node child facade with `exited: Promise<number>` because CLI pager/auth flows, long-lived LSP launch, Windows cmd script spawning, stream ownership, and process cleanup still depend on that shape.
- CLI-only, test harness, long-lived LSP shutdown, and async module compatibility callers keep using the legacy facade.

## Why

Related to #936.

The remaining process utility primitive was still a Promise-first wrapper. This PR moves the reusable process execution and cleanup paths behind Effect APIs without forcing every compatibility caller through the Effect graph in one review.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the Effect API owns the real implementation, whether the retained `spawn` facade is still the right compatibility boundary, and whether abort/timeout/process-tree cleanup behavior is preserved.

## Risk Notes

Process and shell cleanup are platform-sensitive. The PR preserves the existing `cross-spawn` child facade, Windows cmd script behavior, stdout/stderr buffering, `nothrow`, missing-command handling, abort cleanup, timeout cleanup, and process-tree termination tests.

Skipped checklist items:

- Visible UI/copy manual check: no visible UI or copy changed.

## How To Verify

```text
bun test test/util/process.test.ts test/session/prompt.test.ts test/pty test/tool/shell.test.ts: 104 passed
bun test test/server/node-runtime-bun-boundary.test.ts: 2 passed
GOMAXPROCS=2 bun run typecheck: passed
git diff --check: passed
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved process execution reliability with enhanced shell command handling
  * Strengthened PTY session termination logic
  * Updated documentation with migration guidance

* **Tests**
  * Expanded test coverage for process execution paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->