### PR TITLE
refactor(opencode): effectify provider models cache

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -196,6 +196,7 @@ Fully migrated (single namespace, InstanceState where needed, flattened facade):
 - [x] `LSP` — `lsp/index.ts`
 - [x] `MCP` — `mcp/index.ts`
 - [x] `McpAuth` — `mcp/auth.ts`
+- [x] `ModelsDev` — `provider/models.ts` (catalog cache and refresh use `Effect.cached`, `AppFileSystem.Service`, and `EffectFlock.Service`; async facade remains for callers)
 - [x] `ModelState` — `provider/model-state.ts` (`recordRecent` write path; `Provider.defaultModel()` still owns the read path)
 - [x] `Permission` — `permission/index.ts`
 - [x] `Plugin` — `plugin/index.ts`
@@ -284,6 +285,7 @@ Some already-effectified areas still use raw `Filesystem.*` or `Process.spawn` i
 - [x] `file/index.ts` — current tree has no remaining `Filesystem.*` calls; untracked diff handling reads through `AppFileSystem.Service`
 - [x] `config/config.ts` — `installDependencies()` now lives on `Config.Service`, uses `AppFileSystem.Service` and `EffectFlock`, and the async facade delegates through `runPromise`
 - [x] `provider/provider.ts` — default model state reads through `AppFileSystem.Service`; no remaining `Filesystem.*` calls in the current file
+- [x] `provider/models.ts` — catalog cache reads, TTL checks, and atomic writes now run through `AppFileSystem.Service`
 
 ### `Process.spawn` → `ChildProcessSpawner` (yield in layer)
 
@@ -306,16 +308,16 @@ Current raw fs users that will convert during tool migration:
 
 - [x] `util/lock.ts` — removed; no production callers remained, and the only direct references were the util export plus `test/util/lock.test.ts`
 - [ ] `util/flock.ts` — `packages/core/src/util/effect-flock.ts` is the Effect-native implementation; Effect/service callers should use `EffectFlock.Service`, while legacy Promise callers still use the `packages/opencode/src/util/flock.ts` facade
-  - Converted in this slice: `EffectFlock.withLockPromise` now backs Promise critical sections for `Config.withConfigFileLock`, provider models catalog refresh, plugin config patching, and plugin metadata reads; `Config` service schema write-back uses the injected `EffectFlock.Service`
+  - Converted in this slice: provider models catalog refresh now uses the injected `EffectFlock.Service`; `Config.withConfigFileLock`, plugin config patching, and plugin metadata reads still keep Promise critical sections behind `EffectFlock.withLockPromise`
   - Retained Promise lease boundary: automation run leases/scheduler ownership and direct flock compatibility tests still need the legacy lease object facade
   - Guardrail: `test/effect/legacy-boundaries.test.ts` prevents new production imports of `@/util/flock` outside the automation lease owners
 - [x] `util/process.ts` — `Process.Service` and Effect-native `run/text/lines/stop/descendants/terminateTree` now own execution and cleanup; the async facade delegates through `runPromise`
   - Retained compatibility boundary: `Process.spawn` still returns the Node child facade because CLI pager/auth flows, long-lived LSP launch, Windows cmd script spawning, and stream ownership still depend on that shape
   - Converted in this slice: `session/prompt.ts` inline shell expansion, `pty/index.ts` teardown cleanup, and `tool/shell.ts` abort/timeout cleanup use `Process.*Effect` directly
 - [ ] `util/lazy.ts` — sync-only route factories, shell selection, native module loading, and zod recursion stay on `lazy`; async Effect code should use `Effect.cached`
-  - Converted in this slice: `tool/shell.ts` parser initialization now uses `Effect.cached` inside the tool's Effect definition
-  - Retained async legacy boundary: provider models catalog cache and control-plane built-in adaptor import still expose Promise facades
-  - Guardrail: `test/effect/legacy-boundaries.test.ts` keeps async `lazy` limited to the provider catalog cache and built-in adaptor import compatibility boundaries
+  - Converted in this slice: provider models catalog cache now uses `Effect.cached` inside `ModelsDev.Service`; `tool/shell.ts` parser initialization also uses `Effect.cached` inside the tool's Effect definition
+  - Retained async legacy boundary: control-plane built-in adaptor import still exposes a Promise facade
+  - Guardrail: `test/effect/legacy-boundaries.test.ts` keeps async `lazy` limited to the built-in adaptor import compatibility boundary
 
 ## Destroying the facades
 

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -1,15 +1,15 @@
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Global } from "@opencode-ai/core/global"
 import { Log } from "../util"
 import path from "path"
