### PR TITLE
refactor(opencode): route promise flock locks through service

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -308,9 +308,9 @@ Current raw fs users that will convert during tool migration:
 
 - [x] `util/lock.ts` — removed; no production callers remained, and the only direct references were the util export plus `test/util/lock.test.ts`
 - [ ] `util/flock.ts` — `packages/core/src/util/effect-flock.ts` is the Effect-native implementation; Effect/service callers should use `EffectFlock.Service`, while legacy Promise callers still use the `packages/opencode/src/util/flock.ts` facade
-  - Converted in this slice: provider models catalog refresh now uses the injected `EffectFlock.Service`; `Config.withConfigFileLock`, plugin config patching, and plugin metadata reads still keep Promise critical sections behind `EffectFlock.withLockPromise`
+  - Converted in this slice: provider models catalog refresh, `Config.withConfigFileLock`, plugin config patching, and plugin metadata reads now run their critical sections through `EffectFlock.Service`
   - Retained Promise lease boundary: automation run leases/scheduler ownership and direct flock compatibility tests still need the legacy lease object facade
-  - Guardrail: `test/effect/legacy-boundaries.test.ts` prevents new production imports of `@/util/flock` outside the automation lease owners
+  - Guardrail: `test/effect/legacy-boundaries.test.ts` prevents new production imports of `@/util/flock` outside the automation lease owners and rejects production `EffectFlock.withLockPromise` usage
 - [x] `util/process.ts` — `Process.Service` and Effect-native `run/text/lines/stop/descendants/terminateTree` now own execution and cleanup; the async facade delegates through `runPromise`
   - Retained compatibility boundary: `Process.spawn` still returns the Node child facade because CLI pager/auth flows, long-lived LSP launch, Windows cmd script spawning, and stream ownership still depend on that shape
   - Converted in this slice: `session/prompt.ts` inline shell expansion, `pty/index.ts` teardown cleanup, and `tool/shell.ts` abort/timeout cleanup use `Process.*Effect` directly

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -422,8 +422,18 @@ export function configFileLockKey(file: string) {
   return `config-file:${Filesystem.resolve(file)}`
 }
 
