### PR TITLE
refactor(opencode): serve control docs from HttpApi source

### DIFF
--- a/packages/opencode/src/server/control-openapi.ts
+++ b/packages/opencode/src/server/control-openapi.ts
@@ -1,0 +1,90 @@
+import { HttpApi, OpenApi } from "effect/unstable/httpapi"
+import { resolver } from "hono-openapi"
+import { BadRequestErrorSchema } from "./error"
+import { globalEventOpenApiSchema, globalSyncEventOpenApiSchema } from "./global-openapi-schema"
+import { ControlApi } from "./routes/instance/httpapi/groups/control"
+import { GlobalApi } from "./routes/instance/httpapi/groups/global"
+
+type OpenApiDocument = {
+  openapi?: string
+  info?: {
+    title?: string
+    version?: string
+    description?: string
+  }
+  paths?: Record<string, Record<string, unknown>>
+  components?: {
+    schemas?: Record<string, unknown>
+  }
+}
+
+const ControlDocApi = HttpApi.make("controlDoc").addHttpApi(ControlApi).addHttpApi(GlobalApi)
+
+function mergeSchemas(document: OpenApiDocument, schemas: Record<string, unknown>, options?: { override?: boolean }) {
+  document.components ??= {}
+  document.components.schemas = options?.override
+    ? {
+        ...document.components.schemas,
+        ...schemas,
+      }
+    : {
+        ...schemas,
+        ...document.components.schemas,
+      }
+}
+
+export async function controlOpenApi() {
+  const document = structuredClone(OpenApi.fromApi(ControlDocApi) as OpenApiDocument)
+  const [globalEvent, globalSyncEvent, badRequest] = await Promise.all([
+    resolver(globalEventOpenApiSchema()).toOpenAPISchema(),
+    resolver(globalSyncEventOpenApiSchema()).toOpenAPISchema(),
+    resolver(BadRequestErrorSchema).toOpenAPISchema(),
+  ])
+
+  document.openapi = "3.1.1"
+  document.info = {
+    title: "opencode",
+    version: "0.0.3",
+    description: "opencode api",
+  }
+  document.paths ??= {}
+  delete document.paths["/doc"]
+  document.paths["/global/event"] = {
+    get: {
+      operationId: "global.event",
+      summary: "Get global events",
+      description: "Subscribe to global events from the OpenCode system using server-sent events.",
+      responses: {
+        200: {
+          description: "Event stream",
+          content: {
+            "text/event-stream": {
+              schema: globalEvent.schema,
+            },
+          },
+        },
+      },
+    },
+  }
+  document.paths["/global/sync-event"] = {
+    get: {
+      operationId: "global.sync-event.subscribe",
+      summary: "Subscribe to global sync events",
+      description: "Get global sync events",
+      responses: {
+        200: {
+          description: "Event stream",
+          content: {
+            "text/event-stream": {
+              schema: globalSyncEvent.schema,
+            },
+          },
+        },
+      },
+    },
+  }
+  mergeSchemas(document, globalEvent.components?.schemas ?? {})
+  mergeSchemas(document, globalSyncEvent.components?.schemas ?? {})
+  mergeSchemas(document, badRequest.components?.schemas ?? {}, { override: true })
+  return document
+}

--- a/packages/opencode/src/server/global-openapi-schema.ts
+++ b/packages/opencode/src/server/global-openapi-schema.ts
@@ -1,0 +1,26 @@
+import { BusEvent } from "@/bus/bus-event"
+import { SyncEvent } from "@/sync"
+import z from "zod"
+
+export function globalEventOpenApiSchema() {
+  return z
+    .object({
+      directory: z.string(),
+      project: z.string().optional(),
+      workspace: z.string().optional(),
+      payload: BusEvent.payloads(),
+    })
+    .meta({
+      ref: "GlobalEvent",
+    })
+}
+
+export function globalSyncEventOpenApiSchema() {
+  return z
+    .object({
+      payload: SyncEvent.payloads(),
+    })
+    .meta({
+      ref: "SyncEvent",
+    })
+}

--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -14,6 +14,7 @@ import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
 import { errors } from "../error"
 import { EventReplayStore, type GlobalEventEnvelope, type ReplayRecord } from "../event-replay"
+import { globalEventOpenApiSchema, globalSyncEventOpenApiSchema } from "../global-openapi-schema"
 import { requestContextFromHono, withRequestContext } from "@/server/request-context"
 import { createSseResponse } from "../sse"
 