-import { rename, rm } from "fs/promises"
 import z from "zod"
 import { Installation } from "../installation"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
-import { lazy } from "@/util/lazy"
-import { Filesystem } from "../util/filesystem"
 import { Hash } from "../util/hash"
 import { withPawWorkProviders } from "./pawwork-providers"
+import { Context, Effect, Layer, Option } from "effect"
+import { makeRuntime } from "../effect/run-service"
 
 // Try to import bundled snapshot (generated at build time)
 // Falls back to undefined in dev mode when snapshot doesn't exist
@@ -190,98 +190,221 @@ export function version() {
   return catalogVersion
 }
 
-function fresh() {
-  return Date.now() - Number(Filesystem.stat(filepath)?.mtimeMs ?? 0) < ttl
-}
-
-function skip(force: boolean) {
-  return !force && fresh()
-}
-
-const fetchApi = async () => {
-  const result = await fetch(`${url()}/api.json`, {
-    headers: { "User-Agent": Installation.HTTP_USER_AGENT },
-    signal: AbortSignal.timeout(10000),
-  })
-  return { ok: result.ok, text: await result.text() }
-}
+const fetchApi = Effect.fn("ModelsDev.fetchApi")(function* () {
+  const result = yield* Effect.tryPromise(() =>
+    fetch(`${url()}/api.json`, {
+      headers: { "User-Agent": Installation.HTTP_USER_AGENT },
+      signal: AbortSignal.timeout(10000),
+    }),
+  )
+  return {
+    ok: result.ok,
+    text: yield* Effect.tryPromise(() => result.text()),
+  }
+})
 
 type Catalog = Record<string, Provider>
 
-function parseCatalog(text: string): Catalog {
-  const parsed = JSON.parse(text)
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("models.dev catalog must be an object")
-  }
-  return PublishCatalog.parse(parsed) as unknown as Catalog
+export interface Interface {
+  readonly data: () => Effect.Effect<Catalog, unknown>
+  readonly reset: () => Effect.Effect<void>
+  readonly refresh: (force?: boolean) => Effect.Effect<void>
 }
 
