### PR TITLE
fix(opencode): remove async workspace adaptor boundary

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -316,8 +316,8 @@ Current raw fs users that will convert during tool migration:
   - Converted in this slice: `session/prompt.ts` inline shell expansion, `pty/index.ts` teardown cleanup, and `tool/shell.ts` abort/timeout cleanup use `Process.*Effect` directly
 - [ ] `util/lazy.ts` — sync-only route factories, shell selection, native module loading, and zod recursion stay on `lazy`; async Effect code should use `Effect.cached`
   - Converted in this slice: provider models catalog cache now uses `Effect.cached` inside `ModelsDev.Service`; `tool/shell.ts` parser initialization also uses `Effect.cached` inside the tool's Effect definition
-  - Retained async legacy boundary: control-plane built-in adaptor import still exposes a Promise facade
-  - Guardrail: `test/effect/legacy-boundaries.test.ts` keeps async `lazy` limited to the built-in adaptor import compatibility boundary
+  - Converted in this slice: control-plane built-in workspace adaptors now use a static map, and `WorktreeAdaptor` calls `Worktree.Service` through the service runtime instead of the `Worktree` Promise facade
+  - Guardrail: `test/effect/legacy-boundaries.test.ts` rejects async `lazy` in production source and keeps the worktree adaptor off the Promise facade path
 
 ## Destroying the facades
 

--- a/packages/opencode/src/control-plane/adaptors/index.ts
+++ b/packages/opencode/src/control-plane/adaptors/index.ts
@@ -1,9 +1,9 @@
-import { lazy } from "@/util/lazy"
 import type { ProjectID } from "@/project/schema"
 import type { Adaptor } from "../types"
+import { WorktreeAdaptor } from "./worktree"
 