@@ -26,29 +27,6 @@ const LifecycleCloseResult = z.object({
   lifecycleActionID: z.string(),
   affectedDirectoryKeys: z.array(z.string()),
 })
-
-export function globalEventOpenApiSchema() {
-  return z
-    .object({
-      directory: z.string(),
-      project: z.string().optional(),
-      workspace: z.string().optional(),
-      payload: BusEvent.payloads(),
-    })
-    .meta({
-      ref: "GlobalEvent",
-    })
-}
-
-export function globalSyncEventOpenApiSchema() {
-  return z
-    .object({
-      payload: SyncEvent.payloads(),
-    })
-    .meta({
-      ref: "SyncEvent",
-    })
-}
 
 function emitGlobalDisposed() {
   GlobalBus.emit("event", {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/control.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/control.ts
@@ -5,19 +5,9 @@ import { NamedError } from "@opencode-ai/util/error"
 import { Effect } from "effect"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { resolver } from "hono-openapi"
 import z from "zod"
-import { ControlPlaneRoutes } from "@/server/control"
-import { BadRequestErrorSchema } from "@/server/error"
-import { globalEventOpenApiSchema, globalSyncEventOpenApiSchema } from "@/server/instance/global"
+import { controlOpenApi } from "@/server/control-openapi"
 import { ControlApi } from "../groups/control"
-
-type OpenApiDocument = {
-  paths?: unknown
-  components?: {
-    schemas?: Record<string, unknown>
-  }
-}
 
 const LogPayload = z.object({
   service: z.string(),
@@ -81,55 +71,6 @@ function writeLog(payload: LogPayload) {
   }
 }
 
-function collectSchemaRefs(value: unknown, refs = new Set<string>()) {
-  if (!value || typeof value !== "object") return refs
-  if (Array.isArray(value)) {
-    for (const item of value) collectSchemaRefs(item, refs)
-    return refs
-  }
-
-  const record = value as Record<string, unknown>
-  if (typeof record.$ref === "string" && record.$ref.startsWith("#/components/schemas/")) refs.add(record.$ref)
-  for (const item of Object.values(record)) collectSchemaRefs(item, refs)
-  return refs
-}
-
-function mergeSchemas(document: OpenApiDocument, schemas: Record<string, unknown>) {
-  document.components ??= {}
-  document.components.schemas = {
-    ...schemas,
-    ...document.components.schemas,
-  }
-}
-
-async function ensureReferencedControlDocSchemas(document: OpenApiDocument) {
-  const refs = collectSchemaRefs(document.paths)
-  const schemas = document.components?.schemas ?? {}
-  const missingGlobalEvent = refs.has("#/components/schemas/GlobalEvent") && !schemas.GlobalEvent
-  const missingSyncEvent = refs.has("#/components/schemas/SyncEvent") && !schemas.SyncEvent
-  const missingBadRequestError = refs.has("#/components/schemas/BadRequestError") && !schemas.BadRequestError
-
-  if (missingGlobalEvent) {
-    const generated = await resolver(globalEventOpenApiSchema()).toOpenAPISchema()
-    mergeSchemas(document, generated.components?.schemas ?? {})
-  }
-  if (missingSyncEvent) {
-    const generated = await resolver(globalSyncEventOpenApiSchema()).toOpenAPISchema()
-    mergeSchemas(document, generated.components?.schemas ?? {})
-  }
-  if (missingBadRequestError) {
-    const generated = await resolver(BadRequestErrorSchema).toOpenAPISchema()
-    mergeSchemas(document, generated.components?.schemas ?? {})
-  }
-}
-
-async function controlOpenApiDocument() {
-  const response = await ControlPlaneRoutes().request("/doc")
-  const document = await response.json()
-  await ensureReferencedControlDocSchemas(document)
-  return document
-}
-
 export const controlHandlers = HttpApiBuilder.group(ControlApi, "control", (handlers) =>
   Effect.gen(function* () {
     const auth = yield* Auth.Service
@@ -180,7 +121,7 @@ export const controlHandlers = HttpApiBuilder.group(ControlApi, "control", (hand
         }),
       )
       .handleRaw("doc", () =>
-        Effect.promise(() => controlOpenApiDocument()).pipe(Effect.map((document) => HttpServerResponse.jsonUnsafe(document))),
+        Effect.promise(() => controlOpenApi()).pipe(Effect.map((document) => HttpServerResponse.jsonUnsafe(document))),
       )
   }),
 )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -16,7 +16,6 @@ import { initProjectors } from "./projectors"
 import { createProductionHttpApiDispatcher, isProductionHttpApiRequest } from "./production-httpapi"
 import { createProductionSpecialHandler } from "./production-special"
 import { createWebSocketCompatibilityApp } from "./websocket-compatibility"
-import { serverOpenApi } from "./openapi"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -217,6 +216,7 @@ function create(opts: { cors?: string[] }) {
 }
 
 export async function openapi() {
+  const { serverOpenApi } = await import("./openapi")
   return serverOpenApi()
 }
 

--- a/packages/opencode/test/server/control-routes.test.ts
+++ b/packages/opencode/test/server/control-routes.test.ts
@@ -63,8 +63,6 @@ describe("control routes", () => {
   })
 
   test("serves the generated OpenAPI document through the HttpApi handlers", async () => {
-    await Server.openapi()
-
     const response = await requestControlHttpApi("/doc")
     const spec = await response.json()
 
@@ -82,6 +80,7 @@ describe("control routes", () => {
     expect(spec.paths).toHaveProperty("/global/event")
     expect(spec.paths).toHaveProperty("/global/sync-event")
     expect(spec.paths).not.toHaveProperty("/doc")
+    expect(spec.paths).not.toHaveProperty("/question")
 
     const schemas = spec.components?.schemas ?? {}
     for (const ref of collectSchemaRefs(spec.paths)) {

--- a/packages/opencode/test/server/production-boundary.test.ts
+++ b/packages/opencode/test/server/production-boundary.test.ts
@@ -115,4 +115,24 @@ describe("production server boundary", () => {
     expect(openapi).toContain("ControlPlaneRoutes")
     expect(openapi).toContain("GlobalRoutes")
   })
+
+  test("keeps production /doc out of the legacy control route tree", async () => {
+    const server = await readFile(path.join(import.meta.dir, "../../src/server/server.ts"), "utf8")
+    const controlHandler = await readFile(
+      path.join(import.meta.dir, "../../src/server/routes/instance/httpapi/handlers/control.ts"),
+      "utf8",
+    )
+    const controlOpenApi = await readFile(path.join(import.meta.dir, "../../src/server/control-openapi.ts"), "utf8")
+
+    expect(server).not.toContain('from "./openapi"')
+    expect(server).toContain('await import("./openapi")')
+    expect(controlHandler).not.toContain("ControlPlaneRoutes")
+    expect(controlHandler).not.toContain('request("/doc")')
+    expect(controlHandler).not.toContain("@/server/openapi")
+    expect(controlOpenApi).not.toContain("ControlPlaneRoutes")
+    expect(controlOpenApi).not.toContain("InstanceRoutes")
+    expect(controlOpenApi).not.toContain("GlobalRoutes")
+    expect(controlOpenApi).not.toContain("server/instance/global")
+    expect(controlOpenApi).not.toContain("from \"hono\"")
+  })
 })


### PR DESCRIPTION
## Summary

Move the production `/doc` OpenAPI source onto an HttpApi-owned builder for the control-plane document.

## Why

The production HttpApi `/doc` handler still generated its response by calling `ControlPlaneRoutes().request("/doc")`, which pulled the legacy Hono control route tree back into the production documentation path. This keeps the existing HTTP contract while making the production `/doc` path independent from that legacy route tree.

Related to #936

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the production `/doc` import boundary, especially that the handler now calls `controlOpenApi()` from a module that does not import the legacy Hono route tree, and that `Server.openapi()` remains the only lazy entry point for the legacy spec-generation module.

## Risk Notes

- No visible UI or copy changed, so no screenshots or recordings are included.
- This changes a server OpenAPI document source, but the focused tests verify the existing `/doc` metadata, global SSE paths, schema refs, and stale `/question` exclusion.
- No platform, packaging, dependency, permission, credential, deletion, generated-content, or local-file behavior changed.

## How To Verify

```text
Focused server tests: 39 passed with bun test test/server/control-routes.test.ts test/server/production-boundary.test.ts test/server/route-inventory-harness.test.ts from packages/opencode
Route inventory: counts remained hono=128, openapi=100, legacySdk=64, v2Sdk=124, localHttpApi=122; /question remains openapi-only; /doc remains localHttpApi=true with specialSurface=OpenAPI source
Typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode
Diff check: git diff --check passed from the worktree root
Fresh-eye review: final fresh-eye reviewer found no P0/P1 and no remaining P2/P3 worth fixing before PR
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized OpenAPI schema definitions for improved maintainability and code structure.
  * Optimized OpenAPI document generation for the control API.

* **Tests**
  * Added production boundary tests ensuring proper API documentation handling.
  * Updated existing tests to verify API documentation completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->