+const { runPromise: runFlockPromise } = makeRuntime(EffectFlock.Service, EffectFlock.defaultLayer)
+
 export async function withConfigFileLock<T>(file: string, fn: () => Promise<T>) {
-  return EffectFlock.withLockPromise(configFileLockKey(file), fn)
+  return runFlockPromise((flock) =>
+    flock.withLock(
+      Effect.tryPromise({
+        try: fn,
+        catch: (error) => error,
+      }),
+      configFileLockKey(file),
+    ),
+  )
 }
 
 function isWindowsSyncUnsupportedError(error: unknown) {

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -6,8 +6,10 @@ import {
   parse as parseJsonc,
   printParseErrorCode,
 } from "jsonc-parser"
+import { Effect } from "effect"
 
 import { Config } from "@/config"
+import { makeRuntime } from "@/effect/run-service"
 import { ConfigPaths } from "@/config/paths"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
@@ -89,6 +91,20 @@ const defaultPatchDeps: PatchDeps = {
   },
   exists: (file) => Filesystem.exists(file),
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
+}
+
+const { runPromise: runFlockPromise } = makeRuntime(EffectFlock.Service, EffectFlock.defaultLayer)
+
+function withLock<T>(key: string, fn: () => Promise<T>) {
+  return runFlockPromise((flock) =>
+    flock.withLock(
+      Effect.tryPromise({
+        try: fn,
+        catch: (error) => error,
+      }),
+      key,
+    ),
+  )
 }
 
 function pluginSpec(item: unknown) {
@@ -352,7 +368,7 @@ async function selectConfigFile(files: string[], dep: PatchDeps) {
 
 async function patchOne(dir: string, files: string[], target: Target, spec: string, force: boolean, dep: PatchDeps): Promise<PatchOne> {
   const name = Runtime.isPawWork() ? "pawwork" : "opencode"
-  return await EffectFlock.withLockPromise(`plug-config:${Filesystem.resolve(path.join(dir, name))}`, async () => {
+  return await withLock(`plug-config:${Filesystem.resolve(path.join(dir, name))}`, async () => {
     let cfg = await selectConfigFile(files, dep)
 
     return await Config.withConfigFileLock(cfg, async () => {

--- a/packages/opencode/src/plugin/meta.ts
+++ b/packages/opencode/src/plugin/meta.ts
@@ -1,8 +1,10 @@
 import path from "path"
 import { fileURLToPath } from "url"
 
+import { Effect } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { makeRuntime } from "@/effect/run-service"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 
@@ -44,6 +46,20 @@ export namespace PluginMeta {
 
   function lock(file: string) {
     return `plugin-meta:${file}`
+  }
+
+  const { runPromise: runFlockPromise } = makeRuntime(EffectFlock.Service, EffectFlock.defaultLayer)
+
+  function withLock<T>(key: string, fn: () => Promise<T>) {
+    return runFlockPromise((flock) =>
+      flock.withLock(
+        Effect.tryPromise({
+          try: fn,
+          catch: (error) => error,
+        }),
+        key,
+      ),
+    )
   }
 
   function fileTarget(spec: string, target: string) {
@@ -136,7 +152,7 @@ export namespace PluginMeta {
     const file = storePath()
     const rows = await Promise.all(items.map((item) => row(item)))
 
-    return EffectFlock.withLockPromise(lock(file), async () => {
+    return withLock(lock(file), async () => {
       const store = await read(file)
       const now = Date.now()
       const out: Array<{ state: State; entry: Entry }> = []
@@ -160,6 +176,6 @@ export namespace PluginMeta {
 
   export async function list(): Promise<Store> {
     const file = storePath()
-    return EffectFlock.withLockPromise(lock(file), async () => read(file))
+    return withLock(lock(file), async () => read(file))
   }
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -44,10 +44,14 @@ test("async lazy stays in explicit compatibility boundaries", async () => {
   expect(hits.sort()).toEqual([])
 })
 
-test("provider models catalog cache does not use Promise flock compatibility", async () => {
-  const text = await readFile(path.join(srcRoot, "provider/models.ts"), "utf8")
+test("production source does not use Promise flock compatibility", async () => {
+  const hits: string[] = []
+  for (const file of await sourceFiles(srcRoot)) {
+    const text = await readFile(file, "utf8")
+    if (text.includes("EffectFlock.withLockPromise")) hits.push(relativeSource(file))
+  }
 
-  expect(text).not.toContain("EffectFlock.withLockPromise")
+  expect(hits.sort()).toEqual([])
 })
 
 test("worktree adaptor does not call Worktree Promise facades", async () => {


### PR DESCRIPTION
## Summary

Route the remaining config/plugin Promise-facing flock helpers through `EffectFlock.Service.withLock` while keeping their public Promise APIs intact.

## Why

Related to #936. The Effect migration had already moved provider model locking to the injected service path, but config/plugin production code still called `EffectFlock.withLockPromise` directly. This closes that Promise lock boundary without touching the automation lease facade.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the Promise-facing helpers preserve their existing lock keys, critical sections, and error behavior while routing through `EffectFlock.Service.withLock`.

## Risk Notes

No visible UI changes. The lock implementation is unchanged; this PR only changes the production bridge used by config/plugin callers. Fresh-eye review reported no P0/P1/P2/P3 findings and recommended not extracting a shared helper because that would add a new migration-era public seam.

Skipped conditional checklist items:
- Visible UI/copy check: not applicable; no UI or copy changed.
- Platform/packaging check: not applicable; no platform, packaging, updater, signing, shell, or permission behavior changed.
- Docs/release/dependencies/generated/local files: only the existing Effect migration note was updated; no release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local-only files changed.

## How To Verify

```text
RED check: bun test test/effect/legacy-boundaries.test.ts failed before production changes with config/config.ts, plugin/install.ts, and plugin/meta.ts still using EffectFlock.withLockPromise.
Boundary guard: bun test test/effect/legacy-boundaries.test.ts passed after the production bridge changes.
Plugin behavior: bun test test/plugin/install.test.ts test/plugin/meta.test.ts passed, 37 tests.
Config behavior: bun test test/config/config.test.ts test/config/pawwork-global-config.test.ts passed, 166 tests.
Typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode.
Diff hygiene: git diff --check passed from the repository root.
Fresh-eye review: no P0/P1/P2/P3 findings; reviewer answered that this is the simplest, most reassuring solution in scope.
Source scan: rg "EffectFlock\\.withLockPromise" packages/opencode/src has no production matches.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal locking mechanisms across configuration and plugin modules to use a unified Effect-based approach.
  * Updated error handling behavior for lock operations.

* **Documentation**
  * Updated migration checklist documenting the transition to standardized locking utilities.

* **Tests**
  * Enhanced guardrail tests to prevent legacy locking utilities from being used in production code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->