-const BUILTIN: Record<string, () => Promise<Adaptor>> = {
-  worktree: lazy(async () => (await import("./worktree")).WorktreeAdaptor),
+const BUILTIN: Record<string, Adaptor> = {
+  worktree: WorktreeAdaptor,
 }
 
 const CUSTOM = new Map<ProjectID, Map<string, Map<string, Adaptor>>>()
@@ -16,7 +16,7 @@ export function getBuiltinAdaptor(type: string) {
   return BUILTIN[type]
 }
 
-export async function getAdaptor(projectID: ProjectID, type: string, owner?: string): Promise<Adaptor> {
+export function getAdaptor(projectID: ProjectID, type: string, owner?: string): Adaptor {
   const project = CUSTOM.get(projectID)?.get(type)
   if (project) {
     if (owner) {
@@ -31,7 +31,7 @@ export async function getAdaptor(projectID: ProjectID, type: string, owner?: str
   }
 
   const builtin = BUILTIN[type]
-  if (builtin) return builtin()
+  if (builtin) return builtin
 
   throw new Error(`Unknown workspace adaptor: ${type}`)
 }

--- a/packages/opencode/src/control-plane/adaptors/worktree.ts
+++ b/packages/opencode/src/control-plane/adaptors/worktree.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { makeRuntime } from "@/effect/run-service"
 import { Worktree } from "@/worktree"
 import { type Adaptor, WorkspaceInfo } from "../types"
 
@@ -10,9 +11,11 @@ const Config = WorkspaceInfo.extend({
 
 type Config = z.infer<typeof Config>
 
+const worktreeRuntime = makeRuntime(Worktree.Service, Worktree.defaultLayer)
+
 export const WorktreeAdaptor: Adaptor = {
   async configure(info) {
-    const worktree = await Worktree.makeWorktreeInfo(info.name ?? undefined)
+    const worktree = await worktreeRuntime.runPromise((worktrees) => worktrees.makeWorktreeInfo(info.name ?? undefined))
     return {
       ...info,
       name: worktree.name,
@@ -22,16 +25,18 @@ export const WorktreeAdaptor: Adaptor = {
   },
   async create(info) {
     const config = Config.parse(info)
-    await Worktree.createFromInfo({
-      name: config.name,
-      directory: config.directory,
-      branch: config.branch,
-      source: "created",
-    })
+    await worktreeRuntime.runPromise((worktrees) =>
+      worktrees.createFromInfo({
+        name: config.name,
+        directory: config.directory,
+        branch: config.branch,
+        source: "created",
+      }),
+    )
   },
   async remove(info) {
     const config = Config.parse(info)
-    await Worktree.remove({ directory: config.directory })
+    await worktreeRuntime.runPromise((worktrees) => worktrees.remove({ directory: config.directory }))
   },
   target(info) {
     const config = Config.parse(info)

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -177,7 +177,7 @@ export namespace Workspace {
       ),
     ]
     let lastError = error
-    const resolved: { owner: string; adaptor: Awaited<ReturnType<typeof getAdaptor>> }[] = []
+    const resolved: { owner: string; adaptor: ReturnType<typeof getAdaptor> }[] = []
 
     for (const directory of candidates) {
       try {
@@ -188,7 +188,7 @@ export namespace Workspace {
             const owner = ownerKey(Instance.directory, Instance.worktree)
             return {
               owner,
-              adaptor: await getAdaptor(input.projectID, input.type, owner),
+              adaptor: getAdaptor(input.projectID, input.type, owner),
             }
           },
         })
@@ -231,14 +231,14 @@ export namespace Workspace {
 
     if (input.owner) {
       try {
-        return await getAdaptor(input.projectID, input.type, input.owner)
+        return getAdaptor(input.projectID, input.type, input.owner)
       } catch (error) {
         return bootstrapAdaptor({ ...input, hint }, error)
       }
     }
 
     const builtin = getBuiltinAdaptor(input.type)
-    if (builtin) return builtin()
+    if (builtin) return builtin
 
     const project = Project.get(input.projectID)
     if (project?.worktree === "/" && !hint) {
@@ -251,7 +251,7 @@ export namespace Workspace {
   export const create = fn(CreateInput, async (input) => {
     const id = WorkspaceID.ascending(input.id)
     const owner = ownerKey(Instance.directory, Instance.worktree)
-    const adaptor = await getAdaptor(input.projectID, input.type, owner)
+    const adaptor = getAdaptor(input.projectID, input.type, owner)
 
     const config = await adaptor.configure({ ...input, id, name: null, directory: null })
 

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -41,11 +41,19 @@ test("async lazy stays in explicit compatibility boundaries", async () => {
     if (/\blazy\s*\(\s*async\b/.test(text)) hits.push(relativeSource(file))
   }
 
-  expect(hits.sort()).toEqual(["control-plane/adaptors/index.ts"])
+  expect(hits.sort()).toEqual([])
 })
 
 test("provider models catalog cache does not use Promise flock compatibility", async () => {
   const text = await readFile(path.join(srcRoot, "provider/models.ts"), "utf8")
 
   expect(text).not.toContain("EffectFlock.withLockPromise")
+})
+
+test("worktree adaptor does not call Worktree Promise facades", async () => {
+  const text = await readFile(path.join(srcRoot, "control-plane/adaptors/worktree.ts"), "utf8")
+
+  expect(text).not.toContain("Worktree.makeWorktreeInfo")
+  expect(text).not.toContain("Worktree.createFromInfo")
+  expect(text).not.toContain("Worktree.remove")
 })

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -313,7 +313,7 @@ describe("plugin.workspace", () => {
 
     await Instance.disposeAll()
 
-    await expect(getAdaptor(owner.projectID, source.extra.type, owner.owner)).rejects.toThrow(/workspace adaptor/i)
+    expect(() => getAdaptor(owner.projectID, source.extra.type, owner.owner)).toThrow(/workspace adaptor/i)
 
     await expect(
       Instance.provide({


### PR DESCRIPTION
## Summary

Remove the final async lazy compatibility boundary from the control-plane workspace adaptor registry.

- replace the built-in adaptor lazy import with a static `worktree` adaptor map
- run built-in worktree adaptor operations through `Worktree.Service` instead of the `Worktree` Promise facade
- make `getAdaptor` synchronous now that both custom and built-in adaptor lookup are in-memory
- tighten the legacy boundary guardrails and update the Effect migration notes

## Why

The last allowed async `lazy(...)` boundary was the built-in worktree adaptor import. With the worktree service already Effect-native, the registry no longer needs a Promise-shaped built-in path or Promise facade calls for create/remove/configure.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

Please check that the static built-in adaptor map preserves custom/plugin adaptor precedence and that the worktree adaptor runtime bridge is the narrowest safe service path without reintroducing an AppRuntime initialization cycle.

## Risk Notes

Worktree operations touch git worktree creation/removal and filesystem paths; focused local workspace/worktree tests passed, with broader macOS/Windows coverage left to PR CI. No visible UI or copy changed, so no screenshot was taken. `packages/opencode/specs/effect-migration.md` was updated only for facts changed in this PR.

## How To Verify

```text
RED check: bun test test/effect/legacy-boundaries.test.ts failed before the production fix on the async lazy allowlist and Worktree facade guard.
Focused adaptor tests: bun test test/effect/legacy-boundaries.test.ts test/plugin/workspace-adaptor.test.ts passed, 11 tests.
Workspace routing tests: bun test test/control-plane/sse.test.ts test/server/workspace-routes.test.ts test/server/workspace-routing-decision.test.ts test/server/workspace-router.test.ts passed, 34 tests.
Combined final focused suite: bun test test/effect/legacy-boundaries.test.ts test/plugin/workspace-adaptor.test.ts test/control-plane/sse.test.ts test/server/workspace-routes.test.ts test/server/workspace-routing-decision.test.ts test/server/workspace-router.test.ts passed, 45 tests.
Typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode.
Diff check: git diff --check passed from the repo root.
Fresh-eye review: independent final review found no P0/P1 and no worthwhile remaining P2/P3.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.