### PR TITLE
fix(ui): render ready question marker in timeline

### DIFF
--- a/packages/app/e2e/snap/fixtures/trow-snap-fixture-data.ts
+++ b/packages/app/e2e/snap/fixtures/trow-snap-fixture-data.ts
@@ -192,6 +192,7 @@ export const singleErrorParts = [tool("single-error", "Command blocked", "rm -rf
 export const singleRunningParts = [tool("single-running", "long command", "sleep 30", "running")]
 
 export const readyQuestionMarkerParts: Part[] = [
+  tool("ready-question-before", "prepare question", "echo before"),
   {
     id: "ready-question-marker",
     sessionID: "snap-session",

--- a/packages/app/e2e/snap/fixtures/trow-snap-fixture-data.ts
+++ b/packages/app/e2e/snap/fixtures/trow-snap-fixture-data.ts
@@ -191,6 +191,31 @@ export const singleResultParts = [tool("single-result", "prints one line", "echo
 export const singleErrorParts = [tool("single-error", "Command blocked", "rm -rf /", "error")]
 export const singleRunningParts = [tool("single-running", "long command", "sleep 30", "running")]
 
+export const readyQuestionMarkerParts: Part[] = [
+  {
+    id: "ready-question-marker",
+    sessionID: "snap-session",
+    messageID: "snap-message",
+    type: "tool",
+    callID: "call-ready-question-marker",
+    tool: "question",
+    state: {
+      status: "running",
+      input: {
+        questions: [
+          {
+            header: "Follow up",
+            question: "这个问题应该在下方回答吗?",
+            options: [{ label: "是" }],
+          },
+        ],
+      },
+      metadata: { externalResultReady: true },
+      time: { start: 0 },
+    },
+  },
+]
+
 export const toolOutputParts = [
   realTool(
     "glob-output",

--- a/packages/app/e2e/snap/fixtures/trow-snap-fixture.tsx
+++ b/packages/app/e2e/snap/fixtures/trow-snap-fixture.tsx
@@ -17,6 +17,7 @@ import {
   metadataDetailParts,
   mixedRealToolParts,
   questionDetailParts,
+  readyQuestionMarkerParts,
   reasoningOnlyParts,
   runningReasoningParts,
   reasoningWithToolsParts,
@@ -238,6 +239,9 @@ function TrowSnapFixture() {
       </div>
       <div data-snap="dismissed-question-collapsed">
         <AssistantPartsCase parts={dismissedQuestionParts} />
+      </div>
+      <div data-snap="ready-question-marker">
+        <AssistantPartsCase parts={readyQuestionMarkerParts} working />
       </div>
       <div data-snap="metadata-detail-collapsed">
         <TrowBlock

--- a/packages/app/e2e/snap/session-trow.snap.ts
+++ b/packages/app/e2e/snap/session-trow.snap.ts
@@ -226,10 +226,9 @@ test("session-trow", async ({ page }) => {
   shots.push(await captureBlock("dismissed-question-expanded", dismissedQuestion))
 
   const readyQuestionMarker = page.locator('[data-snap="ready-question-marker"]')
-  await expect(readyQuestionMarker.locator('[data-component="question-inline-marker"]')).toContainText(
-    "在下方回答这个问题",
-    { timeout: 30_000 },
-  )
+  const readyQuestionMarkerInline = readyQuestionMarker.locator('[data-component="question-inline-marker"]')
+  await expect(readyQuestionMarkerInline).toBeVisible({ timeout: 30_000 })
+  await expect(readyQuestionMarkerInline).toContainText("在下方回答这个问题", { timeout: 30_000 })
   shots.push(await captureBlock("ready-question-marker", readyQuestionMarker))
 
   const metadataDetailCollapsed = page.locator('[data-snap="metadata-detail-collapsed"]')

--- a/packages/app/e2e/snap/session-trow.snap.ts
+++ b/packages/app/e2e/snap/session-trow.snap.ts
@@ -225,6 +225,13 @@ test("session-trow", async ({ page }) => {
   await expect(dismissedQuestion.getByText("问题已忽略")).toBeVisible({ timeout: 30_000 })
   shots.push(await captureBlock("dismissed-question-expanded", dismissedQuestion))
 
+  const readyQuestionMarker = page.locator('[data-snap="ready-question-marker"]')
+  await expect(readyQuestionMarker.locator('[data-component="question-inline-marker"]')).toContainText(
+    "在下方回答这个问题",
+    { timeout: 30_000 },
+  )
+  shots.push(await captureBlock("ready-question-marker", readyQuestionMarker))
+
   const metadataDetailCollapsed = page.locator('[data-snap="metadata-detail-collapsed"]')
   await expect(metadataDetailCollapsed.locator('[data-slot="trow-summary-chev"]')).toBeVisible({ timeout: 30_000 })
   await expect(metadataDetailCollapsed).not.toContainText("这组工具详情还能看到吗?", { timeout: 30_000 })

--- a/packages/ui/src/components/message-part-stale.test.ts
+++ b/packages/ui/src/components/message-part-stale.test.ts
@@ -92,7 +92,7 @@ test("synthetic stop tool parts are hidden through reactive metadata", () => {
   expect(source).toMatch(/partMetadata\(\)\??\.diagnostics\?\.loop\?\.loopAction\s*===\s*"stop"/)
 })
 
-test("tool part wrapper suppresses both pending questions and synthetic stop tools", () => {
+test("tool part wrapper suppresses legacy pending questions and synthetic stop tools", () => {
   const source = readMessagePartSources()
 
   expect(source).toContain("<Show when={!hideQuestion() && !hideSyntheticStop()}>")

--- a/packages/ui/src/components/message-part/grouping.test.ts
+++ b/packages/ui/src/components/message-part/grouping.test.ts
@@ -156,22 +156,25 @@ describe("message-part groupParts", () => {
     expect(result[0].type).toBe("trow")
   })
 
-  test("ready running question tools render the inline pending marker", () => {
+  test("ready running question tools split into a visible single trow marker", () => {
     const result = groupRenderable([
       toolPart("t1", "bash"),
       toolPart("q1", "question", "running", { externalResultReady: true }),
     ])
 
     expect(renderable(toolPart("q1", "question", "running", { externalResultReady: true }))).toBe(true)
-    expect(result).toHaveLength(1)
-    expect(result[0]).toEqual({
-      key: "trow:t1",
-      type: "trow",
-      refs: [
-        { messageID: "m", partID: "t1" },
-        { messageID: "m", partID: "q1" },
-      ],
-    })
+    expect(result).toEqual([
+      {
+        key: "trow:t1",
+        type: "trow",
+        refs: [{ messageID: "m", partID: "t1" }],
+      },
+      {
+        key: "trow:q1",
+        type: "trow",
+        refs: [{ messageID: "m", partID: "q1" }],
+      },
+    ])
   })
 
   test("a reasoning part folds into a trow group, not a standalone part", () => {

--- a/packages/ui/src/components/message-part/grouping.test.ts
+++ b/packages/ui/src/components/message-part/grouping.test.ts
@@ -12,7 +12,12 @@ function textPart(id: string, text: string): TextPart {
   }
 }
 
-function toolPart(id: string, tool: string, status: "pending" | "running" | "completed" | "error" = "completed"): ToolPart {
+function toolPart(
+  id: string,
+  tool: string,
+  status: "pending" | "running" | "completed" | "error" = "completed",
+  metadata?: Record<string, unknown>,
+): ToolPart {
   if (status === "pending") {
     return {
       id,
@@ -32,7 +37,7 @@ function toolPart(id: string, tool: string, status: "pending" | "running" | "com
       type: "tool",
       callID: `call-${id}`,
       tool,
-      state: { status: "running", input: {}, time: { start: 0 } },
+      state: { status: "running", input: {}, metadata, time: { start: 0 } },
     }
   }
   if (status === "error") {
@@ -142,11 +147,31 @@ describe("message-part groupParts", () => {
     })
   })
 
-  test("pending question tools are filtered before grouping", () => {
+  test("unready pending question tools are filtered before grouping", () => {
     const result = groupRenderable([toolPart("t1", "bash"), toolPart("q1", "question", "pending"), toolPart("t2", "bash")])
 
+    expect(renderable(toolPart("q1", "question", "pending"))).toBe(false)
+    expect(renderable(toolPart("q2", "question", "running", { externalResultReady: false }))).toBe(false)
     expect(result).toHaveLength(1)
     expect(result[0].type).toBe("trow")
+  })
+
+  test("ready running question tools render the inline pending marker", () => {
+    const result = groupRenderable([
+      toolPart("t1", "bash"),
+      toolPart("q1", "question", "running", { externalResultReady: true }),
+    ])
+
+    expect(renderable(toolPart("q1", "question", "running", { externalResultReady: true }))).toBe(true)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      key: "trow:t1",
+      type: "trow",
+      refs: [
+        { messageID: "m", partID: "t1" },
+        { messageID: "m", partID: "q1" },
+      ],
+    })
   })
 
   test("a reasoning part folds into a trow group, not a standalone part", () => {

--- a/packages/ui/src/components/message-part/grouping.ts
+++ b/packages/ui/src/components/message-part/grouping.ts
@@ -98,7 +98,11 @@ export function groupParts(parts: { messageID: string; part: PartType }[]) {
 export function renderable(part: PartType) {
   if (part.type === "tool") {
     if (HIDDEN_TOOLS.has(part.tool)) return false
-    if (part.tool === TOOL_QUESTION) return part.state.status !== "pending" && part.state.status !== "running"
+    if (part.tool === TOOL_QUESTION) {
+      if (part.state.status === "pending") return false
+      if (part.state.status === "running") return part.state.metadata?.externalResultReady === true
+      return true
+    }
     return true
   }
   if (part.type === "text") return !!part.text?.trim()

--- a/packages/ui/src/components/message-part/grouping.ts
+++ b/packages/ui/src/components/message-part/grouping.ts
@@ -37,6 +37,15 @@ function sameGroup(a: PartGroup, b: PartGroup) {
   return a.refs.every((ref, i) => sameRef(ref, b.refs[i]!))
 }
 
+function isReadyQuestionMarker(part: PartType) {
+  return (
+    part.type === "tool" &&
+    part.tool === TOOL_QUESTION &&
+    part.state.status === "running" &&
+    part.state.metadata?.externalResultReady === true
+  )
+}
+
 export function sameGroups(a: readonly PartGroup[] | undefined, b: readonly PartGroup[] | undefined) {
   if (a === b) return true
   if (!a || !b) return false
@@ -75,6 +84,13 @@ export function groupParts(parts: { messageID: string; part: PartType }[]) {
   }
 
   parts.forEach((item, index) => {
+    if (isReadyQuestionMarker(item.part)) {
+      flush(index - 1)
+      start = index
+      flush(index)
+      return
+    }
+
     if (item.part.type === "tool" || item.part.type === "reasoning") {
       if (start < 0) start = index
       return
@@ -100,7 +116,7 @@ export function renderable(part: PartType) {
     if (HIDDEN_TOOLS.has(part.tool)) return false
     if (part.tool === TOOL_QUESTION) {
       if (part.state.status === "pending") return false
-      if (part.state.status === "running") return part.state.metadata?.externalResultReady === true
+      if (part.state.status === "running") return isReadyQuestionMarker(part)
       return true
     }
     return true


### PR DESCRIPTION
## Summary

Fixes a directly reported question sequencing regression with no separate issue: the question dock could appear while the timeline still lacked a visible handoff marker for the running question.

## Why

The dock intentionally appears only after `externalResultReady === true`, but the timeline grouping layer originally filtered every pending or running `question` tool. The first fix allowed ready running questions to render, and this follow-up keeps that marker visible even when it follows a normal tool: ready running questions now split into their own single trow instead of being hidden inside a default-collapsed multi-tool trow.

## Related Issue

None. This PR follows a direct maintainer report in Codex.

## Human Review Status

Approved by @Astro-Han

## Review Focus

- `renderable()` still keeps legacy pending and unready running questions hidden, but allows running questions with `metadata.externalResultReady === true` to reach the existing inline marker renderer.
- `groupParts()` now cuts a ready running question into its own trow, so the single-row auto-open path makes the marker visible without expanding unrelated tool details.
- The `session-trow` snap case exercises the production `AssistantParts -> groupParts -> ToolPartDisplay` path with a normal tool immediately before the ready question marker.

## Risk Notes

No platform, persistence, dependency, permission, or migration surface is touched. This is a visible UI sequencing fix only.

## How To Verify

```text
Regression RED: packages/ui grouping test failed before the follow-up because the ready question still shared trow:t1 refs with the previous tool.
Diff check: git diff --check passed with no whitespace errors.
UI unit tests: packages/ui message-part grouping/tool/stale focused tests passed, 26 passed.
UI typecheck: cd packages/ui && bun run typecheck passed.
Dock predicate tests: cd packages/app && bun test --preload ./happydom.ts src/pages/session/blockers/use-session-blockers.test.ts passed, 14 passed.
App typecheck: cd packages/app && bun run typecheck passed.
Visual snap: bun run snap session-trow passed, including a normal tool immediately before the ready-question-marker case and a visible marker assertion.
Manual visual review: reviewed docs/design/preview/screenshots/session-trow.png and confirmed the ready-question-marker tile shows the preceding tool row plus the visible inline pending-question marker.
```

## Screenshots or Recordings

`bun run snap session-trow` generated the local grid at `docs/design/preview/screenshots/session-trow.png`; the `ready-question-marker` tile was reviewed after the run.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.