### PR TITLE
refactor(opencode): move lock boundaries to EffectFlock

### DIFF
--- a/packages/core/src/util/effect-flock.ts
+++ b/packages/core/src/util/effect-flock.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import os from "os"
 import { randomUUID } from "crypto"
-import { Context, Effect, Function, Layer, Option, Schedule, Schema } from "effect"
+import { Context, Effect, Function, Layer, ManagedRuntime, Option, Schedule, Schema } from "effect"
 import type { FileSystem, Scope } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { AppFileSystem } from "../filesystem"
@@ -240,4 +240,21 @@ export namespace EffectFlock {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(AppFileSystem.defaultLayer), Layer.provide(Global.layer))
+
+  const runtime = ManagedRuntime.make(defaultLayer)
+
+  export async function withLockPromise<T>(key: string, fn: () => Promise<T>, dir?: string): Promise<T> {
+    return runtime.runPromise(
+      Service.use((flock) =>
+        flock.withLock(
+          Effect.tryPromise({
+            try: fn,
+            catch: (error) => error,
+          }),
+          key,
+          dir,
+        ),
+      ),
+    )
+  }
 }

--- a/packages/core/test/util/effect-flock.test.ts
+++ b/packages/core/test/util/effect-flock.test.ts
@@ -129,6 +129,38 @@ describe("util.effect-flock", () => {
   )
 
   it.live(
+    "withLockPromise serializes Promise critical sections",
+    () =>
+      Effect.promise(async () => {
+        const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "eflock-promise-"))
+        const dir = path.join(tmp, "locks")
+        const active = new Set<number>()
+        let maxActive = 0
+
+        try {
+          await Promise.all(
+            Array.from({ length: 3 }, (_, index) =>
+              EffectFlock.withLockPromise(
+                "eflock:promise",
+                async () => {
+                  active.add(index)
+                  maxActive = Math.max(maxActive, active.size)
+                  await sleep(20)
+                  active.delete(index)
+                },
+                dir,
+              ),
+            ),
+          )
+
+          expect(maxActive).toBe(1)
+        } finally {
+          await fs.rm(tmp, { recursive: true, force: true })
+        }
+      }),
+  )
+
+  it.live(
     "recovers after a crashed lock owner",
     () =>
       Effect.promise(async () => {

--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -306,14 +306,16 @@ Current raw fs users that will convert during tool migration:
 
 - [x] `util/lock.ts` — removed; no production callers remained, and the only direct references were the util export plus `test/util/lock.test.ts`
 - [ ] `util/flock.ts` — `packages/core/src/util/effect-flock.ts` is the Effect-native implementation; Effect/service callers should use `EffectFlock.Service`, while legacy Promise callers still use the `packages/opencode/src/util/flock.ts` facade
-  - Converted in this slice: `Config.updateGlobal` now uses `EffectFlock.Service.withLock`
-  - Retained Promise boundary: provider models, plugin config patching/meta reads, automation run leases/scheduler ownership, and direct flock compatibility tests
+  - Converted in this slice: `EffectFlock.withLockPromise` now backs Promise critical sections for `Config.withConfigFileLock`, provider models catalog refresh, plugin config patching, and plugin metadata reads; `Config` service schema write-back uses the injected `EffectFlock.Service`
+  - Retained Promise lease boundary: automation run leases/scheduler ownership and direct flock compatibility tests still need the legacy lease object facade
+  - Guardrail: `test/effect/legacy-boundaries.test.ts` prevents new production imports of `@/util/flock` outside the automation lease owners
 - [x] `util/process.ts` — `Process.Service` and Effect-native `run/text/lines/stop/descendants/terminateTree` now own execution and cleanup; the async facade delegates through `runPromise`
   - Retained compatibility boundary: `Process.spawn` still returns the Node child facade because CLI pager/auth flows, long-lived LSP launch, Windows cmd script spawning, and stream ownership still depend on that shape
   - Converted in this slice: `session/prompt.ts` inline shell expansion, `pty/index.ts` teardown cleanup, and `tool/shell.ts` abort/timeout cleanup use `Process.*Effect` directly
 - [ ] `util/lazy.ts` — sync-only route factories, shell selection, native module loading, and zod recursion stay on `lazy`; async Effect code should use `Effect.cached`
   - Converted in this slice: `tool/shell.ts` parser initialization now uses `Effect.cached` inside the tool's Effect definition
   - Retained async legacy boundary: provider models catalog cache and control-plane built-in adaptor import still expose Promise facades
+  - Guardrail: `test/effect/legacy-boundaries.test.ts` keeps async `lazy` limited to the provider catalog cache and built-in adaptor import compatibility boundaries
 
 ## Destroying the facades
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -47,7 +47,6 @@ import { ConfigVariable } from "./variable"
 import { RemoteAuthError } from "./error"
 import { Npm } from "@opencode-ai/core/npm"
 import { Filesystem } from "@/util/filesystem"
-import { Flock } from "@/util/flock"
 import { Installation } from "@/installation"
 import { InstallationPluginVersion } from "@opencode-ai/core/installation/version"
 import { withLifecycleOrigin } from "@/session/lifecycle-provenance"
@@ -424,8 +423,7 @@ export function configFileLockKey(file: string) {
 }
 
 export async function withConfigFileLock<T>(file: string, fn: () => Promise<T>) {
-  await using _ = await Flock.acquire(configFileLockKey(file))
-  return await fn()
+  return EffectFlock.withLockPromise(configFileLockKey(file), fn)
 }
 
 function isWindowsSyncUnsupportedError(error: unknown) {
@@ -759,9 +757,9 @@ const rawLayer = Layer.effect(
       if (!data.$schema) {
         data.$schema = "https://opencode.ai/config.json"
         const updated = text.replace(/^\s*\{/, '{\n  "$schema": "https://opencode.ai/config.json",')
-        yield* Effect.promise(() =>
-          withConfigFileLock(options.path, () => writeConfigTextAtomic(options.path, updated)),
-        ).pipe(Effect.catch(() => Effect.void))
+        yield* flock
+          .withLock(Effect.promise(() => writeConfigTextAtomic(options.path, updated)), configFileLockKey(options.path))
+          .pipe(Effect.catch(() => Effect.void))
       }
       return data
     })

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -11,10 +11,10 @@ import { Config } from "@/config"
 import { ConfigPaths } from "@/config/paths"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
-import { Flock } from "@/util/flock"
 import { isRecord } from "@/util/record"
 import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Runtime } from "@opencode-ai/core/runtime"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 
 import { parsePluginSpecifier, readPluginPackage, resolvePluginTarget } from "./shared"
 
@@ -352,46 +352,65 @@ async function selectConfigFile(files: string[], dep: PatchDeps) {
 
 async function patchOne(dir: string, files: string[], target: Target, spec: string, force: boolean, dep: PatchDeps): Promise<PatchOne> {
   const name = Runtime.isPawWork() ? "pawwork" : "opencode"
-  await using _ = await Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, name))}`)
+  return await EffectFlock.withLockPromise(`plug-config:${Filesystem.resolve(path.join(dir, name))}`, async () => {
+    let cfg = await selectConfigFile(files, dep)
 
-  let cfg = await selectConfigFile(files, dep)
-
-  return await Config.withConfigFileLock(cfg, async () => {
-    cfg = await selectConfigFile(files, dep)
-    const src = await dep.readText(cfg).catch((err: NodeJS.ErrnoException) => {
-      if (err.code === "ENOENT") return "{}"
-      return err
-    })
-    if (src instanceof Error) {
-      return {
-        ok: false,
-        code: "patch_failed",
-        kind: target.kind,
-        error: src,
+    return await Config.withConfigFileLock(cfg, async () => {
+      cfg = await selectConfigFile(files, dep)
+      const src = await dep.readText(cfg).catch((err: NodeJS.ErrnoException) => {
+        if (err.code === "ENOENT") return "{}"
+        return err
+      })
+      if (src instanceof Error) {
+        return {
+          ok: false,
+          code: "patch_failed",
+          kind: target.kind,
+          error: src,
+        }
       }
-    }
-    const text = src.trim() ? src : "{}"
+      const text = src.trim() ? src : "{}"
 
-    const errs: JsoncParseError[] = []
-    const data = parseJsonc(text, errs, { allowTrailingComma: true })
-    if (errs.length) {
-      const err = errs[0]
-      const lines = text.substring(0, err.offset).split("\n")
-      return {
-        ok: false,
-        code: "invalid_json",
-        kind: target.kind,
-        file: cfg,
-        line: lines.length,
-        col: lines[lines.length - 1].length + 1,
-        parse: printParseErrorCode(err.error),
+      const errs: JsoncParseError[] = []
+      const data = parseJsonc(text, errs, { allowTrailingComma: true })
+      if (errs.length) {
+        const err = errs[0]
+        const lines = text.substring(0, err.offset).split("\n")
+        return {
+          ok: false,
+          code: "invalid_json",
+          kind: target.kind,
+          file: cfg,
+          line: lines.length,
+          col: lines[lines.length - 1].length + 1,
+          parse: printParseErrorCode(err.error),
+        }
       }
-    }
 
-    const list = pluginList(data)
-    const item = target.opts ? ([spec, target.opts] as const) : spec
-    const out = patchPluginList(text, list, spec, item, force)
-    if (out.mode === "noop") {
+      const list = pluginList(data)
+      const item = target.opts ? ([spec, target.opts] as const) : spec
+      const out = patchPluginList(text, list, spec, item, force)
+      if (out.mode === "noop") {
+        return {
+          ok: true,
+          item: {
+            kind: target.kind,
+            mode: out.mode,
+            file: cfg,
+          },
+        }
+      }
+
+      const write = await dep.write(cfg, out.text).catch((error: unknown) => error)
+      if (write instanceof Error) {
+        return {
+          ok: false,
+          code: "patch_failed",
+          kind: target.kind,
+          error: write,
+        }
+      }
+
       return {
         ok: true,
         item: {
@@ -400,26 +419,7 @@ async function patchOne(dir: string, files: string[], target: Target, spec: stri
           file: cfg,
         },
       }
-    }
-
-    const write = await dep.write(cfg, out.text).catch((error: unknown) => error)
-    if (write instanceof Error) {
-      return {
-        ok: false,
-        code: "patch_failed",
-        kind: target.kind,
-        error: write,
-      }
-    }
-
-    return {
-      ok: true,
-      item: {
-        kind: target.kind,
-        mode: out.mode,
-        file: cfg,
-      },
-    }
+    })
   })
 }
 

--- a/packages/opencode/src/plugin/meta.ts
+++ b/packages/opencode/src/plugin/meta.ts
@@ -2,9 +2,9 @@ import path from "path"
 import { fileURLToPath } from "url"
 
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
-import { Flock } from "@/util/flock"
 
 import { parsePluginSpecifier, pluginSource } from "./shared"
 
@@ -136,7 +136,7 @@ export namespace PluginMeta {
     const file = storePath()
     const rows = await Promise.all(items.map((item) => row(item)))
 
-    return Flock.withLock(lock(file), async () => {
+    return EffectFlock.withLockPromise(lock(file), async () => {
       const store = await read(file)
       const now = Date.now()
       const out: Array<{ state: State; entry: Entry }> = []
@@ -160,6 +160,6 @@ export namespace PluginMeta {
 
   export async function list(): Promise<Store> {
     const file = storePath()
-    return Flock.withLock(lock(file), async () => read(file))
+    return EffectFlock.withLockPromise(lock(file), async () => read(file))
   }
 }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -5,9 +5,9 @@ import { rename, rm } from "fs/promises"
 import z from "zod"
 import { Installation } from "../installation"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { lazy } from "@/util/lazy"
 import { Filesystem } from "../util/filesystem"
-import { Flock } from "../util/flock"
 import { Hash } from "../util/hash"
 import { withPawWorkProviders } from "./pawwork-providers"
 
@@ -260,7 +260,7 @@ export const Data = lazy(async () => {
     .catch(() => undefined)
   if (snapshot) return snapshot
   if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
-  return Flock.withLock(`models-dev:${filepath}`, async () => {
+  return EffectFlock.withLockPromise(`models-dev:${filepath}`, async () => {
     const overridePath = modelsPathOverride()
     const result = await Filesystem.readJson(overridePath ?? filepath).catch(() => {})
     if (result) return result
@@ -313,7 +313,7 @@ export async function refresh(force = false) {
     catalogVersion++
     return Data.reset()
   }
-  await Flock.withLock(`models-dev:${filepath}`, async () => {
+  await EffectFlock.withLockPromise(`models-dev:${filepath}`, async () => {
     if (skip(force)) {
       catalogVersion++
       return Data.reset()

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import { readdir, readFile } from "fs/promises"
+import path from "path"
+
+const srcRoot = path.resolve(import.meta.dir, "../../src")
+
+async function sourceFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const filepath = path.join(dir, entry.name)
+      if (entry.isDirectory()) return sourceFiles(filepath)
+      if (!entry.isFile()) return []
+      if (!/\.[cm]?tsx?$/.test(entry.name)) return []
+      return [filepath]
+    }),
+  )
+  return files.flat()
+}
+
+function relativeSource(file: string) {
+  return path.relative(srcRoot, file).split(path.sep).join("/")
+}
+
+test("legacy Flock imports stay in explicit Promise lease boundaries", async () => {
+  const hits: string[] = []
+  for (const file of await sourceFiles(srcRoot)) {
+    const text = await readFile(file, "utf8")
+    if (/\bfrom\s+["'](?:@\/util\/flock|@opencode-ai\/core\/util\/flock|(?:\.\.\/)+util\/flock)["']/.test(text)) {
+      hits.push(relativeSource(file))
+    }
+  }
+
+  expect(hits.sort()).toEqual(["automation/index.ts", "automation/scheduler.ts"])
+})
+
+test("async lazy stays in explicit compatibility boundaries", async () => {
+  const hits: string[] = []
+  for (const file of await sourceFiles(srcRoot)) {
+    const text = await readFile(file, "utf8")
+    if (/\blazy\s*\(\s*async\b/.test(text)) hits.push(relativeSource(file))
+  }
+
+  expect(hits.sort()).toEqual(["control-plane/adaptors/index.ts", "provider/models.ts"])
+})


### PR DESCRIPTION
## Summary

- Added `EffectFlock.withLockPromise` for Promise critical sections that can use the Effect-native lock implementation without keeping legacy lease objects.
- Moved config file locking, provider model catalog locking, plugin config patching, and plugin metadata locking off the legacy `Flock` facade.
- Added a source guardrail that keeps production legacy `Flock` imports and async `lazy` boundaries from expanding again.

## Why

#936 is closing the remaining non-UI backend Effect migration gaps. After the previous slices, live scans still found production callers using the legacy `Flock` facade for lock critical sections that do not need explicit lease ownership. This PR moves those callers to `EffectFlock` while retaining the automation lease boundaries that still own long-lived `Flock.Lease` objects.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

- Confirm `EffectFlock.withLockPromise` preserves the existing lock lifetime for Promise critical sections.
- Confirm automation run leases and scheduler ownership stay on the legacy facade because they keep/release lease objects across async ownership boundaries.
- Confirm the guardrail allowlists only the retained compatibility boundaries.

## Risk Notes

Retained compatibility boundaries are intentional: automation run leases and scheduler ownership still need legacy `Flock.Lease` objects. The provider catalog `lazy(async)` cache and control-plane built-in adaptor import remain Promise compatibility boundaries. No visible UI/copy or platform/packaging surface changed. Docs touched only `packages/opencode/specs/effect-migration.md` to record this PR's migration facts.

## How To Verify

```text
Dependency install: bun install --frozen-lockfile passed in the new worktree.
Baseline opencode focused tests before changes: 179 passed across config/plugin/provider/flock/lazy owners.
Baseline core focused tests before changes: 6 passed across effect-flock/flock owners.
Guardrail RED: bun test test/effect/legacy-boundaries.test.ts failed for config/config.ts, plugin/install.ts, plugin/meta.ts, and provider/models.ts legacy Flock imports.
Focused opencode tests after changes: bun test test/effect/legacy-boundaries.test.ts test/config/config.test.ts test/plugin/install.test.ts test/plugin/meta.test.ts test/provider/models-refresh.test.ts test/util/flock.test.ts test/util/lazy.test.ts passed 181 tests.
Focused core tests after changes: bun test test/util/effect-flock.test.ts test/util/flock.test.ts passed 7 tests.
Diff check: git diff --check passed.
Typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode.
Fresh-eye review: no P0/P1/P2/P3 findings.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