-async function validateCatalog(catalog: Catalog) {
-  const runtime = await import("./provider")
-  const withLocalProviders = withPawWorkProviders(catalog)
-  for (const provider of Object.values(withLocalProviders)) {
-    runtime.fromModelsDevProvider(provider)
-  }
+export class Service extends Context.Service<Service, Interface>()("@opencode/ModelsDev") {}
+
+function cacheFresh(fs: AppFileSystem.Interface) {
+  return fs.stat(filepath).pipe(
+    Effect.map((info) => {
+      const mtime = info.mtime.pipe(
+        Option.map((date) => date.getTime()),
+        Option.getOrElse(() => 0),
+      )
+      return Date.now() - mtime < ttl
+    }),
+    Effect.catch(() => Effect.succeed(false)),
+  )
 }
 
-async function atomicWriteFile(target: string, content: string) {
-  const temp = `${target}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
-  try {
-    await Filesystem.write(temp, content)
-    await rename(temp, target)
-  } catch (error) {
-    await rm(temp, { force: true })
-    throw error
-  }
+function skipCache(fs: AppFileSystem.Interface, force: boolean) {
+  if (force) return Effect.succeed(false)
+  return cacheFresh(fs)
 }
 
-async function publishCandidate(text: string) {
-  const catalog = parseCatalog(text)
-  await validateCatalog(catalog)
-  await atomicWriteFile(filepath, text)
-  catalogVersion++
-  Data.reset()
-  return withPawWorkProviders(catalog)
+function lockKey() {
+  return `models-dev:${filepath}`
 }
 
-async function loadCandidate(text: string) {
-  const catalog = parseCatalog(text)
-  await validateCatalog(catalog)
-  return withPawWorkProviders(catalog)
+function readJsonOptional(fs: AppFileSystem.Interface, target: string) {
+  return fs.readFileString(target).pipe(
+    Effect.flatMap((text) =>
+      Effect.try({
+        try: () => JSON.parse(text) as unknown,
+        catch: (error) => error,
+      }),
+    ),
+    Effect.catch(() => Effect.succeed(undefined)),
+  )
 }
 
-export const Data = lazy(async () => {
-  const overridePath = modelsPathOverride()
-  const result = await Filesystem.readJson(overridePath ?? filepath).catch(() => {})
-  if (result) return result
-  // @ts-ignore
-  const snapshot = await import("./models-snapshot.js")
-    .then((m) => m.snapshot as Record<string, unknown>)
-    .catch(() => undefined)
-  if (snapshot) return snapshot
-  if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
-  return EffectFlock.withLockPromise(`models-dev:${filepath}`, async () => {
-    const overridePath = modelsPathOverride()
-    const result = await Filesystem.readJson(overridePath ?? filepath).catch(() => {})
-    if (result) return result
-    const result2 = await fetchApi()
-    if (result2.ok) {
-      try {
-        const catalog = await loadCandidate(result2.text)
-        try {
-          await atomicWriteFile(filepath, result2.text)
-          catalogVersion++
-        } catch (e) {
-          log.warn("failed to write initial models.dev catalog", { error: e })
-        }
-        return catalog
-      } catch (e) {
-        log.warn("failed to publish initial models.dev catalog", { error: e })
-      }
-    }
-    return {}
+function loadSnapshot() {
+  return Effect.promise(async () => {
+    // @ts-ignore generated at build time
+    return import("./models-snapshot.js")
+      .then((m) => m.snapshot as Record<string, unknown>)
+      .catch(() => undefined)
   })
-})
+}
+
+function atomicWriteFile(fs: AppFileSystem.Interface, target: string, content: string) {
+  const temp = `${target}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
+  return Effect.gen(function* () {
+    yield* fs.writeWithDirs(temp, content)
+    yield* fs.rename(temp, target)
+  }).pipe(Effect.ensuring(fs.remove(temp).pipe(Effect.ignore)))
+}
+
+function loadCandidate(text: string) {
+  return Effect.gen(function* () {
+    const catalog = yield* Effect.try({
+      try: () => parseCatalog(text),
+      catch: (error) => error,
+    })
+    const runtime = yield* Effect.tryPromise({
+      try: () => import("./provider"),
+      catch: (error) => error,
+    })
+    const withLocalProviders = withPawWorkProviders(catalog)
+    yield* Effect.try({
+      try: () => {
+        for (const provider of Object.values(withLocalProviders)) {
+          runtime.fromModelsDevProvider(provider)
+        }
+      },
+      catch: (error) => error,
+    })
+    return withLocalProviders
+  })
+}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const fs = yield* AppFileSystem.Service
+    const flock = yield* EffectFlock.Service
+
+    const loadData = Effect.fn("ModelsDev.data.load")(function* () {
+      const overridePath = modelsPathOverride()
+      const result = yield* readJsonOptional(fs, overridePath ?? filepath)
+      if (result) return result as Catalog
+      const snapshot = yield* loadSnapshot()
+      if (snapshot) return snapshot as Catalog
+      if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
+
+      return yield* flock.withLock(
+        Effect.gen(function* () {
+          const overridePath = modelsPathOverride()
+          const result = yield* readJsonOptional(fs, overridePath ?? filepath)
+          if (result) return result as Catalog
+          const result2 = yield* fetchApi()
+          if (!result2.ok) return {}
+
+          return yield* loadCandidate(result2.text).pipe(
+            Effect.matchEffect({
+              onFailure: (error) =>
+                Effect.sync(() => {
+                  log.warn("failed to publish initial models.dev catalog", { error })
+                  return {}
+                }),
+              onSuccess: (catalog) =>
+                Effect.gen(function* () {
+                  yield* atomicWriteFile(fs, filepath, result2.text).pipe(
+                    Effect.tap(() =>
+                      Effect.sync(() => {
+                        catalogVersion++
+                      }),
+                    ),
+                    Effect.catch((error) =>
+                      Effect.sync(() => {
+                        log.warn("failed to write initial models.dev catalog", { error })
+                      }),
+                    ),
+                  )
+                  return catalog
+                }),
+            }),
+          )
+        }),
+        lockKey(),
+      )
+    })
+
+    let cachedData = yield* Effect.cached(loadData())
+
+    const reset = Effect.fn("ModelsDev.reset")(function* () {
+      cachedData = yield* Effect.cached(loadData())
+    })
+
+    const data = Effect.fn("ModelsDev.data")(function* () {
+      return yield* cachedData
+    })
+
+    const publishCandidate = Effect.fn("ModelsDev.publishCandidate")(function* (text: string) {
+      const catalog = yield* loadCandidate(text)
+      yield* atomicWriteFile(fs, filepath, text)
+      catalogVersion++
+      yield* reset()
+      return catalog
+    })
+
+    const refresh = Effect.fn("ModelsDev.refresh")(function* (force = false) {
+      if (modelsPathOverride()) {
+        catalogVersion++
+        yield* reset()
+        return
+      }
+      if (yield* skipCache(fs, force)) {
+        catalogVersion++
+        yield* reset()
+        return
+      }
+      yield* flock
+        .withLock(
+          Effect.gen(function* () {
+            if (yield* skipCache(fs, force)) {
+              catalogVersion++
+              yield* reset()
+              return
+            }
+            const result = yield* fetchApi()
+            if (!result.ok) return
+            yield* publishCandidate(result.text)
+          }),
+          lockKey(),
+        )
+        .pipe(
+          Effect.catch((error) =>
+            Effect.sync(() => {
+              log.error("Failed to fetch models.dev", { error })
+            }),
+          ),
+        )
+    })
+
+    return Service.of({ data, reset, refresh })
+  }),
+)
+
+export const defaultLayer = layer.pipe(Layer.provide(EffectFlock.defaultLayer), Layer.provide(AppFileSystem.defaultLayer))
+
+const { runPromise, runSync } = makeRuntime(Service, defaultLayer)
+
+export const Data = Object.assign(
+  () => runPromise((svc) => svc.data()),
+  {
+    reset: () => runSync((svc) => svc.reset()),
+  },
+)
 
 export async function get() {
   const result = await Data()
@@ -304,32 +427,22 @@ export async function getWithVersion() {
 }
 
 export async function refresh(force = false) {
-  if (modelsPathOverride()) {
-    catalogVersion++
-    Data.reset()
-    return
+  return runPromise((svc) => svc.refresh(force))
+}
+
+function parseCatalog(text: string): Catalog {
+  const parsed = JSON.parse(text)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("models.dev catalog must be an object")
   }
-  if (skip(force)) {
-    catalogVersion++
-    return Data.reset()
-  }
-  await EffectFlock.withLockPromise(`models-dev:${filepath}`, async () => {
-    if (skip(force)) {
-      catalogVersion++
-      return Data.reset()
-    }
-    const result = await fetchApi()
-    if (!result.ok) return
-    await publishCandidate(result.text)
-  }).catch((e) => {
-    log.error("Failed to fetch models.dev", {
-      error: e,
-    })
-  })
+  return PublishCatalog.parse(parsed) as unknown as Catalog
 }
 
 const ModelsDevModelValue = Model
 const ModelsDevProviderValue = Provider
+const ModelsDevServiceValue = Service
+const ModelsDevLayerValue = layer
+const ModelsDevDefaultLayerValue = defaultLayer
 const ModelsDevDataValue = Data
 const ModelsDevGetValue = get
 const ModelsDevGetWithVersionValue = getWithVersion
@@ -339,9 +452,13 @@ const ModelsDevVersionValue = version
 export namespace ModelsDev {
   export type Model = import("./models").Model
   export type Provider = import("./models").Provider
+  export type Interface = import("./models").Interface
 
   export const Model = ModelsDevModelValue
   export const Provider = ModelsDevProviderValue
+  export const Service = ModelsDevServiceValue
+  export const layer = ModelsDevLayerValue
+  export const defaultLayer = ModelsDevDefaultLayerValue
   export const Data = ModelsDevDataValue
   export const get = ModelsDevGetValue
   export const getWithVersion = ModelsDevGetWithVersionValue

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -41,5 +41,11 @@ test("async lazy stays in explicit compatibility boundaries", async () => {
     if (/\blazy\s*\(\s*async\b/.test(text)) hits.push(relativeSource(file))
   }
 
-  expect(hits.sort()).toEqual(["control-plane/adaptors/index.ts", "provider/models.ts"])
+  expect(hits.sort()).toEqual(["control-plane/adaptors/index.ts"])
+})
+
+test("provider models catalog cache does not use Promise flock compatibility", async () => {
+  const text = await readFile(path.join(srcRoot, "provider/models.ts"), "utf8")
+
+  expect(text).not.toContain("EffectFlock.withLockPromise")
 })

--- a/packages/opencode/test/provider/models-refresh.test.ts
+++ b/packages/opencode/test/provider/models-refresh.test.ts
@@ -2,6 +2,9 @@ import { afterEach, expect, test } from "bun:test"
 import { mkdir, readFile, rm, writeFile } from "fs/promises"
 import path from "path"
 
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { Effect, Layer } from "effect"
 import { tmpdir } from "../fixture/fixture"
 import { makeRuntime } from "../../src/effect/run-service"
 import { Env } from "../../src/env"
@@ -9,17 +12,14 @@ import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { ModelsDev, Provider } from "../../src/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
-import { Filesystem } from "../../src/util/filesystem"
 
 const originalFetch = globalThis.fetch
 const originalModelsPath = process.env.OPENCODE_MODELS_PATH
-const originalWrite = Filesystem.write
 const env = makeRuntime(Env.Service, Env.defaultLayer)
 const setEnv = (key: string, value: string) => env.runSync((svc) => svc.set(key, value))
 
 afterEach(async () => {
   globalThis.fetch = originalFetch
-  ;(Filesystem as { write: typeof Filesystem.write }).write = originalWrite
   if (originalModelsPath === undefined) delete process.env.OPENCODE_MODELS_PATH
   else process.env.OPENCODE_MODELS_PATH = originalModelsPath
   ModelsDev.Data.reset()
@@ -177,12 +177,25 @@ test("refresh keeps existing cache when atomic publish write fails", async () =>
   const beforeCache = await readCacheText()
   const beforeVersion = ModelsDev.version()
   mockFetchWithCatalog(catalogWithModels(["kimi-k2.5", "kimi-k2.6"]))
-  ;(Filesystem as { write: typeof Filesystem.write }).write = async (target, content, mode) => {
-    if (target.endsWith(".tmp")) throw new Error("write failed")
-    return originalWrite(target, content, mode)
-  }
+  const failingFsLayer = Layer.effect(
+    AppFileSystem.Service,
+    AppFileSystem.Service.use((fs) =>
+      Effect.succeed(
+        AppFileSystem.Service.of({
+          ...fs,
+          writeWithDirs: (target, content, mode) => {
+            if (target.endsWith(".tmp")) {
+              return Effect.fail(new AppFileSystem.FileSystemError({ method: "writeWithDirs", cause: "write failed" }))
+            }
+            return fs.writeWithDirs(target, content, mode)
+          },
+        }),
+      ),
+    ),
+  ).pipe(Layer.provide(AppFileSystem.defaultLayer))
+  const failingLayer = ModelsDev.layer.pipe(Layer.provide(failingFsLayer), Layer.provide(EffectFlock.defaultLayer))
 
-  await ModelsDev.refresh(true)
+  await Effect.runPromise(ModelsDev.Service.use((svc) => svc.refresh(true)).pipe(Effect.provide(failingLayer)))
 
   expect(await readCacheText()).toBe(beforeCache)
   expect(ModelsDev.version()).toBe(beforeVersion)


### PR DESCRIPTION
## Summary

Moves the models.dev catalog cache behind a `ModelsDev.Service` while preserving the existing `ModelsDev.Data`, `get`, `getWithVersion`, `refresh`, and `version` facades.

## Why

The provider models catalog was still one of the explicit #936 compatibility boundaries: it used `lazy(async ...)`, raw filesystem helpers, and `EffectFlock.withLockPromise` for refresh/load critical sections. This PR keeps the public behavior stable while moving the cache, refresh, TTL check, and atomic write path to injected Effect services.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the new service preserves the old cache semantics: override path refresh, fresh-cache version bumps, failed candidate handling, failed atomic writes, and provider state rebuilds after `Data.reset()`.

## Risk Notes

The async facade remains intentionally, so callers do not need to migrate in this review boundary. No visible UI/copy, platform packaging, dependency, permission, credential, generated content, or release-note surface changed.

## How To Verify

```text
Focused tests: bun test test/provider/models-refresh.test.ts test/effect/legacy-boundaries.test.ts -> 17 passed
Provider graph subset: bun test test/provider/provider.test.ts -t "Volcano|Coding Plan" -> 5 passed, 105 filtered out
Typecheck: GOMAXPROCS=2 bun run typecheck -> passed
Diff check: git diff --check -> passed
Fresh-eye review: no P0/P1 findings and no P2/P3 findings
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
