### PR TITLE
fix(opencode): generate SDK OpenAPI from production source

### DIFF
--- a/packages/opencode/src/cli/cmd/generate.ts
+++ b/packages/opencode/src/cli/cmd/generate.ts
@@ -5,11 +5,10 @@ export const GenerateCommand = {
   command: "generate",
   handler: async () => {
     const specs = await Server.openapi()
-    for (const item of Object.values(specs.paths)) {
+    for (const item of Object.values(specs.paths ?? {})) {
       for (const method of ["get", "post", "put", "delete", "patch"] as const) {
         const operation = item[method]
         if (!operation?.operationId) continue
-        // @ts-expect-error
         operation["x-codeSamples"] = [
           {
             lang: "js",

--- a/packages/opencode/src/server/control-openapi.ts
+++ b/packages/opencode/src/server/control-openapi.ts
@@ -1,8 +1,19 @@
 import { OpenApi } from "effect/unstable/httpapi"
 import { resolver } from "hono-openapi"
+import { Automation } from "@/automation"
 import { BusEvent } from "@/bus/bus-event"
 import { Info as ConfigInfo } from "@/config/config"
+import { LSP } from "@/lsp"
+import { ListResult as ProviderListResult, ConfigProvidersResult } from "@/provider/provider"
 import { PtyID } from "@/pty/schema"
+import { MessageV2 } from "@/session/message-v2"
+import { Session } from "@/session"
+import { SessionPrompt } from "@/session/prompt"
+import { SessionRevert } from "@/session/revert"
+import { SessionStatus } from "@/session/status"
+import { SessionSummary } from "@/session/summary"
+import { Todo } from "@/session/todo"
+import { TurnChange } from "@/session/turn-change"
 import { BadRequestErrorSchema } from "./error"
 import { globalEventOpenApiSchema, globalSyncEventOpenApiSchema } from "./global-openapi-schema"
 import { ProductionApi } from "./production-api"
@@ -15,7 +26,7 @@ type OpenApiDocument = {
     version?: string
     description?: string
   }
-  paths?: Record<string, Record<string, unknown>>
+  paths?: Record<string, Record<string, any>>
   components?: {
     schemas?: Record<string, unknown>
   }
@@ -54,6 +65,195 @@ function sortRefUnions(value: unknown) {
   for (const item of Object.values(record)) sortRefUnions(item)
 }
 
+function schemaRef(name: string) {
+  return { $ref: `#/components/schemas/${name}` }
+}
+
+function arrayOf(schema: unknown) {
+  return {
+    type: "array",
+    items: schema,
+  }
+}
+
+function messageWithParts(info: unknown = schemaRef("Message")) {
+  return {
+    type: "object",
+    properties: {
+      info,
+      parts: arrayOf(schemaRef("Part")),
+    },
+    required: ["info", "parts"],
+  }
+}
+
+function jsonContent(schema: unknown) {
+  return {
+    "application/json": {
+      schema,
+    },
+  }
+}
+
+function patchJsonResponse(document: OpenApiDocument, path: string, method: string, schema: unknown) {
+  const operation = document.paths?.[path]?.[method] as
+    | { responses?: Record<string, { content?: Record<string, unknown> }> }
+    | undefined
+  const response = operation?.responses?.["200"]
+  if (!response) return
+  response.content = jsonContent(schema)
+}
+
+function patchRequestBody(
+  document: OpenApiDocument,
+  path: string,
+  method: string,
+  schema: unknown,
+  options?: { required?: boolean },
+) {
+  const operation = document.paths?.[path]?.[method] as
+    | { requestBody?: { required?: boolean; content?: Record<string, unknown> } }
+    | undefined
+  if (!operation) return
+  operation.requestBody = {
+    required: options?.required ?? true,
+    content: jsonContent(schema),
+  }
+}
+
+function patchParameterSchemas(
+  document: OpenApiDocument,
+  path: string,
+  method: string,
+  schemas: Record<string, unknown>,
+) {
+  const operation = document.paths?.[path]?.[method] as { parameters?: Array<{ name?: string; schema?: unknown }> } | undefined
+  if (!operation?.parameters) return
+  for (const parameter of operation.parameters) {
+    if (!parameter.name) continue
+    const schema = schemas[parameter.name]
+    if (schema) parameter.schema = schema
+  }
+}
+
+function patchSessionSchemas(document: OpenApiDocument, schemas: Record<string, unknown>) {
+  const session = schemaRef("Session")
+  const message = schemaRef("Message")
+  const assistant = schemaRef("AssistantMessage")
+  const sessionStatus = schemaRef("SessionStatus")
+  const promptBody = schemas.PromptBodyInline
+  const commandBody = schemas.CommandBodyInline
+  const shellBody = schemas.ShellBodyInline
+  const createBody = schemas.SessionCreateBodyInline
+  const revertBody = schemas.SessionRevertBodyInline
+  const diff = schemaRef("TurnChangeAggregate")
+  const todoSnapshot = schemaRef("TodoSnapshot")
+  const turnChangeDisplay = schemaRef("TurnChangeDisplay")
+  const turnChangeMutation = schemaRef("TurnChangeMutationResult")
+
+  patchParameterSchemas(document, "/session", "get", {
+    roots: { type: "boolean" },
+    start: { type: "number" },
+    limit: { type: "number" },
+  })
+  patchJsonResponse(document, "/session", "get", arrayOf(session))
+  patchRequestBody(document, "/session", "post", createBody, { required: false })
+  patchJsonResponse(document, "/session", "post", session)
+  patchJsonResponse(document, "/session/status", "get", {
+    type: "object",
+    additionalProperties: sessionStatus,
+  })
+  patchJsonResponse(document, "/session/{sessionID}", "get", session)
+  patchJsonResponse(document, "/session/{sessionID}", "patch", session)
+  patchJsonResponse(document, "/session/{sessionID}/children", "get", arrayOf(session))
+  patchJsonResponse(document, "/session/{sessionID}/message", "get", arrayOf(messageWithParts(message)))
+  patchRequestBody(document, "/session/{sessionID}/message", "post", promptBody)
+  patchJsonResponse(document, "/session/{sessionID}/message", "post", messageWithParts(assistant))
+  patchJsonResponse(document, "/session/{sessionID}/message/{messageID}", "get", messageWithParts(message))
+  patchRequestBody(document, "/session/{sessionID}/message/{messageID}/part/{partID}", "patch", schemaRef("Part"))
+  patchJsonResponse(document, "/session/{sessionID}/message/{messageID}/part/{partID}", "patch", schemaRef("Part"))
+  patchJsonResponse(document, "/session/{sessionID}/todo", "get", todoSnapshot)
+  patchRequestBody(document, "/session/{sessionID}/prompt_async", "post", promptBody)
+  patchRequestBody(document, "/session/{sessionID}/command", "post", commandBody)
+  patchJsonResponse(document, "/session/{sessionID}/command", "post", messageWithParts(assistant))
+  patchRequestBody(document, "/session/{sessionID}/fork", "post", schemas.SessionForkBodyInline, { required: false })
+  patchJsonResponse(document, "/session/{sessionID}/fork", "post", session)
+  patchJsonResponse(document, "/session/{sessionID}/share", "post", session)
+  patchJsonResponse(document, "/session/{sessionID}/share", "delete", session)
+  patchJsonResponse(document, "/session/{sessionID}/diff", "get", diff)
+  patchRequestBody(document, "/session/{sessionID}/shell", "post", shellBody)
+  patchJsonResponse(document, "/session/{sessionID}/shell", "post", messageWithParts(message))
+  patchRequestBody(document, "/session/{sessionID}/revert", "post", revertBody)
+  patchJsonResponse(document, "/session/{sessionID}/revert", "post", session)
+  patchJsonResponse(document, "/session/{sessionID}/unrevert", "post", session)
+  patchJsonResponse(document, "/session/{sessionID}/turn-change/{messageID}", "get", {
+    anyOf: [turnChangeDisplay, { type: "null" }],
+  })
+  patchJsonResponse(document, "/session/{sessionID}/turn-change/{messageID}/undo", "post", turnChangeMutation)
+  patchJsonResponse(document, "/session/{sessionID}/turn-change/{messageID}/redo", "post", turnChangeMutation)
+  patchJsonResponse(document, "/session/{sessionID}/turn/{userMessageID}/changes", "get", diff)
+  patchJsonResponse(document, "/session/{sessionID}/turn/{userMessageID}/changes/undo", "post", turnChangeMutation)
+  patchJsonResponse(document, "/session/{sessionID}/turn/{userMessageID}/changes/redo", "post", turnChangeMutation)
+}
+
+function patchAutomationSchemas(document: OpenApiDocument, schemas: Record<string, unknown>) {
+  const definition = schemaRef("AutomationDefinition")
+  const automationID = { type: "string", pattern: "^automation_(?!run_)" }
+  const runID = { type: "string", pattern: "^automation_run_" }
+  const runLimit = { type: "integer", exclusiveMinimum: 0, maximum: 100 }
+
+  patchParameterSchemas(document, "/automation/{automationID}", "get", { automationID })
+  patchParameterSchemas(document, "/automation/{automationID}", "put", { automationID })
+  patchParameterSchemas(document, "/automation/{automationID}", "delete", { automationID })
+  patchParameterSchemas(document, "/automation/{automationID}/runs", "get", { automationID, cursor: runID, limit: runLimit })
+  patchParameterSchemas(document, "/automation/{automationID}/run", "post", { automationID })
+  patchParameterSchemas(document, "/automation/{automationID}/pause", "post", { automationID })
+  patchParameterSchemas(document, "/automation/{automationID}/resume", "post", { automationID })
+
+  patchJsonResponse(document, "/automation", "get", schemaRef("AutomationListResponse"))
+  patchRequestBody(document, "/automation", "post", schemas.AutomationCreateInputInline)
+  patchJsonResponse(document, "/automation", "post", definition)
+  patchJsonResponse(document, "/automation/{automationID}", "get", definition)
+  patchRequestBody(document, "/automation/{automationID}", "put", schemas.AutomationUpdateInputInline)
+  patchJsonResponse(document, "/automation/{automationID}", "put", definition)
+  patchJsonResponse(document, "/automation/{automationID}", "delete", schemaRef("AutomationDefinitionTombstone"))
+  patchJsonResponse(document, "/automation/{automationID}/runs", "get", schemaRef("AutomationRunsResponse"))
+  patchJsonResponse(document, "/automation/{automationID}/run", "post", schemaRef("AutomationRun"))
+  patchJsonResponse(document, "/automation/{automationID}/pause", "post", definition)
+  patchJsonResponse(document, "/automation/{automationID}/resume", "post", definition)
+}
+
+function memoryStateSchema() {
+  return {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      disabled: { type: "boolean" },
+      status: { type: "string", enum: ["ok", "safe_mode"] },
+      reason: { type: "string" },
+      content: { type: "string" },
+      profile: { type: "string" },
+      profileTooLarge: { type: "boolean" },
+    },
+    required: ["path", "disabled", "status", "content"],
+  }
+}
+
+function patchMemorySchemas(document: OpenApiDocument) {
+  const memoryState = schemaRef("MemoryState")
+  patchJsonResponse(document, "/memory", "get", memoryState)
+  patchJsonResponse(document, "/memory", "patch", memoryState)
+  patchJsonResponse(document, "/memory/reset", "post", memoryState)
+  patchJsonResponse(document, "/memory/disabled", "patch", memoryState)
+  patchJsonResponse(document, "/memory/entry/{id}", "delete", memoryState)
+}
+
+function patchAdditionalRouteSchemas(document: OpenApiDocument) {
+  patchJsonResponse(document, "/experimental/session", "get", arrayOf(schemaRef("GlobalSession")))
+  patchJsonResponse(document, "/session/{sessionID}/artifacts", "get", arrayOf(schemaRef("SessionArtifact")))
+  patchJsonResponse(document, "/find/symbol", "get", arrayOf(schemaRef("Symbol")))
+}
+
 const workspaceRoutingParameters = [
   {
     in: "query",
@@ -73,13 +273,76 @@ const workspaceRoutingParameters = [
 
 export async function controlOpenApi() {
   const document = structuredClone(OpenApi.fromApi(ProductionApi) as OpenApiDocument)
-  const [instanceEvent, globalEvent, globalSyncEvent, badRequest, config, ptyID] = await Promise.all([
+  const promptBody = SessionPrompt.PromptInput.omit({ sessionID: true, automationID: true }).meta({ ref: "PromptBody" })
+  const commandBody = SessionPrompt.CommandInput.omit({ sessionID: true }).meta({ ref: "CommandBody" })
+  const shellBody = SessionPrompt.ShellInput.omit({ sessionID: true }).meta({ ref: "ShellBody" })
+  const sessionCreateBody = Session.CreateInput.meta({ ref: "SessionCreateBody" })
+  const sessionForkBody = Session.ForkInput.omit({ sessionID: true }).meta({ ref: "SessionForkBody" })
+  const sessionRevertBody = SessionRevert.RevertInput.omit({ sessionID: true }).meta({ ref: "SessionRevertBody" })
+  const [
+    instanceEvent,
+    globalEvent,
+    globalSyncEvent,
+    badRequest,
+    config,
+    ptyID,
+    providerList,
+    configProviders,
+    sessionInfo,
+    globalSessionInfo,
+    messageWithParts,
+    sessionStatus,
+    sessionArtifact,
+    lspSymbol,
+    prompt,
+    command,
+    shell,
+    sessionCreate,
+    sessionFork,
+    sessionRevert,
+    automationList,
+    automationCreate,
+    automationUpdate,
+    automationDefinition,
+    automationTombstone,
+    automationRuns,
+    automationRun,
+    todo,
+    turnChangeDisplay,
+    turnChangeAggregate,
+    turnChangeMutation,
+  ] = await Promise.all([
     resolver(BusEvent.payloads({ include: productionBusEventTypes })).toOpenAPISchema(),
     resolver(globalEventOpenApiSchema({ busEventTypes: productionBusEventTypes })).toOpenAPISchema(),
     resolver(globalSyncEventOpenApiSchema({ syncEventTypes: productionSyncEventTypes })).toOpenAPISchema(),
     resolver(BadRequestErrorSchema).toOpenAPISchema(),
     resolver(ConfigInfo.zod).toOpenAPISchema(),
     resolver(PtyID.zod).toOpenAPISchema(),
+    resolver(ProviderListResult.zod).toOpenAPISchema(),
+    resolver(ConfigProvidersResult.zod).toOpenAPISchema(),
+    resolver(Session.Info).toOpenAPISchema(),
+    resolver(Session.GlobalInfo).toOpenAPISchema(),
+    resolver(MessageV2.WithParts).toOpenAPISchema(),
+    resolver(SessionStatus.Info).toOpenAPISchema(),
+    resolver(SessionSummary.Artifact).toOpenAPISchema(),
+    resolver(LSP.Symbol).toOpenAPISchema(),
+    resolver(promptBody).toOpenAPISchema(),
+    resolver(commandBody).toOpenAPISchema(),
+    resolver(shellBody).toOpenAPISchema(),
+    resolver(sessionCreateBody).toOpenAPISchema(),
+    resolver(sessionForkBody).toOpenAPISchema(),
+    resolver(sessionRevertBody).toOpenAPISchema(),
+    resolver(Automation.ListResponse).toOpenAPISchema(),
+    resolver(Automation.CreateInput).toOpenAPISchema(),
+    resolver(Automation.UpdateInput).toOpenAPISchema(),
+    resolver(Automation.Definition).toOpenAPISchema(),
+    resolver(Automation.Tombstone).toOpenAPISchema(),
+    resolver(Automation.RunsResponse).toOpenAPISchema(),
+    resolver(Automation.Run).toOpenAPISchema(),
+    resolver(Todo.Snapshot).toOpenAPISchema(),
+    resolver(TurnChange.DisplaySchema.meta({ ref: "TurnChangeDisplay" })).toOpenAPISchema(),
+    resolver(TurnChange.AggregateSchema.meta({ ref: "TurnChangeAggregate" })).toOpenAPISchema(),
+    resolver(TurnChange.MutationResultSchema.meta({ ref: "TurnChangeMutationResult" })).toOpenAPISchema(),
   ])
 
   document.openapi = "3.1.1"
@@ -191,6 +454,65 @@ export async function controlOpenApi() {
   mergeSchemas(document, globalEvent.components?.schemas ?? {})
   mergeSchemas(document, globalSyncEvent.components?.schemas ?? {})
   mergeSchemas(document, ptyID.components?.schemas ?? {})
+  mergeSchemas(document, providerList.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, configProviders.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, sessionInfo.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, globalSessionInfo.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, messageWithParts.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, sessionStatus.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, sessionArtifact.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, lspSymbol.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, automationList.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, automationDefinition.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, automationTombstone.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, automationRuns.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, automationRun.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, todo.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, turnChangeDisplay.components?.schemas ?? {}, { override: true })
+  mergeSchemas(document, turnChangeMutation.components?.schemas ?? {}, { override: true })
+  const sessionPatchSchemas = {
+    ...(prompt.components?.schemas ?? {}),
+    ...(command.components?.schemas ?? {}),
+    ...(shell.components?.schemas ?? {}),
+    ...(sessionCreate.components?.schemas ?? {}),
+    ...(sessionFork.components?.schemas ?? {}),
+    ...(sessionRevert.components?.schemas ?? {}),
+    ...(turnChangeAggregate.components?.schemas ?? {}),
+  }
+  const automationPatchSchemas = {
+    ...(automationCreate.components?.schemas ?? {}),
+    ...(automationUpdate.components?.schemas ?? {}),
+  }
+  mergeSchemas(document, automationPatchSchemas, { override: true })
+  document.components ??= {}
+  document.components.schemas = {
+    ...document.components.schemas,
+    MemoryState: memoryStateSchema(),
+  }
+  const sessionPatchRefs = {
+    PromptBody: prompt.schema,
+    CommandBody: command.schema,
+    ShellBody: shell.schema,
+    SessionCreateBody: sessionCreate.schema,
+    SessionForkBody: sessionFork.schema,
+    SessionRevertBody: sessionRevert.schema,
+    TurnChangeAggregate: turnChangeAggregate.schema,
+    PromptBodyInline: prompt.components?.schemas?.PromptBody ?? prompt.schema,
+    CommandBodyInline: command.components?.schemas?.CommandBody ?? command.schema,
+    ShellBodyInline: shell.components?.schemas?.ShellBody ?? shell.schema,
+    SessionCreateBodyInline: sessionCreate.components?.schemas?.SessionCreateBody ?? sessionCreate.schema,
+    SessionForkBodyInline: sessionFork.components?.schemas?.SessionForkBody ?? sessionFork.schema,
+    SessionRevertBodyInline: sessionRevert.components?.schemas?.SessionRevertBody ?? sessionRevert.schema,
+  }
+  const automationPatchRefs = {
+    AutomationCreateInputInline: automationCreate.components?.schemas?.AutomationCreateInput ?? automationCreate.schema,
+    AutomationUpdateInputInline: automationUpdate.components?.schemas?.AutomationUpdateInput ?? automationUpdate.schema,
+  }
+  mergeSchemas(document, sessionPatchSchemas, { override: true })
+  patchSessionSchemas(document, sessionPatchRefs)
+  patchAutomationSchemas(document, automationPatchRefs)
+  patchMemorySchemas(document)
+  patchAdditionalRouteSchemas(document)
   mergeSchemas(document, badRequest.components?.schemas ?? {}, { override: true })
   mergeSchemas(document, config.components?.schemas ?? {}, { override: true })
   sortRefUnions(document)

--- a/packages/opencode/src/server/control-openapi.ts
+++ b/packages/opencode/src/server/control-openapi.ts
@@ -95,11 +95,11 @@ function jsonContent(schema: unknown) {
   }
 }
 
-function patchJsonResponse(document: OpenApiDocument, path: string, method: string, schema: unknown) {
+function patchJsonResponse(document: OpenApiDocument, path: string, method: string, schema: unknown, status = "200") {
   const operation = document.paths?.[path]?.[method] as
     | { responses?: Record<string, { content?: Record<string, unknown> }> }
     | undefined
-  const response = operation?.responses?.["200"]
+  const response = operation?.responses?.[status]
   if (!response) return
   response.content = jsonContent(schema)
 }
@@ -295,6 +295,12 @@ function patchAdditionalRouteSchemas(document: OpenApiDocument) {
   patchJsonResponse(document, "/file/content", "get", schemaRef("FileContent"))
 }
 
+function patchVcsFailureSchemas(document: OpenApiDocument) {
+  patchJsonResponse(document, "/vcs/apply", "post", schemaRef("VcsApplyFailure"), "400")
+  patchJsonResponse(document, "/vcs/apply", "post", schemaRef("VcsApplyFailure"), "413")
+  patchJsonResponse(document, "/vcs/diff/raw", "get", schemaRef("VcsDiffRawFailure"), "413")
+}
+
 function memoryInputSchemas() {
   return {
     MemoryRawInput: {
@@ -390,6 +396,33 @@ function pendingExternalResultSchema() {
       part: schemaRef("Part"),
     },
     required: ["session", "message", "part"],
+  }
+}
+
+function vcsFailureSchemas() {
+  return {
+    VcsApplyFailure: {
+      type: "object",
+      properties: {
+        error: { const: "vcs_apply_failed" },
+        reason: { enum: ["non-git", "not-clean", "too-large", "invalid-input"] },
+        message: { type: "string" },
+      },
+      required: ["error", "reason", "message"],
+      additionalProperties: false,
+      description: "VCS patch apply failure",
+    },
+    VcsDiffRawFailure: {
+      type: "object",
+      properties: {
+        error: { const: "vcs_diff_raw_failed" },
+        reason: { const: "too-large" },
+        message: { type: "string" },
+      },
+      required: ["error", "reason", "message"],
+      additionalProperties: false,
+      description: "Raw VCS diff is too large",
+    },
   }
 }
 
@@ -631,6 +664,7 @@ export async function controlOpenApi() {
     ...worktreeInputSchemas(),
     FileContent: fileContentSchema(),
     PendingExternalResult: pendingExternalResultSchema(),
+    ...vcsFailureSchemas(),
   }
   const sessionPatchRefs = {
     PromptBody: prompt.schema,
@@ -656,6 +690,7 @@ export async function controlOpenApi() {
   patchAutomationSchemas(document, automationPatchRefs)
   patchMemorySchemas(document)
   patchAdditionalRouteSchemas(document)
+  patchVcsFailureSchemas(document)
   mergeSchemas(document, badRequest.components?.schemas ?? {}, { override: true })
   mergeSchemas(document, config.components?.schemas ?? {}, { override: true })
   sortRefUnions(document)

--- a/packages/opencode/src/server/control-openapi.ts
+++ b/packages/opencode/src/server/control-openapi.ts
@@ -136,6 +136,17 @@ function patchParameterSchemas(
   }
 }
 
+function upsertQueryParameters(document: OpenApiDocument, path: string, method: string, parameters: Array<Record<string, unknown>>) {
+  const operation = document.paths?.[path]?.[method] as { parameters?: Array<Record<string, unknown>> } | undefined
+  if (!operation) return
+  operation.parameters ??= []
+  for (const parameter of parameters) {
+    const existing = operation.parameters.find((item) => item.in === "query" && item.name === parameter.name)
+    if (existing) Object.assign(existing, parameter)
+    else operation.parameters.push(parameter)
+  }
+}
+
 function patchSessionSchemas(document: OpenApiDocument, schemas: Record<string, unknown>) {
   const session = schemaRef("Session")
   const message = schemaRef("Message")
@@ -166,6 +177,9 @@ function patchSessionSchemas(document: OpenApiDocument, schemas: Record<string, 
   patchJsonResponse(document, "/session/{sessionID}", "get", session)
   patchJsonResponse(document, "/session/{sessionID}", "patch", session)
   patchJsonResponse(document, "/session/{sessionID}/children", "get", arrayOf(session))
+  patchParameterSchemas(document, "/session/{sessionID}/message", "get", {
+    limit: { type: "number" },
+  })
   patchJsonResponse(document, "/session/{sessionID}/message", "get", arrayOf(messageWithParts(message)))
   patchRequestBody(document, "/session/{sessionID}/message", "post", promptBody)
   patchJsonResponse(document, "/session/{sessionID}/message", "post", messageWithParts(assistant))
@@ -211,10 +225,10 @@ function patchAutomationSchemas(document: OpenApiDocument, schemas: Record<strin
   patchParameterSchemas(document, "/automation/{automationID}/resume", "post", { automationID })
 
   patchJsonResponse(document, "/automation", "get", schemaRef("AutomationListResponse"))
-  patchRequestBody(document, "/automation", "post", schemas.AutomationCreateInputInline)
+  patchRequestBody(document, "/automation", "post", schemaRef("AutomationCreateInput"))
   patchJsonResponse(document, "/automation", "post", definition)
   patchJsonResponse(document, "/automation/{automationID}", "get", definition)
-  patchRequestBody(document, "/automation/{automationID}", "put", schemas.AutomationUpdateInputInline)
+  patchRequestBody(document, "/automation/{automationID}", "put", schemaRef("AutomationUpdateInput"))
   patchJsonResponse(document, "/automation/{automationID}", "put", definition)
   patchJsonResponse(document, "/automation/{automationID}", "delete", schemaRef("AutomationDefinitionTombstone"))
   patchJsonResponse(document, "/automation/{automationID}/runs", "get", schemaRef("AutomationRunsResponse"))
@@ -242,16 +256,141 @@ function memoryStateSchema() {
 function patchMemorySchemas(document: OpenApiDocument) {
   const memoryState = schemaRef("MemoryState")
   patchJsonResponse(document, "/memory", "get", memoryState)
+  patchRequestBody(document, "/memory", "patch", schemaRef("MemoryRawInput"))
   patchJsonResponse(document, "/memory", "patch", memoryState)
   patchJsonResponse(document, "/memory/reset", "post", memoryState)
+  patchRequestBody(document, "/memory/disabled", "patch", schemaRef("MemoryDisabledInput"))
   patchJsonResponse(document, "/memory/disabled", "patch", memoryState)
   patchJsonResponse(document, "/memory/entry/{id}", "delete", memoryState)
 }
 
 function patchAdditionalRouteSchemas(document: OpenApiDocument) {
+  patchParameterSchemas(document, "/path", "get", {
+    ensureConfig: { type: "boolean" },
+  })
+  patchJsonResponse(document, "/project", "get", arrayOf(schemaRef("Project")))
+  patchJsonResponse(document, "/project/current", "get", schemaRef("Project"))
+  patchJsonResponse(document, "/project", "patch", schemaRef("Project"))
+  patchParameterSchemas(document, "/experimental/session", "get", {
+    roots: { type: "boolean" },
+    start: { type: "number" },
+    limit: { type: "number" },
+    archived: { type: "boolean" },
+  })
   patchJsonResponse(document, "/experimental/session", "get", arrayOf(schemaRef("GlobalSession")))
+  upsertQueryParameters(document, "/experimental/worktree", "get", workspaceRoutingParameters)
+  upsertQueryParameters(document, "/experimental/worktree", "post", workspaceRoutingParameters)
+  upsertQueryParameters(document, "/experimental/worktree", "delete", workspaceRoutingParameters)
+  upsertQueryParameters(document, "/experimental/worktree/reset", "post", workspaceRoutingParameters)
+  patchRequestBody(document, "/experimental/worktree", "post", schemaRef("WorktreeCreateInput"), { required: false })
+  patchRequestBody(document, "/experimental/worktree", "delete", schemaRef("WorktreeRemoveInput"))
+  patchRequestBody(document, "/experimental/worktree/reset", "post", schemaRef("WorktreeResetInput"))
+  patchJsonResponse(document, "/permission", "get", arrayOf(schemaRef("PermissionRequest")))
+  patchJsonResponse(document, "/external-result", "get", arrayOf(schemaRef("PendingExternalResult")))
   patchJsonResponse(document, "/session/{sessionID}/artifacts", "get", arrayOf(schemaRef("SessionArtifact")))
+  patchParameterSchemas(document, "/find/file", "get", {
+    limit: { type: "number" },
+  })
   patchJsonResponse(document, "/find/symbol", "get", arrayOf(schemaRef("Symbol")))
+  patchJsonResponse(document, "/file/content", "get", schemaRef("FileContent"))
+}
+
+function memoryInputSchemas() {
+  return {
+    MemoryRawInput: {
+      type: "object",
+      properties: {
+        content: { type: "string" },
+      },
+      required: ["content"],
+    },
+    MemoryDisabledInput: {
+      type: "object",
+      properties: {
+        disabled: { type: "boolean" },
+      },
+      required: ["disabled"],
+    },
+  }
+}
+
+function worktreeInputSchemas() {
+  return {
+    WorktreeCreateInput: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        startCommand: {
+          type: "string",
+          description: "Additional startup script to run after the project's start command",
+        },
+      },
+    },
+    WorktreeRemoveInput: {
+      type: "object",
+      properties: {
+        directory: { type: "string" },
+      },
+      required: ["directory"],
+    },
+    WorktreeResetInput: {
+      type: "object",
+      properties: {
+        directory: { type: "string" },
+      },
+      required: ["directory"],
+    },
+  }
+}
+
+function fileContentSchema() {
+  const patchHunk = {
+    type: "object",
+    properties: {
+      oldStart: { type: "number" },
+      oldLines: { type: "number" },
+      newStart: { type: "number" },
+      newLines: { type: "number" },
+      lines: arrayOf({ type: "string" }),
+    },
+    required: ["oldStart", "oldLines", "newStart", "newLines", "lines"],
+  }
+
+  return {
+    type: "object",
+    properties: {
+      type: { type: "string", enum: ["text", "binary"] },
+      content: { type: "string" },
+      diff: { type: "string" },
+      patch: {
+        type: "object",
+        properties: {
+          oldFileName: { type: "string" },
+          newFileName: { type: "string" },
+          oldHeader: { type: "string" },
+          newHeader: { type: "string" },
+          hunks: arrayOf(patchHunk),
+          index: { type: "string" },
+        },
+        required: ["oldFileName", "newFileName", "hunks"],
+      },
+      encoding: { type: "string", enum: ["base64"] },
+      mimeType: { type: "string" },
+    },
+    required: ["type", "content"],
+  }
+}
+
+function pendingExternalResultSchema() {
+  return {
+    type: "object",
+    properties: {
+      session: schemaRef("Session"),
+      message: schemaRef("Message"),
+      part: schemaRef("Part"),
+    },
+    required: ["session", "message", "part"],
+  }
 }
 
 const workspaceRoutingParameters = [
@@ -488,6 +627,10 @@ export async function controlOpenApi() {
   document.components.schemas = {
     ...document.components.schemas,
     MemoryState: memoryStateSchema(),
+    ...memoryInputSchemas(),
+    ...worktreeInputSchemas(),
+    FileContent: fileContentSchema(),
+    PendingExternalResult: pendingExternalResultSchema(),
   }
   const sessionPatchRefs = {
     PromptBody: prompt.schema,

--- a/packages/opencode/src/server/openapi.ts
+++ b/packages/opencode/src/server/openapi.ts
@@ -7,7 +7,7 @@ import { InstanceRoutes } from "./routes/instance"
 import { InstanceMiddleware } from "./routes/instance/middleware"
 import { WorkspaceRoutes } from "./routes/control/workspace"
 
-export async function serverOpenApi() {
+export async function legacyServerOpenApi() {
   // Spec-generation compatibility only. Production requests are dispatched by
   // the native server app in server.ts, not this Hono documentation tree.
   const app = new Hono().route("/global", GlobalRoutes())

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -189,6 +189,7 @@ export const SessionApi = HttpApi.make("session")
           success: Schema.Array(Schema.Any),
         }).annotateMerge(operation("session.list")),
         HttpApiEndpoint.post("create", SessionPaths.create, {
+          query: WorkspaceRoutingQuery,
           payload: Schema.optional(Schema.Any),
           success: Schema.Any,
           error: BadRequestError,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -216,8 +216,8 @@ function create(opts: { cors?: string[] }) {
 }
 
 export async function openapi() {
-  const { serverOpenApi } = await import("./openapi")
-  return serverOpenApi()
+  const { controlOpenApi } = await import("./control-openapi")
+  return controlOpenApi()
 }
 
 export let url: URL

--- a/packages/opencode/test/server/openapi-generation-source.test.ts
+++ b/packages/opencode/test/server/openapi-generation-source.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
 import { controlOpenApi } from "../../src/server/control-openapi"
+import { Server } from "../../src/server/server"
 
 const expectedProductionEventSchemaRefs = [
   "Event.automation.definition.deleted",
@@ -157,38 +158,18 @@ describe("OpenAPI generation source", () => {
     expect(JSON.stringify(schemas.Config)).toContain("#/components/schemas/AgentConfig")
   })
 
-  test("documents the remaining checked-in SDK OpenAPI drift from the production source", async () => {
+  test("keeps the public generated OpenAPI path set aligned with the production source", async () => {
     const checkedIn = JSON.parse(await readFile(path.join(import.meta.dir, "../../../sdk/openapi.json"), "utf8"))
+    const generated = await Server.openapi()
     const production = await controlOpenApi()
     const checkedInPaths = new Set(Object.keys(checkedIn.paths ?? {}))
+    const generatedPaths = new Set(Object.keys(generated.paths ?? {}))
     const productionPaths = new Set(Object.keys(production.paths ?? {}))
 
-    expect([...productionPaths].filter((routePath) => !checkedInPaths.has(routePath)).sort()).toEqual([
-      "/automation",
-      "/automation/{automationID}",
-      "/automation/{automationID}/pause",
-      "/automation/{automationID}/resume",
-      "/automation/{automationID}/run",
-      "/automation/{automationID}/runs",
-      "/external-result",
-      "/memory",
-      "/memory/disabled",
-      "/memory/entry/{id}",
-      "/memory/reset",
-      "/permission/__e2e/ask",
-      "/provider/recent",
-      "/session/__e2e/update-todos",
-      "/session/{sessionID}/tool/respond",
-      "/session/{sessionID}/turn-change/{messageID}",
-      "/session/{sessionID}/turn-change/{messageID}/redo",
-      "/session/{sessionID}/turn-change/{messageID}/undo",
-      "/session/{sessionID}/turn/{userMessageID}/changes",
-      "/session/{sessionID}/turn/{userMessageID}/changes/redo",
-      "/session/{sessionID}/turn/{userMessageID}/changes/undo",
-      "/vcs/apply",
-      "/vcs/diff/raw",
-      "/vcs/status",
-    ])
+    expect(generated.info).toEqual(production.info)
+    expect([...productionPaths].filter((routePath) => !generatedPaths.has(routePath)).sort()).toEqual([])
+    expect([...generatedPaths].filter((routePath) => !productionPaths.has(routePath)).sort()).toEqual([])
+    expect([...productionPaths].filter((routePath) => !checkedInPaths.has(routePath)).sort()).toEqual([])
     expect([...checkedInPaths].filter((routePath) => !productionPaths.has(routePath)).sort()).toEqual([])
   })
 })

--- a/packages/opencode/test/server/openapi-generation-source.test.ts
+++ b/packages/opencode/test/server/openapi-generation-source.test.ts
@@ -75,6 +75,27 @@ function syncEventSchemaRefs(spec: Awaited<ReturnType<typeof controlOpenApi>>) {
     .sort()
 }
 
+function requestBodySchemaRef(spec: Awaited<ReturnType<typeof controlOpenApi>>, routePath: string, method: string) {
+  const operation = spec.paths?.[routePath]?.[method] as
+    | { requestBody?: { content?: { "application/json"?: { schema?: { $ref?: string } } } } }
+    | undefined
+  return operation?.requestBody?.content?.["application/json"]?.schema?.$ref
+}
+
+function queryParameterSchema(spec: Awaited<ReturnType<typeof controlOpenApi>>, routePath: string, method: string, name: string) {
+  const operation = spec.paths?.[routePath]?.[method] as
+    | { parameters?: Array<{ in?: string; name?: string; schema?: unknown }> }
+    | undefined
+  return operation?.parameters?.find((parameter) => parameter.in === "query" && parameter.name === name)?.schema
+}
+
+function jsonResponseSchema(spec: Awaited<ReturnType<typeof controlOpenApi>>, routePath: string, method: string) {
+  const operation = spec.paths?.[routePath]?.[method] as
+    | { responses?: Record<string, { content?: { "application/json"?: { schema?: unknown } } }> }
+    | undefined
+  return operation?.responses?.["200"]?.content?.["application/json"]?.schema
+}
+
 function generateAfterIsolatedEventLeak() {
   const script = `
     import z from "zod"
@@ -156,6 +177,62 @@ describe("OpenAPI generation source", () => {
 
     expect(schemas).toHaveProperty("AgentConfig")
     expect(JSON.stringify(schemas.Config)).toContain("#/components/schemas/AgentConfig")
+  })
+
+  test("keeps generated SDK parameter and response shapes compatible with the production source", async () => {
+    const spec = await controlOpenApi()
+    const schemas = spec.components?.schemas as Record<string, any>
+
+    expect(requestBodySchemaRef(spec, "/memory", "patch")).toBe("#/components/schemas/MemoryRawInput")
+    expect(requestBodySchemaRef(spec, "/memory/disabled", "patch")).toBe("#/components/schemas/MemoryDisabledInput")
+    expect(requestBodySchemaRef(spec, "/automation", "post")).toBe("#/components/schemas/AutomationCreateInput")
+    expect(requestBodySchemaRef(spec, "/automation/{automationID}", "put")).toBe(
+      "#/components/schemas/AutomationUpdateInput",
+    )
+    expect(requestBodySchemaRef(spec, "/experimental/worktree", "post")).toBe(
+      "#/components/schemas/WorktreeCreateInput",
+    )
+    expect(requestBodySchemaRef(spec, "/experimental/worktree", "delete")).toBe(
+      "#/components/schemas/WorktreeRemoveInput",
+    )
+    expect(requestBodySchemaRef(spec, "/experimental/worktree/reset", "post")).toBe(
+      "#/components/schemas/WorktreeResetInput",
+    )
+
+    expect(queryParameterSchema(spec, "/path", "get", "ensureConfig")).toMatchObject({ type: "boolean" })
+    expect(queryParameterSchema(spec, "/session/{sessionID}/message", "get", "limit")).toMatchObject({
+      type: "number",
+    })
+    expect(queryParameterSchema(spec, "/experimental/session", "get", "roots")).toMatchObject({ type: "boolean" })
+    expect(queryParameterSchema(spec, "/experimental/session", "get", "start")).toMatchObject({ type: "number" })
+    expect(queryParameterSchema(spec, "/experimental/session", "get", "limit")).toMatchObject({ type: "number" })
+    expect(queryParameterSchema(spec, "/experimental/session", "get", "archived")).toMatchObject({ type: "boolean" })
+    expect(queryParameterSchema(spec, "/find/file", "get", "limit")).toMatchObject({ type: "number" })
+
+    expect(jsonResponseSchema(spec, "/project", "get")).toEqual({
+      type: "array",
+      items: { $ref: "#/components/schemas/Project" },
+    })
+    expect(jsonResponseSchema(spec, "/permission", "get")).toEqual({
+      type: "array",
+      items: { $ref: "#/components/schemas/PermissionRequest" },
+    })
+    expect(jsonResponseSchema(spec, "/external-result", "get")).toEqual({
+      type: "array",
+      items: { $ref: "#/components/schemas/PendingExternalResult" },
+    })
+    expect(schemas.PendingExternalResult.properties).toMatchObject({
+      session: { $ref: "#/components/schemas/Session" },
+      message: { $ref: "#/components/schemas/Message" },
+      part: { $ref: "#/components/schemas/Part" },
+    })
+    expect(schemas.FileContent.properties.patch.properties.hunks.items.properties).toMatchObject({
+      oldStart: { type: "number" },
+      oldLines: { type: "number" },
+      newStart: { type: "number" },
+      newLines: { type: "number" },
+      lines: { type: "array", items: { type: "string" } },
+    })
   })
 
   test("keeps the public generated OpenAPI path set aligned with the production source", async () => {

--- a/packages/opencode/test/server/production-boundary.test.ts
+++ b/packages/opencode/test/server/production-boundary.test.ts
@@ -106,10 +106,10 @@ describe("production server boundary", () => {
     expect(server).not.toContain("compatibility.fetch")
   })
 
-  test("keeps legacy route tree usage isolated to spec generation", async () => {
+  test("keeps the legacy route tree explicitly named as legacy", async () => {
     const openapi = await readFile(path.join(import.meta.dir, "../../src/server/openapi.ts"), "utf8")
 
-    expect(openapi).toContain("serverOpenApi")
+    expect(openapi).toContain("legacyServerOpenApi")
     expect(openapi).toContain("generateSpecs")
     expect(openapi).toContain("InstanceRoutes")
     expect(openapi).toContain("ControlPlaneRoutes")
@@ -125,7 +125,8 @@ describe("production server boundary", () => {
     const controlOpenApi = await readFile(path.join(import.meta.dir, "../../src/server/control-openapi.ts"), "utf8")
 
     expect(server).not.toContain('from "./openapi"')
-    expect(server).toContain('await import("./openapi")')
+    expect(server).not.toContain('await import("./openapi")')
+    expect(server).toContain('await import("./control-openapi")')
     expect(controlHandler).not.toContain("ControlPlaneRoutes")
     expect(controlHandler).not.toContain('request("/doc")')
     expect(controlHandler).not.toContain("@/server/openapi")

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -371,7 +371,7 @@ describe("pty routes", () => {
     expect(tokenResponse?.content).toBeTruthy()
 
     const parameters = spec.paths?.["/pty/{ptyID}/connect"]?.get?.parameters ?? []
-    const names = parameters.map((parameter) => ("name" in parameter ? parameter.name : undefined))
+    const names = parameters.map((parameter: { name?: string }) => parameter.name)
 
     expect(names).toContain("cursor")
     expect(names).toContain("ticket")

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -20,7 +20,7 @@ function hasRoute(routes: ReadonlyArray<{ method: string; path: string }>, metho
 }
 
 describe("route inventory harness", () => {
-  test("discovers PawWork-owned Hono routes that the checked-in OpenAPI surface can miss", async () => {
+  test("discovers PawWork-owned Hono routes now covered by the checked-in OpenAPI surface", async () => {
     const inventory = await buildRouteInventory({ root, requireUpstream: false })
 
     expect(hasRoute(inventory.hono.routes, "GET", "/external-result")).toBe(true)
@@ -29,7 +29,7 @@ describe("route inventory harness", () => {
     expect(hasRoute(inventory.hono.routes, "POST", "/session/:sessionID/tool/respond")).toBe(true)
     expect(hasRoute(inventory.hono.routes, "GET", "/session/:sessionID/turn/:userMessageID/changes")).toBe(true)
 
-    expect(hasRoute(inventory.openapi.routes, "GET", "/external-result")).toBe(false)
+    expect(hasRoute(inventory.openapi.routes, "GET", "/external-result")).toBe(true)
     expect(hasRoute(inventory.legacySdk.routes, "GET", "/external-result")).toBe(false)
     expect(hasRoute(inventory.v2Sdk.routes, "GET", "/external-result")).toBe(true)
   })
@@ -40,10 +40,10 @@ describe("route inventory harness", () => {
     const externalResult = inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")
     expect(externalResult).toMatchObject({
       hono: true,
-      openapi: false,
+      openapi: true,
       legacySdk: false,
       v2Sdk: true,
-      classification: "pawwork-owned-sdk-v2-only",
+      classification: "pawwork-owned",
     })
 
     expect(inventory.counts.openapi).toBeGreaterThanOrEqual(90)
@@ -101,7 +101,7 @@ describe("route inventory harness", () => {
     expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")).toMatchObject({
       hono: true,
       localHttpApi: true,
-      classification: "pawwork-owned-sdk-v2-only",
+      classification: "pawwork-owned",
     })
   })
 
@@ -133,7 +133,8 @@ describe("route inventory harness", () => {
     }
 
     expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")).toMatchObject({
-      classification: "pawwork-owned-sdk-v2-only",
+      openapi: true,
+      classification: "pawwork-owned",
     })
   })
 
@@ -402,7 +403,7 @@ describe("route inventory harness", () => {
 
     expect(
       inventory.rows.find((row) => row.method === "POST" && row.path === "/permission/__e2e/ask"),
-    ).toMatchObject({ hono: true, openapi: false, v2Sdk: true, localHttpApi: true, classification: "hono-v2-sdk" })
+    ).toMatchObject({ hono: true, openapi: true, v2Sdk: true, localHttpApi: true, classification: "openapi-v2-sdk" })
   })
 
   test("does not report retired question HTTP routes as OpenAPI-only residue", async () => {

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -10,10 +10,12 @@ import { readFile, writeFile } from "fs/promises"
 
 import { createClient } from "@hey-api/openapi-ts"
 
-await $`bun dev generate > ${dir}/openapi.json`.cwd(path.resolve(dir, "../../opencode"))
+const openApiPath = path.resolve(dir, "../openapi.json")
+
+await $`bun dev generate > ${openApiPath}`.cwd(path.resolve(dir, "../../opencode"))
 
 await createClient({
-  input: "./openapi.json",
+  input: openApiPath,
   output: {
     path: "./src/v2/gen",
     tsConfigPath: path.join(dir, "tsconfig.json"),
@@ -49,7 +51,6 @@ await patchV2SseSplitCrLfHandling()
 await $`bun prettier --write src/v2`
 await $`rm -rf dist`
 await $`bun tsc`
-await $`rm openapi.json`
 
 async function patchV2ClientErrorInterceptorOptions() {
   const clientPath = path.join(dir, "src/v2/gen/client/client.gen.ts")

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -3,7 +3,33 @@ export * from "./gen/types.gen.js"
 import { createClient } from "./gen/client/client.gen.js"
 import { type Config } from "./gen/client/types.gen.js"
 import { OpencodeClient } from "./gen/sdk.gen.js"
+import type {
+  AppAgentsResponse,
+  CommandListResponse,
+  FileListResponse,
+  FileReadResponse,
+  LspStatusResponse,
+  McpStatusResponse,
+  PathGetResponse,
+  VcsGetResponse,
+} from "./gen/types.gen.js"
 export { type Config as OpencodeClientConfig, OpencodeClient }
+
+export type FileNode = FileListResponse[number]
+export type FileContent = FileReadResponse
+export type McpStatus = McpStatusResponse[string]
+export type Path = PathGetResponse
+export type VcsInfo = VcsGetResponse
+export type VcsFileDiff = {
+  file: string
+  patch: string
+  additions: number
+  deletions: number
+  status?: "added" | "deleted" | "modified"
+}
+export type Command = CommandListResponse[number]
+export type Agent = AppAgentsResponse[number]
+export type LspStatus = LspStatusResponse[number]
 
 function pick(value: string | null, fallback?: string, encode?: (value: string) => string) {
   if (!value) return

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -14,26 +14,24 @@ import type {
   AuthSetErrors,
   AuthSetResponses,
   AutomationCreateErrors,
+  AutomationCreateInput,
   AutomationCreateResponses,
   AutomationDeleteErrors,
   AutomationDeleteResponses,
   AutomationGetErrors,
   AutomationGetResponses,
   AutomationListResponses,
-  AutomationModel,
   AutomationPauseErrors,
   AutomationPauseResponses,
   AutomationResumeErrors,
   AutomationResumeResponses,
-  AutomationRhythm,
   AutomationRunNowErrors,
   AutomationRunNowResponses,
   AutomationRunsErrors,
   AutomationRunsResponses,
-  AutomationStop,
   AutomationUpdateErrors,
+  AutomationUpdateInput,
   AutomationUpdateResponses,
-  AutomationWhere,
   CommandListResponses,
   Config as Config3,
   ConfigGetResponses,
@@ -92,8 +90,10 @@ import type {
   McpStatusResponses,
   MemoryDeleteEntryResponses,
   MemoryDisabledErrors,
+  MemoryDisabledInput,
   MemoryDisabledResponses,
   MemoryGetResponses,
+  MemoryRawInput,
   MemoryResetResponses,
   MemoryUpdateErrors,
   MemoryUpdateResponses,
@@ -217,11 +217,14 @@ import type {
   VcsGetResponses,
   VcsStatusResponses,
   WorktreeCreateErrors,
+  WorktreeCreateInput,
   WorktreeCreateResponses,
   WorktreeListResponses,
   WorktreeRemoveErrors,
+  WorktreeRemoveInput,
   WorktreeRemoveResponses,
   WorktreeResetErrors,
+  WorktreeResetInput,
   WorktreeResetResponses,
 } from "./types.gen.js"
 
@@ -791,12 +794,12 @@ export class Session extends HeyApiClient {
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
-      roots?: "true" | "false"
-      start?: string
+      roots?: boolean
+      start?: number
       cursor?: string
       search?: string
-      limit?: string
-      archived?: "true" | "false"
+      limit?: number
+      archived?: boolean
       sort?: "updated" | "created" | "activity"
     },
     options?: Options<never, ThrowOnError>,
@@ -890,7 +893,7 @@ export class Path extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
-      ensureConfig?: "true" | "false"
+      ensureConfig?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1618,11 +1621,24 @@ export class Worktree extends HeyApiClient {
    */
   public remove<ThrowOnError extends boolean = false>(
     parameters: {
-      directory: string
+      directory?: string
+      workspace?: string
+      worktreeRemoveInput: WorktreeRemoveInput
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "directory" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { key: "worktreeRemoveInput", map: "body" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).delete<WorktreeRemoveResponses, WorktreeRemoveErrors, ThrowOnError>({
       url: "/experimental/worktree",
       ...options,
@@ -1640,10 +1656,28 @@ export class Worktree extends HeyApiClient {
    *
    * List all sandbox worktrees for the current project.
    */
-  public list<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).get<WorktreeListResponses, unknown, ThrowOnError>({
       url: "/experimental/worktree",
       ...options,
+      ...params,
     })
   }
 
@@ -1653,15 +1687,25 @@ export class Worktree extends HeyApiClient {
    * Create a new git worktree for the current project and run any configured startup scripts.
    */
   public create<ThrowOnError extends boolean = false>(
-    parameters: {
-      body: {
-        name?: string
-        startCommand?: string
-      } | null
+    parameters?: {
+      directory?: string
+      workspace?: string
+      worktreeCreateInput?: WorktreeCreateInput
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ key: "body", map: "body" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { key: "worktreeCreateInput", map: "body" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).post<WorktreeCreateResponses, WorktreeCreateErrors, ThrowOnError>({
       url: "/experimental/worktree",
       ...options,
@@ -1681,11 +1725,24 @@ export class Worktree extends HeyApiClient {
    */
   public reset<ThrowOnError extends boolean = false>(
     parameters: {
-      directory: string
+      directory?: string
+      workspace?: string
+      worktreeResetInput: WorktreeResetInput
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "directory" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { key: "worktreeResetInput", map: "body" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).post<WorktreeResetResponses, WorktreeResetErrors, ThrowOnError>({
       url: "/experimental/worktree/reset",
       ...options,
@@ -2007,7 +2064,7 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
-      limit?: string
+      limit?: number
       before?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -3398,7 +3455,7 @@ export class Memory extends HeyApiClient {
     parameters: {
       directory?: string
       workspace?: string
-      content: string
+      memoryRawInput: MemoryRawInput
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3409,7 +3466,7 @@ export class Memory extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { in: "body", key: "content" },
+            { key: "memoryRawInput", map: "body" },
           ],
         },
       ],
@@ -3461,7 +3518,7 @@ export class Memory extends HeyApiClient {
     parameters: {
       directory?: string
       workspace?: string
-      disabled: boolean
+      memoryDisabledInput: MemoryDisabledInput
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3472,7 +3529,7 @@ export class Memory extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { in: "body", key: "disabled" },
+            { key: "memoryDisabledInput", map: "body" },
           ],
         },
       ],
@@ -3560,30 +3617,7 @@ export class Automation extends HeyApiClient {
     parameters: {
       directory?: string
       workspace?: string
-      body:
-        | {
-            kind: "oneshot"
-            title: string
-            prompt: string
-            context: "continue" | "fresh"
-            where: AutomationWhere
-            timezone: string
-            model: AutomationModel
-            variant?: string
-            fireAt: number
-          }
-        | {
-            kind: "recurring"
-            title: string
-            prompt: string
-            context: "continue" | "fresh"
-            where: AutomationWhere
-            timezone: string
-            model: AutomationModel
-            variant?: string
-            rhythm: AutomationRhythm
-            stop: AutomationStop
-          }
+      automationCreateInput: AutomationCreateInput
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3594,7 +3628,7 @@ export class Automation extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { key: "body", map: "body" },
+            { key: "automationCreateInput", map: "body" },
           ],
         },
       ],
@@ -3685,17 +3719,7 @@ export class Automation extends HeyApiClient {
       automationID: string
       directory?: string
       workspace?: string
-      title?: string
-      prompt?: string
-      paused?: boolean
-      context?: "continue" | "fresh"
-      where?: AutomationWhere
-      timezone?: string
-      fireAt?: number
-      rhythm?: AutomationRhythm
-      stop?: AutomationStop
-      model?: AutomationModel
-      variant?: string | null
+      automationUpdateInput: AutomationUpdateInput
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3707,17 +3731,7 @@ export class Automation extends HeyApiClient {
             { in: "path", key: "automationID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { in: "body", key: "title" },
-            { in: "body", key: "prompt" },
-            { in: "body", key: "paused" },
-            { in: "body", key: "context" },
-            { in: "body", key: "where" },
-            { in: "body", key: "timezone" },
-            { in: "body", key: "fireAt" },
-            { in: "body", key: "rhythm" },
-            { in: "body", key: "stop" },
-            { in: "body", key: "model" },
-            { in: "body", key: "variant" },
+            { key: "automationUpdateInput", map: "body" },
           ],
         },
       ],
@@ -3912,7 +3926,7 @@ export class Find extends HeyApiClient {
       query: string
       dirs?: "true" | "false"
       type?: "file" | "directory"
-      limit?: string
+      limit?: number
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -14,24 +14,26 @@ import type {
   AuthSetErrors,
   AuthSetResponses,
   AutomationCreateErrors,
-  AutomationCreateInput,
   AutomationCreateResponses,
   AutomationDeleteErrors,
   AutomationDeleteResponses,
   AutomationGetErrors,
   AutomationGetResponses,
   AutomationListResponses,
+  AutomationModel,
   AutomationPauseErrors,
   AutomationPauseResponses,
   AutomationResumeErrors,
   AutomationResumeResponses,
+  AutomationRhythm,
   AutomationRunNowErrors,
   AutomationRunNowResponses,
   AutomationRunsErrors,
   AutomationRunsResponses,
+  AutomationStop,
   AutomationUpdateErrors,
-  AutomationUpdateInput,
   AutomationUpdateResponses,
+  AutomationWhere,
   CommandListResponses,
   Config as Config3,
   ConfigGetResponses,
@@ -42,6 +44,7 @@ import type {
   EventSubscribeResponses,
   ExperimentalConsoleGetResponses,
   ExperimentalConsoleListOrgsResponses,
+  ExperimentalConsoleSwitchOrgErrors,
   ExperimentalConsoleSwitchOrgResponses,
   ExperimentalResourceListResponses,
   ExperimentalSessionListResponses,
@@ -79,7 +82,6 @@ import type {
   McpAuthAuthenticateResponses,
   McpAuthCallbackErrors,
   McpAuthCallbackResponses,
-  McpAuthRemoveErrors,
   McpAuthRemoveResponses,
   McpAuthStartErrors,
   McpAuthStartResponses,
@@ -89,10 +91,9 @@ import type {
   McpRemoteConfig,
   McpStatusResponses,
   MemoryDeleteEntryResponses,
-  MemoryDisabledInput,
+  MemoryDisabledErrors,
   MemoryDisabledResponses,
   MemoryGetResponses,
-  MemoryRawInput,
   MemoryResetResponses,
   MemoryUpdateErrors,
   MemoryUpdateResponses,
@@ -103,14 +104,14 @@ import type {
   PartUpdateErrors,
   PartUpdateResponses,
   PathGetResponses,
+  PermissionE2eAskErrors,
+  PermissionE2eAskResponses,
   PermissionListResponses,
   PermissionReplyErrors,
   PermissionReplyResponses,
   PermissionRespondErrors,
   PermissionRespondResponses,
   PermissionRuleset,
-  PostPermissionE2eAskResponses,
-  PostSessionE2eUpdateTodosResponses,
   ProjectCurrentResponses,
   ProjectInitGitResponses,
   ProjectListResponses,
@@ -125,7 +126,6 @@ import type {
   ProviderRecordRecentErrors,
   ProviderRecordRecentResponses,
   PtyConnectErrors,
-  PtyConnectResponses,
   PtyConnectTokenErrors,
   PtyConnectTokenResponses,
   PtyCreateErrors,
@@ -151,6 +151,8 @@ import type {
   SessionDeleteMessageResponses,
   SessionDeleteResponses,
   SessionDiffResponses,
+  SessionE2eUpdateTodosErrors,
+  SessionE2eUpdateTodosResponses,
   SessionExportErrors,
   SessionExportResponses,
   SessionForkErrors,
@@ -215,14 +217,11 @@ import type {
   VcsGetResponses,
   VcsStatusResponses,
   WorktreeCreateErrors,
-  WorktreeCreateInput,
   WorktreeCreateResponses,
   WorktreeListResponses,
   WorktreeRemoveErrors,
-  WorktreeRemoveInput,
   WorktreeRemoveResponses,
   WorktreeResetErrors,
-  WorktreeResetInput,
   WorktreeResetResponses,
 } from "./types.gen.js"
 
@@ -270,132 +269,6 @@ class HeyApiRegistry<T> {
   }
 }
 
-export class SyncEvent extends HeyApiClient {
-  /**
-   * Subscribe to global sync events
-   *
-   * Get global sync events
-   */
-  public subscribe<ThrowOnError extends boolean = false>(
-    options?: Options<never, ThrowOnError, GlobalSyncEventSubscribeResponse>,
-  ) {
-    return (options?.client ?? this.client).sse.get<GlobalSyncEventSubscribeResponses, unknown, ThrowOnError>({
-      url: "/global/sync-event",
-      ...options,
-    })
-  }
-}
-
-export class Config extends HeyApiClient {
-  /**
-   * Get global configuration
-   *
-   * Retrieve the current global OpenCode configuration settings and preferences.
-   */
-  public get<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
-    return (options?.client ?? this.client).get<GlobalConfigGetResponses, unknown, ThrowOnError>({
-      url: "/global/config",
-      ...options,
-    })
-  }
-
-  /**
-   * Update global configuration
-   *
-   * Update global OpenCode configuration settings and preferences.
-   */
-  public update<ThrowOnError extends boolean = false>(
-    parameters?: {
-      config?: Config3
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams([parameters], [{ args: [{ key: "config", map: "body" }] }])
-    return (options?.client ?? this.client).patch<GlobalConfigUpdateResponses, GlobalConfigUpdateErrors, ThrowOnError>({
-      url: "/global/config",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-}
-
-export class Global extends HeyApiClient {
-  /**
-   * Get health
-   *
-   * Get health information about the OpenCode server.
-   */
-  public health<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
-    return (options?.client ?? this.client).get<GlobalHealthResponses, unknown, ThrowOnError>({
-      url: "/global/health",
-      ...options,
-    })
-  }
-
-  /**
-   * Get global events
-   *
-   * Subscribe to global events from the OpenCode system using server-sent events.
-   */
-  public event<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError, GlobalEventResponse>) {
-    return (options?.client ?? this.client).sse.get<GlobalEventResponses, unknown, ThrowOnError>({
-      url: "/global/event",
-      ...options,
-    })
-  }
-
-  /**
-   * Dispose instance
-   *
-   * Clean up and dispose all OpenCode instances, releasing all resources.
-   */
-  public dispose<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
-    return (options?.client ?? this.client).post<GlobalDisposeResponses, unknown, ThrowOnError>({
-      url: "/global/dispose",
-      ...options,
-    })
-  }
-
-  /**
-   * Upgrade opencode
-   *
-   * Upgrade opencode to the specified version or latest if not specified.
-   */
-  public upgrade<ThrowOnError extends boolean = false>(
-    parameters?: {
-      target?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "target" }] }])
-    return (options?.client ?? this.client).post<GlobalUpgradeResponses, GlobalUpgradeErrors, ThrowOnError>({
-      url: "/global/upgrade",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  private _syncEvent?: SyncEvent
-  get syncEvent(): SyncEvent {
-    return (this._syncEvent ??= new SyncEvent({ client: this.client }))
-  }
-
-  private _config?: Config
-  get config(): Config {
-    return (this._config ??= new Config({ client: this.client }))
-  }
-}
-
 export class Auth extends HeyApiClient {
   /**
    * Remove auth credentials
@@ -424,7 +297,7 @@ export class Auth extends HeyApiClient {
   public set<ThrowOnError extends boolean = false>(
     parameters: {
       providerID: string
-      auth?: Auth3
+      auth: Auth3
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -467,7 +340,7 @@ export class App extends HeyApiClient {
       message: string
       extra?: {
         [key: string]: unknown
-      }
+      } | null
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -559,6 +432,132 @@ export class App extends HeyApiClient {
   }
 }
 
+export class Config extends HeyApiClient {
+  /**
+   * Get global configuration
+   *
+   * Retrieve the current global OpenCode configuration settings and preferences.
+   */
+  public get<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<GlobalConfigGetResponses, unknown, ThrowOnError>({
+      url: "/global/config",
+      ...options,
+    })
+  }
+
+  /**
+   * Update global configuration
+   *
+   * Update global OpenCode configuration settings and preferences.
+   */
+  public update<ThrowOnError extends boolean = false>(
+    parameters: {
+      config: Config3
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ key: "config", map: "body" }] }])
+    return (options?.client ?? this.client).patch<GlobalConfigUpdateResponses, GlobalConfigUpdateErrors, ThrowOnError>({
+      url: "/global/config",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class SyncEvent extends HeyApiClient {
+  /**
+   * Subscribe to global sync events
+   *
+   * Get global sync events
+   */
+  public subscribe<ThrowOnError extends boolean = false>(
+    options?: Options<never, ThrowOnError, GlobalSyncEventSubscribeResponse>,
+  ) {
+    return (options?.client ?? this.client).sse.get<GlobalSyncEventSubscribeResponses, unknown, ThrowOnError>({
+      url: "/global/sync-event",
+      ...options,
+    })
+  }
+}
+
+export class Global extends HeyApiClient {
+  /**
+   * Get health
+   *
+   * Get health information about the OpenCode server.
+   */
+  public health<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<GlobalHealthResponses, unknown, ThrowOnError>({
+      url: "/global/health",
+      ...options,
+    })
+  }
+
+  /**
+   * Dispose instance
+   *
+   * Clean up and dispose all OpenCode instances, releasing all resources.
+   */
+  public dispose<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).post<GlobalDisposeResponses, unknown, ThrowOnError>({
+      url: "/global/dispose",
+      ...options,
+    })
+  }
+
+  /**
+   * Upgrade opencode
+   *
+   * Upgrade opencode to the specified version or latest if not specified.
+   */
+  public upgrade<ThrowOnError extends boolean = false>(
+    parameters?: {
+      target?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "target" }] }])
+    return (options?.client ?? this.client).post<GlobalUpgradeResponses, GlobalUpgradeErrors, ThrowOnError>({
+      url: "/global/upgrade",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Get global events
+   *
+   * Subscribe to global events from the OpenCode system using server-sent events.
+   */
+  public event<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError, GlobalEventResponse>) {
+    return (options?.client ?? this.client).sse.get<GlobalEventResponses, unknown, ThrowOnError>({
+      url: "/global/event",
+      ...options,
+    })
+  }
+
+  private _config?: Config
+  get config(): Config {
+    return (this._config ??= new Config({ client: this.client }))
+  }
+
+  private _syncEvent?: SyncEvent
+  get syncEvent(): SyncEvent {
+    return (this._syncEvent ??= new SyncEvent({ client: this.client }))
+  }
+}
+
 export class Workspace extends HeyApiClient {
   /**
    * List workspaces
@@ -599,7 +598,7 @@ export class Workspace extends HeyApiClient {
     parameters: {
       directory?: string
       workspace?: string
-      id?: string
+      id?: string | null
       type: string
       branch: string | null
       extra: unknown | null
@@ -710,28 +709,10 @@ export class Console extends HeyApiClient {
    *
    * Get the active Console org name and the set of provider IDs managed by that Console org.
    */
-  public get<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
+  public get<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
     return (options?.client ?? this.client).get<ExperimentalConsoleGetResponses, unknown, ThrowOnError>({
       url: "/experimental/console",
       ...options,
-      ...params,
     })
   }
 
@@ -740,28 +721,10 @@ export class Console extends HeyApiClient {
    *
    * Get the available Console orgs across logged-in accounts, including the current active org.
    */
-  public listOrgs<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
+  public listOrgs<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
     return (options?.client ?? this.client).get<ExperimentalConsoleListOrgsResponses, unknown, ThrowOnError>({
       url: "/experimental/console/orgs",
       ...options,
-      ...params,
     })
   }
 
@@ -772,8 +735,6 @@ export class Console extends HeyApiClient {
    */
   public switchOrg<ThrowOnError extends boolean = false>(
     parameters: {
-      directory?: string
-      workspace?: string
       accountID: string
       orgID: string
     },
@@ -784,15 +745,17 @@ export class Console extends HeyApiClient {
       [
         {
           args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
             { in: "body", key: "accountID" },
             { in: "body", key: "orgID" },
           ],
         },
       ],
     )
-    return (options?.client ?? this.client).post<ExperimentalConsoleSwitchOrgResponses, unknown, ThrowOnError>({
+    return (options?.client ?? this.client).post<
+      ExperimentalConsoleSwitchOrgResponses,
+      ExperimentalConsoleSwitchOrgErrors,
+      ThrowOnError
+    >({
       url: "/experimental/console/switch",
       ...options,
       ...params,
@@ -805,22 +768,35 @@ export class Console extends HeyApiClient {
   }
 }
 
+export class Resource extends HeyApiClient {
+  /**
+   * Get MCP resources
+   *
+   * Get all available MCP resources from connected servers. Optionally filter by name.
+   */
+  public list<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<ExperimentalResourceListResponses, unknown, ThrowOnError>({
+      url: "/experimental/resource",
+      ...options,
+    })
+  }
+}
+
 export class Session extends HeyApiClient {
   /**
-   * List sessions
+   * List global sessions
    *
-   * Get a list of all OpenCode sessions across projects. Defaults to most recently updated; use sort=created for creation-time order or sort=activity for latest user-message activity order. Archived sessions are excluded by default.
+   * List OpenCode sessions across projects with the same cursor and sort semantics as the Hono route.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
-      workspace?: string
-      roots?: boolean
-      start?: number
-      cursor?: number | string
+      roots?: "true" | "false"
+      start?: string
+      cursor?: string
       search?: string
-      limit?: number
-      archived?: boolean
+      limit?: string
+      archived?: "true" | "false"
       sort?: "updated" | "created" | "activity"
     },
     options?: Options<never, ThrowOnError>,
@@ -831,7 +807,6 @@ export class Session extends HeyApiClient {
         {
           args: [
             { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
             { in: "query", key: "roots" },
             { in: "query", key: "start" },
             { in: "query", key: "cursor" },
@@ -851,11 +826,260 @@ export class Session extends HeyApiClient {
   }
 }
 
-export class Resource extends HeyApiClient {
+export class Experimental extends HeyApiClient {
+  private _workspace?: Workspace
+  get workspace(): Workspace {
+    return (this._workspace ??= new Workspace({ client: this.client }))
+  }
+
+  private _console?: Console
+  get console(): Console {
+    return (this._console ??= new Console({ client: this.client }))
+  }
+
+  private _resource?: Resource
+  get resource(): Resource {
+    return (this._resource ??= new Resource({ client: this.client }))
+  }
+
+  private _session?: Session
+  get session(): Session {
+    return (this._session ??= new Session({ client: this.client }))
+  }
+}
+
+export class Instance extends HeyApiClient {
   /**
-   * Get MCP resources
+   * Dispose instance
    *
-   * Get all available MCP resources from connected servers. Optionally filter by name.
+   * Clean up and dispose the current OpenCode instance, releasing all resources.
+   */
+  public dispose<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<InstanceDisposeResponses, unknown, ThrowOnError>({
+      url: "/instance/dispose",
+      ...options,
+      ...params,
+    })
+  }
+}
+
+export class Path extends HeyApiClient {
+  /**
+   * Get paths
+   *
+   * Retrieve the current working directory and related path information for the OpenCode instance.
+   */
+  public get<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      ensureConfig?: "true" | "false"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "ensureConfig" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<PathGetResponses, unknown, ThrowOnError>({
+      url: "/path",
+      ...options,
+      ...params,
+    })
+  }
+}
+
+export class Vcs extends HeyApiClient {
+  /**
+   * Get VCS info
+   *
+   * Retrieve version control system information for the current project.
+   */
+  public get<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<VcsGetResponses, unknown, ThrowOnError>({
+      url: "/vcs",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get VCS status
+   *
+   * Retrieve working tree file status summaries for the current project.
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<VcsStatusResponses, unknown, ThrowOnError>({
+      url: "/vcs/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get VCS diff
+   *
+   * Retrieve the current working-tree diff.
+   */
+  public diff<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      workspace?: string
+      mode: "git" | "branch"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "mode" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<VcsDiffResponses, unknown, ThrowOnError>({
+      url: "/vcs/diff",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get raw VCS diff
+   *
+   * Retrieve the current git diff as raw patch text.
+   */
+  public diffRaw<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<VcsDiffRawResponses, VcsDiffRawErrors, ThrowOnError>({
+      url: "/vcs/diff/raw",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Apply VCS patch
+   *
+   * Apply a git patch to the current project.
+   */
+  public apply<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      workspace?: string
+      patch: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "patch" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<VcsApplyResponses, VcsApplyErrors, ThrowOnError>({
+      url: "/vcs/apply",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Command extends HeyApiClient {
+  /**
+   * List commands
+   *
+   * Get a list of all available commands in the OpenCode system.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
@@ -875,33 +1099,43 @@ export class Resource extends HeyApiClient {
         },
       ],
     )
-    return (options?.client ?? this.client).get<ExperimentalResourceListResponses, unknown, ThrowOnError>({
-      url: "/experimental/resource",
+    return (options?.client ?? this.client).get<CommandListResponses, unknown, ThrowOnError>({
+      url: "/command",
       ...options,
       ...params,
     })
   }
 }
 
-export class Experimental extends HeyApiClient {
-  private _workspace?: Workspace
-  get workspace(): Workspace {
-    return (this._workspace ??= new Workspace({ client: this.client }))
-  }
-
-  private _console?: Console
-  get console(): Console {
-    return (this._console ??= new Console({ client: this.client }))
-  }
-
-  private _session?: Session
-  get session(): Session {
-    return (this._session ??= new Session({ client: this.client }))
-  }
-
-  private _resource?: Resource
-  get resource(): Resource {
-    return (this._resource ??= new Resource({ client: this.client }))
+export class Lsp extends HeyApiClient {
+  /**
+   * Get LSP status
+   *
+   * Get LSP server status.
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<LspStatusResponses, unknown, ThrowOnError>({
+      url: "/lsp",
+      ...options,
+      ...params,
+    })
   }
 }
 
@@ -1013,9 +1247,6 @@ export class Project extends HeyApiClient {
         color?: string
       }
       commands?: {
-        /**
-         * Startup script to run when creating a new workspace (worktree)
-         */
         start?: string
       }
     },
@@ -1055,29 +1286,8 @@ export class Pty extends HeyApiClient {
    *
    * Get a list of all active pseudo-terminal (PTY) sessions managed by OpenCode.
    */
-  public list<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<PtyListResponses, unknown, ThrowOnError>({
-      url: "/pty",
-      ...options,
-      ...params,
-    })
+  public list<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<PtyListResponses, unknown, ThrowOnError>({ url: "/pty", ...options })
   }
 
   /**
@@ -1087,15 +1297,13 @@ export class Pty extends HeyApiClient {
    */
   public create<ThrowOnError extends boolean = false>(
     parameters?: {
-      directory?: string
-      workspace?: string
-      command?: string
-      args?: Array<string>
-      cwd?: string
-      title?: string
+      command?: string | null
+      args?: Array<string> | null
+      cwd?: string | null
+      title?: string | null
       env?: {
         [key: string]: string
-      }
+      } | null
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1104,8 +1312,6 @@ export class Pty extends HeyApiClient {
       [
         {
           args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
             { in: "body", key: "command" },
             { in: "body", key: "args" },
             { in: "body", key: "cwd" },
@@ -1135,23 +1341,10 @@ export class Pty extends HeyApiClient {
   public remove<ThrowOnError extends boolean = false>(
     parameters: {
       ptyID: string
-      directory?: string
-      workspace?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "ptyID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "ptyID" }] }])
     return (options?.client ?? this.client).delete<PtyRemoveResponses, PtyRemoveErrors, ThrowOnError>({
       url: "/pty/{ptyID}",
       ...options,
@@ -1167,23 +1360,10 @@ export class Pty extends HeyApiClient {
   public get<ThrowOnError extends boolean = false>(
     parameters: {
       ptyID: string
-      directory?: string
-      workspace?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "ptyID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "ptyID" }] }])
     return (options?.client ?? this.client).get<PtyGetResponses, PtyGetErrors, ThrowOnError>({
       url: "/pty/{ptyID}",
       ...options,
@@ -1199,13 +1379,11 @@ export class Pty extends HeyApiClient {
   public update<ThrowOnError extends boolean = false>(
     parameters: {
       ptyID: string
-      directory?: string
-      workspace?: string
-      title?: string
+      title?: string | null
       size?: {
-        rows: number
-        cols: number
-      }
+        rows: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+        cols: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      } | null
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1215,8 +1393,6 @@ export class Pty extends HeyApiClient {
         {
           args: [
             { in: "path", key: "ptyID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
             { in: "body", key: "title" },
             { in: "body", key: "size" },
           ],
@@ -1243,23 +1419,10 @@ export class Pty extends HeyApiClient {
   public connectToken<ThrowOnError extends boolean = false>(
     parameters: {
       ptyID: string
-      directory?: string
-      workspace?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "ptyID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "ptyID" }] }])
     return (options?.client ?? this.client).post<PtyConnectTokenResponses, PtyConnectTokenErrors, ThrowOnError>({
       url: "/pty/{ptyID}/connect-token",
       ...options,
@@ -1296,7 +1459,7 @@ export class Pty extends HeyApiClient {
         },
       ],
     )
-    return (options?.client ?? this.client).get<PtyConnectResponses, PtyConnectErrors, ThrowOnError>({
+    return (options?.client ?? this.client).get<unknown, PtyConnectErrors, ThrowOnError>({
       url: "/pty/{ptyID}/connect",
       ...options,
       ...params,
@@ -1341,10 +1504,10 @@ export class Config2 extends HeyApiClient {
    * Update OpenCode configuration settings and preferences.
    */
   public update<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      config?: Config3
+      config: Config3
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1405,44 +1568,12 @@ export class Config2 extends HeyApiClient {
 
 export class Tool extends HeyApiClient {
   /**
-   * List tool IDs
-   *
-   * Get a list of all available tool IDs, including both built-in tools and dynamically registered tools.
-   */
-  public ids<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<ToolIdsResponses, ToolIdsErrors, ThrowOnError>({
-      url: "/experimental/tool/ids",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
    * List tools
    *
    * Get a list of available tools with their JSON schema parameters for a specific provider and model combination.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters: {
-      directory?: string
-      workspace?: string
       provider: string
       model: string
     },
@@ -1453,8 +1584,6 @@ export class Tool extends HeyApiClient {
       [
         {
           args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
             { in: "query", key: "provider" },
             { in: "query", key: "model" },
           ],
@@ -1467,6 +1596,18 @@ export class Tool extends HeyApiClient {
       ...params,
     })
   }
+
+  /**
+   * List tool IDs
+   *
+   * Get a list of all available tool IDs, including both built-in tools and dynamically registered tools.
+   */
+  public ids<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<ToolIdsResponses, ToolIdsErrors, ThrowOnError>({
+      url: "/experimental/tool/ids",
+      ...options,
+    })
+  }
 }
 
 export class Worktree extends HeyApiClient {
@@ -1476,25 +1617,12 @@ export class Worktree extends HeyApiClient {
    * Remove a git worktree and delete its branch.
    */
   public remove<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-      worktreeRemoveInput?: WorktreeRemoveInput
+    parameters: {
+      directory: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { key: "worktreeRemoveInput", map: "body" },
-          ],
-        },
-      ],
-    )
+    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "directory" }] }])
     return (options?.client ?? this.client).delete<WorktreeRemoveResponses, WorktreeRemoveErrors, ThrowOnError>({
       url: "/experimental/worktree",
       ...options,
@@ -1512,28 +1640,10 @@ export class Worktree extends HeyApiClient {
    *
    * List all sandbox worktrees for the current project.
    */
-  public list<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
+  public list<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
     return (options?.client ?? this.client).get<WorktreeListResponses, unknown, ThrowOnError>({
       url: "/experimental/worktree",
       ...options,
-      ...params,
     })
   }
 
@@ -1543,25 +1653,15 @@ export class Worktree extends HeyApiClient {
    * Create a new git worktree for the current project and run any configured startup scripts.
    */
   public create<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-      worktreeCreateInput?: WorktreeCreateInput
+    parameters: {
+      body: {
+        name?: string
+        startCommand?: string
+      } | null
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { key: "worktreeCreateInput", map: "body" },
-          ],
-        },
-      ],
-    )
+    const params = buildClientParams([parameters], [{ args: [{ key: "body", map: "body" }] }])
     return (options?.client ?? this.client).post<WorktreeCreateResponses, WorktreeCreateErrors, ThrowOnError>({
       url: "/experimental/worktree",
       ...options,
@@ -1580,25 +1680,12 @@ export class Worktree extends HeyApiClient {
    * Reset a worktree branch to the primary default branch.
    */
   public reset<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-      worktreeResetInput?: WorktreeResetInput
+    parameters: {
+      directory: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { key: "worktreeResetInput", map: "body" },
-          ],
-        },
-      ],
-    )
+    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "directory" }] }])
     return (options?.client ?? this.client).post<WorktreeResetResponses, WorktreeResetErrors, ThrowOnError>({
       url: "/experimental/worktree/reset",
       ...options,
@@ -1613,11 +1700,6 @@ export class Worktree extends HeyApiClient {
 }
 
 export class Session2 extends HeyApiClient {
-  /**
-   * List sessions
-   *
-   * Get a list of all OpenCode sessions. Defaults to most recently updated; use sort=created for creation-time order.
-   */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
@@ -1653,11 +1735,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Create session
-   *
-   * Create a new OpenCode session for interacting with AI assistants and managing conversations.
-   */
   public create<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
@@ -1702,11 +1779,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Get session status
-   *
-   * Retrieve the current status of all sessions, including active, idle, and completed states.
-   */
   public status<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
@@ -1733,10 +1805,44 @@ export class Session2 extends HeyApiClient {
   }
 
   /**
-   * Delete session
+   * Update session todos in e2e tests
    *
-   * Delete a session and permanently remove all associated data, including messages and history.
+   * Test-only route gated by the OPENCODE_E2E_ENABLED and OPENCODE_E2E_LLM_URL environment flags.
    */
+  public e2eUpdateTodos<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      todos: Array<unknown>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "sessionID" },
+            { in: "body", key: "todos" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionE2eUpdateTodosResponses,
+      SessionE2eUpdateTodosErrors,
+      ThrowOnError
+    >({
+      url: "/session/__e2e/update-todos",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
   public delete<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -1764,11 +1870,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Get session
-   *
-   * Retrieve detailed information about a specific OpenCode session.
-   */
   public get<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -1796,20 +1897,15 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Update session
-   *
-   * Update properties of an existing session, such as title or other metadata.
-   */
   public update<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
       directory?: string
       workspace?: string
       title?: string
-      permission?: PermissionRuleset
+      permission?: unknown
       time?: {
-        archived?: number
+        archived?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
       }
     },
     options?: Options<never, ThrowOnError>,
@@ -1841,11 +1937,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Get session children
-   *
-   * Retrieve all child sessions that were forked from the specified parent session.
-   */
   public children<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -1873,43 +1964,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Get session todos
-   *
-   * Retrieve the todo list associated with a specific session, showing tasks and action items.
-   */
-  public todo<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<SessionTodoResponses, SessionTodoErrors, ThrowOnError>({
-      url: "/session/{sessionID}/todo",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Initialize session
-   *
-   * Analyze the current application and create an AGENTS.md file with project-specific agent configurations.
-   */
   public init<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -1948,575 +2002,12 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Fork session
-   *
-   * Create a new session by forking an existing session at a specific message point.
-   */
-  public fork<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-      messageID?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "body", key: "messageID" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<SessionForkResponses, SessionForkErrors, ThrowOnError>({
-      url: "/session/{sessionID}/fork",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  /**
-   * Respond to an external-result tool call
-   *
-   * Resolve a pending external-result Deferred (e.g. question tool) with the user's submitted payload or a dismiss action.
-   */
-  public toolRespond<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-      body?:
-        | {
-            kind: "submit"
-            messageID: string
-            callID: string
-            payload: unknown
-          }
-        | {
-            kind: "dismiss"
-            messageID: string
-            callID: string
-          }
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { key: "body", map: "body" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<SessionToolRespondResponses, SessionToolRespondErrors, ThrowOnError>({
-      url: "/session/{sessionID}/tool/respond",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  /**
-   * Abort session
-   *
-   * Abort an active session and stop any ongoing AI processing or command execution.
-   */
-  public abort<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-      source?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "query", key: "source" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<SessionAbortResponses, SessionAbortErrors, ThrowOnError>({
-      url: "/session/{sessionID}/abort",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Unshare session
-   *
-   * Remove the shareable link for a session, making it private again.
-   */
-  public unshare<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).delete<SessionUnshareResponses, SessionUnshareErrors, ThrowOnError>({
-      url: "/session/{sessionID}/share",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Share session
-   *
-   * Create a shareable link for a session, allowing others to view the conversation.
-   */
-  public share<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<SessionShareResponses, SessionShareErrors, ThrowOnError>({
-      url: "/session/{sessionID}/share",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Export session log
-   *
-   * Export the full root session tree as a single JSON document for local debugging. If a child session id is provided, climbs to the topmost ancestor and exports the whole tree.
-   */
-  public export<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<SessionExportResponses, SessionExportErrors, ThrowOnError>({
-      url: "/session/{sessionID}/export",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Get message diff
-   *
-   * Get the file changes (diff) that resulted from a specific user message in the session.
-   */
-  public diff<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-      messageID?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "query", key: "messageID" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<SessionDiffResponses, unknown, ThrowOnError>({
-      url: "/session/{sessionID}/diff",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Get assistant turn changes
-   *
-   * Get files explicitly changed by PawWork file-writing tools during one assistant turn.
-   */
-  public turnChange<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      messageID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "path", key: "messageID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<SessionTurnChangeResponses, SessionTurnChangeErrors, ThrowOnError>({
-      url: "/session/{sessionID}/turn-change/{messageID}",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Undo assistant turn file changes
-   */
-  public turnChangeUndo<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      messageID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "path", key: "messageID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<
-      SessionTurnChangeUndoResponses,
-      SessionTurnChangeUndoErrors,
-      ThrowOnError
-    >({
-      url: "/session/{sessionID}/turn-change/{messageID}/undo",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Redo assistant turn file changes
-   */
-  public turnChangeRedo<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      messageID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "path", key: "messageID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<
-      SessionTurnChangeRedoResponses,
-      SessionTurnChangeRedoErrors,
-      ThrowOnError
-    >({
-      url: "/session/{sessionID}/turn-change/{messageID}/redo",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Get aggregated turn changes
-   *
-   * Aggregate file changes across all assistants in one user turn.
-   */
-  public turnChangesAggregate<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      userMessageID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "path", key: "userMessageID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<
-      SessionTurnChangesAggregateResponses,
-      SessionTurnChangesAggregateErrors,
-      ThrowOnError
-    >({
-      url: "/session/{sessionID}/turn/{userMessageID}/changes",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Undo all assistant changes in a turn
-   */
-  public turnChangesAggregateUndo<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      userMessageID: string
-      directory?: string
-      workspace?: string
-      force?: boolean
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "path", key: "userMessageID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "body", key: "force" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<
-      SessionTurnChangesAggregateUndoResponses,
-      SessionTurnChangesAggregateUndoErrors,
-      ThrowOnError
-    >({
-      url: "/session/{sessionID}/turn/{userMessageID}/changes/undo",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  /**
-   * Redo all assistant changes in a turn
-   */
-  public turnChangesAggregateRedo<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      userMessageID: string
-      directory?: string
-      workspace?: string
-      force?: boolean
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "path", key: "userMessageID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "body", key: "force" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<
-      SessionTurnChangesAggregateRedoResponses,
-      SessionTurnChangesAggregateRedoErrors,
-      ThrowOnError
-    >({
-      url: "/session/{sessionID}/turn/{userMessageID}/changes/redo",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  /**
-   * Get session artifacts
-   *
-   * Get the cumulative files created or updated across a session.
-   */
-  public artifacts<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<SessionArtifactsResponses, unknown, ThrowOnError>({
-      url: "/session/{sessionID}/artifacts",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Summarize session
-   *
-   * Generate a concise summary of the session using AI compaction to preserve key information.
-   */
-  public summarize<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-      workspace?: string
-      providerID: string
-      modelID: string
-      auto?: boolean
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "body", key: "providerID" },
-            { in: "body", key: "modelID" },
-            { in: "body", key: "auto" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<SessionSummarizeResponses, SessionSummarizeErrors, ThrowOnError>({
-      url: "/session/{sessionID}/summarize",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  /**
-   * Get session messages
-   *
-   * Retrieve all messages in a session, including user prompts and AI responses.
-   */
   public messages<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
       directory?: string
       workspace?: string
-      limit?: number
+      limit?: string
       before?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -2542,11 +2033,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Send message
-   *
-   * Create and send a new message to a session, streaming the AI response.
-   */
   public prompt<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2566,7 +2052,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
-      parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
+      parts: Array<AgentPartInput | FilePartInput | SkillPartInput | SubtaskPartInput | TextPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2604,11 +2090,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Delete message
-   *
-   * Permanently delete a specific message (and all of its parts) from a session. This does not revert any file changes that may have been made while processing the message.
-   */
   public deleteMessage<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2642,11 +2123,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Get message
-   *
-   * Retrieve a specific message from a session by its message ID.
-   */
   public message<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2676,11 +2152,33 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Send async message
-   *
-   * Create and send a new message to a session asynchronously, starting the session if needed and returning immediately.
-   */
+  public todo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionTodoResponses, SessionTodoErrors, ThrowOnError>({
+      url: "/session/{sessionID}/todo",
+      ...options,
+      ...params,
+    })
+  }
+
   public promptAsync<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2700,7 +2198,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
-      parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
+      parts: Array<AgentPartInput | FilePartInput | SkillPartInput | SubtaskPartInput | TextPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2738,11 +2236,35 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Send command
-   *
-   * Send a new command to a session for execution by the AI assistant.
-   */
+  public abort<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      source?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "source" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionAbortResponses, SessionAbortErrors, ThrowOnError>({
+      url: "/session/{sessionID}/abort",
+      ...options,
+      ...params,
+    })
+  }
+
   public command<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2801,11 +2323,161 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Run shell command
-   *
-   * Execute a shell command within the session context and return the AI's response.
-   */
+  public fork<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      messageID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "messageID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionForkResponses, SessionForkErrors, ThrowOnError>({
+      url: "/session/{sessionID}/fork",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  public diff<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      messageID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "messageID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionDiffResponses, unknown, ThrowOnError>({
+      url: "/session/{sessionID}/diff",
+      ...options,
+      ...params,
+    })
+  }
+
+  public unshare<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<SessionUnshareResponses, SessionUnshareErrors, ThrowOnError>({
+      url: "/session/{sessionID}/share",
+      ...options,
+      ...params,
+    })
+  }
+
+  public share<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionShareResponses, SessionShareErrors, ThrowOnError>({
+      url: "/session/{sessionID}/share",
+      ...options,
+      ...params,
+    })
+  }
+
+  public summarize<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      modelID: string
+      providerID: string
+      auto?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "modelID" },
+            { in: "body", key: "providerID" },
+            { in: "body", key: "auto" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionSummarizeResponses, SessionSummarizeErrors, ThrowOnError>({
+      url: "/session/{sessionID}/summarize",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
   public shell<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2849,11 +2521,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Revert message
-   *
-   * Revert a specific message in a session, undoing its effects and restoring the previous state.
-   */
   public revert<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2890,11 +2557,6 @@ export class Session2 extends HeyApiClient {
     })
   }
 
-  /**
-   * Restore reverted messages
-   *
-   * Restore all previously reverted messages in a session.
-   */
   public unrevert<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2921,12 +2583,320 @@ export class Session2 extends HeyApiClient {
       ...params,
     })
   }
+
+  public artifacts<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionArtifactsResponses, unknown, ThrowOnError>({
+      url: "/session/{sessionID}/artifacts",
+      ...options,
+      ...params,
+    })
+  }
+
+  public export<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionExportResponses, SessionExportErrors, ThrowOnError>({
+      url: "/session/{sessionID}/export",
+      ...options,
+      ...params,
+    })
+  }
+
+  public toolRespond<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      body:
+        | {
+            kind: "submit"
+            messageID: string
+            callID: string
+            payload: unknown
+          }
+        | {
+            kind: "dismiss"
+            messageID: string
+            callID: string
+          }
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { key: "body", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionToolRespondResponses, SessionToolRespondErrors, ThrowOnError>({
+      url: "/session/{sessionID}/tool/respond",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  public turnChange<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      messageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "messageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionTurnChangeResponses, SessionTurnChangeErrors, ThrowOnError>({
+      url: "/session/{sessionID}/turn-change/{messageID}",
+      ...options,
+      ...params,
+    })
+  }
+
+  public turnChangeUndo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      messageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "messageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionTurnChangeUndoResponses,
+      SessionTurnChangeUndoErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn-change/{messageID}/undo",
+      ...options,
+      ...params,
+    })
+  }
+
+  public turnChangeRedo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      messageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "messageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionTurnChangeRedoResponses,
+      SessionTurnChangeRedoErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn-change/{messageID}/redo",
+      ...options,
+      ...params,
+    })
+  }
+
+  public turnChangesAggregate<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      userMessageID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "userMessageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<
+      SessionTurnChangesAggregateResponses,
+      SessionTurnChangesAggregateErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn/{userMessageID}/changes",
+      ...options,
+      ...params,
+    })
+  }
+
+  public turnChangesAggregateUndo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      userMessageID: string
+      directory?: string
+      workspace?: string
+      body: {
+        force?: boolean
+      } | null
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "userMessageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { key: "body", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionTurnChangesAggregateUndoResponses,
+      SessionTurnChangesAggregateUndoErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn/{userMessageID}/changes/undo",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  public turnChangesAggregateRedo<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      userMessageID: string
+      directory?: string
+      workspace?: string
+      body: {
+        force?: boolean
+      } | null
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "userMessageID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { key: "body", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionTurnChangesAggregateRedoResponses,
+      SessionTurnChangesAggregateRedoErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/turn/{userMessageID}/changes/redo",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
 }
 
 export class Part extends HeyApiClient {
-  /**
-   * Delete a part from a message
-   */
   public delete<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2958,9 +2928,6 @@ export class Part extends HeyApiClient {
     })
   }
 
-  /**
-   * Update a part in a message
-   */
   public update<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -2968,7 +2935,7 @@ export class Part extends HeyApiClient {
       partID: string
       directory?: string
       workspace?: string
-      part?: Part2
+      part: Part2
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3000,14 +2967,52 @@ export class Part extends HeyApiClient {
   }
 }
 
-export class Permission extends HeyApiClient {
+export class E2E extends HeyApiClient {
   /**
-   * Respond to permission
+   * Seed an e2e permission request
    *
-   * Approve or deny a permission request from the AI assistant.
-   *
-   * @deprecated
+   * Test-only route gated by the OPENCODE_E2E_ENABLED and OPENCODE_E2E_LLM_URL environment flags.
    */
+  public ask<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      permission: string
+      patterns: Array<string>
+      metadata?: {
+        [key: string]: unknown
+      } | null
+      always?: Array<string> | null
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "sessionID" },
+            { in: "body", key: "permission" },
+            { in: "body", key: "patterns" },
+            { in: "body", key: "metadata" },
+            { in: "body", key: "always" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PermissionE2eAskResponses, PermissionE2eAskErrors, ThrowOnError>({
+      url: "/permission/__e2e/ask",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Permission extends HeyApiClient {
   public respond<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
@@ -3034,47 +3039,6 @@ export class Permission extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<PermissionRespondResponses, PermissionRespondErrors, ThrowOnError>({
       url: "/session/{sessionID}/permissions/{permissionID}",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  /**
-   * Respond to permission request
-   *
-   * Approve or deny a permission request from the AI assistant.
-   */
-  public reply<ThrowOnError extends boolean = false>(
-    parameters: {
-      requestID: string
-      directory?: string
-      workspace?: string
-      reply: "once" | "always" | "reject"
-      message?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "requestID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "body", key: "reply" },
-            { in: "body", key: "message" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<PermissionReplyResponses, PermissionReplyErrors, ThrowOnError>({
-      url: "/permission/{requestID}/reply",
       ...options,
       ...params,
       headers: {
@@ -3114,13 +3078,59 @@ export class Permission extends HeyApiClient {
       ...params,
     })
   }
+
+  /**
+   * Respond to permission request
+   *
+   * Approve or deny a permission request from the AI assistant.
+   */
+  public reply<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: string
+      directory?: string
+      workspace?: string
+      reply: "once" | "always" | "reject"
+      message?: string | null
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "reply" },
+            { in: "body", key: "message" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PermissionReplyResponses, PermissionReplyErrors, ThrowOnError>({
+      url: "/permission/{requestID}/reply",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  private _e2E?: E2E
+  get e2E(): E2E {
+    return (this._e2E ??= new E2E({ client: this.client }))
+  }
 }
 
 export class ExternalResult extends HeyApiClient {
   /**
    * List pending external-result tool calls
    *
-   * Return the (session, message, part) trio for every external-result Deferred currently awaiting a user response. Used by the app to hydrate the dock after reload / cold-open.
+   * Return the (session, message, part) trio for every external-result Deferred currently awaiting a user response.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
@@ -3159,10 +3169,10 @@ export class Oauth extends HeyApiClient {
       providerID: string
       directory?: string
       workspace?: string
-      method: number
+      method: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
       inputs?: {
         [key: string]: string
-      }
+      } | null
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3206,8 +3216,8 @@ export class Oauth extends HeyApiClient {
       providerID: string
       directory?: string
       workspace?: string
-      method: number
-      code?: string
+      method: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      code?: string | null
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3303,6 +3313,11 @@ export class Provider extends HeyApiClient {
     })
   }
 
+  /**
+   * Record recent model
+   *
+   * Persist the user's picked model as the recent default that model-less sessions (e.g. a Telegram /new) inherit. Called by the desktop model picker on an explicit pick.
+   */
   public recordRecent<ThrowOnError extends boolean = false>(
     parameters: {
       directory?: string
@@ -3380,10 +3395,10 @@ export class Memory extends HeyApiClient {
    * Update raw PawWork memory
    */
   public update<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      memoryRawInput?: MemoryRawInput
+      content: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3394,7 +3409,7 @@ export class Memory extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { key: "memoryRawInput", map: "body" },
+            { in: "body", key: "content" },
           ],
         },
       ],
@@ -3443,10 +3458,10 @@ export class Memory extends HeyApiClient {
    * Disable or enable PawWork memory
    */
   public disabled<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      memoryDisabledInput?: MemoryDisabledInput
+      disabled: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3457,12 +3472,12 @@ export class Memory extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { key: "memoryDisabledInput", map: "body" },
+            { in: "body", key: "disabled" },
           ],
         },
       ],
     )
-    return (options?.client ?? this.client).patch<MemoryDisabledResponses, unknown, ThrowOnError>({
+    return (options?.client ?? this.client).patch<MemoryDisabledResponses, MemoryDisabledErrors, ThrowOnError>({
       url: "/memory/disabled",
       ...options,
       ...params,
@@ -3542,10 +3557,33 @@ export class Automation extends HeyApiClient {
    * Create an automation definition without executing it.
    */
   public create<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      automationCreateInput?: AutomationCreateInput
+      body:
+        | {
+            kind: "oneshot"
+            title: string
+            prompt: string
+            context: "continue" | "fresh"
+            where: AutomationWhere
+            timezone: string
+            model: AutomationModel
+            variant?: string
+            fireAt: number
+          }
+        | {
+            kind: "recurring"
+            title: string
+            prompt: string
+            context: "continue" | "fresh"
+            where: AutomationWhere
+            timezone: string
+            model: AutomationModel
+            variant?: string
+            rhythm: AutomationRhythm
+            stop: AutomationStop
+          }
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3556,7 +3594,7 @@ export class Automation extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { key: "automationCreateInput", map: "body" },
+            { key: "body", map: "body" },
           ],
         },
       ],
@@ -3647,7 +3685,17 @@ export class Automation extends HeyApiClient {
       automationID: string
       directory?: string
       workspace?: string
-      automationUpdateInput?: AutomationUpdateInput
+      title?: string
+      prompt?: string
+      paused?: boolean
+      context?: "continue" | "fresh"
+      where?: AutomationWhere
+      timezone?: string
+      fireAt?: number
+      rhythm?: AutomationRhythm
+      stop?: AutomationStop
+      model?: AutomationModel
+      variant?: string | null
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3659,7 +3707,17 @@ export class Automation extends HeyApiClient {
             { in: "path", key: "automationID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { key: "automationUpdateInput", map: "body" },
+            { in: "body", key: "title" },
+            { in: "body", key: "prompt" },
+            { in: "body", key: "paused" },
+            { in: "body", key: "context" },
+            { in: "body", key: "where" },
+            { in: "body", key: "timezone" },
+            { in: "body", key: "fireAt" },
+            { in: "body", key: "rhythm" },
+            { in: "body", key: "stop" },
+            { in: "body", key: "model" },
+            { in: "body", key: "variant" },
           ],
         },
       ],
@@ -3673,6 +3731,74 @@ export class Automation extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  /**
+   * List automation runs
+   *
+   * List automation runs newest first.
+   */
+  public runs<ThrowOnError extends boolean = false>(
+    parameters: {
+      automationID: string
+      directory?: string
+      workspace?: string
+      limit?: number
+      cursor?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "automationID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "limit" },
+            { in: "query", key: "cursor" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<AutomationRunsResponses, AutomationRunsErrors, ThrowOnError>({
+      url: "/automation/{automationID}/runs",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Run automation now
+   *
+   * Create a queued automation run, start execution in the background, and return the queued run immediately.
+   */
+  public runNow<ThrowOnError extends boolean = false>(
+    parameters: {
+      automationID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "automationID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<AutomationRunNowResponses, AutomationRunNowErrors, ThrowOnError>({
+      url: "/automation/{automationID}/run",
+      ...options,
+      ...params,
     })
   }
 
@@ -3739,74 +3865,6 @@ export class Automation extends HeyApiClient {
       ...params,
     })
   }
-
-  /**
-   * Run automation now
-   *
-   * Create a queued automation run, start execution in the background, and return the queued run immediately.
-   */
-  public runNow<ThrowOnError extends boolean = false>(
-    parameters: {
-      automationID: string
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "automationID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<AutomationRunNowResponses, AutomationRunNowErrors, ThrowOnError>({
-      url: "/automation/{automationID}/run",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * List automation runs
-   *
-   * List automation runs newest first.
-   */
-  public runs<ThrowOnError extends boolean = false>(
-    parameters: {
-      automationID: string
-      directory?: string
-      workspace?: string
-      limit?: number
-      cursor?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "automationID" },
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "query", key: "limit" },
-            { in: "query", key: "cursor" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<AutomationRunsResponses, AutomationRunsErrors, ThrowOnError>({
-      url: "/automation/{automationID}/runs",
-      ...options,
-      ...params,
-    })
-  }
 }
 
 export class Find extends HeyApiClient {
@@ -3854,7 +3912,7 @@ export class Find extends HeyApiClient {
       query: string
       dirs?: "true" | "false"
       type?: "file" | "directory"
-      limit?: number
+      limit?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -4009,38 +4067,6 @@ export class File_ extends HeyApiClient {
   }
 }
 
-export class Event_ extends HeyApiClient {
-  /**
-   * Subscribe to events
-   *
-   * Get events
-   */
-  public subscribe<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError, EventSubscribeResponse>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({
-      url: "/event",
-      ...options,
-      ...params,
-    })
-  }
-}
-
 export class Auth2 extends HeyApiClient {
   /**
    * Remove MCP OAuth
@@ -4067,7 +4093,7 @@ export class Auth2 extends HeyApiClient {
         },
       ],
     )
-    return (options?.client ?? this.client).delete<McpAuthRemoveResponses, McpAuthRemoveErrors, ThrowOnError>({
+    return (options?.client ?? this.client).delete<McpAuthRemoveResponses, unknown, ThrowOnError>({
       url: "/mcp/{name}/auth",
       ...options,
       ...params,
@@ -4316,18 +4342,18 @@ export class Mcp extends HeyApiClient {
   }
 }
 
-export class Instance extends HeyApiClient {
+export class Event_ extends HeyApiClient {
   /**
-   * Dispose instance
+   * Subscribe to events
    *
-   * Clean up and dispose the current OpenCode instance, releasing all resources.
+   * Get events
    */
-  public dispose<ThrowOnError extends boolean = false>(
+  public subscribe<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
       workspace?: string
     },
-    options?: Options<never, ThrowOnError>,
+    options?: Options<never, ThrowOnError, EventSubscribeResponse>,
   ) {
     const params = buildClientParams(
       [parameters],
@@ -4340,267 +4366,8 @@ export class Instance extends HeyApiClient {
         },
       ],
     )
-    return (options?.client ?? this.client).post<InstanceDisposeResponses, unknown, ThrowOnError>({
-      url: "/instance/dispose",
-      ...options,
-      ...params,
-    })
-  }
-}
-
-export class Path extends HeyApiClient {
-  /**
-   * Get paths
-   *
-   * Retrieve the current working directory and related path information for the OpenCode instance.
-   */
-  public get<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-      ensureConfig?: boolean
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "query", key: "ensureConfig" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<PathGetResponses, unknown, ThrowOnError>({
-      url: "/path",
-      ...options,
-      ...params,
-    })
-  }
-}
-
-export class Vcs extends HeyApiClient {
-  /**
-   * Get VCS info
-   *
-   * Retrieve version control system (VCS) information for the current project, such as git branch.
-   */
-  public get<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<VcsGetResponses, unknown, ThrowOnError>({
-      url: "/vcs",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Get VCS diff
-   *
-   * Retrieve the current working-tree diff. `git` compares the working tree against HEAD (covers staged and unstaged changes plus untracked files); `branch` compares the working tree against the merge base with the default branch.
-   */
-  public diff<ThrowOnError extends boolean = false>(
-    parameters: {
-      directory?: string
-      workspace?: string
-      mode: "git" | "branch"
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "query", key: "mode" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<VcsDiffResponses, unknown, ThrowOnError>({
-      url: "/vcs/diff",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Get VCS status
-   *
-   * Retrieve working tree file status summaries for the current project.
-   */
-  public status<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<VcsStatusResponses, unknown, ThrowOnError>({
-      url: "/vcs/status",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Get raw VCS diff
-   *
-   * Retrieve the current git diff as raw patch text. Review-oriented unified diff; not guaranteed to apply cleanly via `git apply` for mixed index/worktree states in pre-first-commit repos (the same path may appear in both staged and worktree sections).
-   */
-  public diffRaw<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<VcsDiffRawResponses, VcsDiffRawErrors, ThrowOnError>({
-      url: "/vcs/diff/raw",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Apply VCS patch
-   *
-   * Apply a git patch to the current project.
-   */
-  public apply<ThrowOnError extends boolean = false>(
-    parameters: {
-      directory?: string
-      workspace?: string
-      patch: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "body", key: "patch" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<VcsApplyResponses, VcsApplyErrors, ThrowOnError>({
-      url: "/vcs/apply",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-}
-
-export class Command extends HeyApiClient {
-  /**
-   * List commands
-   *
-   * Get a list of all available commands in the OpenCode system.
-   */
-  public list<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<CommandListResponses, unknown, ThrowOnError>({
-      url: "/command",
-      ...options,
-      ...params,
-    })
-  }
-}
-
-export class Lsp extends HeyApiClient {
-  /**
-   * Get LSP status
-   *
-   * Get LSP server status
-   */
-  public status<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<LspStatusResponses, unknown, ThrowOnError>({
-      url: "/lsp",
+    return (options?.client ?? this.client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({
+      url: "/event",
       ...options,
       ...params,
     })
@@ -4615,101 +4382,6 @@ export class OpencodeClient extends HeyApiClient {
     OpencodeClient.__registry.set(this, args?.key)
   }
 
-  public postSessionE2eUpdateTodos<ThrowOnError extends boolean = false>(
-    parameters: {
-      directory?: string
-      workspace?: string
-      sessionID: string
-      todos: Array<{
-        id?: string
-        /**
-         * Brief description of the task
-         */
-        content: string
-        /**
-         * Current status of the task: pending, in_progress, completed, cancelled
-         */
-        status: string
-        /**
-         * Priority level of the task: high, medium, low
-         */
-        priority: string
-      }>
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "body", key: "sessionID" },
-            { in: "body", key: "todos" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<PostSessionE2eUpdateTodosResponses, unknown, ThrowOnError>({
-      url: "/session/__e2e/update-todos",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  public postPermissionE2eAsk<ThrowOnError extends boolean = false>(
-    parameters: {
-      directory?: string
-      workspace?: string
-      sessionID: string
-      permission: string
-      patterns: Array<string>
-      metadata?: {
-        [key: string]: unknown
-      }
-      always?: Array<string>
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "body", key: "sessionID" },
-            { in: "body", key: "permission" },
-            { in: "body", key: "patterns" },
-            { in: "body", key: "metadata" },
-            { in: "body", key: "always" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<PostPermissionE2eAskResponses, unknown, ThrowOnError>({
-      url: "/permission/__e2e/ask",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  private _global?: Global
-  get global(): Global {
-    return (this._global ??= new Global({ client: this.client }))
-  }
-
   private _auth?: Auth
   get auth(): Auth {
     return (this._auth ??= new Auth({ client: this.client }))
@@ -4720,9 +4392,39 @@ export class OpencodeClient extends HeyApiClient {
     return (this._app ??= new App({ client: this.client }))
   }
 
+  private _global?: Global
+  get global(): Global {
+    return (this._global ??= new Global({ client: this.client }))
+  }
+
   private _experimental?: Experimental
   get experimental(): Experimental {
     return (this._experimental ??= new Experimental({ client: this.client }))
+  }
+
+  private _instance?: Instance
+  get instance(): Instance {
+    return (this._instance ??= new Instance({ client: this.client }))
+  }
+
+  private _path?: Path
+  get path(): Path {
+    return (this._path ??= new Path({ client: this.client }))
+  }
+
+  private _vcs?: Vcs
+  get vcs(): Vcs {
+    return (this._vcs ??= new Vcs({ client: this.client }))
+  }
+
+  private _command?: Command
+  get command(): Command {
+    return (this._command ??= new Command({ client: this.client }))
+  }
+
+  private _lsp?: Lsp
+  get lsp(): Lsp {
+    return (this._lsp ??= new Lsp({ client: this.client }))
   }
 
   private _project?: Project
@@ -4795,38 +4497,13 @@ export class OpencodeClient extends HeyApiClient {
     return (this._file ??= new File_({ client: this.client }))
   }
 
-  private _event?: Event_
-  get event(): Event_ {
-    return (this._event ??= new Event_({ client: this.client }))
-  }
-
   private _mcp?: Mcp
   get mcp(): Mcp {
     return (this._mcp ??= new Mcp({ client: this.client }))
   }
 
-  private _instance?: Instance
-  get instance(): Instance {
-    return (this._instance ??= new Instance({ client: this.client }))
-  }
-
-  private _path?: Path
-  get path(): Path {
-    return (this._path ??= new Path({ client: this.client }))
-  }
-
-  private _vcs?: Vcs
-  get vcs(): Vcs {
-    return (this._vcs ??= new Vcs({ client: this.client }))
-  }
-
-  private _command?: Command
-  get command(): Command {
-    return (this._command ??= new Command({ client: this.client }))
-  }
-
-  private _lsp?: Lsp
-  get lsp(): Lsp {
-    return (this._lsp ??= new Lsp({ client: this.client }))
+  private _event?: Event_
+  get event(): Event_ {
+    return (this._event ??= new Event_({ client: this.client }))
   }
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2425,6 +2425,58 @@ export type MemoryState = {
   profileTooLarge?: boolean
 }
 
+export type MemoryRawInput = {
+  content: string
+}
+
+export type MemoryDisabledInput = {
+  disabled: boolean
+}
+
+export type WorktreeCreateInput = {
+  name?: string
+  /**
+   * Additional startup script to run after the project's start command
+   */
+  startCommand?: string
+}
+
+export type WorktreeRemoveInput = {
+  directory: string
+}
+
+export type WorktreeResetInput = {
+  directory: string
+}
+
+export type FileContent = {
+  type: "text" | "binary"
+  content: string
+  diff?: string
+  patch?: {
+    oldFileName: string
+    newFileName: string
+    oldHeader?: string
+    newHeader?: string
+    hunks: Array<{
+      oldStart: number
+      oldLines: number
+      newStart: number
+      newLines: number
+      lines: Array<string>
+    }>
+    index?: string
+  }
+  encoding?: "base64"
+  mimeType?: string
+}
+
+export type PendingExternalResult = {
+  session: Session
+  message: Message
+  part: Part
+}
+
 export type TextPartInput = {
   id?: string
   type: "text"
@@ -3119,7 +3171,7 @@ export type PathGetData = {
   query?: {
     directory?: string
     workspace?: string
-    ensureConfig?: "true" | "false"
+    ensureConfig?: boolean
   }
   url: "/path"
 }
@@ -3404,26 +3456,7 @@ export type ProjectListResponses = {
   /**
    * Success
    */
-  200: Array<{
-    id: string
-    worktree: string
-    vcs?: "git"
-    name?: string
-    icon?: {
-      url?: string
-      override?: string
-      color?: string
-    }
-    commands?: {
-      start?: string
-    }
-    time: {
-      created: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
-      updated: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
-      initialized?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
-    }
-    sandboxes: Array<string>
-  }>
+  200: Array<Project>
 }
 
 export type ProjectListResponse = ProjectListResponses[keyof ProjectListResponses]
@@ -3442,26 +3475,7 @@ export type ProjectCurrentResponses = {
   /**
    * Success
    */
-  200: {
-    id: string
-    worktree: string
-    vcs?: "git"
-    name?: string
-    icon?: {
-      url?: string
-      override?: string
-      color?: string
-    }
-    commands?: {
-      start?: string
-    }
-    time: {
-      created: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
-      updated: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
-      initialized?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
-    }
-    sandboxes: Array<string>
-  }
+  200: Project
 }
 
 export type ProjectCurrentResponse = ProjectCurrentResponses[keyof ProjectCurrentResponses]
@@ -3999,12 +4013,12 @@ export type ExperimentalSessionListData = {
   path?: never
   query?: {
     directory?: string
-    roots?: "true" | "false"
-    start?: string
+    roots?: boolean
+    start?: number
     cursor?: string
     search?: string
-    limit?: string
-    archived?: "true" | "false"
+    limit?: number
+    archived?: boolean
     sort?: "updated" | "created" | "activity"
   }
   url: "/experimental/session"
@@ -4020,11 +4034,12 @@ export type ExperimentalSessionListResponses = {
 export type ExperimentalSessionListResponse = ExperimentalSessionListResponses[keyof ExperimentalSessionListResponses]
 
 export type WorktreeRemoveData = {
-  body: {
-    directory: string
-  }
+  body: WorktreeRemoveInput
   path?: never
-  query?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
   url: "/experimental/worktree"
 }
 
@@ -4049,7 +4064,10 @@ export type WorktreeRemoveResponse = WorktreeRemoveResponses[keyof WorktreeRemov
 export type WorktreeListData = {
   body?: never
   path?: never
-  query?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
   url: "/experimental/worktree"
 }
 
@@ -4068,12 +4086,12 @@ export type WorktreeListResponses = {
 export type WorktreeListResponse = WorktreeListResponses[keyof WorktreeListResponses]
 
 export type WorktreeCreateData = {
-  body: {
-    name?: string
-    startCommand?: string
-  } | null
+  body?: WorktreeCreateInput
   path?: never
-  query?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
   url: "/experimental/worktree"
 }
 
@@ -4101,11 +4119,12 @@ export type WorktreeCreateResponses = {
 export type WorktreeCreateResponse = WorktreeCreateResponses[keyof WorktreeCreateResponses]
 
 export type WorktreeResetData = {
-  body: {
-    directory: string
-  }
+  body: WorktreeResetInput
   path?: never
-  query?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
   url: "/experimental/worktree/reset"
 }
 
@@ -4435,7 +4454,7 @@ export type SessionMessagesData = {
   query?: {
     directory?: string
     workspace?: string
-    limit?: string
+    limit?: number
     before?: string
   }
   url: "/session/{sessionID}/message"
@@ -5555,20 +5574,7 @@ export type PermissionListResponses = {
   /**
    * Success
    */
-  200: Array<{
-    id: string
-    sessionID: string
-    permission: string
-    patterns: Array<string>
-    metadata: {
-      [key: string]: unknown
-    }
-    always: Array<string>
-    tool?: {
-      messageID: string
-      callID: string
-    } | null
-  }>
+  200: Array<PermissionRequest>
 }
 
 export type PermissionListResponse = PermissionListResponses[keyof PermissionListResponses]
@@ -5655,11 +5661,7 @@ export type ExternalResultListResponses = {
   /**
    * Success
    */
-  200: Array<{
-    session: unknown
-    message: unknown
-    part: unknown
-  }>
+  200: Array<PendingExternalResult>
 }
 
 export type ExternalResultListResponse = ExternalResultListResponses[keyof ExternalResultListResponses]
@@ -5835,9 +5837,7 @@ export type MemoryGetResponses = {
 export type MemoryGetResponse = MemoryGetResponses[keyof MemoryGetResponses]
 
 export type MemoryUpdateData = {
-  body: {
-    content: string
-  }
+  body: MemoryRawInput
   path?: never
   query?: {
     directory?: string
@@ -5884,9 +5884,7 @@ export type MemoryResetResponses = {
 export type MemoryResetResponse = MemoryResetResponses[keyof MemoryResetResponses]
 
 export type MemoryDisabledData = {
-  body: {
-    disabled: boolean
-  }
+  body: MemoryDisabledInput
   path?: never
   query?: {
     directory?: string
@@ -5954,30 +5952,7 @@ export type AutomationListResponses = {
 export type AutomationListResponse2 = AutomationListResponses[keyof AutomationListResponses]
 
 export type AutomationCreateData = {
-  body:
-    | {
-        kind: "oneshot"
-        title: string
-        prompt: string
-        context: "continue" | "fresh"
-        where: AutomationWhere
-        timezone: string
-        model: AutomationModel
-        variant?: string
-        fireAt: number
-      }
-    | {
-        kind: "recurring"
-        title: string
-        prompt: string
-        context: "continue" | "fresh"
-        where: AutomationWhere
-        timezone: string
-        model: AutomationModel
-        variant?: string
-        rhythm: AutomationRhythm
-        stop: AutomationStop
-      }
+  body: AutomationCreateInput
   path?: never
   query?: {
     directory?: string
@@ -6077,19 +6052,7 @@ export type AutomationGetResponses = {
 export type AutomationGetResponse = AutomationGetResponses[keyof AutomationGetResponses]
 
 export type AutomationUpdateData = {
-  body: {
-    title?: string
-    prompt?: string
-    paused?: boolean
-    context?: "continue" | "fresh"
-    where?: AutomationWhere
-    timezone?: string
-    fireAt?: number
-    rhythm?: AutomationRhythm
-    stop?: AutomationStop
-    model?: AutomationModel
-    variant?: string | null
-  }
+  body: AutomationUpdateInput
   path: {
     automationID: string
   }
@@ -6325,7 +6288,7 @@ export type FindFilesData = {
     query: string
     dirs?: "true" | "false"
     type?: "file" | "directory"
-    limit?: string
+    limit?: number
   }
   url: "/find/file"
 }
@@ -6400,14 +6363,7 @@ export type FileReadResponses = {
   /**
    * Success
    */
-  200: {
-    type: "text" | "binary"
-    content: string
-    diff?: string
-    patch?: unknown
-    encoding?: "base64"
-    mimeType?: string
-  }
+  200: FileContent
 }
 
 export type FileReadResponse = FileReadResponses[keyof FileReadResponses]

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3307,11 +3307,11 @@ export type VcsApplyErrors = {
   /**
    * Bad request | VCS patch apply failure
    */
-  400: BadRequestError | VcsApplyFailure
+  400: VcsApplyFailure
   /**
    * VCS patch apply request is too large
    */
-  413: VcsApplyTooLargeFailure
+  413: VcsApplyFailure
 }
 
 export type VcsApplyError = VcsApplyErrors[keyof VcsApplyErrors]

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4,906 +4,13 @@ export type ClientOptions = {
   baseUrl: `${string}://${string}` | (string & {})
 }
 
-export type EventServerConnected = {
-  type: "server.connected"
-  properties: {
-    [key: string]: unknown
-  }
-}
-
-export type EventGlobalDisposed = {
-  type: "global.disposed"
-  properties: {
-    [key: string]: unknown
-  }
-}
-
-export type EventInstallationUpdated = {
-  type: "installation.updated"
-  properties: {
-    version: string
-  }
-}
-
-export type EventInstallationUpdateAvailable = {
-  type: "installation.update-available"
-  properties: {
-    version: string
-  }
-}
-
-export type EventServerInstanceDisposed = {
-  type: "server.instance.disposed"
-  properties: {
-    directory: string
-  }
-}
-
-export type EventLspClientDiagnostics = {
-  type: "lsp.client.diagnostics"
-  properties: {
-    serverID: string
-    path: string
-  }
-}
-
-export type RetryClassification =
-  | {
-      kind: "free_quota_exhausted"
-      providerID: string
-      raw: string
-      statusCode?: number
-      retryAfterMs?: number
-      resetAt?: number
-    }
-  | {
-      kind: "unknown"
-      raw: string
-      statusCode?: number
-      retryAfterMs?: number
-    }
-
-export type SessionStatus =
-  | {
-      type: "idle"
-    }
-  | {
-      type: "retry"
-      attempt: number
-      message: string
-      next: number
-      presentation?: "recovery" | "safe_recovery"
-      reason?: "network_connection_dropped"
-      classification?: RetryClassification
-    }
-  | {
-      type: "busy"
-    }
-  | {
-      type: "rate_limit_blocked"
-      classification: RetryClassification
-    }
-
-export type EventSessionStatus = {
-  type: "session.status"
-  properties: {
-    sessionID: string
-    status: SessionStatus
-  }
-}
-
-export type EventSessionIdle = {
-  type: "session.idle"
-  properties: {
-    sessionID: string
-  }
-}
-
-export type EventLspUpdated = {
-  type: "lsp.updated"
-  properties: {
-    [key: string]: unknown
-  }
-}
-
-export type EventLspServerInstallFailed = {
-  type: "lsp.server.install.failed"
-  properties: {
-    add: Array<string>
-    dir: string
-    error: string
-  }
-}
-
-export type PermissionRequest = {
-  id: string
-  sessionID: string
-  permission: string
-  patterns: Array<string>
-  metadata: {
-    [key: string]: unknown
-  }
-  always: Array<string>
-  tool?: {
-    messageID: string
-    callID: string
-  }
-}
-
-export type EventPermissionAsked = {
-  type: "permission.asked"
-  properties: PermissionRequest
-}
-
-export type EventPermissionReplied = {
-  type: "permission.replied"
-  properties: {
-    sessionID: string
-    requestID: string
-    reply: "once" | "always" | "reject"
-  }
-}
-
-export type EventMessagePartDelta = {
-  type: "message.part.delta"
-  properties: {
+export type SyncEventMessagePartRemoved = {
+  type: "message.part.removed.1"
+  aggregate: "sessionID"
+  data: {
     sessionID: string
     messageID: string
     partID: string
-    field: string
-    delta: string
-  }
-}
-
-export type SnapshotFileDiff = {
-  file: string
-  patch: string
-  additions: number
-  deletions: number
-  status?: "added" | "deleted" | "modified"
-}
-
-export type EventSessionDiff = {
-  type: "session.diff"
-  properties: {
-    sessionID: string
-    diff: Array<SnapshotFileDiff>
-  }
-}
-
-export type EventSessionTurnChangeInvalidated = {
-  type: "session.turn_change_invalidated"
-  properties: {
-    sessionID: string
-  }
-}
-
-export type ProviderAuthError = {
-  name: "ProviderAuthError"
-  data: {
-    providerID: string
-    message: string
-  }
-}
-
-export type UnknownError = {
-  name: "UnknownError"
-  data: {
-    message: string
-  }
-}
-
-export type MessageOutputLengthError = {
-  name: "MessageOutputLengthError"
-  data: {
-    [key: string]: unknown
-  }
-}
-
-export type MessageAbortedError = {
-  name: "MessageAbortedError"
-  data: {
-    message: string
-  }
-}
-
-export type StructuredOutputError = {
-  name: "StructuredOutputError"
-  data: {
-    message: string
-    retries: number
-  }
-}
-
-export type ContextOverflowError = {
-  name: "ContextOverflowError"
-  data: {
-    message: string
-    responseBody?: string
-  }
-}
-
-export type ApiError = {
-  name: "APIError"
-  data: {
-    message: string
-    statusCode?: number
-    isRetryable: boolean
-    responseHeaders?: {
-      [key: string]: string
-    }
-    responseBody?: string
-    metadata?: {
-      [key: string]: string
-    }
-    providerID?: string
-    providerFailure?: {
-      kind:
-        | "auth"
-        | "rate_limit"
-        | "quota_exhausted"
-        | "server_overload"
-        | "invalid_request"
-        | "transport_disconnect"
-        | "decompression"
-        | "unknown"
-      code?: string
-    }
-  }
-}
-
-export type EventSessionError = {
-  type: "session.error"
-  properties: {
-    sessionID?: string
-    error?:
-      | ProviderAuthError
-      | UnknownError
-      | MessageOutputLengthError
-      | MessageAbortedError
-      | StructuredOutputError
-      | ContextOverflowError
-      | ApiError
-  }
-}
-
-export type Project = {
-  id: string
-  worktree: string
-  vcs?: "git"
-  name?: string
-  icon?: {
-    url?: string
-    override?: string
-    color?: string
-  }
-  commands?: {
-    /**
-     * Startup script to run when creating a new workspace (worktree)
-     */
-    start?: string
-  }
-  time: {
-    created: number
-    updated: number
-    initialized?: number
-  }
-  sandboxes: Array<string>
-}
-
-export type EventProjectUpdated = {
-  type: "project.updated"
-  properties: Project
-}
-
-export type EventFileEdited = {
-  type: "file.edited"
-  properties: {
-    file: string
-  }
-}
-
-export type EventFileWatcherUpdated = {
-  type: "file.watcher.updated"
-  properties: {
-    file: string
-    event: "add" | "change" | "unlink"
-  }
-}
-
-export type EventFileWatcherRescan = {
-  type: "file.watcher.rescan"
-  properties: {
-    directory: string
-  }
-}
-
-export type Todo = {
-  id: string
-  /**
-   * Brief description of the task
-   */
-  content: string
-  /**
-   * Current status of the task: pending, in_progress, completed, cancelled
-   */
-  status: string
-  /**
-   * Priority level of the task: high, medium, low
-   */
-  priority: string
-}
-
-export type EventTodoUpdated = {
-  type: "todo.updated"
-  properties: {
-    sessionID: string
-    revision: number
-    todos: Array<Todo>
-  }
-}
-
-export type EventWorktreeReady = {
-  type: "worktree.ready"
-  properties: {
-    name: string
-    branch: string
-  }
-}
-
-export type EventWorktreeFailed = {
-  type: "worktree.failed"
-  properties: {
-    message: string
-  }
-}
-
-export type EventSessionCompacted = {
-  type: "session.compacted"
-  properties: {
-    sessionID: string
-  }
-}
-
-export type AutomationWhere = {
-  projectID: string
-  worktree?: string
-}
-
-export type AutomationModel = {
-  providerID: string
-  modelID: string
-}
-
-export type AutomationRhythm =
-  | {
-      kind: "interval"
-      everyMs: number
-    }
-  | {
-      kind: "cron"
-      expression: string
-    }
-
-export type AutomationStop =
-  | {
-      kind: "count"
-      count: number
-    }
-  | {
-      kind: "condition"
-      condition: string
-    }
-  | {
-      kind: "never"
-    }
-
-export type AutomationDefinition =
-  | {
-      kind: "oneshot"
-      id: string
-      title: string
-      prompt: string
-      revision: number
-      paused: boolean
-      context: "continue" | "fresh"
-      where: AutomationWhere
-      createdAt: number
-      updatedAt: number
-      timezone: string
-      sourceSessionID?: string
-      normalizationWarnings: Array<string>
-      model: AutomationModel
-      variant?: string
-      fireAt: number
-    }
-  | {
-      kind: "recurring"
-      id: string
-      title: string
-      prompt: string
-      revision: number
-      paused: boolean
-      context: "continue" | "fresh"
-      where: AutomationWhere
-      createdAt: number
-      updatedAt: number
-      timezone: string
-      sourceSessionID?: string
-      normalizationWarnings: Array<string>
-      model: AutomationModel
-      variant?: string
-      rhythm: AutomationRhythm
-      stop: AutomationStop
-      nextFireAt: number | null
-      nextFires: Array<number>
-      failureStreak: number
-    }
-
-export type EventAutomationDefinitionUpdated = {
-  type: "automation.definition.updated"
-  properties: AutomationDefinition
-}
-
-export type AutomationDefinitionTombstone = {
-  id: string
-  deleted: true
-  revision: number
-}
-
-export type EventAutomationDefinitionDeleted = {
-  type: "automation.definition.deleted"
-  properties: AutomationDefinitionTombstone
-}
-
-export type AutomationRunBlocker =
-  | {
-      kind: "permission"
-      requestID: string
-    }
-  | {
-      kind: "question"
-      callID: string
-    }
-
-export type AutomationRunError = {
-  code: "needs_user_input" | "execution_failed" | "step_cap" | "loop_gate"
-  message: string
-}
-
-export type AutomationRun =
-  | {
-      id: string
-      automationID: string
-      revision: number
-      definitionRevision: number
-      triggeredAt: number
-      cost: number | null
-      state: "scheduled"
-      sessionID: string | null
-      startedAt: null
-      completedAt: null
-      result: null
-      error: null
-    }
-  | {
-      id: string
-      automationID: string
-      revision: number
-      definitionRevision: number
-      triggeredAt: number
-      cost: number | null
-      sessionID: string
-      startedAt: number
-      completedAt: null
-      result: null
-      error: null
-      state: "running"
-    }
-  | {
-      id: string
-      automationID: string
-      revision: number
-      definitionRevision: number
-      triggeredAt: number
-      cost: number | null
-      sessionID: string
-      startedAt: number
-      completedAt: null
-      result: null
-      error: null
-      state: "awaiting_input"
-      blocker: AutomationRunBlocker
-    }
-  | {
-      id: string
-      automationID: string
-      revision: number
-      definitionRevision: number
-      triggeredAt: number
-      cost: number | null
-      sessionID: string
-      startedAt: number
-      completedAt: number
-      result: string | null
-      error: null
-      state: "succeeded"
-    }
-  | {
-      id: string
-      automationID: string
-      revision: number
-      definitionRevision: number
-      triggeredAt: number
-      cost: number | null
-      sessionID: string
-      startedAt: number
-      completedAt: number
-      result: null
-      error: AutomationRunError
-      state: "failed"
-    }
-  | {
-      id: string
-      automationID: string
-      revision: number
-      definitionRevision: number
-      triggeredAt: number
-      cost: number | null
-      state: "stopped"
-      sessionID: string | null
-      startedAt: number | null
-      completedAt: number
-      result: null
-      error: null
-      stopReason: "previous_run_awaiting_input" | "missed_schedule" | "cancelled" | "expired" | "blocker_lost"
-    }
-
-export type EventAutomationRunUpdated = {
-  type: "automation.run.updated"
-  properties: AutomationRun
-}
-
-export type EventMcpToolsChanged = {
-  type: "mcp.tools.changed"
-  properties: {
-    server: string
-  }
-}
-
-export type EventMcpBrowserOpenFailed = {
-  type: "mcp.browser.open.failed"
-  properties: {
-    mcpName: string
-    url: string
-  }
-}
-
-export type EventCommandExecuted = {
-  type: "command.executed"
-  properties: {
-    name: string
-    sessionID: string
-    arguments: string
-    messageID: string
-  }
-}
-
-export type EventVcsBranchUpdated = {
-  type: "vcs.branch.updated"
-  properties: {
-    branch?: string
-  }
-}
-
-export type Pty = {
-  id: string
-  title: string
-  command: string
-  args: Array<string>
-  cwd: string
-  status: "running" | "exited"
-  pid: number
-}
-
-export type EventPtyCreated = {
-  type: "pty.created"
-  properties: {
-    info: Pty
-  }
-}
-
-export type EventPtyUpdated = {
-  type: "pty.updated"
-  properties: {
-    info: Pty
-  }
-}
-
-export type EventPtyExited = {
-  type: "pty.exited"
-  properties: {
-    id: string
-    exitCode: number
-  }
-}
-
-export type EventPtyDeleted = {
-  type: "pty.deleted"
-  properties: {
-    id: string
-  }
-}
-
-export type EventWorkspaceReady = {
-  type: "workspace.ready"
-  properties: {
-    name: string
-  }
-}
-
-export type EventWorkspaceFailed = {
-  type: "workspace.failed"
-  properties: {
-    message: string
-  }
-}
-
-export type EventWorkspaceStatus = {
-  type: "workspace.status"
-  properties: {
-    workspaceID: string
-    status: "connected" | "connecting" | "disconnected" | "error"
-    error?: string
-  }
-}
-
-export type OutputFormatText = {
-  type: "text"
-}
-
-export type JsonSchema = {
-  [key: string]: unknown
-}
-
-export type OutputFormatJsonSchema = {
-  type: "json_schema"
-  schema: JsonSchema
-  retryCount?: number
-}
-
-export type OutputFormat = OutputFormatText | OutputFormatJsonSchema
-
-export type UserMessage = {
-  id: string
-  sessionID: string
-  role: "user"
-  time: {
-    created: number
-  }
-  format?: OutputFormat
-  summary?: {
-    title?: string
-    body?: string
-    diffs?: Array<SnapshotFileDiff>
-  }
-  agent: string
-  automationID?: string
-  model: {
-    providerID: string
-    modelID: string
-    variant?: string
-  }
-  locale?: string
-  system?: string
-  tools?: {
-    [key: string]: boolean
-  }
-  replay?: boolean
-  diagnostics?: {
-    run_lifecycle?: Array<{
-      schema_version: 1
-      type: string
-      session_id: string
-      message_id?: string
-      assistant_message_id?: string
-      at: number
-      duration_ms?: number
-      reason?: string
-      lifecycle?: {
-        action_id: string
-        kind: string
-        initiated_at?: number
-        initiated_monotonic_ms?: number
-        affected_directory_keys?: Array<string>
-        origin?: unknown
-        request?: unknown
-      }
-    }>
-  }
-}
-
-export type AssistantMessage = {
-  id: string
-  sessionID: string
-  role: "assistant"
-  time: {
-    created: number
-    completed?: number
-  }
-  error?:
-    | ProviderAuthError
-    | UnknownError
-    | MessageOutputLengthError
-    | MessageAbortedError
-    | StructuredOutputError
-    | ContextOverflowError
-    | ApiError
-  parentID: string
-  modelID: string
-  providerID: string
-  mode: string
-  agent: string
-  path:
-    | {
-        cwd: string
-        root: string
-      }
-    | string
-  summary?: boolean
-  cost: number
-  tokens: {
-    total?: number
-    input: number
-    output: number
-    reasoning: number
-    cache: {
-      read: number
-      write: number
-    }
-  }
-  tokensCumulative?: {
-    total?: number
-    input: number
-    output: number
-    reasoning: number
-    cache: {
-      read: number
-      write: number
-    }
-  }
-  structured?: unknown
-  variant?: string
-  finish?: string
-  diagnostics?: {
-    llm_trace?: {
-      schema_version: 1
-      trace_id: string
-      session_id: string
-      message_id: string
-      parent_message_id?: string
-      provider: string
-      model: string
-      agent: string
-      variant?: string
-      request?: {
-        streaming: true
-        tool_count: number
-        tool_choice?: "auto" | "required" | "none"
-        small: boolean
-        reasoning_capability: boolean
-        interleaved_field?: string
-        options?: {
-          temperature?: number
-          top_p?: number
-          top_k?: number
-          max_output_tokens?: number
-        }
-      }
-      stream_events: {
-        start: number
-        start_step: number
-        finish_step: number
-        finish: number
-        text_start: number
-        text_delta: number
-        text_end: number
-        reasoning_start: number
-        reasoning_delta: number
-        reasoning_end: number
-        tool_input_start: number
-        tool_input_delta: number
-        tool_input_end: number
-        tool_call: number
-        tool_result: number
-        tool_error: number
-        error: number
-        finish_reason?: string
-      }
-      stored_parts: {
-        text: number
-        reasoning: number
-        tool: number
-        step_start: number
-        step_finish: number
-        patch: number
-        file: number
-        other: number
-      }
-      tokens?: {
-        input: number
-        output: number
-        reasoning: number
-        cache_read: number
-        cache_write: number
-      }
-      flags: {
-        empty_completion: boolean
-        stream_error?: boolean
-        aborted?: boolean
-      }
-      created_at: number
-      completed_at?: number
-      stream?: unknown
-    }
-    run_observability?: unknown
-    run_lifecycle?: Array<{
-      schema_version: 1
-      type: string
-      session_id: string
-      message_id?: string
-      assistant_message_id?: string
-      at: number
-      duration_ms?: number
-      reason?: string
-      lifecycle?: {
-        action_id: string
-        kind: string
-        initiated_at?: number
-        initiated_monotonic_ms?: number
-        affected_directory_keys?: Array<string>
-        origin?: unknown
-        request?: unknown
-      }
-    }>
-    abort?: {
-      source?: string
-      reason?: string
-      title_generation_state?: "not_started" | "in_flight" | "completed_before_abort" | "completed_after_abort"
-      propagation_point?: string
-      error_name?: string
-      error_message?: string
-      via_ctx_abort?: boolean
-      recorded_at?: number
-    }
-    title_generation?: {
-      source?: string
-      parent_message_id?: string
-      started_at: number
-      completed_at?: number
-      success: boolean
-      applied?: boolean
-      error_name?: string
-      error_message?: string
-    }
-  }
-}
-
-export type Message = UserMessage | AssistantMessage
-
-export type EventMessageUpdated = {
-  type: "message.updated"
-  properties: {
-    sessionID: string
-    info: Message
-  }
-}
-
-export type EventMessageRemoved = {
-  type: "message.removed"
-  properties: {
-    sessionID: string
-    messageID: string
   }
 }
 
@@ -1063,7 +170,7 @@ export type ResourceSource = {
   uri: string
 }
 
-export type FilePartSource = FileSource | SymbolSource | ResourceSource
+export type FilePartSource = FileSource | ResourceSource | SymbolSource
 
 export type FilePart = {
   id: string
@@ -1135,7 +242,7 @@ export type ToolStateError = {
   }
 }
 
-export type ToolState = ToolStatePending | ToolStateRunning | ToolStateCompleted | ToolStateError
+export type ToolState = ToolStateCompleted | ToolStateError | ToolStatePending | ToolStateRunning
 
 export type ToolPart = {
   id: string
@@ -1221,6 +328,35 @@ export type SkillPart = {
   }
 }
 
+export type ApiError = {
+  name: "APIError"
+  data: {
+    message: string
+    statusCode?: number
+    isRetryable: boolean
+    responseHeaders?: {
+      [key: string]: string
+    }
+    responseBody?: string
+    metadata?: {
+      [key: string]: string
+    }
+    providerID?: string
+    providerFailure?: {
+      kind:
+        | "auth"
+        | "rate_limit"
+        | "quota_exhausted"
+        | "server_overload"
+        | "invalid_request"
+        | "transport_disconnect"
+        | "decompression"
+        | "unknown"
+      code?: string
+    }
+  }
+}
+
 export type RetryPart = {
   id: string
   sessionID: string
@@ -1247,36 +383,332 @@ export type CompactionPart = {
 }
 
 export type Part =
-  | TextPart
-  | SubtaskPart
-  | ReasoningPart
-  | NoticePart
-  | FilePart
-  | ToolPart
-  | StepStartPart
-  | StepFinishPart
-  | SnapshotPart
-  | PatchPart
   | AgentPart
-  | SkillPart
-  | RetryPart
   | CompactionPart
+  | FilePart
+  | NoticePart
+  | PatchPart
+  | ReasoningPart
+  | RetryPart
+  | SkillPart
+  | SnapshotPart
+  | StepFinishPart
+  | StepStartPart
+  | SubtaskPart
+  | TextPart
+  | ToolPart
 
-export type EventMessagePartUpdated = {
-  type: "message.part.updated"
-  properties: {
+export type SyncEventMessagePartUpdated = {
+  type: "message.part.updated.1"
+  aggregate: "sessionID"
+  data: {
     sessionID: string
     part: Part
     time: number
   }
 }
 
-export type EventMessagePartRemoved = {
-  type: "message.part.removed"
-  properties: {
+export type SyncEventMessageRemoved = {
+  type: "message.removed.1"
+  aggregate: "sessionID"
+  data: {
     sessionID: string
     messageID: string
-    partID: string
+  }
+}
+
+export type OutputFormatText = {
+  type: "text"
+}
+
+export type JsonSchema = {
+  [key: string]: unknown
+}
+
+export type OutputFormatJsonSchema = {
+  type: "json_schema"
+  schema: JsonSchema
+  retryCount?: number
+}
+
+export type OutputFormat = OutputFormatJsonSchema | OutputFormatText
+
+export type SnapshotFileDiff = {
+  file: string
+  patch: string
+  additions: number
+  deletions: number
+  status?: "added" | "deleted" | "modified"
+}
+
+export type UserMessage = {
+  id: string
+  sessionID: string
+  role: "user"
+  time: {
+    created: number
+  }
+  format?: OutputFormat
+  summary?: {
+    title?: string
+    body?: string
+    diffs?: Array<SnapshotFileDiff>
+  }
+  agent: string
+  automationID?: string
+  model: {
+    providerID: string
+    modelID: string
+    variant?: string
+  }
+  locale?: string
+  system?: string
+  tools?: {
+    [key: string]: boolean
+  }
+  replay?: boolean
+  diagnostics?: {
+    run_lifecycle?: Array<{
+      schema_version: 1
+      type: string
+      session_id: string
+      message_id?: string
+      assistant_message_id?: string
+      at: number
+      duration_ms?: number
+      reason?: string
+      lifecycle?: {
+        action_id: string
+        kind: string
+        initiated_at?: number
+        initiated_monotonic_ms?: number
+        affected_directory_keys?: Array<string>
+        origin?: unknown
+        request?: unknown
+      }
+    }>
+  }
+}
+
+export type ProviderAuthError = {
+  name: "ProviderAuthError"
+  data: {
+    providerID: string
+    message: string
+  }
+}
+
+export type UnknownError = {
+  name: "UnknownError"
+  data: {
+    message: string
+  }
+}
+
+export type MessageOutputLengthError = {
+  name: "MessageOutputLengthError"
+  data: {
+    [key: string]: unknown
+  }
+}
+
+export type MessageAbortedError = {
+  name: "MessageAbortedError"
+  data: {
+    message: string
+  }
+}
+
+export type StructuredOutputError = {
+  name: "StructuredOutputError"
+  data: {
+    message: string
+    retries: number
+  }
+}
+
+export type ContextOverflowError = {
+  name: "ContextOverflowError"
+  data: {
+    message: string
+    responseBody?: string
+  }
+}
+
+export type AssistantMessage = {
+  id: string
+  sessionID: string
+  role: "assistant"
+  time: {
+    created: number
+    completed?: number
+  }
+  error?:
+    | ApiError
+    | ContextOverflowError
+    | MessageAbortedError
+    | MessageOutputLengthError
+    | ProviderAuthError
+    | StructuredOutputError
+    | UnknownError
+  parentID: string
+  modelID: string
+  providerID: string
+  mode: string
+  agent: string
+  path:
+    | {
+        cwd: string
+        root: string
+      }
+    | string
+  summary?: boolean
+  cost: number
+  tokens: {
+    total?: number
+    input: number
+    output: number
+    reasoning: number
+    cache: {
+      read: number
+      write: number
+    }
+  }
+  tokensCumulative?: {
+    total?: number
+    input: number
+    output: number
+    reasoning: number
+    cache: {
+      read: number
+      write: number
+    }
+  }
+  structured?: unknown
+  variant?: string
+  finish?: string
+  diagnostics?: {
+    llm_trace?: {
+      schema_version: 1
+      trace_id: string
+      session_id: string
+      message_id: string
+      parent_message_id?: string
+      provider: string
+      model: string
+      agent: string
+      variant?: string
+      request?: {
+        streaming: true
+        tool_count: number
+        tool_choice?: "auto" | "required" | "none"
+        small: boolean
+        reasoning_capability: boolean
+        interleaved_field?: string
+        options?: {
+          temperature?: number
+          top_p?: number
+          top_k?: number
+          max_output_tokens?: number
+        }
+      }
+      stream_events: {
+        start: number
+        start_step: number
+        finish_step: number
+        finish: number
+        text_start: number
+        text_delta: number
+        text_end: number
+        reasoning_start: number
+        reasoning_delta: number
+        reasoning_end: number
+        tool_input_start: number
+        tool_input_delta: number
+        tool_input_end: number
+        tool_call: number
+        tool_result: number
+        tool_error: number
+        error: number
+        finish_reason?: string
+      }
+      stored_parts: {
+        text: number
+        reasoning: number
+        tool: number
+        step_start: number
+        step_finish: number
+        patch: number
+        file: number
+        other: number
+      }
+      tokens?: {
+        input: number
+        output: number
+        reasoning: number
+        cache_read: number
+        cache_write: number
+      }
+      flags: {
+        empty_completion: boolean
+        stream_error?: boolean
+        aborted?: boolean
+      }
+      created_at: number
+      completed_at?: number
+      stream?: unknown
+    }
+    run_observability?: unknown
+    run_lifecycle?: Array<{
+      schema_version: 1
+      type: string
+      session_id: string
+      message_id?: string
+      assistant_message_id?: string
+      at: number
+      duration_ms?: number
+      reason?: string
+      lifecycle?: {
+        action_id: string
+        kind: string
+        initiated_at?: number
+        initiated_monotonic_ms?: number
+        affected_directory_keys?: Array<string>
+        origin?: unknown
+        request?: unknown
+      }
+    }>
+    abort?: {
+      source?: string
+      reason?: string
+      title_generation_state?: "not_started" | "in_flight" | "completed_before_abort" | "completed_after_abort"
+      propagation_point?: string
+      error_name?: string
+      error_message?: string
+      via_ctx_abort?: boolean
+      recorded_at?: number
+    }
+    title_generation?: {
+      source?: string
+      parent_message_id?: string
+      started_at: number
+      completed_at?: number
+      success: boolean
+      applied?: boolean
+      error_name?: string
+      error_message?: string
+    }
+  }
+}
+
+export type Message = AssistantMessage | UserMessage
+
+export type SyncEventMessageUpdated = {
+  type: "message.updated.1"
+  aggregate: "sessionID"
+  data: {
+    sessionID: string
+    info: Message
   }
 }
 
@@ -1337,124 +769,17 @@ export type Session = {
   }
 }
 
-export type EventSessionCreated = {
-  type: "session.created"
-  properties: {
-    sessionID: string
-    info: Session
-  }
-}
-
-export type EventSessionUpdated = {
-  type: "session.updated"
-  properties: {
-    sessionID: string
-    info: Session
-  }
-}
-
-export type EventSessionDeleted = {
-  type: "session.deleted"
-  properties: {
-    sessionID: string
-    info: Session
-  }
-}
-
-export type Event =
-  | EventServerConnected
-  | EventGlobalDisposed
-  | EventInstallationUpdated
-  | EventInstallationUpdateAvailable
-  | EventServerInstanceDisposed
-  | EventLspClientDiagnostics
-  | EventSessionStatus
-  | EventSessionIdle
-  | EventLspUpdated
-  | EventLspServerInstallFailed
-  | EventPermissionAsked
-  | EventPermissionReplied
-  | EventMessagePartDelta
-  | EventSessionDiff
-  | EventSessionTurnChangeInvalidated
-  | EventSessionError
-  | EventProjectUpdated
-  | EventFileEdited
-  | EventFileWatcherUpdated
-  | EventFileWatcherRescan
-  | EventTodoUpdated
-  | EventWorktreeReady
-  | EventWorktreeFailed
-  | EventSessionCompacted
-  | EventAutomationDefinitionUpdated
-  | EventAutomationDefinitionDeleted
-  | EventAutomationRunUpdated
-  | EventMcpToolsChanged
-  | EventMcpBrowserOpenFailed
-  | EventCommandExecuted
-  | EventVcsBranchUpdated
-  | EventPtyCreated
-  | EventPtyUpdated
-  | EventPtyExited
-  | EventPtyDeleted
-  | EventWorkspaceReady
-  | EventWorkspaceFailed
-  | EventWorkspaceStatus
-  | EventMessageUpdated
-  | EventMessageRemoved
-  | EventMessagePartUpdated
-  | EventMessagePartRemoved
-  | EventSessionCreated
-  | EventSessionUpdated
-  | EventSessionDeleted
-
-export type GlobalEvent = {
-  directory: string
-  project?: string
-  workspace?: string
-  payload: Event
-}
-
-export type SyncEventMessageUpdated = {
-  type: "message.updated.1"
-  aggregate: "sessionID"
-  data: {
-    sessionID: string
-    info: Message
-  }
-}
-
-export type SyncEventMessageRemoved = {
-  type: "message.removed.1"
-  aggregate: "sessionID"
-  data: {
-    sessionID: string
-    messageID: string
-  }
-}
-
-export type SyncEventMessagePartUpdated = {
-  type: "message.part.updated.1"
-  aggregate: "sessionID"
-  data: {
-    sessionID: string
-    part: Part
-    time: number
-  }
-}
-
-export type SyncEventMessagePartRemoved = {
-  type: "message.part.removed.1"
-  aggregate: "sessionID"
-  data: {
-    sessionID: string
-    messageID: string
-    partID: string
-  }
-}
-
 export type SyncEventSessionCreated = {
   type: "session.created.1"
+  aggregate: "sessionID"
+  data: {
+    sessionID: string
+    info: Session
+  }
+}
+
+export type SyncEventSessionDeleted = {
+  type: "session.deleted.1"
   aggregate: "sessionID"
   data: {
     sessionID: string
@@ -1516,48 +841,725 @@ export type SyncEventSessionUpdated = {
   }
 }
 
-export type SyncEventSessionDeleted = {
-  type: "session.deleted.1"
-  aggregate: "sessionID"
-  data: {
+export type SyncEvent = {
+  payload: SyncEvent
+}
+
+export type AutomationDefinitionTombstone = {
+  id: string
+  deleted: true
+  revision: number
+}
+
+export type EventAutomationDefinitionDeleted = {
+  type: "automation.definition.deleted"
+  properties: AutomationDefinitionTombstone
+}
+
+export type AutomationWhere = {
+  projectID: string
+  worktree?: string
+}
+
+export type AutomationModel = {
+  providerID: string
+  modelID: string
+}
+
+export type AutomationRhythm =
+  | {
+      kind: "interval"
+      everyMs: number
+    }
+  | {
+      kind: "cron"
+      expression: string
+    }
+
+export type AutomationStop =
+  | {
+      kind: "count"
+      count: number
+    }
+  | {
+      kind: "condition"
+      condition: string
+    }
+  | {
+      kind: "never"
+    }
+
+export type AutomationDefinition =
+  | {
+      kind: "oneshot"
+      id: string
+      title: string
+      prompt: string
+      revision: number
+      paused: boolean
+      context: "continue" | "fresh"
+      where: AutomationWhere
+      createdAt: number
+      updatedAt: number
+      timezone: string
+      sourceSessionID?: string
+      normalizationWarnings: Array<string>
+      model: AutomationModel
+      variant?: string
+      fireAt: number
+    }
+  | {
+      kind: "recurring"
+      id: string
+      title: string
+      prompt: string
+      revision: number
+      paused: boolean
+      context: "continue" | "fresh"
+      where: AutomationWhere
+      createdAt: number
+      updatedAt: number
+      timezone: string
+      sourceSessionID?: string
+      normalizationWarnings: Array<string>
+      model: AutomationModel
+      variant?: string
+      rhythm: AutomationRhythm
+      stop: AutomationStop
+      nextFireAt: number | null
+      nextFires: Array<number>
+      failureStreak: number
+    }
+
+export type EventAutomationDefinitionUpdated = {
+  type: "automation.definition.updated"
+  properties: AutomationDefinition
+}
+
+export type AutomationRunBlocker =
+  | {
+      kind: "permission"
+      requestID: string
+    }
+  | {
+      kind: "question"
+      callID: string
+    }
+
+export type AutomationRunError = {
+  code: "needs_user_input" | "execution_failed" | "step_cap" | "loop_gate"
+  message: string
+}
+
+export type AutomationRun =
+  | {
+      id: string
+      automationID: string
+      revision: number
+      definitionRevision: number
+      triggeredAt: number
+      cost: number | null
+      state: "scheduled"
+      sessionID: string | null
+      startedAt: null
+      completedAt: null
+      result: null
+      error: null
+    }
+  | {
+      id: string
+      automationID: string
+      revision: number
+      definitionRevision: number
+      triggeredAt: number
+      cost: number | null
+      sessionID: string
+      startedAt: number
+      completedAt: null
+      result: null
+      error: null
+      state: "running"
+    }
+  | {
+      id: string
+      automationID: string
+      revision: number
+      definitionRevision: number
+      triggeredAt: number
+      cost: number | null
+      sessionID: string
+      startedAt: number
+      completedAt: null
+      result: null
+      error: null
+      state: "awaiting_input"
+      blocker: AutomationRunBlocker
+    }
+  | {
+      id: string
+      automationID: string
+      revision: number
+      definitionRevision: number
+      triggeredAt: number
+      cost: number | null
+      sessionID: string
+      startedAt: number
+      completedAt: number
+      result: string | null
+      error: null
+      state: "succeeded"
+    }
+  | {
+      id: string
+      automationID: string
+      revision: number
+      definitionRevision: number
+      triggeredAt: number
+      cost: number | null
+      sessionID: string
+      startedAt: number
+      completedAt: number
+      result: null
+      error: AutomationRunError
+      state: "failed"
+    }
+  | {
+      id: string
+      automationID: string
+      revision: number
+      definitionRevision: number
+      triggeredAt: number
+      cost: number | null
+      state: "stopped"
+      sessionID: string | null
+      startedAt: number | null
+      completedAt: number
+      result: null
+      error: null
+      stopReason: "previous_run_awaiting_input" | "missed_schedule" | "cancelled" | "expired" | "blocker_lost"
+    }
+
+export type EventAutomationRunUpdated = {
+  type: "automation.run.updated"
+  properties: AutomationRun
+}
+
+export type EventCommandExecuted = {
+  type: "command.executed"
+  properties: {
+    name: string
+    sessionID: string
+    arguments: string
+    messageID: string
+  }
+}
+
+export type EventFileEdited = {
+  type: "file.edited"
+  properties: {
+    file: string
+  }
+}
+
+export type EventFileWatcherRescan = {
+  type: "file.watcher.rescan"
+  properties: {
+    directory: string
+  }
+}
+
+export type EventFileWatcherUpdated = {
+  type: "file.watcher.updated"
+  properties: {
+    file: string
+    event: "add" | "change" | "unlink"
+  }
+}
+
+export type EventGlobalDisposed = {
+  type: "global.disposed"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type EventInstallationUpdateAvailable = {
+  type: "installation.update-available"
+  properties: {
+    version: string
+  }
+}
+
+export type EventInstallationUpdated = {
+  type: "installation.updated"
+  properties: {
+    version: string
+  }
+}
+
+export type EventLspClientDiagnostics = {
+  type: "lsp.client.diagnostics"
+  properties: {
+    serverID: string
+    path: string
+  }
+}
+
+export type EventLspServerInstallFailed = {
+  type: "lsp.server.install.failed"
+  properties: {
+    add: Array<string>
+    dir: string
+    error: string
+  }
+}
+
+export type EventLspUpdated = {
+  type: "lsp.updated"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type EventMcpBrowserOpenFailed = {
+  type: "mcp.browser.open.failed"
+  properties: {
+    mcpName: string
+    url: string
+  }
+}
+
+export type EventMcpToolsChanged = {
+  type: "mcp.tools.changed"
+  properties: {
+    server: string
+  }
+}
+
+export type EventMessagePartDelta = {
+  type: "message.part.delta"
+  properties: {
+    sessionID: string
+    messageID: string
+    partID: string
+    field: string
+    delta: string
+  }
+}
+
+export type EventMessagePartRemoved = {
+  type: "message.part.removed"
+  properties: {
+    sessionID: string
+    messageID: string
+    partID: string
+  }
+}
+
+export type EventMessagePartUpdated = {
+  type: "message.part.updated"
+  properties: {
+    sessionID: string
+    part: Part
+    time: number
+  }
+}
+
+export type EventMessageRemoved = {
+  type: "message.removed"
+  properties: {
+    sessionID: string
+    messageID: string
+  }
+}
+
+export type EventMessageUpdated = {
+  type: "message.updated"
+  properties: {
+    sessionID: string
+    info: Message
+  }
+}
+
+export type PermissionRequest = {
+  id: string
+  sessionID: string
+  permission: string
+  patterns: Array<string>
+  metadata: {
+    [key: string]: unknown
+  }
+  always: Array<string>
+  tool?: {
+    messageID: string
+    callID: string
+  }
+}
+
+export type EventPermissionAsked = {
+  type: "permission.asked"
+  properties: PermissionRequest
+}
+
+export type EventPermissionReplied = {
+  type: "permission.replied"
+  properties: {
+    sessionID: string
+    requestID: string
+    reply: "once" | "always" | "reject"
+  }
+}
+
+export type Project = {
+  id: string
+  worktree: string
+  vcs?: "git"
+  name?: string
+  icon?: {
+    url?: string
+    override?: string
+    color?: string
+  }
+  commands?: {
+    /**
+     * Startup script to run when creating a new workspace (worktree)
+     */
+    start?: string
+  }
+  time: {
+    created: number
+    updated: number
+    initialized?: number
+  }
+  sandboxes: Array<string>
+}
+
+export type EventProjectUpdated = {
+  type: "project.updated"
+  properties: Project
+}
+
+export type Pty = {
+  id: string
+  title: string
+  command: string
+  args: Array<string>
+  cwd: string
+  status: "running" | "exited"
+  pid: number
+}
+
+export type EventPtyCreated = {
+  type: "pty.created"
+  properties: {
+    info: Pty
+  }
+}
+
+export type EventPtyDeleted = {
+  type: "pty.deleted"
+  properties: {
+    id: string
+  }
+}
+
+export type EventPtyExited = {
+  type: "pty.exited"
+  properties: {
+    id: string
+    exitCode: number
+  }
+}
+
+export type EventPtyUpdated = {
+  type: "pty.updated"
+  properties: {
+    info: Pty
+  }
+}
+
+export type EventServerConnected = {
+  type: "server.connected"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type EventServerInstanceDisposed = {
+  type: "server.instance.disposed"
+  properties: {
+    directory: string
+  }
+}
+
+export type EventSessionCompacted = {
+  type: "session.compacted"
+  properties: {
+    sessionID: string
+  }
+}
+
+export type EventSessionCreated = {
+  type: "session.created"
+  properties: {
     sessionID: string
     info: Session
   }
 }
 
-export type SyncEvent = {
-  payload: SyncEvent
+export type EventSessionDeleted = {
+  type: "session.deleted"
+  properties: {
+    sessionID: string
+    info: Session
+  }
 }
 
-/**
- * Log level
- */
-export type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR"
+export type EventSessionDiff = {
+  type: "session.diff"
+  properties: {
+    sessionID: string
+    diff: Array<SnapshotFileDiff>
+  }
+}
 
-/**
- * Server configuration for opencode serve and web commands
- */
-export type ServerConfig = {
+export type EventSessionError = {
+  type: "session.error"
+  properties: {
+    sessionID?: string
+    error?:
+      | ApiError
+      | ContextOverflowError
+      | MessageAbortedError
+      | MessageOutputLengthError
+      | ProviderAuthError
+      | StructuredOutputError
+      | UnknownError
+  }
+}
+
+export type EventSessionIdle = {
+  type: "session.idle"
+  properties: {
+    sessionID: string
+  }
+}
+
+export type RetryClassification =
+  | {
+      kind: "free_quota_exhausted"
+      providerID: string
+      raw: string
+      statusCode?: number
+      retryAfterMs?: number
+      resetAt?: number
+    }
+  | {
+      kind: "unknown"
+      raw: string
+      statusCode?: number
+      retryAfterMs?: number
+    }
+
+export type SessionStatus =
+  | {
+      type: "idle"
+    }
+  | {
+      type: "retry"
+      attempt: number
+      message: string
+      next: number
+      presentation?: "recovery" | "safe_recovery"
+      reason?: "network_connection_dropped"
+      classification?: RetryClassification
+    }
+  | {
+      type: "busy"
+    }
+  | {
+      type: "rate_limit_blocked"
+      classification: RetryClassification
+    }
+
+export type EventSessionStatus = {
+  type: "session.status"
+  properties: {
+    sessionID: string
+    status: SessionStatus
+  }
+}
+
+export type EventSessionTurnChangeInvalidated = {
+  type: "session.turn_change_invalidated"
+  properties: {
+    sessionID: string
+  }
+}
+
+export type EventSessionUpdated = {
+  type: "session.updated"
+  properties: {
+    sessionID: string
+    info: Session
+  }
+}
+
+export type Todo = {
+  id: string
   /**
-   * Port to listen on
+   * Brief description of the task
    */
-  port?: number
+  content: string
   /**
-   * Hostname to listen on
+   * Current status of the task: pending, in_progress, completed, cancelled
    */
-  hostname?: string
+  status: string
   /**
-   * Enable mDNS service discovery
+   * Priority level of the task: high, medium, low
    */
-  mdns?: boolean
-  /**
-   * Custom domain name for mDNS service (default: opencode.local)
-   */
-  mdnsDomain?: string
-  /**
-   * Additional domains to allow for CORS
-   */
-  cors?: Array<string>
+  priority: string
+}
+
+export type EventTodoUpdated = {
+  type: "todo.updated"
+  properties: {
+    sessionID: string
+    revision: number
+    todos: Array<Todo>
+  }
+}
+
+export type EventVcsBranchUpdated = {
+  type: "vcs.branch.updated"
+  properties: {
+    branch?: string
+  }
+}
+
+export type EventWorkspaceFailed = {
+  type: "workspace.failed"
+  properties: {
+    message: string
+  }
+}
+
+export type EventWorkspaceReady = {
+  type: "workspace.ready"
+  properties: {
+    name: string
+  }
+}
+
+export type EventWorkspaceStatus = {
+  type: "workspace.status"
+  properties: {
+    workspaceID: string
+    status: "connected" | "connecting" | "disconnected" | "error"
+    error?: string
+  }
+}
+
+export type EventWorktreeFailed = {
+  type: "worktree.failed"
+  properties: {
+    message: string
+  }
+}
+
+export type EventWorktreeReady = {
+  type: "worktree.ready"
+  properties: {
+    name: string
+    branch: string
+  }
+}
+
+export type Event =
+  | EventAutomationDefinitionDeleted
+  | EventAutomationDefinitionUpdated
+  | EventAutomationRunUpdated
+  | EventCommandExecuted
+  | EventFileEdited
+  | EventFileWatcherRescan
+  | EventFileWatcherUpdated
+  | EventGlobalDisposed
+  | EventInstallationUpdateAvailable
+  | EventInstallationUpdated
+  | EventLspClientDiagnostics
+  | EventLspServerInstallFailed
+  | EventLspUpdated
+  | EventMcpBrowserOpenFailed
+  | EventMcpToolsChanged
+  | EventMessagePartDelta
+  | EventMessagePartRemoved
+  | EventMessagePartUpdated
+  | EventMessageRemoved
+  | EventMessageUpdated
+  | EventPermissionAsked
+  | EventPermissionReplied
+  | EventProjectUpdated
+  | EventPtyCreated
+  | EventPtyDeleted
+  | EventPtyExited
+  | EventPtyUpdated
+  | EventServerConnected
+  | EventServerInstanceDisposed
+  | EventSessionCompacted
+  | EventSessionCreated
+  | EventSessionDeleted
+  | EventSessionDiff
+  | EventSessionError
+  | EventSessionIdle
+  | EventSessionStatus
+  | EventSessionTurnChangeInvalidated
+  | EventSessionUpdated
+  | EventTodoUpdated
+  | EventVcsBranchUpdated
+  | EventWorkspaceFailed
+  | EventWorkspaceReady
+  | EventWorkspaceStatus
+  | EventWorktreeFailed
+  | EventWorktreeReady
+
+export type GlobalEvent = {
+  directory: string
+  project?: string
+  workspace?: string
+  payload: Event
+}
+
+export type OAuth = {
+  type: "oauth"
+  refresh: string
+  access: string
+  expires: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  accountId?: string | null
+  enterpriseUrl?: string | null
+}
+
+export type ApiAuth = {
+  type: "api"
+  key: string
+  metadata?: {
+    [key: string]: string
+  } | null
+}
+
+export type WellKnownAuth = {
+  type: "wellknown"
+  key: string
+  token: string
+}
+
+export type Auth = ApiAuth | OAuth | WellKnownAuth
+
+export type BadRequestError = {
+  data: unknown
+  error: Array<{
+    [key: string]: unknown
+  }>
+  success: false
 }
 
 /**
@@ -1572,80 +1574,6 @@ export type SkillsConfig = {
    * URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)
    */
   urls?: Array<string>
-}
-
-export type PermissionActionConfig = "ask" | "allow" | "deny"
-
-export type PermissionObjectConfig = {
-  [key: string]: PermissionActionConfig
-}
-
-export type PermissionRuleConfig = PermissionActionConfig | PermissionObjectConfig
-
-export type PermissionConfig =
-  | PermissionActionConfig
-  | {
-      read?: PermissionRuleConfig
-      edit?: PermissionRuleConfig
-      glob?: PermissionRuleConfig
-      grep?: PermissionRuleConfig
-      list?: PermissionRuleConfig
-      bash?: PermissionRuleConfig
-      agent?: PermissionRuleConfig
-      task?: PermissionRuleConfig
-      external_directory?: PermissionRuleConfig
-      todowrite?: PermissionActionConfig
-      question?: PermissionActionConfig
-      webfetch?: PermissionActionConfig
-      websearch?: PermissionActionConfig
-      lsp?: PermissionRuleConfig
-      doom_loop?: PermissionActionConfig
-      skill?: PermissionRuleConfig
-      [key: string]: PermissionRuleConfig | PermissionActionConfig | undefined
-    }
-
-export type AgentConfig = {
-  model?: string
-  /**
-   * Default model variant for this agent (applies only when using the agent's configured model).
-   */
-  variant?: string
-  temperature?: number
-  top_p?: number
-  prompt?: string
-  /**
-   * @deprecated Use 'permission' field instead
-   */
-  tools?: {
-    [key: string]: boolean
-  }
-  disable?: boolean
-  /**
-   * Description of when to use the agent
-   */
-  description?: string
-  mode?: "subagent" | "primary" | "all"
-  /**
-   * Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)
-   */
-  hidden?: boolean
-  options?: {
-    [key: string]: unknown
-  }
-  /**
-   * Hex color code (e.g., #FF5733) or theme color (e.g., primary)
-   */
-  color?: string | "primary" | "secondary" | "accent" | "success" | "warning" | "error" | "info"
-  /**
-   * Maximum number of agentic iterations before forcing text-only response
-   */
-  steps?: number
-  /**
-   * @deprecated Use 'steps' field instead.
-   */
-  maxSteps?: number
-  permission?: PermissionConfig
-  [key: string]: unknown
 }
 
 export type ProviderConfig = {
@@ -1818,6 +1746,37 @@ export type McpRemoteConfig = {
  * @deprecated Always uses stretch layout.
  */
 export type LayoutConfig = "auto" | "stretch"
+
+export type PermissionActionConfig = "ask" | "allow" | "deny"
+
+export type PermissionObjectConfig = {
+  [key: string]: PermissionActionConfig
+}
+
+export type PermissionRuleConfig = PermissionActionConfig | PermissionObjectConfig
+
+export type PermissionConfig =
+  | PermissionActionConfig
+  | {
+      read?: PermissionRuleConfig
+      edit?: PermissionRuleConfig
+      glob?: PermissionRuleConfig
+      grep?: PermissionRuleConfig
+      list?: PermissionRuleConfig
+      bash?: PermissionRuleConfig
+      agent?: PermissionRuleConfig
+      task?: PermissionRuleConfig
+      external_directory?: PermissionRuleConfig
+      todowrite?: PermissionActionConfig
+      question?: PermissionActionConfig
+      webfetch?: PermissionActionConfig
+      websearch?: PermissionActionConfig
+      lsp?: PermissionRuleConfig
+      doom_loop?: PermissionActionConfig
+      skill?: PermissionRuleConfig
+      browser?: PermissionRuleConfig
+      [key: string]: PermissionRuleConfig | PermissionActionConfig | undefined
+    }
 
 export type Config = {
   /**
@@ -2017,59 +1976,57 @@ export type Config = {
   }
 }
 
-export type BadRequestError = {
-  data: unknown
-  errors: Array<{
-    [key: string]: unknown
-  }>
+/**
+ * Global upgrade request cannot be fulfilled
+ */
+export type GlobalUpgradeBadRequest = {
   success: false
+  error: string
 }
 
-export type OAuth = {
-  type: "oauth"
-  refresh: string
-  access: string
-  expires: number
-  accountId?: string
-  enterpriseUrl?: string
+/**
+ * Global upgrade failed
+ */
+export type GlobalUpgradeServerError = {
+  success: false
+  error: string
 }
 
-export type ApiAuth = {
-  type: "api"
-  key: string
-  metadata?: {
-    [key: string]: string
-  }
+/**
+ * Raw VCS diff is too large
+ */
+export type VcsDiffRawFailure = {
+  error: "vcs_diff_raw_failed"
+  reason: "too-large"
+  message: string
 }
 
-export type WellKnownAuth = {
-  type: "wellknown"
-  key: string
-  token: string
+/**
+ * VCS patch apply failure
+ */
+export type VcsApplyFailure = {
+  error: "vcs_apply_failed"
+  reason: "non-git" | "not-clean" | "too-large" | "invalid-input"
+  message: string
 }
 
-export type Auth = OAuth | ApiAuth | WellKnownAuth
-
-export type Workspace = {
-  id: string
-  type: string
-  branch: string | null
-  name: string | null
-  directory: string | null
-  extra: unknown | null
-  projectID: string
+/**
+ * VCS patch apply request is too large
+ */
+export type VcsApplyTooLargeFailure = {
+  error: "vcs_apply_failed"
+  reason: "too-large"
+  message: string
 }
 
+/**
+ * Not found
+ */
 export type NotFoundError = {
   name: "NotFoundError"
   data: {
     message: string
   }
-}
-
-export type PtyConnectToken = {
-  ticket: string
-  expires_in: number
 }
 
 export type Model = {
@@ -2159,41 +2116,98 @@ export type Provider = {
 
 export type ConsoleState = {
   consoleManagedProviders: Array<string>
-  activeOrgName?: string
-  switchableOrgCount: number
+  activeOrgName?: string | null
+  switchableOrgCount: unknown
 }
 
-export type ToolIds = Array<string>
-
-export type ToolListItem = {
-  id: string
-  description: string
-  parameters: unknown
-}
-
-export type ToolList = Array<ToolListItem>
-
-export type Worktree = {
+/**
+ * Session conflict
+ */
+export type SessionConflictError = {
   name: string
-  branch: string
-  directory: string
-  source?: "created" | "existing"
+  data: {
+    message: string
+  }
 }
 
-export type WorktreeCreateInput = {
-  name?: string
-  /**
-   * Additional startup script to run after the project's start command
-   */
-  startCommand?: string
+/**
+ * Cloud sharing is disabled
+ */
+export type SessionShareDisabledError = {
+  error: "cloud_share_disabled"
 }
 
-export type WorktreeRemoveInput = {
-  directory: string
+export type ProviderAuthMethod = {
+  type: "oauth" | "api"
+  label: string
+  prompts?: Array<
+    | {
+        type: "text"
+        key: string
+        message: string
+        placeholder?: string | null
+        when?: {
+          key: string
+          op: "eq" | "neq"
+          value: string
+        } | null
+      }
+    | {
+        type: "select"
+        key: string
+        message: string
+        options: Array<{
+          label: string
+          value: string
+          hint?: string | null
+        }>
+        when?: {
+          key: string
+          op: "eq" | "neq"
+          value: string
+        } | null
+      }
+  > | null
 }
 
-export type WorktreeResetInput = {
-  directory: string
+export type ProviderAuthAuthorization = {
+  url: string
+  method: "auto" | "code"
+  instructions: string
+}
+
+/**
+ * Invalid PawWork memory file
+ */
+export type InvalidMemoryFileError = {
+  error: "invalid_memory_file"
+  reason: string
+}
+
+/**
+ * Automation validation failed
+ */
+export type AutomationValidationError = {
+  error: "invalid_automation"
+  details: Array<{
+    field: string
+    message: string
+  }>
+}
+
+/**
+ * Automation update conflict
+ */
+export type AutomationConflictError = {
+  error: "automation_conflict"
+  message: string
+}
+
+/**
+ * MCP server does not support OAuth
+ */
+export type McpUnsupportedOAuthError = {
+  error: string
 }
 
 export type ProjectSummary = {
@@ -2252,12 +2266,27 @@ export type GlobalSession = {
   lastUserMessageAt?: number
 }
 
-export type McpResource = {
+export type SessionArtifact = {
+  file: string
+  kind: "added" | "modified"
+}
+
+export type Symbol = {
   name: string
-  uri: string
-  description?: string
-  mimeType?: string
-  client: string
+  kind: number
+  location: {
+    uri: string
+    range: Range
+  }
+}
+
+export type AutomationListResponse = {
+  items: Array<AutomationDefinition>
+}
+
+export type AutomationRunsResponse = {
+  items: Array<AutomationRun>
+  nextCursor: string | null
 }
 
 export type TodoSnapshot = {
@@ -2265,9 +2294,135 @@ export type TodoSnapshot = {
   todos: Array<Todo>
 }
 
-export type SessionArtifact = {
-  file: string
-  kind: "added" | "modified"
+export type TurnChangeDisplay = {
+  sessionID: string
+  turnID: string
+  messageID: string
+  undoAvailable: boolean
+  redoAvailable: boolean
+  truncated?: boolean
+  omittedCount?: number
+  files: Array<{
+    path: string
+    openPath?: string
+    status: "added" | "modified" | "deleted"
+    additions?: number
+    deletions?: number
+    patch?: string
+    sensitive?: boolean
+    binary?: boolean
+    large?: boolean
+    restoreAvailable?: boolean
+    expandable: boolean
+  }>
+}
+
+export type TurnChangeMutationResult =
+  | {
+      status: "applied"
+      display: {
+        sessionID: string
+        turnID: string
+        messageID: string
+        undoAvailable: boolean
+        redoAvailable: boolean
+        truncated?: boolean
+        omittedCount?: number
+        files: Array<{
+          path: string
+          openPath?: string
+          status: "added" | "modified" | "deleted"
+          additions?: number
+          deletions?: number
+          patch?: string
+          sensitive?: boolean
+          binary?: boolean
+          large?: boolean
+          restoreAvailable?: boolean
+          expandable: boolean
+        }>
+      }
+      skipped?: Array<{
+        messageID: string
+        reason: "conflict" | "permission_denied"
+        files: Array<{
+          path: string
+          reason: string
+        }>
+      }>
+      mutatedPaths?: Array<string>
+    }
+  | {
+      status: "blocked"
+      reason:
+        | "conflict"
+        | "restore_missing"
+        | "permission_denied"
+        | "unsupported_size"
+        | "write_failed"
+        | "rollback_failed"
+      files: Array<{
+        path: string
+        reason: string
+        omittedCount?: number
+      }>
+      skipped?: Array<{
+        messageID: string
+        reason: "conflict" | "permission_denied"
+        files: Array<{
+          path: string
+          reason: string
+        }>
+      }>
+    }
+
+export type AutomationCreateInput =
+  | {
+      kind: "oneshot"
+      title: string
+      prompt: string
+      context: "continue" | "fresh"
+      where: AutomationWhere
+      timezone: string
+      model: AutomationModel
+      variant?: string
+      fireAt: number
+    }
+  | {
+      kind: "recurring"
+      title: string
+      prompt: string
+      context: "continue" | "fresh"
+      where: AutomationWhere
+      timezone: string
+      model: AutomationModel
+      variant?: string
+      rhythm: AutomationRhythm
+      stop: AutomationStop
+    }
+
+export type AutomationUpdateInput = {
+  title?: string
+  prompt?: string
+  paused?: boolean
+  context?: "continue" | "fresh"
+  where?: AutomationWhere
+  timezone?: string
+  fireAt?: number
+  rhythm?: AutomationRhythm
+  stop?: AutomationStop
+  model?: AutomationModel
+  variant?: string | null
+}
+
+export type MemoryState = {
+  path: string
+  disabled: boolean
+  status: "ok" | "safe_mode"
+  reason?: string
+  content: string
+  profile?: string
+  profileTooLarge?: boolean
 }
 
 export type TextPartInput = {
@@ -2390,420 +2545,211 @@ export type SubtaskPartInput = {
   }
 }
 
-export type ProviderAuthMethod = {
-  type: "oauth" | "api"
-  label: string
-  prompts?: Array<
-    | {
-        type: "text"
-        key: string
-        message: string
-        placeholder?: string
-        when?: {
-          key: string
-          op: "eq" | "neq"
-          value: string
-        }
-      }
-    | {
-        type: "select"
-        key: string
-        message: string
-        options: Array<{
-          label: string
-          value: string
-          hint?: string
-        }>
-        when?: {
-          key: string
-          op: "eq" | "neq"
-          value: string
-        }
-      }
-  >
-}
-
-export type ProviderAuthAuthorization = {
-  url: string
-  method: "auto" | "code"
-  instructions: string
-}
-
-export type MemoryState = unknown
-
-export type MemoryRawInput = {
-  content: string
-}
-
-export type MemoryDisabledInput = {
-  disabled: boolean
-}
-
-export type AutomationListResponse = {
-  items: Array<AutomationDefinition>
-}
-
-export type AutomationValidationErrorDetail = {
-  field: string
-  message: string
-}
-
-export type AutomationValidationError = {
-  error: "invalid_automation"
-  details: Array<AutomationValidationErrorDetail>
-}
-
-export type AutomationCreateInput =
-  | {
-      kind: "oneshot"
-      title: string
-      prompt: string
-      context: "continue" | "fresh"
-      where: AutomationWhere
-      timezone: string
-      model: AutomationModel
-      variant?: string
-      fireAt: number
-    }
-  | {
-      kind: "recurring"
-      title: string
-      prompt: string
-      context: "continue" | "fresh"
-      where: AutomationWhere
-      timezone: string
-      model: AutomationModel
-      variant?: string
-      rhythm: AutomationRhythm
-      stop: AutomationStop
-    }
-
-export type AutomationConflictError = {
-  error: "automation_conflict"
-  message: string
-}
-
-export type AutomationUpdateInput = {
-  title?: string
-  prompt?: string
-  paused?: boolean
-  context?: "continue" | "fresh"
-  where?: AutomationWhere
-  timezone?: string
-  fireAt?: number
-  rhythm?: AutomationRhythm
-  stop?: AutomationStop
-  model?: AutomationModel
-  variant?: string | null
-}
-
-export type AutomationRunsResponse = {
-  items: Array<AutomationRun>
-  nextCursor: string | null
-}
-
-export type Symbol = {
-  name: string
-  kind: number
-  location: {
-    uri: string
-    range: Range
+export type PromptBody = {
+  messageID?: string
+  model?: {
+    providerID: string
+    modelID: string
   }
-}
-
-export type FileNode = {
-  name: string
-  path: string
-  absolute: string
-  type: "file" | "directory"
-  ignored: boolean
-}
-
-export type FileContent = {
-  type: "text" | "binary"
-  content: string
-  diff?: string
-  patch?: {
-    oldFileName: string
-    newFileName: string
-    oldHeader?: string
-    newHeader?: string
-    hunks: Array<{
-      oldStart: number
-      oldLines: number
-      newStart: number
-      newLines: number
-      lines: Array<string>
-    }>
-    index?: string
+  agent?: string
+  locale?: string
+  noReply?: boolean
+  /**
+   * @deprecated tools and permissions have been merged, you can set permissions on the session itself now
+   */
+  tools?: {
+    [key: string]: boolean
   }
-  encoding?: "base64"
-  mimeType?: string
+  format?: OutputFormat
+  system?: string
+  variant?: string
+  parts: Array<AgentPartInput | FilePartInput | SkillPartInput | SubtaskPartInput | TextPartInput>
 }
 
-export type File = {
-  path: string
-  added: number
-  removed: number
-  status: "added" | "deleted" | "modified"
-}
-
-export type McpStatusConnected = {
-  status: "connected"
-}
-
-export type McpStatusDisabled = {
-  status: "disabled"
-}
-
-export type McpStatusFailed = {
-  status: "failed"
-  error: string
-}
-
-export type McpStatusNeedsAuth = {
-  status: "needs_auth"
-}
-
-export type McpStatusNeedsClientRegistration = {
-  status: "needs_client_registration"
-  error: string
-}
-
-export type McpStatus =
-  | McpStatusConnected
-  | McpStatusDisabled
-  | McpStatusFailed
-  | McpStatusNeedsAuth
-  | McpStatusNeedsClientRegistration
-
-export type Path = {
-  home: string
-  state: string
-  config: string
-  worktree: string
-  directory: string
-}
-
-export type VcsInfo = {
-  branch?: string
-  default_branch?: string
-}
-
-export type VcsFileDiff = {
-  file: string
-  patch: string
-  additions: number
-  deletions: number
-  status?: "added" | "deleted" | "modified"
-}
-
-export type VcsFileStatus = {
-  file: string
-  additions: number
-  deletions: number
-  status: "added" | "deleted" | "modified"
-}
-
-export type VcsDiffRawFailure = {
-  error: "vcs_diff_raw_failed"
-  reason: "too-large"
-  message: string
-}
-
-export type VcsApplyFailure = {
-  error: "vcs_apply_failed"
-  reason: "non-git" | "not-clean" | "too-large" | "invalid-input"
-  message: string
-}
-
-export type Command = {
-  name: string
-  description?: string
+export type CommandBody = {
+  messageID?: string
   agent?: string
   model?: string
-  source?: "command" | "mcp" | "skill"
-  template: string
-  subtask?: boolean
-  hints: Array<string>
+  locale?: string
+  arguments: string
+  command: string
+  variant?: string
+  parts?: Array<{
+    id?: string
+    type: "file"
+    mime: string
+    filename?: string
+    url: string
+    source?: FilePartSource
+    metadata?: {
+      [key: string]: unknown
+    }
+  }>
 }
 
-export type Agent = {
-  name: string
-  description?: string
-  mode: "subagent" | "primary" | "all"
-  native?: boolean
-  hidden?: boolean
-  topP?: number
-  temperature?: number
-  color?: string
-  permission: PermissionRuleset
+export type ShellBody = {
+  messageID?: string
+  agent: string
   model?: {
-    modelID: string
     providerID: string
+    modelID: string
   }
+  command: string
+}
+
+export type SessionCreateBody = {
+  parentID?: string
+  title?: string
+  skill?: string
+  permission?: PermissionRuleset
+  workspaceID?: string
+  createdByAgentTool?: boolean
+  subagentType?: string | null
+}
+
+export type SessionForkBody = {
+  messageID?: string
+}
+
+export type SessionRevertBody = {
+  messageID: string
+  partID?: string
+}
+
+export type TurnChangeAggregate =
+  | {
+      kind: "empty"
+      sessionID: string
+      turnID?: string
+      messageID?: string
+    }
+  | {
+      kind: "captured"
+      sessionID: string
+      turnID?: string
+      messageID?: string
+      files: Array<{
+        path: string
+        openPath?: string
+        status: "added" | "modified" | "deleted"
+        additions?: number
+        deletions?: number
+        patch?: string
+        sensitive?: boolean
+        binary?: boolean
+        large?: boolean
+        restoreAvailable?: boolean
+        expandable: boolean
+        restoreState: "applied" | "undone" | "redo_invalidated"
+      }>
+      truncated?: boolean
+      omittedCount?: number
+    }
+  | {
+      kind: "uncaptured"
+      sessionID: string
+      turnID?: string
+      messageID?: string
+      count: number
+    }
+  | {
+      kind: "mixed"
+      sessionID: string
+      turnID?: string
+      messageID?: string
+      files: Array<{
+        path: string
+        openPath?: string
+        status: "added" | "modified" | "deleted"
+        additions?: number
+        deletions?: number
+        patch?: string
+        sensitive?: boolean
+        binary?: boolean
+        large?: boolean
+        restoreAvailable?: boolean
+        expandable: boolean
+        restoreState: "applied" | "undone" | "redo_invalidated"
+      }>
+      count: number
+      truncated?: boolean
+      omittedCount?: number
+    }
+
+/**
+ * Log level
+ */
+export type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR"
+
+/**
+ * Server configuration for opencode serve and web commands
+ */
+export type ServerConfig = {
+  /**
+   * Port to listen on
+   */
+  port?: number
+  /**
+   * Hostname to listen on
+   */
+  hostname?: string
+  /**
+   * Enable mDNS service discovery
+   */
+  mdns?: boolean
+  /**
+   * Custom domain name for mDNS service (default: opencode.local)
+   */
+  mdnsDomain?: string
+  /**
+   * Additional domains to allow for CORS
+   */
+  cors?: Array<string>
+}
+
+export type AgentConfig = {
+  model?: string
+  /**
+   * Default model variant for this agent (applies only when using the agent's configured model).
+   */
   variant?: string
+  temperature?: number
+  top_p?: number
   prompt?: string
-  options: {
+  /**
+   * @deprecated Use 'permission' field instead
+   */
+  tools?: {
+    [key: string]: boolean
+  }
+  disable?: boolean
+  /**
+   * Description of when to use the agent
+   */
+  description?: string
+  mode?: "subagent" | "primary" | "all"
+  /**
+   * Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)
+   */
+  hidden?: boolean
+  options?: {
     [key: string]: unknown
   }
+  /**
+   * Hex color code (e.g., #FF5733) or theme color (e.g., primary)
+   */
+  color?: string | "primary" | "secondary" | "accent" | "success" | "warning" | "error" | "info"
+  /**
+   * Maximum number of agentic iterations before forcing text-only response
+   */
   steps?: number
-}
-
-export type LspStatus = {
-  id: string
-  name: string
-  root: string
-  status: "connected" | "error"
-}
-
-export type GlobalHealthData = {
-  body?: never
-  path?: never
-  query?: never
-  url: "/global/health"
-}
-
-export type GlobalHealthResponses = {
   /**
-   * Health information
+   * @deprecated Use 'steps' field instead.
    */
-  200: {
-    healthy: true
-    version: string
-  }
+  maxSteps?: number
+  permission?: PermissionConfig
+  [key: string]: unknown
 }
-
-export type GlobalHealthResponse = GlobalHealthResponses[keyof GlobalHealthResponses]
-
-export type GlobalEventData = {
-  body?: never
-  path?: never
-  query?: never
-  url: "/global/event"
-}
-
-export type GlobalEventResponses = {
-  /**
-   * Event stream
-   */
-  200: GlobalEvent
-}
-
-export type GlobalEventResponse = GlobalEventResponses[keyof GlobalEventResponses]
-
-export type GlobalSyncEventSubscribeData = {
-  body?: never
-  path?: never
-  query?: never
-  url: "/global/sync-event"
-}
-
-export type GlobalSyncEventSubscribeResponses = {
-  /**
-   * Event stream
-   */
-  200: SyncEvent
-}
-
-export type GlobalSyncEventSubscribeResponse =
-  GlobalSyncEventSubscribeResponses[keyof GlobalSyncEventSubscribeResponses]
-
-export type GlobalConfigGetData = {
-  body?: never
-  path?: never
-  query?: never
-  url: "/global/config"
-}
-
-export type GlobalConfigGetResponses = {
-  /**
-   * Get global config info
-   */
-  200: Config
-}
-
-export type GlobalConfigGetResponse = GlobalConfigGetResponses[keyof GlobalConfigGetResponses]
-
-export type GlobalConfigUpdateData = {
-  body?: Config
-  path?: never
-  query?: never
-  url: "/global/config"
-}
-
-export type GlobalConfigUpdateErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-}
-
-export type GlobalConfigUpdateError = GlobalConfigUpdateErrors[keyof GlobalConfigUpdateErrors]
-
-export type GlobalConfigUpdateResponses = {
-  /**
-   * Successfully updated global config
-   */
-  200: Config
-}
-
-export type GlobalConfigUpdateResponse = GlobalConfigUpdateResponses[keyof GlobalConfigUpdateResponses]
-
-export type GlobalDisposeData = {
-  body?: never
-  path?: never
-  query?: never
-  url: "/global/dispose"
-}
-
-export type GlobalDisposeResponses = {
-  /**
-   * Global disposed
-   */
-  200: {
-    status: "completed" | "deferred"
-    lifecycleActionID: string
-    affectedDirectoryKeys: Array<string>
-  }
-}
-
-export type GlobalDisposeResponse = GlobalDisposeResponses[keyof GlobalDisposeResponses]
-
-export type GlobalUpgradeData = {
-  body?: {
-    target?: string
-  }
-  path?: never
-  query?: never
-  url: "/global/upgrade"
-}
-
-export type GlobalUpgradeErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-}
-
-export type GlobalUpgradeError = GlobalUpgradeErrors[keyof GlobalUpgradeErrors]
-
-export type GlobalUpgradeResponses = {
-  /**
-   * Upgrade result
-   */
-  200:
-    | {
-        success: true
-        version: string
-      }
-    | {
-        success: false
-        error: string
-      }
-}
-
-export type GlobalUpgradeResponse = GlobalUpgradeResponses[keyof GlobalUpgradeResponses]
 
 export type AuthRemoveData = {
   body?: never
@@ -2825,7 +2771,7 @@ export type AuthRemoveError = AuthRemoveErrors[keyof AuthRemoveErrors]
 
 export type AuthRemoveResponses = {
   /**
-   * Successfully removed authentication credentials
+   * Success
    */
   200: boolean
 }
@@ -2833,7 +2779,7 @@ export type AuthRemoveResponses = {
 export type AuthRemoveResponse = AuthRemoveResponses[keyof AuthRemoveResponses]
 
 export type AuthSetData = {
-  body?: Auth
+  body: Auth
   path: {
     providerID: string
   }
@@ -2852,7 +2798,7 @@ export type AuthSetError = AuthSetErrors[keyof AuthSetErrors]
 
 export type AuthSetResponses = {
   /**
-   * Successfully set authentication credentials
+   * Success
    */
   200: boolean
 }
@@ -2860,25 +2806,13 @@ export type AuthSetResponses = {
 export type AuthSetResponse = AuthSetResponses[keyof AuthSetResponses]
 
 export type AppLogData = {
-  body?: {
-    /**
-     * Service name for the log entry
-     */
+  body: {
     service: string
-    /**
-     * Log level
-     */
     level: "debug" | "info" | "error" | "warn"
-    /**
-     * Log message
-     */
     message: string
-    /**
-     * Additional metadata for the log entry
-     */
     extra?: {
       [key: string]: unknown
-    }
+    } | null
   }
   path?: never
   query?: {
@@ -2899,12 +2833,131 @@ export type AppLogError = AppLogErrors[keyof AppLogErrors]
 
 export type AppLogResponses = {
   /**
-   * Log entry written successfully
+   * Success
    */
   200: boolean
 }
 
 export type AppLogResponse = AppLogResponses[keyof AppLogResponses]
+
+export type GlobalConfigGetData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/global/config"
+}
+
+export type GlobalConfigGetResponses = {
+  /**
+   * Config
+   */
+  200: Config
+}
+
+export type GlobalConfigGetResponse = GlobalConfigGetResponses[keyof GlobalConfigGetResponses]
+
+export type GlobalConfigUpdateData = {
+  body: Config
+  path?: never
+  query?: never
+  url: "/global/config"
+}
+
+export type GlobalConfigUpdateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type GlobalConfigUpdateError = GlobalConfigUpdateErrors[keyof GlobalConfigUpdateErrors]
+
+export type GlobalConfigUpdateResponses = {
+  /**
+   * Config
+   */
+  200: Config
+}
+
+export type GlobalConfigUpdateResponse = GlobalConfigUpdateResponses[keyof GlobalConfigUpdateResponses]
+
+export type GlobalHealthData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/global/health"
+}
+
+export type GlobalHealthResponses = {
+  /**
+   * Success
+   */
+  200: {
+    healthy: true
+    version: string
+  }
+}
+
+export type GlobalHealthResponse = GlobalHealthResponses[keyof GlobalHealthResponses]
+
+export type GlobalDisposeData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/global/dispose"
+}
+
+export type GlobalDisposeResponses = {
+  /**
+   * Success
+   */
+  200: {
+    status: "completed" | "deferred"
+    lifecycleActionID: string
+    affectedDirectoryKeys: Array<string>
+  }
+}
+
+export type GlobalDisposeResponse = GlobalDisposeResponses[keyof GlobalDisposeResponses]
+
+export type GlobalUpgradeData = {
+  body: {
+    target?: string
+  }
+  path?: never
+  query?: never
+  url: "/global/upgrade"
+}
+
+export type GlobalUpgradeErrors = {
+  /**
+   * Bad request | Global upgrade request cannot be fulfilled
+   */
+  400: BadRequestError | GlobalUpgradeBadRequest
+  /**
+   * Global upgrade failed
+   */
+  500: GlobalUpgradeServerError
+}
+
+export type GlobalUpgradeError = GlobalUpgradeErrors[keyof GlobalUpgradeErrors]
+
+export type GlobalUpgradeResponses = {
+  /**
+   * Success
+   */
+  200:
+    | {
+        success: true
+        version: string
+      }
+    | {
+        success: false
+        error: string
+      }
+}
+
+export type GlobalUpgradeResponse = GlobalUpgradeResponses[keyof GlobalUpgradeResponses]
 
 export type ExperimentalWorkspaceListData = {
   body?: never
@@ -2918,17 +2971,25 @@ export type ExperimentalWorkspaceListData = {
 
 export type ExperimentalWorkspaceListResponses = {
   /**
-   * Workspaces
+   * Success
    */
-  200: Array<Workspace>
+  200: Array<{
+    id: string
+    type: string
+    branch: string | null
+    name: string | null
+    directory: string | null
+    extra: unknown | null
+    projectID: string
+  }>
 }
 
 export type ExperimentalWorkspaceListResponse =
   ExperimentalWorkspaceListResponses[keyof ExperimentalWorkspaceListResponses]
 
 export type ExperimentalWorkspaceCreateData = {
-  body?: {
-    id?: string
+  body: {
+    id?: string | null
     type: string
     branch: string | null
     extra: unknown | null
@@ -2953,9 +3014,17 @@ export type ExperimentalWorkspaceCreateError =
 
 export type ExperimentalWorkspaceCreateResponses = {
   /**
-   * Workspace created
+   * Success
    */
-  200: Workspace
+  200: {
+    id: string
+    type: string
+    branch: string | null
+    name: string | null
+    directory: string | null
+    extra: unknown | null
+    projectID: string
+  }
 }
 
 export type ExperimentalWorkspaceCreateResponse =
@@ -2973,12 +3042,12 @@ export type ExperimentalWorkspaceStatusData = {
 
 export type ExperimentalWorkspaceStatusResponses = {
   /**
-   * Workspace status
+   * Success
    */
   200: Array<{
     workspaceID: string
     status: "connected" | "connecting" | "disconnected" | "error"
-    error?: string
+    error?: string | null
   }>
 }
 
@@ -3009,13 +3078,317 @@ export type ExperimentalWorkspaceRemoveError =
 
 export type ExperimentalWorkspaceRemoveResponses = {
   /**
-   * Workspace removed
+   * Success
    */
-  200: Workspace
+  200: {
+    id: string
+    type: string
+    branch: string | null
+    name: string | null
+    directory: string | null
+    extra: unknown | null
+    projectID: string
+  } | null
 }
 
 export type ExperimentalWorkspaceRemoveResponse =
   ExperimentalWorkspaceRemoveResponses[keyof ExperimentalWorkspaceRemoveResponses]
+
+export type InstanceDisposeData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/instance/dispose"
+}
+
+export type InstanceDisposeResponses = {
+  /**
+   * Success
+   */
+  200: boolean
+}
+
+export type InstanceDisposeResponse = InstanceDisposeResponses[keyof InstanceDisposeResponses]
+
+export type PathGetData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+    ensureConfig?: "true" | "false"
+  }
+  url: "/path"
+}
+
+export type PathGetResponses = {
+  /**
+   * Success
+   */
+  200: {
+    home: string
+    state: string
+    config: string
+    worktree: string
+    directory: string
+  }
+}
+
+export type PathGetResponse = PathGetResponses[keyof PathGetResponses]
+
+export type VcsGetData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/vcs"
+}
+
+export type VcsGetResponses = {
+  /**
+   * Success
+   */
+  200: {
+    branch?: string
+    default_branch?: string
+  }
+}
+
+export type VcsGetResponse = VcsGetResponses[keyof VcsGetResponses]
+
+export type VcsStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/vcs/status"
+}
+
+export type VcsStatusResponses = {
+  /**
+   * Success
+   */
+  200: Array<{
+    file: string
+    additions: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    deletions: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    status: "added" | "deleted" | "modified"
+  }>
+}
+
+export type VcsStatusResponse = VcsStatusResponses[keyof VcsStatusResponses]
+
+export type VcsDiffData = {
+  body?: never
+  path?: never
+  query: {
+    directory?: string
+    workspace?: string
+    mode: "git" | "branch"
+  }
+  url: "/vcs/diff"
+}
+
+export type VcsDiffResponses = {
+  /**
+   * Success
+   */
+  200: Array<{
+    file: string
+    patch: string
+    additions: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    deletions: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    status?: "added" | "deleted" | "modified"
+  }>
+}
+
+export type VcsDiffResponse = VcsDiffResponses[keyof VcsDiffResponses]
+
+export type VcsDiffRawData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/vcs/diff/raw"
+}
+
+export type VcsDiffRawErrors = {
+  /**
+   * Raw VCS diff is too large
+   */
+  413: VcsDiffRawFailure
+}
+
+export type VcsDiffRawError = VcsDiffRawErrors[keyof VcsDiffRawErrors]
+
+export type VcsDiffRawResponses = {
+  /**
+   * Success
+   */
+  200: string
+}
+
+export type VcsDiffRawResponse = VcsDiffRawResponses[keyof VcsDiffRawResponses]
+
+export type VcsApplyData = {
+  body: {
+    patch: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/vcs/apply"
+}
+
+export type VcsApplyErrors = {
+  /**
+   * Bad request | VCS patch apply failure
+   */
+  400: BadRequestError | VcsApplyFailure
+  /**
+   * VCS patch apply request is too large
+   */
+  413: VcsApplyTooLargeFailure
+}
+
+export type VcsApplyError = VcsApplyErrors[keyof VcsApplyErrors]
+
+export type VcsApplyResponses = {
+  /**
+   * Success
+   */
+  200: {
+    applied: boolean
+  }
+}
+
+export type VcsApplyResponse = VcsApplyResponses[keyof VcsApplyResponses]
+
+export type CommandListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/command"
+}
+
+export type CommandListResponses = {
+  /**
+   * Success
+   */
+  200: Array<{
+    name: string
+    description?: string
+    agent?: string
+    model?: string
+    source?: "command" | "mcp" | "skill"
+    template: unknown
+    subtask?: boolean
+    hints: Array<string>
+  }>
+}
+
+export type CommandListResponse = CommandListResponses[keyof CommandListResponses]
+
+export type AppAgentsData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/agent"
+}
+
+export type AppAgentsResponses = {
+  /**
+   * Success
+   */
+  200: Array<{
+    name: string
+    description?: string
+    mode: "subagent" | "primary" | "all"
+    native?: boolean
+    hidden?: boolean
+    topP?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    temperature?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    color?: string
+    permission: unknown
+    model?: {
+      modelID: string
+      providerID: string
+    }
+    variant?: string
+    prompt?: string
+    options: {
+      [key: string]: unknown
+    }
+    steps?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  }>
+}
+
+export type AppAgentsResponse = AppAgentsResponses[keyof AppAgentsResponses]
+
+export type AppSkillsData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/skill"
+}
+
+export type AppSkillsResponses = {
+  /**
+   * Success
+   */
+  200: Array<{
+    name: string
+    description?: string
+    location: string
+    content: string
+  }>
+}
+
+export type AppSkillsResponse = AppSkillsResponses[keyof AppSkillsResponses]
+
+export type LspStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/lsp"
+}
+
+export type LspStatusResponses = {
+  /**
+   * Success
+   */
+  200: Array<{
+    id: string
+    name: string
+    root: string
+    status: "connected" | "error"
+  }>
+}
+
+export type LspStatusResponse = LspStatusResponses[keyof LspStatusResponses]
 
 export type ProjectListData = {
   body?: never
@@ -3029,9 +3402,28 @@ export type ProjectListData = {
 
 export type ProjectListResponses = {
   /**
-   * List of projects
+   * Success
    */
-  200: Array<Project>
+  200: Array<{
+    id: string
+    worktree: string
+    vcs?: "git"
+    name?: string
+    icon?: {
+      url?: string
+      override?: string
+      color?: string
+    }
+    commands?: {
+      start?: string
+    }
+    time: {
+      created: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      updated: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      initialized?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    }
+    sandboxes: Array<string>
+  }>
 }
 
 export type ProjectListResponse = ProjectListResponses[keyof ProjectListResponses]
@@ -3048,9 +3440,28 @@ export type ProjectCurrentData = {
 
 export type ProjectCurrentResponses = {
   /**
-   * Current project information
+   * Success
    */
-  200: Project
+  200: {
+    id: string
+    worktree: string
+    vcs?: "git"
+    name?: string
+    icon?: {
+      url?: string
+      override?: string
+      color?: string
+    }
+    commands?: {
+      start?: string
+    }
+    time: {
+      created: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      updated: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      initialized?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    }
+    sandboxes: Array<string>
+  }
 }
 
 export type ProjectCurrentResponse = ProjectCurrentResponses[keyof ProjectCurrentResponses]
@@ -3067,15 +3478,12 @@ export type ProjectInitGitData = {
 
 export type ProjectInitGitResponses = {
   /**
-   * Project information after git initialization
+   * Success
    */
-  200: Project
-}
-
-export type ProjectInitGitResponse = ProjectInitGitResponses[keyof ProjectInitGitResponses]
-
-export type ProjectUpdateData = {
-  body?: {
+  200: {
+    id: string
+    worktree: string
+    vcs?: "git"
     name?: string
     icon?: {
       url?: string
@@ -3083,9 +3491,28 @@ export type ProjectUpdateData = {
       color?: string
     }
     commands?: {
-      /**
-       * Startup script to run when creating a new workspace (worktree)
-       */
+      start?: string
+    }
+    time: {
+      created: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      updated: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      initialized?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    }
+    sandboxes: Array<string>
+  }
+}
+
+export type ProjectInitGitResponse = ProjectInitGitResponses[keyof ProjectInitGitResponses]
+
+export type ProjectUpdateData = {
+  body: {
+    name?: string
+    icon?: {
+      url?: string
+      override?: string
+      color?: string
+    }
+    commands?: {
       start?: string
     }
   }
@@ -3114,9 +3541,28 @@ export type ProjectUpdateError = ProjectUpdateErrors[keyof ProjectUpdateErrors]
 
 export type ProjectUpdateResponses = {
   /**
-   * Updated project information
+   * Success
    */
-  200: Project
+  200: {
+    id: string
+    worktree: string
+    vcs?: "git"
+    name?: string
+    icon?: {
+      url?: string
+      override?: string
+      color?: string
+    }
+    commands?: {
+      start?: string
+    }
+    time: {
+      created: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      updated: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      initialized?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    }
+    sandboxes: Array<string>
+  }
 }
 
 export type ProjectUpdateResponse = ProjectUpdateResponses[keyof ProjectUpdateResponses]
@@ -3124,37 +3570,39 @@ export type ProjectUpdateResponse = ProjectUpdateResponses[keyof ProjectUpdateRe
 export type PtyListData = {
   body?: never
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/pty"
 }
 
 export type PtyListResponses = {
   /**
-   * List of sessions
+   * Success
    */
-  200: Array<Pty>
+  200: Array<{
+    id: string
+    title: string
+    command: string
+    args: Array<string>
+    cwd: string
+    status: "running" | "exited"
+    pid: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  }>
 }
 
 export type PtyListResponse = PtyListResponses[keyof PtyListResponses]
 
 export type PtyCreateData = {
-  body?: {
-    command?: string
-    args?: Array<string>
-    cwd?: string
-    title?: string
+  body: {
+    command?: string | null
+    args?: Array<string> | null
+    cwd?: string | null
+    title?: string | null
     env?: {
       [key: string]: string
-    }
+    } | null
   }
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/pty"
 }
 
@@ -3169,9 +3617,17 @@ export type PtyCreateError = PtyCreateErrors[keyof PtyCreateErrors]
 
 export type PtyCreateResponses = {
   /**
-   * Created session
+   * Success
    */
-  200: Pty
+  200: {
+    id: string
+    title: string
+    command: string
+    args: Array<string>
+    cwd: string
+    status: "running" | "exited"
+    pid: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  }
 }
 
 export type PtyCreateResponse = PtyCreateResponses[keyof PtyCreateResponses]
@@ -3181,10 +3637,7 @@ export type PtyRemoveData = {
   path: {
     ptyID: string
   }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/pty/{ptyID}"
 }
 
@@ -3199,7 +3652,7 @@ export type PtyRemoveError = PtyRemoveErrors[keyof PtyRemoveErrors]
 
 export type PtyRemoveResponses = {
   /**
-   * Session removed
+   * Success
    */
   200: boolean
 }
@@ -3211,10 +3664,7 @@ export type PtyGetData = {
   path: {
     ptyID: string
   }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/pty/{ptyID}"
 }
 
@@ -3229,28 +3679,33 @@ export type PtyGetError = PtyGetErrors[keyof PtyGetErrors]
 
 export type PtyGetResponses = {
   /**
-   * Session info
+   * Success
    */
-  200: Pty
+  200: {
+    id: string
+    title: string
+    command: string
+    args: Array<string>
+    cwd: string
+    status: "running" | "exited"
+    pid: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  }
 }
 
 export type PtyGetResponse = PtyGetResponses[keyof PtyGetResponses]
 
 export type PtyUpdateData = {
-  body?: {
-    title?: string
+  body: {
+    title?: string | null
     size?: {
-      rows: number
-      cols: number
-    }
+      rows: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      cols: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    } | null
   }
   path: {
     ptyID: string
   }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/pty/{ptyID}"
 }
 
@@ -3269,9 +3724,17 @@ export type PtyUpdateError = PtyUpdateErrors[keyof PtyUpdateErrors]
 
 export type PtyUpdateResponses = {
   /**
-   * Updated session
+   * Success
    */
-  200: Pty
+  200: {
+    id: string
+    title: string
+    command: string
+    args: Array<string>
+    cwd: string
+    status: "running" | "exited"
+    pid: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  }
 }
 
 export type PtyUpdateResponse = PtyUpdateResponses[keyof PtyUpdateResponses]
@@ -3281,10 +3744,7 @@ export type PtyConnectTokenData = {
   path: {
     ptyID: string
   }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/pty/{ptyID}/connect-token"
 }
 
@@ -3299,44 +3759,15 @@ export type PtyConnectTokenError = PtyConnectTokenErrors[keyof PtyConnectTokenEr
 
 export type PtyConnectTokenResponses = {
   /**
-   * WebSocket connect token
+   * Success
    */
-  200: PtyConnectToken
+  200: {
+    ticket: string
+    expires_in: unknown
+  }
 }
 
 export type PtyConnectTokenResponse = PtyConnectTokenResponses[keyof PtyConnectTokenResponses]
-
-export type PtyConnectData = {
-  body?: never
-  path: {
-    ptyID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-    cursor?: string
-    ticket?: string
-  }
-  url: "/pty/{ptyID}/connect"
-}
-
-export type PtyConnectErrors = {
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type PtyConnectError = PtyConnectErrors[keyof PtyConnectErrors]
-
-export type PtyConnectResponses = {
-  /**
-   * Connected session
-   */
-  200: boolean
-}
-
-export type PtyConnectResponse = PtyConnectResponses[keyof PtyConnectResponses]
 
 export type ConfigGetData = {
   body?: never
@@ -3350,7 +3781,7 @@ export type ConfigGetData = {
 
 export type ConfigGetResponses = {
   /**
-   * Get config info
+   * Config
    */
   200: Config
 }
@@ -3358,7 +3789,7 @@ export type ConfigGetResponses = {
 export type ConfigGetResponse = ConfigGetResponses[keyof ConfigGetResponses]
 
 export type ConfigUpdateData = {
-  body?: Config
+  body: Config
   path?: never
   query?: {
     directory?: string
@@ -3378,7 +3809,7 @@ export type ConfigUpdateError = ConfigUpdateErrors[keyof ConfigUpdateErrors]
 
 export type ConfigUpdateResponses = {
   /**
-   * Successfully updated config
+   * Config
    */
   200: Config
 }
@@ -3397,7 +3828,7 @@ export type ConfigProvidersData = {
 
 export type ConfigProvidersResponses = {
   /**
-   * List of providers
+   * Success
    */
   200: {
     providers: Array<Provider>
@@ -3412,16 +3843,13 @@ export type ConfigProvidersResponse = ConfigProvidersResponses[keyof ConfigProvi
 export type ExperimentalConsoleGetData = {
   body?: never
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/experimental/console"
 }
 
 export type ExperimentalConsoleGetResponses = {
   /**
-   * Active Console provider metadata
+   * ConsoleState
    */
   200: ConsoleState
 }
@@ -3431,16 +3859,13 @@ export type ExperimentalConsoleGetResponse = ExperimentalConsoleGetResponses[key
 export type ExperimentalConsoleListOrgsData = {
   body?: never
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/experimental/console/orgs"
 }
 
 export type ExperimentalConsoleListOrgsResponses = {
   /**
-   * Switchable Console orgs
+   * Success
    */
   200: {
     orgs: Array<{
@@ -3458,21 +3883,28 @@ export type ExperimentalConsoleListOrgsResponse =
   ExperimentalConsoleListOrgsResponses[keyof ExperimentalConsoleListOrgsResponses]
 
 export type ExperimentalConsoleSwitchOrgData = {
-  body?: {
+  body: {
     accountID: string
     orgID: string
   }
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/experimental/console/switch"
 }
 
+export type ExperimentalConsoleSwitchOrgErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ExperimentalConsoleSwitchOrgError =
+  ExperimentalConsoleSwitchOrgErrors[keyof ExperimentalConsoleSwitchOrgErrors]
+
 export type ExperimentalConsoleSwitchOrgResponses = {
   /**
-   * Switch success
+   * Success
    */
   200: boolean
 }
@@ -3480,40 +3912,10 @@ export type ExperimentalConsoleSwitchOrgResponses = {
 export type ExperimentalConsoleSwitchOrgResponse =
   ExperimentalConsoleSwitchOrgResponses[keyof ExperimentalConsoleSwitchOrgResponses]
 
-export type ToolIdsData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/experimental/tool/ids"
-}
-
-export type ToolIdsErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-}
-
-export type ToolIdsError = ToolIdsErrors[keyof ToolIdsErrors]
-
-export type ToolIdsResponses = {
-  /**
-   * Tool IDs
-   */
-  200: ToolIds
-}
-
-export type ToolIdsResponse = ToolIdsResponses[keyof ToolIdsResponses]
-
 export type ToolListData = {
   body?: never
   path?: never
   query: {
-    directory?: string
-    workspace?: string
     provider: string
     model: string
   }
@@ -3531,20 +3933,98 @@ export type ToolListError = ToolListErrors[keyof ToolListErrors]
 
 export type ToolListResponses = {
   /**
-   * Tools
+   * Success
    */
-  200: ToolList
+  200: Array<{
+    id: string
+    description: string
+    parameters: unknown
+  }>
 }
 
 export type ToolListResponse = ToolListResponses[keyof ToolListResponses]
 
-export type WorktreeRemoveData = {
-  body?: WorktreeRemoveInput
+export type ToolIdsData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/experimental/tool/ids"
+}
+
+export type ToolIdsErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ToolIdsError = ToolIdsErrors[keyof ToolIdsErrors]
+
+export type ToolIdsResponses = {
+  /**
+   * Success
+   */
+  200: Array<string>
+}
+
+export type ToolIdsResponse = ToolIdsResponses[keyof ToolIdsResponses]
+
+export type ExperimentalResourceListData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/experimental/resource"
+}
+
+export type ExperimentalResourceListResponses = {
+  /**
+   * Success
+   */
+  200: {
+    [key: string]: {
+      name: string
+      uri: string
+      description?: string
+      mimeType?: string
+      client: string
+    }
+  }
+}
+
+export type ExperimentalResourceListResponse =
+  ExperimentalResourceListResponses[keyof ExperimentalResourceListResponses]
+
+export type ExperimentalSessionListData = {
+  body?: never
   path?: never
   query?: {
     directory?: string
-    workspace?: string
+    roots?: "true" | "false"
+    start?: string
+    cursor?: string
+    search?: string
+    limit?: string
+    archived?: "true" | "false"
+    sort?: "updated" | "created" | "activity"
   }
+  url: "/experimental/session"
+}
+
+export type ExperimentalSessionListResponses = {
+  /**
+   * Success
+   */
+  200: Array<GlobalSession>
+}
+
+export type ExperimentalSessionListResponse = ExperimentalSessionListResponses[keyof ExperimentalSessionListResponses]
+
+export type WorktreeRemoveData = {
+  body: {
+    directory: string
+  }
+  path?: never
+  query?: never
   url: "/experimental/worktree"
 }
 
@@ -3559,7 +4039,7 @@ export type WorktreeRemoveError = WorktreeRemoveErrors[keyof WorktreeRemoveError
 
 export type WorktreeRemoveResponses = {
   /**
-   * Worktree removed
+   * Success
    */
   200: boolean
 }
@@ -3569,29 +4049,31 @@ export type WorktreeRemoveResponse = WorktreeRemoveResponses[keyof WorktreeRemov
 export type WorktreeListData = {
   body?: never
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/experimental/worktree"
 }
 
 export type WorktreeListResponses = {
   /**
-   * List of worktrees
+   * Success
    */
-  200: Array<Worktree>
+  200: Array<{
+    name: string
+    branch: string
+    directory: string
+    source?: "created" | "existing"
+  }>
 }
 
 export type WorktreeListResponse = WorktreeListResponses[keyof WorktreeListResponses]
 
 export type WorktreeCreateData = {
-  body?: WorktreeCreateInput
+  body: {
+    name?: string
+    startCommand?: string
+  } | null
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/experimental/worktree"
 }
 
@@ -3606,20 +4088,24 @@ export type WorktreeCreateError = WorktreeCreateErrors[keyof WorktreeCreateError
 
 export type WorktreeCreateResponses = {
   /**
-   * Worktree created
+   * Success
    */
-  200: Worktree
+  200: {
+    name: string
+    branch: string
+    directory: string
+    source?: "created" | "existing"
+  }
 }
 
 export type WorktreeCreateResponse = WorktreeCreateResponses[keyof WorktreeCreateResponses]
 
 export type WorktreeResetData = {
-  body?: WorktreeResetInput
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
+  body: {
+    directory: string
   }
+  path?: never
+  query?: never
   url: "/experimental/worktree/reset"
 }
 
@@ -3634,113 +4120,23 @@ export type WorktreeResetError = WorktreeResetErrors[keyof WorktreeResetErrors]
 
 export type WorktreeResetResponses = {
   /**
-   * Worktree reset
+   * Success
    */
   200: boolean
 }
 
 export type WorktreeResetResponse = WorktreeResetResponses[keyof WorktreeResetResponses]
 
-export type ExperimentalSessionListData = {
-  body?: never
-  path?: never
-  query?: {
-    /**
-     * Filter sessions by project directory
-     */
-    directory?: string
-    workspace?: string
-    /**
-     * Only return root sessions (no parentID)
-     */
-    roots?: boolean
-    /**
-     * Filter sessions updated on or after this timestamp (milliseconds since epoch)
-     */
-    start?: number
-    /**
-     * Cursor for loading the next page
-     */
-    cursor?: number | string
-    /**
-     * Filter sessions by title (case-insensitive)
-     */
-    search?: string
-    /**
-     * Maximum number of sessions to return
-     */
-    limit?: number
-    /**
-     * Include archived sessions (default false)
-     */
-    archived?: boolean
-    /**
-     * Sort sessions by last update, creation time, or latest user-message activity
-     */
-    sort?: "updated" | "created" | "activity"
-  }
-  url: "/experimental/session"
-}
-
-export type ExperimentalSessionListResponses = {
-  /**
-   * List of sessions
-   */
-  200: Array<GlobalSession>
-}
-
-export type ExperimentalSessionListResponse = ExperimentalSessionListResponses[keyof ExperimentalSessionListResponses]
-
-export type ExperimentalResourceListData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/experimental/resource"
-}
-
-export type ExperimentalResourceListResponses = {
-  /**
-   * MCP resources
-   */
-  200: {
-    [key: string]: McpResource
-  }
-}
-
-export type ExperimentalResourceListResponse =
-  ExperimentalResourceListResponses[keyof ExperimentalResourceListResponses]
-
 export type SessionListData = {
   body?: never
   path?: never
   query?: {
-    /**
-     * Filter sessions by project directory
-     */
     directory?: string
     workspace?: string
-    /**
-     * Only return root sessions (no parentID)
-     */
     roots?: boolean
-    /**
-     * Filter sessions updated on or after this timestamp (milliseconds since epoch)
-     */
     start?: number
-    /**
-     * Filter sessions by title (case-insensitive)
-     */
     search?: string
-    /**
-     * Maximum number of sessions to return
-     */
     limit?: number
-    /**
-     * Sort sessions by last update or creation time
-     */
     sort?: "updated" | "created"
   }
   url: "/session"
@@ -3748,7 +4144,7 @@ export type SessionListData = {
 
 export type SessionListResponses = {
   /**
-   * List of sessions
+   * Success
    */
   200: Array<Session>
 }
@@ -3784,7 +4180,7 @@ export type SessionCreateError = SessionCreateErrors[keyof SessionCreateErrors]
 
 export type SessionCreateResponses = {
   /**
-   * Successfully created session
+   * Success
    */
   200: Session
 }
@@ -3812,7 +4208,7 @@ export type SessionStatusError = SessionStatusErrors[keyof SessionStatusErrors]
 
 export type SessionStatusResponses = {
   /**
-   * Get session status
+   * Success
    */
   200: {
     [key: string]: SessionStatus
@@ -3821,34 +4217,33 @@ export type SessionStatusResponses = {
 
 export type SessionStatusResponse = SessionStatusResponses[keyof SessionStatusResponses]
 
-export type PostSessionE2eUpdateTodosData = {
-  body?: {
+export type SessionE2eUpdateTodosData = {
+  body: {
     sessionID: string
-    todos: Array<{
-      id?: string
-      /**
-       * Brief description of the task
-       */
-      content: string
-      /**
-       * Current status of the task: pending, in_progress, completed, cancelled
-       */
-      status: string
-      /**
-       * Priority level of the task: high, medium, low
-       */
-      priority: string
-    }>
+    todos: Array<unknown>
   }
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
+  query?: never
   url: "/session/__e2e/update-todos"
 }
 
-export type PostSessionE2eUpdateTodosResponses = {
+export type SessionE2eUpdateTodosErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionE2eUpdateTodosError = SessionE2eUpdateTodosErrors[keyof SessionE2eUpdateTodosErrors]
+
+export type SessionE2eUpdateTodosResponses = {
+  /**
+   * <No Content>
+   */
   200: unknown
 }
 
@@ -3879,7 +4274,7 @@ export type SessionDeleteError = SessionDeleteErrors[keyof SessionDeleteErrors]
 
 export type SessionDeleteResponses = {
   /**
-   * Successfully deleted session
+   * Success
    */
   200: boolean
 }
@@ -3913,7 +4308,7 @@ export type SessionGetError = SessionGetErrors[keyof SessionGetErrors]
 
 export type SessionGetResponses = {
   /**
-   * Get session
+   * Success
    */
   200: Session
 }
@@ -3921,11 +4316,11 @@ export type SessionGetResponses = {
 export type SessionGetResponse = SessionGetResponses[keyof SessionGetResponses]
 
 export type SessionUpdateData = {
-  body?: {
+  body: {
     title?: string
-    permission?: PermissionRuleset
+    permission?: unknown
     time?: {
-      archived?: number
+      archived?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
     }
   }
   path: {
@@ -3953,7 +4348,7 @@ export type SessionUpdateError = SessionUpdateErrors[keyof SessionUpdateErrors]
 
 export type SessionUpdateResponses = {
   /**
-   * Successfully updated session
+   * Success
    */
   200: Session
 }
@@ -3987,49 +4382,15 @@ export type SessionChildrenError = SessionChildrenErrors[keyof SessionChildrenEr
 
 export type SessionChildrenResponses = {
   /**
-   * List of children
+   * Success
    */
   200: Array<Session>
 }
 
 export type SessionChildrenResponse = SessionChildrenResponses[keyof SessionChildrenResponses]
 
-export type SessionTodoData = {
-  body?: never
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/todo"
-}
-
-export type SessionTodoErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionTodoError = SessionTodoErrors[keyof SessionTodoErrors]
-
-export type SessionTodoResponses = {
-  /**
-   * Todo list
-   */
-  200: TodoSnapshot
-}
-
-export type SessionTodoResponse = SessionTodoResponses[keyof SessionTodoResponses]
-
 export type SessionInitData = {
-  body?: {
+  body: {
     modelID: string
     providerID: string
     messageID: string
@@ -4059,933 +4420,12 @@ export type SessionInitError = SessionInitErrors[keyof SessionInitErrors]
 
 export type SessionInitResponses = {
   /**
-   * 200
+   * Success
    */
   200: boolean
 }
 
 export type SessionInitResponse = SessionInitResponses[keyof SessionInitResponses]
-
-export type SessionForkData = {
-  body?: {
-    messageID?: string
-  }
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/fork"
-}
-
-export type SessionForkErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionForkError = SessionForkErrors[keyof SessionForkErrors]
-
-export type SessionForkResponses = {
-  /**
-   * 200
-   */
-  200: Session
-}
-
-export type SessionForkResponse = SessionForkResponses[keyof SessionForkResponses]
-
-export type SessionToolRespondData = {
-  body?:
-    | {
-        kind: "submit"
-        messageID: string
-        callID: string
-        payload: unknown
-      }
-    | {
-        kind: "dismiss"
-        messageID: string
-        callID: string
-      }
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/tool/respond"
-}
-
-export type SessionToolRespondErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * No pending tool call for the given (session, message, call)
-   */
-  404: {
-    error: string
-    details?: unknown
-  }
-  /**
-   * The pending tool call was already resolved
-   */
-  409: {
-    error: string
-    details?: unknown
-  }
-  /**
-   * The submitted payload failed the tool-owned decoder
-   */
-  422: {
-    error: string
-    details?: unknown
-  }
-}
-
-export type SessionToolRespondError = SessionToolRespondErrors[keyof SessionToolRespondErrors]
-
-export type SessionToolRespondResponses = {
-  /**
-   * Resolved
-   */
-  200: {
-    status: "ok"
-  }
-}
-
-export type SessionToolRespondResponse = SessionToolRespondResponses[keyof SessionToolRespondResponses]
-
-export type SessionAbortData = {
-  body?: never
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-    source?: string
-  }
-  url: "/session/{sessionID}/abort"
-}
-
-export type SessionAbortErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionAbortError = SessionAbortErrors[keyof SessionAbortErrors]
-
-export type SessionAbortResponses = {
-  /**
-   * Aborted session
-   */
-  200: boolean
-}
-
-export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
-
-export type SessionUnshareData = {
-  body?: never
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/share"
-}
-
-export type SessionUnshareErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionUnshareError = SessionUnshareErrors[keyof SessionUnshareErrors]
-
-export type SessionUnshareResponses = {
-  /**
-   * Successfully unshared session
-   */
-  200: Session
-}
-
-export type SessionUnshareResponse = SessionUnshareResponses[keyof SessionUnshareResponses]
-
-export type SessionShareData = {
-  body?: never
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/share"
-}
-
-export type SessionShareErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionShareError = SessionShareErrors[keyof SessionShareErrors]
-
-export type SessionShareResponses = {
-  /**
-   * Successfully shared session
-   */
-  200: Session
-}
-
-export type SessionShareResponse = SessionShareResponses[keyof SessionShareResponses]
-
-export type SessionExportData = {
-  body?: never
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/export"
-}
-
-export type SessionExportErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionExportError = SessionExportErrors[keyof SessionExportErrors]
-
-export type SessionExportResponses = {
-  /**
-   * Successfully exported session
-   */
-  200: unknown
-}
-
-export type SessionDiffData = {
-  body?: never
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-    messageID?: string
-  }
-  url: "/session/{sessionID}/diff"
-}
-
-export type SessionDiffResponses = {
-  /**
-   * Successfully retrieved diff
-   */
-  200:
-    | {
-        kind: "empty"
-        sessionID: string
-        turnID?: string
-        messageID?: string
-      }
-    | {
-        kind: "captured"
-        sessionID: string
-        turnID?: string
-        messageID?: string
-        files: Array<{
-          path: string
-          openPath?: string
-          status: "added" | "modified" | "deleted"
-          additions?: number
-          deletions?: number
-          patch?: string
-          sensitive?: boolean
-          binary?: boolean
-          large?: boolean
-          restoreAvailable?: boolean
-          expandable: boolean
-          restoreState: "applied" | "undone" | "redo_invalidated"
-        }>
-        truncated?: boolean
-        omittedCount?: number
-      }
-    | {
-        kind: "uncaptured"
-        sessionID: string
-        turnID?: string
-        messageID?: string
-        count: number
-      }
-    | {
-        kind: "mixed"
-        sessionID: string
-        turnID?: string
-        messageID?: string
-        files: Array<{
-          path: string
-          openPath?: string
-          status: "added" | "modified" | "deleted"
-          additions?: number
-          deletions?: number
-          patch?: string
-          sensitive?: boolean
-          binary?: boolean
-          large?: boolean
-          restoreAvailable?: boolean
-          expandable: boolean
-          restoreState: "applied" | "undone" | "redo_invalidated"
-        }>
-        count: number
-        truncated?: boolean
-        omittedCount?: number
-      }
-}
-
-export type SessionDiffResponse = SessionDiffResponses[keyof SessionDiffResponses]
-
-export type SessionTurnChangeData = {
-  body?: never
-  path: {
-    sessionID: string
-    messageID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/turn-change/{messageID}"
-}
-
-export type SessionTurnChangeErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionTurnChangeError = SessionTurnChangeErrors[keyof SessionTurnChangeErrors]
-
-export type SessionTurnChangeResponses = {
-  /**
-   * Turn changes
-   */
-  200: {
-    sessionID: string
-    turnID: string
-    messageID: string
-    undoAvailable: boolean
-    redoAvailable: boolean
-    truncated?: boolean
-    omittedCount?: number
-    files: Array<{
-      path: string
-      openPath?: string
-      status: "added" | "modified" | "deleted"
-      additions?: number
-      deletions?: number
-      patch?: string
-      sensitive?: boolean
-      binary?: boolean
-      large?: boolean
-      restoreAvailable?: boolean
-      expandable: boolean
-    }>
-  } | null
-}
-
-export type SessionTurnChangeResponse = SessionTurnChangeResponses[keyof SessionTurnChangeResponses]
-
-export type SessionTurnChangeUndoData = {
-  body?: never
-  path: {
-    sessionID: string
-    messageID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/turn-change/{messageID}/undo"
-}
-
-export type SessionTurnChangeUndoErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-  /**
-   * Conflict
-   */
-  409: UnknownError
-}
-
-export type SessionTurnChangeUndoError = SessionTurnChangeUndoErrors[keyof SessionTurnChangeUndoErrors]
-
-export type SessionTurnChangeUndoResponses = {
-  /**
-   * Undo result
-   */
-  200:
-    | {
-        status: "applied"
-        display: {
-          sessionID: string
-          turnID: string
-          messageID: string
-          undoAvailable: boolean
-          redoAvailable: boolean
-          truncated?: boolean
-          omittedCount?: number
-          files: Array<{
-            path: string
-            openPath?: string
-            status: "added" | "modified" | "deleted"
-            additions?: number
-            deletions?: number
-            patch?: string
-            sensitive?: boolean
-            binary?: boolean
-            large?: boolean
-            restoreAvailable?: boolean
-            expandable: boolean
-          }>
-        }
-        skipped?: Array<{
-          messageID: string
-          reason: "conflict" | "permission_denied"
-          files: Array<{
-            path: string
-            reason: string
-          }>
-        }>
-        mutatedPaths?: Array<string>
-      }
-    | {
-        status: "blocked"
-        reason:
-          | "conflict"
-          | "restore_missing"
-          | "permission_denied"
-          | "unsupported_size"
-          | "write_failed"
-          | "rollback_failed"
-        files: Array<{
-          path: string
-          reason: string
-          omittedCount?: number
-        }>
-        skipped?: Array<{
-          messageID: string
-          reason: "conflict" | "permission_denied"
-          files: Array<{
-            path: string
-            reason: string
-          }>
-        }>
-      }
-}
-
-export type SessionTurnChangeUndoResponse = SessionTurnChangeUndoResponses[keyof SessionTurnChangeUndoResponses]
-
-export type SessionTurnChangeRedoData = {
-  body?: never
-  path: {
-    sessionID: string
-    messageID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/turn-change/{messageID}/redo"
-}
-
-export type SessionTurnChangeRedoErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-  /**
-   * Conflict
-   */
-  409: UnknownError
-}
-
-export type SessionTurnChangeRedoError = SessionTurnChangeRedoErrors[keyof SessionTurnChangeRedoErrors]
-
-export type SessionTurnChangeRedoResponses = {
-  /**
-   * Redo result
-   */
-  200:
-    | {
-        status: "applied"
-        display: {
-          sessionID: string
-          turnID: string
-          messageID: string
-          undoAvailable: boolean
-          redoAvailable: boolean
-          truncated?: boolean
-          omittedCount?: number
-          files: Array<{
-            path: string
-            openPath?: string
-            status: "added" | "modified" | "deleted"
-            additions?: number
-            deletions?: number
-            patch?: string
-            sensitive?: boolean
-            binary?: boolean
-            large?: boolean
-            restoreAvailable?: boolean
-            expandable: boolean
-          }>
-        }
-        skipped?: Array<{
-          messageID: string
-          reason: "conflict" | "permission_denied"
-          files: Array<{
-            path: string
-            reason: string
-          }>
-        }>
-        mutatedPaths?: Array<string>
-      }
-    | {
-        status: "blocked"
-        reason:
-          | "conflict"
-          | "restore_missing"
-          | "permission_denied"
-          | "unsupported_size"
-          | "write_failed"
-          | "rollback_failed"
-        files: Array<{
-          path: string
-          reason: string
-          omittedCount?: number
-        }>
-        skipped?: Array<{
-          messageID: string
-          reason: "conflict" | "permission_denied"
-          files: Array<{
-            path: string
-            reason: string
-          }>
-        }>
-      }
-}
-
-export type SessionTurnChangeRedoResponse = SessionTurnChangeRedoResponses[keyof SessionTurnChangeRedoResponses]
-
-export type SessionTurnChangesAggregateData = {
-  body?: never
-  path: {
-    sessionID: string
-    userMessageID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/turn/{userMessageID}/changes"
-}
-
-export type SessionTurnChangesAggregateErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionTurnChangesAggregateError =
-  SessionTurnChangesAggregateErrors[keyof SessionTurnChangesAggregateErrors]
-
-export type SessionTurnChangesAggregateResponses = {
-  /**
-   * Aggregated turn changes
-   */
-  200:
-    | {
-        kind: "empty"
-        sessionID: string
-        turnID?: string
-        messageID?: string
-      }
-    | {
-        kind: "captured"
-        sessionID: string
-        turnID?: string
-        messageID?: string
-        files: Array<{
-          path: string
-          openPath?: string
-          status: "added" | "modified" | "deleted"
-          additions?: number
-          deletions?: number
-          patch?: string
-          sensitive?: boolean
-          binary?: boolean
-          large?: boolean
-          restoreAvailable?: boolean
-          expandable: boolean
-          restoreState: "applied" | "undone" | "redo_invalidated"
-        }>
-        truncated?: boolean
-        omittedCount?: number
-      }
-    | {
-        kind: "uncaptured"
-        sessionID: string
-        turnID?: string
-        messageID?: string
-        count: number
-      }
-    | {
-        kind: "mixed"
-        sessionID: string
-        turnID?: string
-        messageID?: string
-        files: Array<{
-          path: string
-          openPath?: string
-          status: "added" | "modified" | "deleted"
-          additions?: number
-          deletions?: number
-          patch?: string
-          sensitive?: boolean
-          binary?: boolean
-          large?: boolean
-          restoreAvailable?: boolean
-          expandable: boolean
-          restoreState: "applied" | "undone" | "redo_invalidated"
-        }>
-        count: number
-        truncated?: boolean
-        omittedCount?: number
-      }
-}
-
-export type SessionTurnChangesAggregateResponse =
-  SessionTurnChangesAggregateResponses[keyof SessionTurnChangesAggregateResponses]
-
-export type SessionTurnChangesAggregateUndoData = {
-  body?: {
-    force?: boolean
-  }
-  path: {
-    sessionID: string
-    userMessageID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/turn/{userMessageID}/changes/undo"
-}
-
-export type SessionTurnChangesAggregateUndoErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-  /**
-   * Conflict
-   */
-  409: UnknownError
-}
-
-export type SessionTurnChangesAggregateUndoError =
-  SessionTurnChangesAggregateUndoErrors[keyof SessionTurnChangesAggregateUndoErrors]
-
-export type SessionTurnChangesAggregateUndoResponses = {
-  /**
-   * Undo result
-   */
-  200:
-    | {
-        status: "applied"
-        display: {
-          sessionID: string
-          turnID: string
-          messageID: string
-          undoAvailable: boolean
-          redoAvailable: boolean
-          truncated?: boolean
-          omittedCount?: number
-          files: Array<{
-            path: string
-            openPath?: string
-            status: "added" | "modified" | "deleted"
-            additions?: number
-            deletions?: number
-            patch?: string
-            sensitive?: boolean
-            binary?: boolean
-            large?: boolean
-            restoreAvailable?: boolean
-            expandable: boolean
-          }>
-        }
-        skipped?: Array<{
-          messageID: string
-          reason: "conflict" | "permission_denied"
-          files: Array<{
-            path: string
-            reason: string
-          }>
-        }>
-        mutatedPaths?: Array<string>
-      }
-    | {
-        status: "blocked"
-        reason:
-          | "conflict"
-          | "restore_missing"
-          | "permission_denied"
-          | "unsupported_size"
-          | "write_failed"
-          | "rollback_failed"
-        files: Array<{
-          path: string
-          reason: string
-          omittedCount?: number
-        }>
-        skipped?: Array<{
-          messageID: string
-          reason: "conflict" | "permission_denied"
-          files: Array<{
-            path: string
-            reason: string
-          }>
-        }>
-      }
-}
-
-export type SessionTurnChangesAggregateUndoResponse =
-  SessionTurnChangesAggregateUndoResponses[keyof SessionTurnChangesAggregateUndoResponses]
-
-export type SessionTurnChangesAggregateRedoData = {
-  body?: {
-    force?: boolean
-  }
-  path: {
-    sessionID: string
-    userMessageID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/turn/{userMessageID}/changes/redo"
-}
-
-export type SessionTurnChangesAggregateRedoErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-  /**
-   * Conflict
-   */
-  409: UnknownError
-}
-
-export type SessionTurnChangesAggregateRedoError =
-  SessionTurnChangesAggregateRedoErrors[keyof SessionTurnChangesAggregateRedoErrors]
-
-export type SessionTurnChangesAggregateRedoResponses = {
-  /**
-   * Redo result
-   */
-  200:
-    | {
-        status: "applied"
-        display: {
-          sessionID: string
-          turnID: string
-          messageID: string
-          undoAvailable: boolean
-          redoAvailable: boolean
-          truncated?: boolean
-          omittedCount?: number
-          files: Array<{
-            path: string
-            openPath?: string
-            status: "added" | "modified" | "deleted"
-            additions?: number
-            deletions?: number
-            patch?: string
-            sensitive?: boolean
-            binary?: boolean
-            large?: boolean
-            restoreAvailable?: boolean
-            expandable: boolean
-          }>
-        }
-        skipped?: Array<{
-          messageID: string
-          reason: "conflict" | "permission_denied"
-          files: Array<{
-            path: string
-            reason: string
-          }>
-        }>
-        mutatedPaths?: Array<string>
-      }
-    | {
-        status: "blocked"
-        reason:
-          | "conflict"
-          | "restore_missing"
-          | "permission_denied"
-          | "unsupported_size"
-          | "write_failed"
-          | "rollback_failed"
-        files: Array<{
-          path: string
-          reason: string
-          omittedCount?: number
-        }>
-        skipped?: Array<{
-          messageID: string
-          reason: "conflict" | "permission_denied"
-          files: Array<{
-            path: string
-            reason: string
-          }>
-        }>
-      }
-}
-
-export type SessionTurnChangesAggregateRedoResponse =
-  SessionTurnChangesAggregateRedoResponses[keyof SessionTurnChangesAggregateRedoResponses]
-
-export type SessionArtifactsData = {
-  body?: never
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/artifacts"
-}
-
-export type SessionArtifactsResponses = {
-  /**
-   * Successfully retrieved artifacts
-   */
-  200: Array<SessionArtifact>
-}
-
-export type SessionArtifactsResponse = SessionArtifactsResponses[keyof SessionArtifactsResponses]
-
-export type SessionSummarizeData = {
-  body?: {
-    providerID: string
-    modelID: string
-    auto?: boolean
-  }
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/session/{sessionID}/summarize"
-}
-
-export type SessionSummarizeErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-  /**
-   * Conflict
-   */
-  409: UnknownError
-}
-
-export type SessionSummarizeError = SessionSummarizeErrors[keyof SessionSummarizeErrors]
-
-export type SessionSummarizeResponses = {
-  /**
-   * Summarized session
-   */
-  200: boolean
-}
-
-export type SessionSummarizeResponse = SessionSummarizeResponses[keyof SessionSummarizeResponses]
 
 export type SessionMessagesData = {
   body?: never
@@ -4995,10 +4435,7 @@ export type SessionMessagesData = {
   query?: {
     directory?: string
     workspace?: string
-    /**
-     * Maximum number of messages to return
-     */
-    limit?: number
+    limit?: string
     before?: string
   }
   url: "/session/{sessionID}/message"
@@ -5019,7 +4456,7 @@ export type SessionMessagesError = SessionMessagesErrors[keyof SessionMessagesEr
 
 export type SessionMessagesResponses = {
   /**
-   * List of messages
+   * Success
    */
   200: Array<{
     info: Message
@@ -5030,7 +4467,7 @@ export type SessionMessagesResponses = {
 export type SessionMessagesResponse = SessionMessagesResponses[keyof SessionMessagesResponses]
 
 export type SessionPromptData = {
-  body?: {
+  body: {
     messageID?: string
     model?: {
       providerID: string
@@ -5048,7 +4485,7 @@ export type SessionPromptData = {
     format?: OutputFormat
     system?: string
     variant?: string
-    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
+    parts: Array<AgentPartInput | FilePartInput | SkillPartInput | SubtaskPartInput | TextPartInput>
   }
   path: {
     sessionID: string
@@ -5075,7 +4512,7 @@ export type SessionPromptError = SessionPromptErrors[keyof SessionPromptErrors]
 
 export type SessionPromptResponses = {
   /**
-   * Created message
+   * Success
    */
   200: {
     info: AssistantMessage
@@ -5108,16 +4545,16 @@ export type SessionDeleteMessageErrors = {
    */
   404: NotFoundError
   /**
-   * Conflict
+   * Session conflict
    */
-  409: UnknownError
+  409: SessionConflictError
 }
 
 export type SessionDeleteMessageError = SessionDeleteMessageErrors[keyof SessionDeleteMessageErrors]
 
 export type SessionDeleteMessageResponses = {
   /**
-   * Successfully deleted message
+   * Success
    */
   200: boolean
 }
@@ -5152,7 +4589,7 @@ export type SessionMessageError = SessionMessageErrors[keyof SessionMessageError
 
 export type SessionMessageResponses = {
   /**
-   * Message
+   * Success
    */
   200: {
     info: Message
@@ -5191,7 +4628,7 @@ export type PartDeleteError = PartDeleteErrors[keyof PartDeleteErrors]
 
 export type PartDeleteResponses = {
   /**
-   * Successfully deleted part
+   * Success
    */
   200: boolean
 }
@@ -5199,7 +4636,7 @@ export type PartDeleteResponses = {
 export type PartDeleteResponse = PartDeleteResponses[keyof PartDeleteResponses]
 
 export type PartUpdateData = {
-  body?: Part
+  body: Part
   path: {
     sessionID: string
     messageID: string
@@ -5227,15 +4664,49 @@ export type PartUpdateError = PartUpdateErrors[keyof PartUpdateErrors]
 
 export type PartUpdateResponses = {
   /**
-   * Successfully updated part
+   * Success
    */
   200: Part
 }
 
 export type PartUpdateResponse = PartUpdateResponses[keyof PartUpdateResponses]
 
+export type SessionTodoData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/todo"
+}
+
+export type SessionTodoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTodoError = SessionTodoErrors[keyof SessionTodoErrors]
+
+export type SessionTodoResponses = {
+  /**
+   * Success
+   */
+  200: TodoSnapshot
+}
+
+export type SessionTodoResponse = SessionTodoResponses[keyof SessionTodoResponses]
+
 export type SessionPromptAsyncData = {
-  body?: {
+  body: {
     messageID?: string
     model?: {
       providerID: string
@@ -5253,7 +4724,7 @@ export type SessionPromptAsyncData = {
     format?: OutputFormat
     system?: string
     variant?: string
-    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
+    parts: Array<AgentPartInput | FilePartInput | SkillPartInput | SubtaskPartInput | TextPartInput>
   }
   path: {
     sessionID: string
@@ -5280,15 +4751,48 @@ export type SessionPromptAsyncError = SessionPromptAsyncErrors[keyof SessionProm
 
 export type SessionPromptAsyncResponses = {
   /**
-   * Prompt accepted
+   * <No Content>
    */
-  204: void
+  200: unknown
 }
 
-export type SessionPromptAsyncResponse = SessionPromptAsyncResponses[keyof SessionPromptAsyncResponses]
+export type SessionAbortData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+    source?: string
+  }
+  url: "/session/{sessionID}/abort"
+}
+
+export type SessionAbortErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionAbortError = SessionAbortErrors[keyof SessionAbortErrors]
+
+export type SessionAbortResponses = {
+  /**
+   * Success
+   */
+  200: boolean
+}
+
+export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
 
 export type SessionCommandData = {
-  body?: {
+  body: {
     messageID?: string
     agent?: string
     model?: string
@@ -5333,7 +4837,7 @@ export type SessionCommandError = SessionCommandErrors[keyof SessionCommandError
 
 export type SessionCommandResponses = {
   /**
-   * Created message
+   * Success
    */
   200: {
     info: AssistantMessage
@@ -5343,8 +4847,184 @@ export type SessionCommandResponses = {
 
 export type SessionCommandResponse = SessionCommandResponses[keyof SessionCommandResponses]
 
-export type SessionShellData = {
+export type SessionForkData = {
   body?: {
+    messageID?: string
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/fork"
+}
+
+export type SessionForkErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionForkError = SessionForkErrors[keyof SessionForkErrors]
+
+export type SessionForkResponses = {
+  /**
+   * Success
+   */
+  200: Session
+}
+
+export type SessionForkResponse = SessionForkResponses[keyof SessionForkResponses]
+
+export type SessionDiffData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+    messageID?: string
+  }
+  url: "/session/{sessionID}/diff"
+}
+
+export type SessionDiffResponses = {
+  /**
+   * Success
+   */
+  200: TurnChangeAggregate
+}
+
+export type SessionDiffResponse = SessionDiffResponses[keyof SessionDiffResponses]
+
+export type SessionUnshareData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/share"
+}
+
+export type SessionUnshareErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Cloud sharing is disabled
+   */
+  410: SessionShareDisabledError
+}
+
+export type SessionUnshareError = SessionUnshareErrors[keyof SessionUnshareErrors]
+
+export type SessionUnshareResponses = {
+  /**
+   * Success
+   */
+  200: Session
+}
+
+export type SessionUnshareResponse = SessionUnshareResponses[keyof SessionUnshareResponses]
+
+export type SessionShareData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/share"
+}
+
+export type SessionShareErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Cloud sharing is disabled
+   */
+  410: SessionShareDisabledError
+}
+
+export type SessionShareError = SessionShareErrors[keyof SessionShareErrors]
+
+export type SessionShareResponses = {
+  /**
+   * Success
+   */
+  200: Session
+}
+
+export type SessionShareResponse = SessionShareResponses[keyof SessionShareResponses]
+
+export type SessionSummarizeData = {
+  body: {
+    modelID: string
+    providerID: string
+    auto?: boolean
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/summarize"
+}
+
+export type SessionSummarizeErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Session conflict
+   */
+  409: SessionConflictError
+}
+
+export type SessionSummarizeError = SessionSummarizeErrors[keyof SessionSummarizeErrors]
+
+export type SessionSummarizeResponses = {
+  /**
+   * Success
+   */
+  200: boolean
+}
+
+export type SessionSummarizeResponse = SessionSummarizeResponses[keyof SessionSummarizeResponses]
+
+export type SessionShellData = {
+  body: {
     messageID?: string
     agent: string
     model?: {
@@ -5373,16 +5053,16 @@ export type SessionShellErrors = {
    */
   404: NotFoundError
   /**
-   * Conflict
+   * Session conflict
    */
-  409: UnknownError
+  409: SessionConflictError
 }
 
 export type SessionShellError = SessionShellErrors[keyof SessionShellErrors]
 
 export type SessionShellResponses = {
   /**
-   * Created message
+   * Success
    */
   200: {
     info: Message
@@ -5393,7 +5073,7 @@ export type SessionShellResponses = {
 export type SessionShellResponse = SessionShellResponses[keyof SessionShellResponses]
 
 export type SessionRevertData = {
-  body?: {
+  body: {
     messageID: string
     partID?: string
   }
@@ -5417,16 +5097,16 @@ export type SessionRevertErrors = {
    */
   404: NotFoundError
   /**
-   * Conflict
+   * Session conflict
    */
-  409: UnknownError
+  409: SessionConflictError
 }
 
 export type SessionRevertError = SessionRevertErrors[keyof SessionRevertErrors]
 
 export type SessionRevertResponses = {
   /**
-   * Updated session
+   * Success
    */
   200: Session
 }
@@ -5455,16 +5135,16 @@ export type SessionUnrevertErrors = {
    */
   404: NotFoundError
   /**
-   * Conflict
+   * Session conflict
    */
-  409: UnknownError
+  409: SessionConflictError
 }
 
 export type SessionUnrevertError = SessionUnrevertErrors[keyof SessionUnrevertErrors]
 
 export type SessionUnrevertResponses = {
   /**
-   * Updated session
+   * Success
    */
   200: Session
 }
@@ -5472,7 +5152,7 @@ export type SessionUnrevertResponses = {
 export type SessionUnrevertResponse = SessionUnrevertResponses[keyof SessionUnrevertResponses]
 
 export type PermissionRespondData = {
-  body?: {
+  body: {
     response: "once" | "always" | "reject"
   }
   path: {
@@ -5501,39 +5181,402 @@ export type PermissionRespondError = PermissionRespondErrors[keyof PermissionRes
 
 export type PermissionRespondResponses = {
   /**
-   * Permission processed successfully
+   * Success
    */
   200: boolean
 }
 
 export type PermissionRespondResponse = PermissionRespondResponses[keyof PermissionRespondResponses]
 
-export type PostPermissionE2eAskData = {
-  body?: {
+export type SessionArtifactsData = {
+  body?: never
+  path: {
     sessionID: string
-    permission: string
-    patterns: Array<string>
-    metadata?: {
-      [key: string]: unknown
-    }
-    always?: Array<string>
   }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/artifacts"
+}
+
+export type SessionArtifactsResponses = {
+  /**
+   * Success
+   */
+  200: Array<SessionArtifact>
+}
+
+export type SessionArtifactsResponse = SessionArtifactsResponses[keyof SessionArtifactsResponses]
+
+export type SessionExportData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/export"
+}
+
+export type SessionExportErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionExportError = SessionExportErrors[keyof SessionExportErrors]
+
+export type SessionExportResponses = {
+  /**
+   * Success
+   */
+  200: unknown
+}
+
+export type SessionToolRespondData = {
+  body:
+    | {
+        kind: "submit"
+        messageID: string
+        callID: string
+        payload: unknown
+      }
+    | {
+        kind: "dismiss"
+        messageID: string
+        callID: string
+      }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/tool/respond"
+}
+
+export type SessionToolRespondErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Error
+   */
+  404: {
+    error: string
+    details?: unknown
+  }
+  /**
+   * Error
+   */
+  409: {
+    error: string
+    details?: unknown
+  }
+  /**
+   * Error
+   */
+  422: {
+    error: string
+    details?: unknown
+  }
+}
+
+export type SessionToolRespondError = SessionToolRespondErrors[keyof SessionToolRespondErrors]
+
+export type SessionToolRespondResponses = {
+  /**
+   * Success
+   */
+  200: {
+    status: "ok"
+  }
+}
+
+export type SessionToolRespondResponse = SessionToolRespondResponses[keyof SessionToolRespondResponses]
+
+export type SessionTurnChangeData = {
+  body?: never
+  path: {
+    sessionID: string
+    messageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn-change/{messageID}"
+}
+
+export type SessionTurnChangeErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTurnChangeError = SessionTurnChangeErrors[keyof SessionTurnChangeErrors]
+
+export type SessionTurnChangeResponses = {
+  /**
+   * Success
+   */
+  200: TurnChangeDisplay | null
+}
+
+export type SessionTurnChangeResponse = SessionTurnChangeResponses[keyof SessionTurnChangeResponses]
+
+export type SessionTurnChangeUndoData = {
+  body?: never
+  path: {
+    sessionID: string
+    messageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn-change/{messageID}/undo"
+}
+
+export type SessionTurnChangeUndoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Session conflict
+   */
+  409: SessionConflictError
+}
+
+export type SessionTurnChangeUndoError = SessionTurnChangeUndoErrors[keyof SessionTurnChangeUndoErrors]
+
+export type SessionTurnChangeUndoResponses = {
+  /**
+   * Success
+   */
+  200: TurnChangeMutationResult
+}
+
+export type SessionTurnChangeUndoResponse = SessionTurnChangeUndoResponses[keyof SessionTurnChangeUndoResponses]
+
+export type SessionTurnChangeRedoData = {
+  body?: never
+  path: {
+    sessionID: string
+    messageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn-change/{messageID}/redo"
+}
+
+export type SessionTurnChangeRedoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Session conflict
+   */
+  409: SessionConflictError
+}
+
+export type SessionTurnChangeRedoError = SessionTurnChangeRedoErrors[keyof SessionTurnChangeRedoErrors]
+
+export type SessionTurnChangeRedoResponses = {
+  /**
+   * Success
+   */
+  200: TurnChangeMutationResult
+}
+
+export type SessionTurnChangeRedoResponse = SessionTurnChangeRedoResponses[keyof SessionTurnChangeRedoResponses]
+
+export type SessionTurnChangesAggregateData = {
+  body?: never
+  path: {
+    sessionID: string
+    userMessageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn/{userMessageID}/changes"
+}
+
+export type SessionTurnChangesAggregateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTurnChangesAggregateError =
+  SessionTurnChangesAggregateErrors[keyof SessionTurnChangesAggregateErrors]
+
+export type SessionTurnChangesAggregateResponses = {
+  /**
+   * Success
+   */
+  200: TurnChangeAggregate
+}
+
+export type SessionTurnChangesAggregateResponse =
+  SessionTurnChangesAggregateResponses[keyof SessionTurnChangesAggregateResponses]
+
+export type SessionTurnChangesAggregateUndoData = {
+  body: {
+    force?: boolean
+  } | null
+  path: {
+    sessionID: string
+    userMessageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn/{userMessageID}/changes/undo"
+}
+
+export type SessionTurnChangesAggregateUndoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Session conflict
+   */
+  409: SessionConflictError
+}
+
+export type SessionTurnChangesAggregateUndoError =
+  SessionTurnChangesAggregateUndoErrors[keyof SessionTurnChangesAggregateUndoErrors]
+
+export type SessionTurnChangesAggregateUndoResponses = {
+  /**
+   * Success
+   */
+  200: TurnChangeMutationResult
+}
+
+export type SessionTurnChangesAggregateUndoResponse =
+  SessionTurnChangesAggregateUndoResponses[keyof SessionTurnChangesAggregateUndoResponses]
+
+export type SessionTurnChangesAggregateRedoData = {
+  body: {
+    force?: boolean
+  } | null
+  path: {
+    sessionID: string
+    userMessageID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/turn/{userMessageID}/changes/redo"
+}
+
+export type SessionTurnChangesAggregateRedoErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Session conflict
+   */
+  409: SessionConflictError
+}
+
+export type SessionTurnChangesAggregateRedoError =
+  SessionTurnChangesAggregateRedoErrors[keyof SessionTurnChangesAggregateRedoErrors]
+
+export type SessionTurnChangesAggregateRedoResponses = {
+  /**
+   * Success
+   */
+  200: TurnChangeMutationResult
+}
+
+export type SessionTurnChangesAggregateRedoResponse =
+  SessionTurnChangesAggregateRedoResponses[keyof SessionTurnChangesAggregateRedoResponses]
+
+export type PermissionListData = {
+  body?: never
   path?: never
   query?: {
     directory?: string
     workspace?: string
   }
-  url: "/permission/__e2e/ask"
+  url: "/permission"
 }
 
-export type PostPermissionE2eAskResponses = {
-  200: unknown
+export type PermissionListResponses = {
+  /**
+   * Success
+   */
+  200: Array<{
+    id: string
+    sessionID: string
+    permission: string
+    patterns: Array<string>
+    metadata: {
+      [key: string]: unknown
+    }
+    always: Array<string>
+    tool?: {
+      messageID: string
+      callID: string
+    } | null
+  }>
 }
+
+export type PermissionListResponse = PermissionListResponses[keyof PermissionListResponses]
 
 export type PermissionReplyData = {
-  body?: {
+  body: {
     reply: "once" | "always" | "reject"
-    message?: string
+    message?: string | null
   }
   path: {
     requestID: string
@@ -5560,31 +5603,43 @@ export type PermissionReplyError = PermissionReplyErrors[keyof PermissionReplyEr
 
 export type PermissionReplyResponses = {
   /**
-   * Permission processed successfully
+   * Success
    */
   200: boolean
 }
 
 export type PermissionReplyResponse = PermissionReplyResponses[keyof PermissionReplyResponses]
 
-export type PermissionListData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
+export type PermissionE2eAskData = {
+  body: {
+    sessionID: string
+    permission: string
+    patterns: Array<string>
+    metadata?: {
+      [key: string]: unknown
+    } | null
+    always?: Array<string> | null
   }
-  url: "/permission"
+  path?: never
+  query?: never
+  url: "/permission/__e2e/ask"
 }
 
-export type PermissionListResponses = {
+export type PermissionE2eAskErrors = {
   /**
-   * List of pending permissions
+   * Bad request
    */
-  200: Array<PermissionRequest>
+  400: BadRequestError
 }
 
-export type PermissionListResponse = PermissionListResponses[keyof PermissionListResponses]
+export type PermissionE2eAskError = PermissionE2eAskErrors[keyof PermissionE2eAskErrors]
+
+export type PermissionE2eAskResponses = {
+  /**
+   * <No Content>
+   */
+  200: unknown
+}
 
 export type ExternalResultListData = {
   body?: never
@@ -5598,12 +5653,12 @@ export type ExternalResultListData = {
 
 export type ExternalResultListResponses = {
   /**
-   * Pending external-result tool calls
+   * Success
    */
   200: Array<{
-    session: Session
-    message: Message
-    part: Part
+    session: unknown
+    message: unknown
+    part: unknown
   }>
 }
 
@@ -5621,7 +5676,7 @@ export type ProviderListData = {
 
 export type ProviderListResponses = {
   /**
-   * List of providers
+   * Success
    */
   200: {
     all: Array<Provider>
@@ -5646,7 +5701,7 @@ export type ProviderAuthData = {
 
 export type ProviderAuthResponses = {
   /**
-   * Provider auth methods
+   * Success
    */
   200: {
     [key: string]: Array<ProviderAuthMethod>
@@ -5656,22 +5711,16 @@ export type ProviderAuthResponses = {
 export type ProviderAuthResponse = ProviderAuthResponses[keyof ProviderAuthResponses]
 
 export type ProviderOauthAuthorizeData = {
-  body?: {
-    /**
-     * Auth method index
-     */
-    method: number
+  body: {
+    method: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
     /**
      * Prompt inputs
      */
     inputs?: {
       [key: string]: string
-    }
+    } | null
   }
   path: {
-    /**
-     * Provider ID
-     */
     providerID: string
   }
   query?: {
@@ -5692,28 +5741,22 @@ export type ProviderOauthAuthorizeError = ProviderOauthAuthorizeErrors[keyof Pro
 
 export type ProviderOauthAuthorizeResponses = {
   /**
-   * Authorization URL and method
+   * Success
    */
-  200: ProviderAuthAuthorization
+  200: ProviderAuthAuthorization | null
 }
 
 export type ProviderOauthAuthorizeResponse = ProviderOauthAuthorizeResponses[keyof ProviderOauthAuthorizeResponses]
 
 export type ProviderOauthCallbackData = {
-  body?: {
-    /**
-     * Auth method index
-     */
-    method: number
+  body: {
+    method: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
     /**
      * OAuth authorization code
      */
-    code?: string
+    code?: string | null
   }
   path: {
-    /**
-     * Provider ID
-     */
     providerID: string
   }
   query?: {
@@ -5734,12 +5777,43 @@ export type ProviderOauthCallbackError = ProviderOauthCallbackErrors[keyof Provi
 
 export type ProviderOauthCallbackResponses = {
   /**
-   * OAuth callback processed successfully
+   * Success
    */
   200: boolean
 }
 
 export type ProviderOauthCallbackResponse = ProviderOauthCallbackResponses[keyof ProviderOauthCallbackResponses]
+
+export type ProviderRecordRecentData = {
+  body: {
+    providerID: string
+    modelID: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/provider/recent"
+}
+
+export type ProviderRecordRecentErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ProviderRecordRecentError = ProviderRecordRecentErrors[keyof ProviderRecordRecentErrors]
+
+export type ProviderRecordRecentResponses = {
+  /**
+   * Success
+   */
+  200: boolean
+}
+
+export type ProviderRecordRecentResponse = ProviderRecordRecentResponses[keyof ProviderRecordRecentResponses]
 
 export type MemoryGetData = {
   body?: never
@@ -5753,7 +5827,7 @@ export type MemoryGetData = {
 
 export type MemoryGetResponses = {
   /**
-   * Memory state
+   * Success
    */
   200: MemoryState
 }
@@ -5761,7 +5835,9 @@ export type MemoryGetResponses = {
 export type MemoryGetResponse = MemoryGetResponses[keyof MemoryGetResponses]
 
 export type MemoryUpdateData = {
-  body?: MemoryRawInput
+  body: {
+    content: string
+  }
   path?: never
   query?: {
     directory?: string
@@ -5772,14 +5848,16 @@ export type MemoryUpdateData = {
 
 export type MemoryUpdateErrors = {
   /**
-   * Invalid memory file
+   * Bad request | Invalid PawWork memory file
    */
-  400: unknown
+  400: BadRequestError | InvalidMemoryFileError
 }
+
+export type MemoryUpdateError = MemoryUpdateErrors[keyof MemoryUpdateErrors]
 
 export type MemoryUpdateResponses = {
   /**
-   * Memory state
+   * Success
    */
   200: MemoryState
 }
@@ -5798,7 +5876,7 @@ export type MemoryResetData = {
 
 export type MemoryResetResponses = {
   /**
-   * Memory state
+   * Success
    */
   200: MemoryState
 }
@@ -5806,7 +5884,9 @@ export type MemoryResetResponses = {
 export type MemoryResetResponse = MemoryResetResponses[keyof MemoryResetResponses]
 
 export type MemoryDisabledData = {
-  body?: MemoryDisabledInput
+  body: {
+    disabled: boolean
+  }
   path?: never
   query?: {
     directory?: string
@@ -5815,9 +5895,18 @@ export type MemoryDisabledData = {
   url: "/memory/disabled"
 }
 
+export type MemoryDisabledErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type MemoryDisabledError = MemoryDisabledErrors[keyof MemoryDisabledErrors]
+
 export type MemoryDisabledResponses = {
   /**
-   * Memory state
+   * Success
    */
   200: MemoryState
 }
@@ -5838,7 +5927,7 @@ export type MemoryDeleteEntryData = {
 
 export type MemoryDeleteEntryResponses = {
   /**
-   * Memory state
+   * Success
    */
   200: MemoryState
 }
@@ -5857,7 +5946,7 @@ export type AutomationListData = {
 
 export type AutomationListResponses = {
   /**
-   * Automation definitions
+   * Success
    */
   200: AutomationListResponse
 }
@@ -5865,7 +5954,30 @@ export type AutomationListResponses = {
 export type AutomationListResponse2 = AutomationListResponses[keyof AutomationListResponses]
 
 export type AutomationCreateData = {
-  body?: AutomationCreateInput
+  body:
+    | {
+        kind: "oneshot"
+        title: string
+        prompt: string
+        context: "continue" | "fresh"
+        where: AutomationWhere
+        timezone: string
+        model: AutomationModel
+        variant?: string
+        fireAt: number
+      }
+    | {
+        kind: "recurring"
+        title: string
+        prompt: string
+        context: "continue" | "fresh"
+        where: AutomationWhere
+        timezone: string
+        model: AutomationModel
+        variant?: string
+        rhythm: AutomationRhythm
+        stop: AutomationStop
+      }
   path?: never
   query?: {
     directory?: string
@@ -5889,7 +6001,7 @@ export type AutomationCreateError = AutomationCreateErrors[keyof AutomationCreat
 
 export type AutomationCreateResponses = {
   /**
-   * Created automation definition
+   * Success
    */
   200: AutomationDefinition
 }
@@ -5910,6 +6022,10 @@ export type AutomationDeleteData = {
 
 export type AutomationDeleteErrors = {
   /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
    * Not found
    */
   404: NotFoundError
@@ -5919,7 +6035,7 @@ export type AutomationDeleteError = AutomationDeleteErrors[keyof AutomationDelet
 
 export type AutomationDeleteResponses = {
   /**
-   * Automation deletion tombstone
+   * Success
    */
   200: AutomationDefinitionTombstone
 }
@@ -5940,6 +6056,10 @@ export type AutomationGetData = {
 
 export type AutomationGetErrors = {
   /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
    * Not found
    */
   404: NotFoundError
@@ -5949,7 +6069,7 @@ export type AutomationGetError = AutomationGetErrors[keyof AutomationGetErrors]
 
 export type AutomationGetResponses = {
   /**
-   * Automation definition
+   * Success
    */
   200: AutomationDefinition
 }
@@ -5957,7 +6077,19 @@ export type AutomationGetResponses = {
 export type AutomationGetResponse = AutomationGetResponses[keyof AutomationGetResponses]
 
 export type AutomationUpdateData = {
-  body?: AutomationUpdateInput
+  body: {
+    title?: string
+    prompt?: string
+    paused?: boolean
+    context?: "continue" | "fresh"
+    where?: AutomationWhere
+    timezone?: string
+    fireAt?: number
+    rhythm?: AutomationRhythm
+    stop?: AutomationStop
+    model?: AutomationModel
+    variant?: string | null
+  }
   path: {
     automationID: string
   }
@@ -5991,110 +6123,12 @@ export type AutomationUpdateError = AutomationUpdateErrors[keyof AutomationUpdat
 
 export type AutomationUpdateResponses = {
   /**
-   * Updated automation definition
+   * Success
    */
   200: AutomationDefinition
 }
 
 export type AutomationUpdateResponse = AutomationUpdateResponses[keyof AutomationUpdateResponses]
-
-export type AutomationPauseData = {
-  body?: never
-  path: {
-    automationID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/automation/{automationID}/pause"
-}
-
-export type AutomationPauseErrors = {
-  /**
-   * Not found
-   */
-  404: NotFoundError
-  /**
-   * Automation update conflict
-   */
-  409: AutomationConflictError
-}
-
-export type AutomationPauseError = AutomationPauseErrors[keyof AutomationPauseErrors]
-
-export type AutomationPauseResponses = {
-  /**
-   * Paused automation definition
-   */
-  200: AutomationDefinition
-}
-
-export type AutomationPauseResponse = AutomationPauseResponses[keyof AutomationPauseResponses]
-
-export type AutomationResumeData = {
-  body?: never
-  path: {
-    automationID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/automation/{automationID}/resume"
-}
-
-export type AutomationResumeErrors = {
-  /**
-   * Not found
-   */
-  404: NotFoundError
-  /**
-   * Automation update conflict
-   */
-  409: AutomationConflictError
-}
-
-export type AutomationResumeError = AutomationResumeErrors[keyof AutomationResumeErrors]
-
-export type AutomationResumeResponses = {
-  /**
-   * Resumed automation definition
-   */
-  200: AutomationDefinition
-}
-
-export type AutomationResumeResponse = AutomationResumeResponses[keyof AutomationResumeResponses]
-
-export type AutomationRunNowData = {
-  body?: never
-  path: {
-    automationID: string
-  }
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/automation/{automationID}/run"
-}
-
-export type AutomationRunNowErrors = {
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type AutomationRunNowError = AutomationRunNowErrors[keyof AutomationRunNowErrors]
-
-export type AutomationRunNowResponses = {
-  /**
-   * Automation run
-   */
-  200: AutomationRun
-}
-
-export type AutomationRunNowResponse = AutomationRunNowResponses[keyof AutomationRunNowResponses]
 
 export type AutomationRunsData = {
   body?: never
@@ -6125,12 +6159,122 @@ export type AutomationRunsError = AutomationRunsErrors[keyof AutomationRunsError
 
 export type AutomationRunsResponses = {
   /**
-   * Automation runs
+   * Success
    */
   200: AutomationRunsResponse
 }
 
 export type AutomationRunsResponse2 = AutomationRunsResponses[keyof AutomationRunsResponses]
+
+export type AutomationRunNowData = {
+  body?: never
+  path: {
+    automationID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/automation/{automationID}/run"
+}
+
+export type AutomationRunNowErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type AutomationRunNowError = AutomationRunNowErrors[keyof AutomationRunNowErrors]
+
+export type AutomationRunNowResponses = {
+  /**
+   * Success
+   */
+  200: AutomationRun
+}
+
+export type AutomationRunNowResponse = AutomationRunNowResponses[keyof AutomationRunNowResponses]
+
+export type AutomationPauseData = {
+  body?: never
+  path: {
+    automationID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/automation/{automationID}/pause"
+}
+
+export type AutomationPauseErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Automation update conflict
+   */
+  409: AutomationConflictError
+}
+
+export type AutomationPauseError = AutomationPauseErrors[keyof AutomationPauseErrors]
+
+export type AutomationPauseResponses = {
+  /**
+   * Success
+   */
+  200: AutomationDefinition
+}
+
+export type AutomationPauseResponse = AutomationPauseResponses[keyof AutomationPauseResponses]
+
+export type AutomationResumeData = {
+  body?: never
+  path: {
+    automationID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/automation/{automationID}/resume"
+}
+
+export type AutomationResumeErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+  /**
+   * Automation update conflict
+   */
+  409: AutomationConflictError
+}
+
+export type AutomationResumeError = AutomationResumeErrors[keyof AutomationResumeErrors]
+
+export type AutomationResumeResponses = {
+  /**
+   * Success
+   */
+  200: AutomationDefinition
+}
+
+export type AutomationResumeResponse = AutomationResumeResponses[keyof AutomationResumeResponses]
 
 export type FindTextData = {
   body?: never
@@ -6145,7 +6289,7 @@ export type FindTextData = {
 
 export type FindTextResponses = {
   /**
-   * Matches
+   * Success
    */
   200: {
     items: Array<{
@@ -6155,14 +6299,14 @@ export type FindTextResponses = {
       lines: {
         text: string
       }
-      line_number: number
-      absolute_offset: number
+      line_number: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      absolute_offset: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
       submatches: Array<{
         match: {
           text: string
         }
-        start: number
-        end: number
+        start: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+        end: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
       }>
     }>
     partial: boolean
@@ -6181,14 +6325,14 @@ export type FindFilesData = {
     query: string
     dirs?: "true" | "false"
     type?: "file" | "directory"
-    limit?: number
+    limit?: string
   }
   url: "/find/file"
 }
 
 export type FindFilesResponses = {
   /**
-   * File paths
+   * Success
    */
   200: Array<string>
 }
@@ -6208,7 +6352,7 @@ export type FindSymbolsData = {
 
 export type FindSymbolsResponses = {
   /**
-   * Symbols
+   * Success
    */
   200: Array<Symbol>
 }
@@ -6228,9 +6372,15 @@ export type FileListData = {
 
 export type FileListResponses = {
   /**
-   * Files and directories
+   * Success
    */
-  200: Array<FileNode>
+  200: Array<{
+    name: string
+    path: string
+    absolute: string
+    type: "file" | "directory"
+    ignored: boolean
+  }>
 }
 
 export type FileListResponse = FileListResponses[keyof FileListResponses]
@@ -6248,9 +6398,16 @@ export type FileReadData = {
 
 export type FileReadResponses = {
   /**
-   * File content
+   * Success
    */
-  200: FileContent
+  200: {
+    type: "text" | "binary"
+    content: string
+    diff?: string
+    patch?: unknown
+    encoding?: "base64"
+    mimeType?: string
+  }
 }
 
 export type FileReadResponse = FileReadResponses[keyof FileReadResponses]
@@ -6267,31 +6424,17 @@ export type FileStatusData = {
 
 export type FileStatusResponses = {
   /**
-   * File status
+   * Success
    */
-  200: Array<File>
+  200: Array<{
+    path: string
+    added: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    removed: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    status: "added" | "deleted" | "modified"
+  }>
 }
 
 export type FileStatusResponse = FileStatusResponses[keyof FileStatusResponses]
-
-export type EventSubscribeData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/event"
-}
-
-export type EventSubscribeResponses = {
-  /**
-   * Event stream
-   */
-  200: Event
-}
-
-export type EventSubscribeResponse = EventSubscribeResponses[keyof EventSubscribeResponses]
 
 export type McpStatusData = {
   body?: never
@@ -6305,17 +6448,34 @@ export type McpStatusData = {
 
 export type McpStatusResponses = {
   /**
-   * MCP server status
+   * Success
    */
   200: {
-    [key: string]: McpStatus
+    [key: string]:
+      | {
+          status: "connected"
+        }
+      | {
+          status: "disabled"
+        }
+      | {
+          status: "failed"
+          error: string
+        }
+      | {
+          status: "needs_auth"
+        }
+      | {
+          status: "needs_client_registration"
+          error: string
+        }
   }
 }
 
 export type McpStatusResponse = McpStatusResponses[keyof McpStatusResponses]
 
 export type McpAddData = {
-  body?: {
+  body: {
     name: string
     config: McpLocalConfig | McpRemoteConfig
   }
@@ -6338,10 +6498,27 @@ export type McpAddError = McpAddErrors[keyof McpAddErrors]
 
 export type McpAddResponses = {
   /**
-   * MCP server added successfully
+   * Success
    */
   200: {
-    [key: string]: McpStatus
+    [key: string]:
+      | {
+          status: "connected"
+        }
+      | {
+          status: "disabled"
+        }
+      | {
+          status: "failed"
+          error: string
+        }
+      | {
+          status: "needs_auth"
+        }
+      | {
+          status: "needs_client_registration"
+          error: string
+        }
   }
 }
 
@@ -6359,18 +6536,9 @@ export type McpAuthRemoveData = {
   url: "/mcp/{name}/auth"
 }
 
-export type McpAuthRemoveErrors = {
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type McpAuthRemoveError = McpAuthRemoveErrors[keyof McpAuthRemoveErrors]
-
 export type McpAuthRemoveResponses = {
   /**
-   * OAuth credentials removed
+   * Success
    */
   200: {
     success: true
@@ -6393,36 +6561,27 @@ export type McpAuthStartData = {
 
 export type McpAuthStartErrors = {
   /**
-   * Bad request
+   * MCP server does not support OAuth
    */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
+  400: McpUnsupportedOAuthError
 }
 
 export type McpAuthStartError = McpAuthStartErrors[keyof McpAuthStartErrors]
 
 export type McpAuthStartResponses = {
   /**
-   * OAuth flow started
+   * Success
    */
   200: {
-    /**
-     * URL to open in browser for authorization
-     */
     authorizationUrl: string
+    oauthState: string
   }
 }
 
 export type McpAuthStartResponse = McpAuthStartResponses[keyof McpAuthStartResponses]
 
 export type McpAuthCallbackData = {
-  body?: {
-    /**
-     * Authorization code from OAuth callback
-     */
+  body: {
     code: string
   }
   path: {
@@ -6440,19 +6599,32 @@ export type McpAuthCallbackErrors = {
    * Bad request
    */
   400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
 }
 
 export type McpAuthCallbackError = McpAuthCallbackErrors[keyof McpAuthCallbackErrors]
 
 export type McpAuthCallbackResponses = {
   /**
-   * OAuth authentication completed
+   * Success
    */
-  200: McpStatus
+  200:
+    | {
+        status: "connected"
+      }
+    | {
+        status: "disabled"
+      }
+    | {
+        status: "failed"
+        error: string
+      }
+    | {
+        status: "needs_auth"
+      }
+    | {
+        status: "needs_client_registration"
+        error: string
+      }
 }
 
 export type McpAuthCallbackResponse = McpAuthCallbackResponses[keyof McpAuthCallbackResponses]
@@ -6471,22 +6643,35 @@ export type McpAuthAuthenticateData = {
 
 export type McpAuthAuthenticateErrors = {
   /**
-   * Bad request
+   * MCP server does not support OAuth
    */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
+  400: McpUnsupportedOAuthError
 }
 
 export type McpAuthAuthenticateError = McpAuthAuthenticateErrors[keyof McpAuthAuthenticateErrors]
 
 export type McpAuthAuthenticateResponses = {
   /**
-   * OAuth authentication completed
+   * Success
    */
-  200: McpStatus
+  200:
+    | {
+        status: "connected"
+      }
+    | {
+        status: "disabled"
+      }
+    | {
+        status: "failed"
+        error: string
+      }
+    | {
+        status: "needs_auth"
+      }
+    | {
+        status: "needs_client_registration"
+        error: string
+      }
 }
 
 export type McpAuthAuthenticateResponse = McpAuthAuthenticateResponses[keyof McpAuthAuthenticateResponses]
@@ -6505,7 +6690,7 @@ export type McpConnectData = {
 
 export type McpConnectResponses = {
   /**
-   * MCP server connected successfully
+   * Success
    */
   200: boolean
 }
@@ -6526,291 +6711,84 @@ export type McpDisconnectData = {
 
 export type McpDisconnectResponses = {
   /**
-   * MCP server disconnected successfully
+   * Success
    */
   200: boolean
 }
 
 export type McpDisconnectResponse = McpDisconnectResponses[keyof McpDisconnectResponses]
 
-export type InstanceDisposeData = {
+export type EventSubscribeData = {
   body?: never
   path?: never
   query?: {
     directory?: string
     workspace?: string
   }
-  url: "/instance/dispose"
+  url: "/event"
 }
 
-export type InstanceDisposeResponses = {
+export type EventSubscribeResponses = {
   /**
-   * Instance disposed
+   * Event stream
    */
-  200: boolean
+  200: Event
 }
 
-export type InstanceDisposeResponse = InstanceDisposeResponses[keyof InstanceDisposeResponses]
+export type EventSubscribeResponse = EventSubscribeResponses[keyof EventSubscribeResponses]
 
-export type PathGetData = {
+export type GlobalEventData = {
   body?: never
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-    /**
-     * Create the global config directory before returning it.
-     */
-    ensureConfig?: boolean
-  }
-  url: "/path"
+  query?: never
+  url: "/global/event"
 }
 
-export type PathGetResponses = {
+export type GlobalEventResponses = {
   /**
-   * Path
+   * Event stream
    */
-  200: Path
+  200: GlobalEvent
 }
 
-export type PathGetResponse = PathGetResponses[keyof PathGetResponses]
+export type GlobalEventResponse = GlobalEventResponses[keyof GlobalEventResponses]
 
-export type VcsGetData = {
+export type GlobalSyncEventSubscribeData = {
   body?: never
   path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/vcs"
+  query?: never
+  url: "/global/sync-event"
 }
 
-export type VcsGetResponses = {
+export type GlobalSyncEventSubscribeResponses = {
   /**
-   * VCS info
+   * Event stream
    */
-  200: VcsInfo
+  200: SyncEvent
 }
 
-export type VcsGetResponse = VcsGetResponses[keyof VcsGetResponses]
+export type GlobalSyncEventSubscribeResponse =
+  GlobalSyncEventSubscribeResponses[keyof GlobalSyncEventSubscribeResponses]
 
-export type VcsDiffData = {
+export type PtyConnectData = {
   body?: never
-  path?: never
-  query: {
-    directory?: string
-    workspace?: string
-    mode: "git" | "branch"
+  path: {
+    ptyID: string
   }
-  url: "/vcs/diff"
-}
-
-export type VcsDiffResponses = {
-  /**
-   * VCS diff
-   */
-  200: Array<VcsFileDiff>
-}
-
-export type VcsDiffResponse = VcsDiffResponses[keyof VcsDiffResponses]
-
-export type VcsStatusData = {
-  body?: never
-  path?: never
   query?: {
     directory?: string
     workspace?: string
+    cursor?: string
+    ticket?: string
   }
-  url: "/vcs/status"
+  url: "/pty/{ptyID}/connect"
 }
 
-export type VcsStatusResponses = {
+export type PtyConnectErrors = {
   /**
-   * VCS status
+   * Not found
    */
-  200: Array<VcsFileStatus>
+  404: NotFoundError
 }
 
-export type VcsStatusResponse = VcsStatusResponses[keyof VcsStatusResponses]
-
-export type VcsDiffRawData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/vcs/diff/raw"
-}
-
-export type VcsDiffRawErrors = {
-  /**
-   * Raw VCS diff failure
-   */
-  413: VcsDiffRawFailure
-}
-
-export type VcsDiffRawError = VcsDiffRawErrors[keyof VcsDiffRawErrors]
-
-export type VcsDiffRawResponses = {
-  /**
-   * Raw VCS diff
-   */
-  200: string
-}
-
-export type VcsDiffRawResponse = VcsDiffRawResponses[keyof VcsDiffRawResponses]
-
-export type VcsApplyData = {
-  body?: {
-    patch: string
-  }
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/vcs/apply"
-}
-
-export type VcsApplyErrors = {
-  /**
-   * VCS patch apply failure
-   */
-  400: VcsApplyFailure
-  /**
-   * VCS patch apply failure
-   */
-  413: VcsApplyFailure
-}
-
-export type VcsApplyError = VcsApplyErrors[keyof VcsApplyErrors]
-
-export type VcsApplyResponses = {
-  /**
-   * Patch apply result
-   */
-  200: {
-    applied: boolean
-  }
-}
-
-export type VcsApplyResponse = VcsApplyResponses[keyof VcsApplyResponses]
-
-export type CommandListData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/command"
-}
-
-export type CommandListResponses = {
-  /**
-   * List of commands
-   */
-  200: Array<Command>
-}
-
-export type CommandListResponse = CommandListResponses[keyof CommandListResponses]
-
-export type AppAgentsData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/agent"
-}
-
-export type AppAgentsResponses = {
-  /**
-   * List of agents
-   */
-  200: Array<Agent>
-}
-
-export type AppAgentsResponse = AppAgentsResponses[keyof AppAgentsResponses]
-
-export type AppSkillsData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/skill"
-}
-
-export type AppSkillsResponses = {
-  /**
-   * List of skills
-   */
-  200: Array<{
-    name: string
-    description?: string
-    location: string
-    content: string
-  }>
-}
-
-export type AppSkillsResponse = AppSkillsResponses[keyof AppSkillsResponses]
-
-export type LspStatusData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/lsp"
-}
-
-export type LspStatusResponses = {
-  /**
-   * LSP server status
-   */
-  200: Array<LspStatus>
-}
-
-export type LspStatusResponse = LspStatusResponses[keyof LspStatusResponses]
-
-export type ProviderRecordRecentData = {
-  body?: {
-    /**
-     * Provider ID
-     */
-    providerID: string
-    /**
-     * Model ID
-     */
-    modelID: string
-  }
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/provider/recent"
-}
-
-export type ProviderRecordRecentErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-}
-
-export type ProviderRecordRecentError = ProviderRecordRecentErrors[keyof ProviderRecordRecentErrors]
-
-export type ProviderRecordRecentResponses = {
-  /**
-   * Recorded
-   */
-  200: boolean
-}
-
-export type ProviderRecordRecentResponse = ProviderRecordRecentResponses[keyof ProviderRecordRecentResponses]
+export type PtyConnectError = PtyConnectErrors[keyof PtyConnectErrors]

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1577,14 +1577,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/BadRequestError"
-                    },
-                    {
-                      "$ref": "#/components/schemas/VcsApplyFailure"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/VcsApplyFailure"
                 }
               }
             }
@@ -1594,7 +1587,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VcsApplyTooLargeFailure"
+                  "$ref": "#/components/schemas/VcsApplyFailure"
                 }
               }
             }
@@ -18481,16 +18474,10 @@
         "type": "object",
         "properties": {
           "error": {
-            "type": "string",
-            "enum": [
-              "vcs_diff_raw_failed"
-            ]
+            "const": "vcs_diff_raw_failed"
           },
           "reason": {
-            "type": "string",
-            "enum": [
-              "too-large"
-            ]
+            "const": "too-large"
           },
           "message": {
             "type": "string"
@@ -18508,13 +18495,9 @@
         "type": "object",
         "properties": {
           "error": {
-            "type": "string",
-            "enum": [
-              "vcs_apply_failed"
-            ]
+            "const": "vcs_apply_failed"
           },
           "reason": {
-            "type": "string",
             "enum": [
               "non-git",
               "not-clean",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2,309 +2,51 @@
   "openapi": "3.1.1",
   "info": {
     "title": "opencode",
-    "description": "opencode api",
-    "version": "1.0.0"
+    "version": "0.0.3",
+    "description": "opencode api"
   },
   "paths": {
-    "/global/health": {
-      "get": {
-        "operationId": "global.health",
-        "summary": "Get health",
-        "description": "Get health information about the OpenCode server.",
-        "responses": {
-          "200": {
-            "description": "Health information",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "healthy": {
-                      "type": "boolean",
-                      "const": true
-                    },
-                    "version": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "healthy",
-                    "version"
-                  ]
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.health({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/global/event": {
-      "get": {
-        "operationId": "global.event",
-        "summary": "Get global events",
-        "description": "Subscribe to global events from the OpenCode system using server-sent events.",
-        "responses": {
-          "200": {
-            "description": "Event stream",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "$ref": "#/components/schemas/GlobalEvent"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.event({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/global/sync-event": {
-      "get": {
-        "operationId": "global.sync-event.subscribe",
-        "summary": "Subscribe to global sync events",
-        "description": "Get global sync events",
-        "responses": {
-          "200": {
-            "description": "Event stream",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "$ref": "#/components/schemas/SyncEvent"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.sync-event.subscribe({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/global/config": {
-      "get": {
-        "operationId": "global.config.get",
-        "summary": "Get global configuration",
-        "description": "Retrieve the current global OpenCode configuration settings and preferences.",
-        "responses": {
-          "200": {
-            "description": "Get global config info",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Config"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.config.get({\n  ...\n})"
-          }
-        ]
-      },
-      "patch": {
-        "operationId": "global.config.update",
-        "summary": "Update global configuration",
-        "description": "Update global OpenCode configuration settings and preferences.",
-        "responses": {
-          "200": {
-            "description": "Successfully updated global config",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Config"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Config"
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.config.update({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/global/dispose": {
-      "post": {
-        "operationId": "global.dispose",
-        "summary": "Dispose instance",
-        "description": "Clean up and dispose all OpenCode instances, releasing all resources.",
-        "responses": {
-          "200": {
-            "description": "Global disposed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.dispose({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/global/upgrade": {
-      "post": {
-        "operationId": "global.upgrade",
-        "summary": "Upgrade opencode",
-        "description": "Upgrade opencode to the specified version or latest if not specified.",
-        "responses": {
-          "200": {
-            "description": "Upgrade result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "success": {
-                          "type": "boolean",
-                          "const": true
-                        },
-                        "version": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "success",
-                        "version"
-                      ]
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "success": {
-                          "type": "boolean",
-                          "const": false
-                        },
-                        "error": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "success",
-                        "error"
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "target": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.upgrade({\n  ...\n})"
-          }
-        ]
-      }
-    },
     "/auth/{providerID}": {
       "put": {
+        "tags": [
+          "control"
+        ],
         "operationId": "auth.set",
-        "summary": "Set auth credentials",
-        "description": "Set authentication credentials",
-        "responses": {
-          "200": {
-            "description": "Successfully set authentication credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          }
-        },
         "parameters": [
           {
-            "in": "path",
             "name": "providerID",
+            "in": "path",
             "schema": {
               "type": "string"
             },
             "required": true
           }
         ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Set authentication credentials",
+        "summary": "Set auth credentials",
         "requestBody": {
           "content": {
             "application/json": {
@@ -312,7 +54,8 @@
                 "$ref": "#/components/schemas/Auth"
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -322,12 +65,24 @@
         ]
       },
       "delete": {
+        "tags": [
+          "control"
+        ],
         "operationId": "auth.remove",
-        "summary": "Remove auth credentials",
-        "description": "Remove authentication credentials",
+        "parameters": [
+          {
+            "name": "providerID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
         "responses": {
           "200": {
-            "description": "Successfully removed authentication credentials",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -347,16 +102,8 @@
             }
           }
         },
-        "parameters": [
-          {
-            "in": "path",
-            "name": "providerID",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          }
-        ],
+        "description": "Remove authentication credentials",
+        "summary": "Remove auth credentials",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -367,28 +114,32 @@
     },
     "/log": {
       "post": {
+        "tags": [
+          "control"
+        ],
         "operationId": "app.log",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Write log",
-        "description": "Write a log entry to the server logs with specified level and metadata.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Log entry written successfully",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -408,6 +159,8 @@
             }
           }
         },
+        "description": "Write a log entry to the server logs with specified level and metadata.",
+        "summary": "Write log",
         "requestBody": {
           "content": {
             "application/json": {
@@ -415,11 +168,9 @@
                 "type": "object",
                 "properties": {
                   "service": {
-                    "description": "Service name for the log entry",
                     "type": "string"
                   },
                   "level": {
-                    "description": "Log level",
                     "type": "string",
                     "enum": [
                       "debug",
@@ -429,26 +180,29 @@
                     ]
                   },
                   "message": {
-                    "description": "Log message",
                     "type": "string"
                   },
                   "extra": {
-                    "description": "Additional metadata for the log entry",
-                    "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
-                    "additionalProperties": {}
+                    "anyOf": [
+                      {
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": [
                   "service",
                   "level",
                   "message"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -458,34 +212,49 @@
         ]
       }
     },
-    "/experimental/workspace": {
-      "post": {
-        "operationId": "experimental.workspace.create",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+    "/global/config": {
+      "get": {
+        "tags": [
+          "global"
         ],
-        "summary": "Create workspace",
-        "description": "Create a workspace for the current project.",
+        "operationId": "global.config.get",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "Workspace created",
+            "description": "Config",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Workspace"
+                  "$ref": "#/components/schemas/Config"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve the current global OpenCode configuration settings and preferences.",
+        "summary": "Get global configuration",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.config.get({\n  ...\n})"
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "global"
+        ],
+        "operationId": "global.config.update",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Config",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Config"
                 }
               }
             }
@@ -501,6 +270,346 @@
             }
           }
         },
+        "description": "Update global OpenCode configuration settings and preferences.",
+        "summary": "Update global configuration",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Config"
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.config.update({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/health": {
+      "get": {
+        "tags": [
+          "global"
+        ],
+        "operationId": "global.health",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "healthy": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "healthy",
+                    "version"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "description": "Get health information about the OpenCode server.",
+        "summary": "Get health",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.health({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/dispose": {
+      "post": {
+        "tags": [
+          "global"
+        ],
+        "operationId": "global.dispose",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "completed",
+                        "deferred"
+                      ]
+                    },
+                    "lifecycleActionID": {
+                      "type": "string"
+                    },
+                    "affectedDirectoryKeys": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "lifecycleActionID",
+                    "affectedDirectoryKeys"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "description": "Clean up and dispose all OpenCode instances, releasing all resources.",
+        "summary": "Dispose instance",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.dispose({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/upgrade": {
+      "post": {
+        "tags": [
+          "global"
+        ],
+        "operationId": "global.upgrade",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "version"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "enum": [
+                            false
+                          ]
+                        },
+                        "error": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "error"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request | Global upgrade request cannot be fulfilled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/BadRequestError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GlobalUpgradeBadRequest"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Global upgrade failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GlobalUpgradeServerError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Upgrade opencode to the specified version or latest if not specified.",
+        "summary": "Upgrade opencode",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.upgrade({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/experimental/workspace": {
+      "post": {
+        "tags": [
+          "workspace"
+        ],
+        "operationId": "experimental.workspace.create",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "extra": {
+                      "anyOf": [
+                        {},
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "projectID": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "type",
+                    "branch",
+                    "name",
+                    "directory",
+                    "extra",
+                    "projectID"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a workspace for the current project.",
+        "summary": "Create workspace",
         "requestBody": {
           "content": {
             "application/json": {
@@ -508,8 +617,14 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string",
-                    "pattern": "^wrk.*"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "type": {
                     "type": "string"
@@ -537,10 +652,12 @@
                   "type",
                   "branch",
                   "extra"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -550,40 +667,105 @@
         ]
       },
       "get": {
+        "tags": [
+          "workspace"
+        ],
         "operationId": "experimental.workspace.list",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "List workspaces",
-        "description": "List all workspaces.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Workspaces",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Workspace"
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "branch": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "name": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "directory": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "extra": {
+                        "anyOf": [
+                          {},
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "projectID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "type",
+                      "branch",
+                      "name",
+                      "directory",
+                      "extra",
+                      "projectID"
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "List all workspaces.",
+        "summary": "List workspaces",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -594,28 +776,32 @@
     },
     "/experimental/workspace/status": {
       "get": {
+        "tags": [
+          "workspace"
+        ],
         "operationId": "experimental.workspace.status",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Workspace status",
-        "description": "Get connection status for workspaces in the current project.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Workspace status",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -624,8 +810,7 @@
                     "type": "object",
                     "properties": {
                       "workspaceID": {
-                        "type": "string",
-                        "pattern": "^wrk.*"
+                        "type": "string"
                       },
                       "status": {
                         "type": "string",
@@ -637,19 +822,29 @@
                         ]
                       },
                       "error": {
-                        "type": "string"
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     },
                     "required": [
                       "workspaceID",
                       "status"
-                    ]
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "Get connection status for workspaces in the current project.",
+        "summary": "Workspace status",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -660,41 +855,110 @@
     },
     "/experimental/workspace/{id}": {
       "delete": {
+        "tags": [
+          "workspace"
+        ],
         "operationId": "experimental.workspace.remove",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "id",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^wrk.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Remove workspace",
-        "description": "Remove an existing workspace.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Workspace removed",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Workspace"
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "branch": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "name": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "directory": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "extra": {
+                          "anyOf": [
+                            {},
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "projectID": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "type",
+                        "branch",
+                        "name",
+                        "directory",
+                        "extra",
+                        "projectID"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -710,6 +974,8 @@
             }
           }
         },
+        "description": "Remove an existing workspace.",
+        "summary": "Remove workspace",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -718,42 +984,1324 @@
         ]
       }
     },
-    "/project": {
-      "get": {
-        "operationId": "project.list",
+    "/instance/dispose": {
+      "post": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "instance.dispose",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "List all projects",
-        "description": "Get a list of projects that have been opened with OpenCode.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of projects",
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "description": "Clean up and dispose the current OpenCode instance, releasing all resources.",
+        "summary": "Dispose instance",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.instance.dispose({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/path": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "path.get",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "ensureConfig",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "home": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string"
+                    },
+                    "config": {
+                      "type": "string"
+                    },
+                    "worktree": {
+                      "type": "string"
+                    },
+                    "directory": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "home",
+                    "state",
+                    "config",
+                    "worktree",
+                    "directory"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve the current working directory and related path information for the OpenCode instance.",
+        "summary": "Get paths",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.path.get({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/vcs": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "vcs.get",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "branch": {
+                      "type": "string"
+                    },
+                    "default_branch": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve version control system information for the current project.",
+        "summary": "Get VCS info",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.get({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/vcs/status": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "vcs.status",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Project"
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "type": "string"
+                      },
+                      "additions": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      },
+                      "deletions": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": [
+                          "added",
+                          "deleted",
+                          "modified"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "file",
+                      "additions",
+                      "deletions",
+                      "status"
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "Retrieve working tree file status summaries for the current project.",
+        "summary": "Get VCS status",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/vcs/diff": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "vcs.diff",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "git",
+                "branch"
+              ]
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "type": "string"
+                      },
+                      "patch": {
+                        "type": "string"
+                      },
+                      "additions": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      },
+                      "deletions": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": [
+                          "added",
+                          "deleted",
+                          "modified"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "file",
+                      "patch",
+                      "additions",
+                      "deletions"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve the current working-tree diff.",
+        "summary": "Get VCS diff",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.diff({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/vcs/diff/raw": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "vcs.diffRaw",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Raw VCS diff is too large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VcsDiffRawFailure"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve the current git diff as raw patch text.",
+        "summary": "Get raw VCS diff",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.diffRaw({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/vcs/apply": {
+      "post": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "vcs.apply",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "applied": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "applied"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request | VCS patch apply failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/BadRequestError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/VcsApplyFailure"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "VCS patch apply request is too large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VcsApplyTooLargeFailure"
+                }
+              }
+            }
+          }
+        },
+        "description": "Apply a git patch to the current project.",
+        "summary": "Apply VCS patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "patch": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "patch"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.apply({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/command": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "command.list",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "agent": {
+                        "type": "string"
+                      },
+                      "model": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string",
+                        "enum": [
+                          "command",
+                          "mcp",
+                          "skill"
+                        ]
+                      },
+                      "template": {},
+                      "subtask": {
+                        "type": "boolean"
+                      },
+                      "hints": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "template",
+                      "hints"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a list of all available commands in the OpenCode system.",
+        "summary": "List commands",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.command.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/agent": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "app.agents",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "subagent",
+                          "primary",
+                          "all"
+                        ]
+                      },
+                      "native": {
+                        "type": "boolean"
+                      },
+                      "hidden": {
+                        "type": "boolean"
+                      },
+                      "topP": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      },
+                      "temperature": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      },
+                      "color": {
+                        "type": "string"
+                      },
+                      "permission": {},
+                      "model": {
+                        "type": "object",
+                        "properties": {
+                          "modelID": {
+                            "type": "string"
+                          },
+                          "providerID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "modelID",
+                          "providerID"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "variant": {
+                        "type": "string"
+                      },
+                      "prompt": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object"
+                      },
+                      "steps": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "mode",
+                      "permission",
+                      "options"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a list of all available AI agents in the OpenCode system.",
+        "summary": "List agents",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.app.agents({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/skill": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "app.skills",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "content": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "location",
+                      "content"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a list of all available skills in the OpenCode system.",
+        "summary": "List skills",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.app.skills({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/lsp": {
+      "get": {
+        "tags": [
+          "root"
+        ],
+        "operationId": "lsp.status",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "root": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": [
+                          "connected",
+                          "error"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "root",
+                      "status"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get LSP server status.",
+        "summary": "Get LSP status",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.lsp.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/project": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "operationId": "project.list",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "worktree": {
+                        "type": "string"
+                      },
+                      "vcs": {
+                        "type": "string",
+                        "enum": [
+                          "git"
+                        ]
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "icon": {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          },
+                          "override": {
+                            "type": "string"
+                          },
+                          "color": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "commands": {
+                        "type": "object",
+                        "properties": {
+                          "start": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "time": {
+                        "type": "object",
+                        "properties": {
+                          "created": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "NaN"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "Infinity"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "-Infinity"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity",
+                                  "-Infinity",
+                                  "NaN"
+                                ]
+                              }
+                            ]
+                          },
+                          "updated": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "NaN"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "Infinity"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "-Infinity"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity",
+                                  "-Infinity",
+                                  "NaN"
+                                ]
+                              }
+                            ]
+                          },
+                          "initialized": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "NaN"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "Infinity"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "-Infinity"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity",
+                                  "-Infinity",
+                                  "NaN"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "created",
+                          "updated"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "sandboxes": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "worktree",
+                      "time",
+                      "sandboxes"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a list of projects that have been opened with OpenCode.",
+        "summary": "List all projects",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -764,37 +2312,218 @@
     },
     "/project/current": {
       "get": {
+        "tags": [
+          "project"
+        ],
         "operationId": "project.current",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Get current project",
-        "description": "Retrieve the currently active project that OpenCode is working with.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Current project information",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Project"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "worktree": {
+                      "type": "string"
+                    },
+                    "vcs": {
+                      "type": "string",
+                      "enum": [
+                        "git"
+                      ]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "override": {
+                          "type": "string"
+                        },
+                        "color": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "commands": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "time": {
+                      "type": "object",
+                      "properties": {
+                        "created": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        },
+                        "updated": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        },
+                        "initialized": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "created",
+                        "updated"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "sandboxes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "worktree",
+                    "time",
+                    "sandboxes"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           }
         },
+        "description": "Retrieve the currently active project that OpenCode is working with.",
+        "summary": "Get current project",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -805,37 +2534,218 @@
     },
     "/project/git/init": {
       "post": {
+        "tags": [
+          "project"
+        ],
         "operationId": "project.initGit",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Initialize git repository",
-        "description": "Create a git repository for the current project and return the refreshed project info.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Project information after git initialization",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Project"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "worktree": {
+                      "type": "string"
+                    },
+                    "vcs": {
+                      "type": "string",
+                      "enum": [
+                        "git"
+                      ]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "override": {
+                          "type": "string"
+                        },
+                        "color": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "commands": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "time": {
+                      "type": "object",
+                      "properties": {
+                        "created": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        },
+                        "updated": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        },
+                        "initialized": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "created",
+                        "updated"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "sandboxes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "worktree",
+                    "time",
+                    "sandboxes"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           }
         },
+        "description": "Create a git repository for the current project and return the refreshed project info.",
+        "summary": "Initialize git repository",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -846,40 +2756,219 @@
     },
     "/project/{projectID}": {
       "patch": {
+        "tags": [
+          "project"
+        ],
         "operationId": "project.update",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "projectID",
+            "in": "path",
             "schema": {
               "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Update project",
-        "description": "Update project properties such as name, icon, and commands.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Updated project information",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Project"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "worktree": {
+                      "type": "string"
+                    },
+                    "vcs": {
+                      "type": "string",
+                      "enum": [
+                        "git"
+                      ]
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "override": {
+                          "type": "string"
+                        },
+                        "color": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "commands": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "time": {
+                      "type": "object",
+                      "properties": {
+                        "created": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        },
+                        "updated": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        },
+                        "initialized": {
+                          "anyOf": [
+                            {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "NaN"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Infinity"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "-Infinity"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity",
+                                "-Infinity",
+                                "NaN"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "created",
+                        "updated"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "sandboxes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "worktree",
+                    "time",
+                    "sandboxes"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
@@ -905,6 +2994,8 @@
             }
           }
         },
+        "description": "Update project properties such as name, icon, and commands.",
+        "summary": "Update project",
         "requestBody": {
           "content": {
             "application/json": {
@@ -926,21 +3017,24 @@
                       "color": {
                         "type": "string"
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   },
                   "commands": {
                     "type": "object",
                     "properties": {
                       "start": {
-                        "description": "Startup script to run when creating a new workspace (worktree)",
                         "type": "string"
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -952,40 +3046,103 @@
     },
     "/pty": {
       "get": {
-        "operationId": "pty.list",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+        "tags": [
+          "pty"
         ],
-        "summary": "List PTY sessions",
-        "description": "Get a list of all active pseudo-terminal (PTY) sessions managed by OpenCode.",
+        "operationId": "pty.list",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of sessions",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Pty"
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "command": {
+                        "type": "string"
+                      },
+                      "args": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "cwd": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": [
+                          "running",
+                          "exited"
+                        ]
+                      },
+                      "pid": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "title",
+                      "command",
+                      "args",
+                      "cwd",
+                      "status",
+                      "pid"
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "Get a list of all active pseudo-terminal (PTY) sessions managed by OpenCode.",
+        "summary": "List PTY sessions",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -994,32 +3151,93 @@
         ]
       },
       "post": {
-        "operationId": "pty.create",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+        "tags": [
+          "pty"
         ],
-        "summary": "Create PTY session",
-        "description": "Create a new pseudo-terminal (PTY) session for running shell commands and processes.",
+        "operationId": "pty.create",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "Created session",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pty"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "command": {
+                      "type": "string"
+                    },
+                    "args": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "cwd": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "running",
+                        "exited"
+                      ]
+                    },
+                    "pid": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "NaN"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "-Infinity"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "Infinity",
+                            "-Infinity",
+                            "NaN"
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "command",
+                    "args",
+                    "cwd",
+                    "status",
+                    "pid"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
@@ -1035,6 +3253,8 @@
             }
           }
         },
+        "description": "Create a new pseudo-terminal (PTY) session for running shell commands and processes.",
+        "summary": "Create PTY session",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1042,33 +3262,67 @@
                 "type": "object",
                 "properties": {
                   "command": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "args": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "cwd": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "title": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "env": {
-                    "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
-                    "additionalProperties": {
-                      "type": "string"
-                    }
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -1080,41 +3334,102 @@
     },
     "/pty/{ptyID}": {
       "get": {
+        "tags": [
+          "pty"
+        ],
         "operationId": "pty.get",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "ptyID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^pty.*"
+              "type": "string"
             },
             "required": true
           }
         ],
-        "summary": "Get PTY session",
-        "description": "Retrieve detailed information about a specific pseudo-terminal (PTY) session.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Session info",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pty"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "command": {
+                      "type": "string"
+                    },
+                    "args": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "cwd": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "running",
+                        "exited"
+                      ]
+                    },
+                    "pid": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "NaN"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "-Infinity"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "Infinity",
+                            "-Infinity",
+                            "NaN"
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "command",
+                    "args",
+                    "cwd",
+                    "status",
+                    "pid"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
@@ -1130,6 +3445,8 @@
             }
           }
         },
+        "description": "Retrieve detailed information about a specific pseudo-terminal (PTY) session.",
+        "summary": "Get PTY session",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -1138,41 +3455,102 @@
         ]
       },
       "put": {
+        "tags": [
+          "pty"
+        ],
         "operationId": "pty.update",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "ptyID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^pty.*"
+              "type": "string"
             },
             "required": true
           }
         ],
-        "summary": "Update PTY session",
-        "description": "Update properties of an existing pseudo-terminal (PTY) session.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Updated session",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Pty"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "command": {
+                      "type": "string"
+                    },
+                    "args": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "cwd": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "running",
+                        "exited"
+                      ]
+                    },
+                    "pid": {
+                      "anyOf": [
+                        {
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "NaN"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Infinity"
+                              ]
+                            },
+                            {
+                              "type": "string",
+                              "enum": [
+                                "-Infinity"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "Infinity",
+                            "-Infinity",
+                            "NaN"
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "command",
+                    "args",
+                    "cwd",
+                    "status",
+                    "pid"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
@@ -1186,8 +3564,20 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
           }
         },
+        "description": "Update properties of an existing pseudo-terminal (PTY) session.",
+        "summary": "Update PTY session",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1195,27 +3585,112 @@
                 "type": "object",
                 "properties": {
                   "title": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "size": {
-                    "type": "object",
-                    "properties": {
-                      "rows": {
-                        "type": "number"
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "rows": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "NaN"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "Infinity"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "-Infinity"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity",
+                                  "-Infinity",
+                                  "NaN"
+                                ]
+                              }
+                            ]
+                          },
+                          "cols": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "NaN"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "Infinity"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "-Infinity"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity",
+                                  "-Infinity",
+                                  "NaN"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "rows",
+                          "cols"
+                        ],
+                        "additionalProperties": false
                       },
-                      "cols": {
-                        "type": "number"
+                      {
+                        "type": "null"
                       }
-                    },
-                    "required": [
-                      "rows",
-                      "cols"
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -1225,37 +3700,24 @@
         ]
       },
       "delete": {
+        "tags": [
+          "pty"
+        ],
         "operationId": "pty.remove",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "ptyID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^pty.*"
+              "type": "string"
             },
             "required": true
           }
         ],
-        "summary": "Remove PTY session",
-        "description": "Remove and terminate a specific pseudo-terminal (PTY) session.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Session removed",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -1275,6 +3737,8 @@
             }
           }
         },
+        "description": "Remove and terminate a specific pseudo-terminal (PTY) session.",
+        "summary": "Remove PTY session",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -1283,57 +3747,48 @@
         ]
       }
     },
-    "/pty/{ptyID}/connect": {
-      "get": {
-        "operationId": "pty.connect",
+    "/pty/{ptyID}/connect-token": {
+      "post": {
+        "tags": [
+          "pty"
+        ],
+        "operationId": "pty.connectToken",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "ptyID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^pty.*"
+              "type": "string"
             },
             "required": true
-          },
-          {
-            "in": "query",
-            "name": "cursor",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "ticket",
-            "schema": {
-              "type": "string"
-            }
           }
         ],
-        "summary": "Connect to PTY session",
-        "description": "Establish a WebSocket connection to interact with a pseudo-terminal (PTY) session in real-time.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Connected session",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "boolean"
+                  "type": "object",
+                  "properties": {
+                    "ticket": {
+                      "type": "string"
+                    },
+                    "expires_in": {
+                      "type": "integer",
+                      "allOf": [
+                        {
+                          "exclusiveMinimum": 0
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ticket",
+                    "expires_in"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
@@ -1349,38 +3804,44 @@
             }
           }
         },
+        "description": "Create a short-lived ticket for opening a PTY WebSocket connection.",
+        "summary": "Create PTY WebSocket token",
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.pty.connect({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.pty.connectToken({\n  ...\n})"
           }
         ]
       }
     },
     "/config": {
       "get": {
+        "tags": [
+          "config"
+        ],
         "operationId": "config.get",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Get configuration",
-        "description": "Retrieve the current OpenCode configuration settings and preferences.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Get config info",
+            "description": "Config",
             "content": {
               "application/json": {
                 "schema": {
@@ -1390,6 +3851,8 @@
             }
           }
         },
+        "description": "Retrieve the current OpenCode configuration settings and preferences.",
+        "summary": "Get configuration",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -1398,28 +3861,32 @@
         ]
       },
       "patch": {
+        "tags": [
+          "config"
+        ],
         "operationId": "config.update",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Update configuration",
-        "description": "Update OpenCode configuration settings and preferences.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Successfully updated config",
+            "description": "Config",
             "content": {
               "application/json": {
                 "schema": {
@@ -1439,6 +3906,8 @@
             }
           }
         },
+        "description": "Update OpenCode configuration settings and preferences.",
+        "summary": "Update configuration",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1446,7 +3915,8 @@
                 "$ref": "#/components/schemas/Config"
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -1458,28 +3928,32 @@
     },
     "/config/providers": {
       "get": {
+        "tags": [
+          "config"
+        ],
         "operationId": "config.providers",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "List config providers",
-        "description": "Get a list of all configured AI providers and their default models.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of providers",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -1493,9 +3967,6 @@
                     },
                     "default": {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string"
                       }
@@ -1504,12 +3975,15 @@
                   "required": [
                     "providers",
                     "default"
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           }
         },
+        "description": "Get a list of all configured AI providers and their default models.",
+        "summary": "List config providers",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -1520,28 +3994,15 @@
     },
     "/experimental/console": {
       "get": {
-        "operationId": "experimental.console.get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+        "tags": [
+          "experimental"
         ],
-        "summary": "Get active Console provider metadata",
-        "description": "Get the active Console org name and the set of provider IDs managed by that Console org.",
+        "operationId": "experimental.console.get",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "Active Console provider metadata",
+            "description": "ConsoleState",
             "content": {
               "application/json": {
                 "schema": {
@@ -1551,6 +4012,8 @@
             }
           }
         },
+        "description": "Get the active Console org name and the set of provider IDs managed by that Console org.",
+        "summary": "Get active Console provider metadata",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -1561,28 +4024,15 @@
     },
     "/experimental/console/orgs": {
       "get": {
-        "operationId": "experimental.console.listOrgs",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+        "tags": [
+          "experimental"
         ],
-        "summary": "List switchable Console orgs",
-        "description": "Get the available Console orgs across logged-in accounts, including the current active org.",
+        "operationId": "experimental.console.listOrgs",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "Switchable Console orgs",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -1619,18 +4069,22 @@
                           "orgID",
                           "orgName",
                           "active"
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     }
                   },
                   "required": [
                     "orgs"
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           }
         },
+        "description": "Get the available Console orgs across logged-in accounts, including the current active org.",
+        "summary": "List switchable Console orgs",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -1641,28 +4095,15 @@
     },
     "/experimental/console/switch": {
       "post": {
-        "operationId": "experimental.console.switchOrg",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+        "tags": [
+          "experimental"
         ],
-        "summary": "Switch active Console org",
-        "description": "Persist a new active Console account/org selection for the current local OpenCode state.",
+        "operationId": "experimental.console.switchOrg",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "Switch success",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -1670,8 +4111,20 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
           }
         },
+        "description": "Persist a new active Console account/org selection for the current local OpenCode state.",
+        "summary": "Switch active Console org",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1688,10 +4141,12 @@
                 "required": [
                   "accountID",
                   "orgID"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -1701,101 +4156,56 @@
         ]
       }
     },
-    "/experimental/tool/ids": {
-      "get": {
-        "operationId": "tool.ids",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "List tool IDs",
-        "description": "Get a list of all available tool IDs, including both built-in tools and dynamically registered tools.",
-        "responses": {
-          "200": {
-            "description": "Tool IDs",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ToolIDs"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.tool.ids({\n  ...\n})"
-          }
-        ]
-      }
-    },
     "/experimental/tool": {
       "get": {
+        "tags": [
+          "experimental"
+        ],
         "operationId": "tool.list",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
             "name": "provider",
+            "in": "query",
             "schema": {
               "type": "string"
             },
             "required": true
           },
           {
-            "in": "query",
             "name": "model",
+            "in": "query",
             "schema": {
               "type": "string"
             },
             "required": true
           }
         ],
-        "summary": "List tools",
-        "description": "Get a list of available tools with their JSON schema parameters for a specific provider and model combination.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Tools",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ToolList"
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "parameters": {}
+                    },
+                    "required": [
+                      "id",
+                      "description",
+                      "parameters"
+                    ],
+                    "additionalProperties": false
+                  }
                 }
               }
             }
@@ -1811,6 +4221,8 @@
             }
           }
         },
+        "description": "Get a list of available tools with their JSON schema parameters for a specific provider and model combination.",
+        "summary": "List tools",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -1819,34 +4231,24 @@
         ]
       }
     },
-    "/experimental/worktree": {
-      "post": {
-        "operationId": "worktree.create",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+    "/experimental/tool/ids": {
+      "get": {
+        "tags": [
+          "experimental"
         ],
-        "summary": "Create worktree",
-        "description": "Create a new git worktree for the current project and run any configured startup scripts.",
+        "operationId": "tool.ids",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "Worktree created",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Worktree"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -1862,275 +4264,161 @@
             }
           }
         },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorktreeCreateInput"
-              }
-            }
-          }
-        },
+        "description": "Get a list of all available tool IDs, including both built-in tools and dynamically registered tools.",
+        "summary": "List tool IDs",
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.create({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.tool.ids({\n  ...\n})"
           }
         ]
-      },
+      }
+    },
+    "/experimental/resource": {
       "get": {
-        "operationId": "worktree.list",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+        "tags": [
+          "experimental"
         ],
-        "summary": "List worktrees",
-        "description": "List all sandbox worktrees for the current project.",
+        "operationId": "experimental.resource.list",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of worktrees",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Worktree"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "uri": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "mimeType": {
+                        "type": "string"
+                      },
+                      "client": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "uri",
+                      "client"
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "Get all available MCP resources from connected servers. Optionally filter by name.",
+        "summary": "Get MCP resources",
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.list({\n  ...\n})"
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "worktree.remove",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Remove worktree",
-        "description": "Remove a git worktree and delete its branch.",
-        "responses": {
-          "200": {
-            "description": "Worktree removed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorktreeRemoveInput"
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.remove({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/experimental/worktree/reset": {
-      "post": {
-        "operationId": "worktree.reset",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Reset worktree",
-        "description": "Reset a worktree branch to the primary default branch.",
-        "responses": {
-          "200": {
-            "description": "Worktree reset",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorktreeResetInput"
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.reset({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.experimental.resource.list({\n  ...\n})"
           }
         ]
       }
     },
     "/experimental/session": {
       "get": {
+        "tags": [
+          "experimental"
+        ],
         "operationId": "experimental.session.list",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
             },
-            "description": "Filter sessions by project directory"
+            "required": false
           },
           {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
             "name": "roots",
-            "schema": {
-              "type": "boolean"
-            },
-            "description": "Only return root sessions (no parentID)"
-          },
-          {
             "in": "query",
-            "name": "start",
             "schema": {
-              "type": "number"
-            },
-            "description": "Filter sessions updated on or after this timestamp (milliseconds since epoch)"
-          },
-          {
-            "in": "query",
-            "name": "cursor",
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "string"
-                }
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
               ]
             },
-            "description": "Cursor for loading the next page"
+            "required": false
           },
           {
+            "name": "start",
             "in": "query",
-            "name": "search",
             "schema": {
               "type": "string"
             },
-            "description": "Filter sessions by title (case-insensitive)"
+            "required": false
           },
           {
+            "name": "cursor",
             "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
             "name": "limit",
+            "in": "query",
             "schema": {
-              "type": "number"
+              "type": "string"
             },
-            "description": "Maximum number of sessions to return"
+            "required": false
           },
           {
-            "in": "query",
             "name": "archived",
+            "in": "query",
             "schema": {
-              "type": "boolean"
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
             },
-            "description": "Include archived sessions (default false)"
+            "required": false
           },
           {
-            "in": "query",
             "name": "sort",
+            "in": "query",
             "schema": {
               "type": "string",
               "enum": [
                 "updated",
-                "created"
+                "created",
+                "activity"
               ]
             },
-            "description": "Sort sessions by last update or creation time"
+            "required": false
           }
         ],
-        "summary": "List sessions",
-        "description": "Get a list of all OpenCode sessions across projects. Defaults to most recently updated; use sort=created for creation-time order. Archived sessions are excluded by default.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of sessions",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -2143,6 +4431,8 @@
             }
           }
         },
+        "description": "List OpenCode sessions across projects with the same cursor and sort semantics as the Hono route.",
+        "summary": "List global sessions",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -2151,107 +4441,325 @@
         ]
       }
     },
-    "/experimental/resource": {
-      "get": {
-        "operationId": "experimental.resource.list",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+    "/experimental/worktree": {
+      "post": {
+        "tags": [
+          "experimental"
         ],
-        "summary": "Get MCP resources",
-        "description": "Get all available MCP resources from connected servers. Optionally filter by name.",
+        "operationId": "worktree.create",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "MCP resources",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "propertyNames": {
-                    "type": "string"
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "branch": {
+                      "type": "string"
+                    },
+                    "directory": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string",
+                      "enum": [
+                        "created",
+                        "existing"
+                      ]
+                    }
                   },
-                  "additionalProperties": {
-                    "$ref": "#/components/schemas/McpResource"
+                  "required": [
+                    "name",
+                    "branch",
+                    "directory"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a new git worktree for the current project and run any configured startup scripts.",
+        "summary": "Create worktree",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "startCommand": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.create({\n  ...\n})"
+          }
+        ]
+      },
+      "get": {
+        "tags": [
+          "experimental"
+        ],
+        "operationId": "worktree.list",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "branch": {
+                        "type": "string"
+                      },
+                      "directory": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string",
+                        "enum": [
+                          "created",
+                          "existing"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "branch",
+                      "directory"
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "List all sandbox worktrees for the current project.",
+        "summary": "List worktrees",
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.experimental.resource.list({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.list({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "experimental"
+        ],
+        "operationId": "worktree.remove",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Remove a git worktree and delete its branch.",
+        "summary": "Remove worktree",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "directory": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "directory"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.remove({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/experimental/worktree/reset": {
+      "post": {
+        "tags": [
+          "experimental"
+        ],
+        "operationId": "worktree.reset",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Reset a worktree branch to the primary default branch.",
+        "summary": "Reset worktree",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "directory": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "directory"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.worktree.reset({\n  ...\n})"
           }
         ]
       }
     },
     "/session": {
       "get": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.list",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
             },
-            "description": "Filter sessions by project directory"
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "roots",
+            "in": "query",
             "schema": {
               "type": "boolean"
             },
-            "description": "Only return root sessions (no parentID)"
+            "required": false
           },
           {
-            "in": "query",
             "name": "start",
+            "in": "query",
             "schema": {
               "type": "number"
             },
-            "description": "Filter sessions updated on or after this timestamp (milliseconds since epoch)"
+            "required": false
           },
           {
-            "in": "query",
             "name": "search",
+            "in": "query",
             "schema": {
               "type": "string"
             },
-            "description": "Filter sessions by title (case-insensitive)"
+            "required": false
           },
           {
-            "in": "query",
             "name": "limit",
+            "in": "query",
             "schema": {
               "type": "number"
             },
-            "description": "Maximum number of sessions to return"
+            "required": false
           },
           {
-            "in": "query",
             "name": "sort",
+            "in": "query",
             "schema": {
               "type": "string",
               "enum": [
@@ -2259,14 +4767,13 @@
                 "created"
               ]
             },
-            "description": "Sort sessions by last update or creation time"
+            "required": false
           }
         ],
-        "summary": "List sessions",
-        "description": "Get a list of all OpenCode sessions. Defaults to most recently updated; use sort=created for creation-time order.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of sessions",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -2287,28 +4794,32 @@
         ]
       },
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.create",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Create session",
-        "description": "Create a new OpenCode session for interacting with AI assistants and managing conversations.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Successfully created session",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -2329,14 +4840,14 @@
           }
         },
         "requestBody": {
+          "required": false,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "parentID": {
-                    "type": "string",
-                    "pattern": "^ses.*"
+                    "type": "string"
                   },
                   "title": {
                     "type": "string"
@@ -2348,8 +4859,7 @@
                     "$ref": "#/components/schemas/PermissionRuleset"
                   },
                   "workspaceID": {
-                    "type": "string",
-                    "pattern": "^wrk.*"
+                    "type": "string"
                   },
                   "createdByAgentTool": {
                     "type": "boolean"
@@ -2379,35 +4889,36 @@
     },
     "/session/status": {
       "get": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.status",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Get session status",
-        "description": "Retrieve the current status of all sessions, including active, idle, and completed states.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Get session status",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
                   "additionalProperties": {
                     "$ref": "#/components/schemas/SessionStatus"
                   }
@@ -2434,42 +4945,108 @@
         ]
       }
     },
+    "/session/__e2e/update-todos": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.e2eUpdateTodos",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "<No Content>"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Test-only route gated by the OPENCODE_E2E_ENABLED and OPENCODE_E2E_LLM_URL environment flags.",
+        "summary": "Update session todos in e2e tests",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string"
+                  },
+                  "todos": {
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "sessionID",
+                  "todos"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.e2eUpdateTodos({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}": {
       "get": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.get",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Get session",
-        "description": "Retrieve detailed information about a specific OpenCode session.",
-        "tags": [
-          "Session"
-        ],
+        "security": [],
         "responses": {
           "200": {
-            "description": "Get session",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -2506,106 +5083,41 @@
           }
         ]
       },
-      "delete": {
-        "operationId": "session.delete",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Delete session",
-        "description": "Delete a session and permanently remove all associated data, including messages and history.",
-        "responses": {
-          "200": {
-            "description": "Successfully deleted session",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.delete({\n  ...\n})"
-          }
-        ]
-      },
       "patch": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.update",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Update session",
-        "description": "Update properties of an existing session, such as title or other metadata.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Successfully updated session",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -2644,17 +5156,123 @@
                   "title": {
                     "type": "string"
                   },
-                  "permission": {
-                    "$ref": "#/components/schemas/PermissionRuleset"
-                  },
+                  "permission": {},
                   "time": {
                     "type": "object",
                     "properties": {
                       "archived": {
-                        "type": "number"
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.update({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.delete",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
                 }
               }
             }
@@ -2663,47 +5281,47 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.update({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.delete({\n  ...\n})"
           }
         ]
       }
     },
     "/session/{sessionID}/children": {
       "get": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.children",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Get session children",
-        "tags": [
-          "Session"
-        ],
-        "description": "Retrieve all child sessions that were forked from the specified parent session.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of children",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -2744,109 +5362,42 @@
         ]
       }
     },
-    "/session/{sessionID}/todo": {
-      "get": {
-        "operationId": "session.todo",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Get session todos",
-        "description": "Retrieve the todo list associated with a specific session, showing tasks and action items.",
-        "responses": {
-          "200": {
-            "description": "Todo list",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TodoSnapshot"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.todo({\n  ...\n})"
-          }
-        ]
-      }
-    },
     "/session/{sessionID}/init": {
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.init",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Initialize session",
-        "description": "Analyze the current application and create an AGENTS.md file with project-specific agent configurations.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "200",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -2889,18 +5440,19 @@
                     "type": "string"
                   },
                   "messageID": {
-                    "type": "string",
-                    "pattern": "^msg.*"
+                    "type": "string"
                   }
                 },
                 "required": [
                   "modelID",
                   "providerID",
                   "messageID"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -2910,612 +5462,58 @@
         ]
       }
     },
-    "/session/{sessionID}/fork": {
-      "post": {
-        "operationId": "session.fork",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Fork session",
-        "description": "Create a new session by forking an existing session at a specific message point.",
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Session"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "messageID": {
-                    "type": "string",
-                    "pattern": "^msg.*"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.fork({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/session/{sessionID}/abort": {
-      "post": {
-        "operationId": "session.abort",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "mode",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "soft",
-                "hard"
-              ]
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Abort session",
-        "description": "Abort an active session and stop any ongoing AI processing or command execution.",
-        "responses": {
-          "200": {
-            "description": "Aborted session",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.abort({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/session/{sessionID}/share": {
-      "post": {
-        "operationId": "session.share",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Share session",
-        "description": "Create a shareable link for a session, allowing others to view the conversation.",
-        "responses": {
-          "200": {
-            "description": "Successfully shared session",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Session"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.share({\n  ...\n})"
-          }
-        ]
-      },
-      "delete": {
-        "operationId": "session.unshare",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Unshare session",
-        "description": "Remove the shareable link for a session, making it private again.",
-        "responses": {
-          "200": {
-            "description": "Successfully unshared session",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Session"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.unshare({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/session/{sessionID}/export": {
-      "get": {
-        "operationId": "session.export",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Export session log",
-        "description": "Export the full root session tree as a single JSON document for local debugging. If a child session id is provided, climbs to the topmost ancestor and exports the whole tree.",
-        "responses": {
-          "200": {
-            "description": "Successfully exported session"
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.export({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/session/{sessionID}/diff": {
-      "get": {
-        "operationId": "session.diff",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          },
-          {
-            "in": "query",
-            "name": "messageID",
-            "schema": {
-              "type": "string",
-              "pattern": "^msg.*"
-            }
-          }
-        ],
-        "summary": "Get message diff",
-        "description": "Get the file changes (diff) that resulted from a specific user message in the session.",
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved diff",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SnapshotFileDiff"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.diff({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/session/{sessionID}/artifacts": {
-      "get": {
-        "operationId": "session.artifacts",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Get session artifacts",
-        "description": "Get the cumulative files created or updated across a session.",
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved artifacts",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SessionArtifact"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.artifacts({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/session/{sessionID}/summarize": {
-      "post": {
-        "operationId": "session.summarize",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "sessionID",
-            "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
-            },
-            "required": true
-          }
-        ],
-        "summary": "Summarize session",
-        "description": "Generate a concise summary of the session using AI compaction to preserve key information.",
-        "responses": {
-          "200": {
-            "description": "Summarized session",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "providerID": {
-                    "type": "string"
-                  },
-                  "modelID": {
-                    "type": "string"
-                  },
-                  "auto": {
-                    "default": false,
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "providerID",
-                  "modelID"
-                ]
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.summarize({\n  ...\n})"
-          }
-        ]
-      }
-    },
     "/session/{sessionID}/message": {
       "get": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.messages",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
           },
           {
+            "name": "directory",
             "in": "query",
-            "name": "limit",
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 9007199254740991
-            },
-            "description": "Maximum number of messages to return"
-          },
-          {
-            "in": "query",
-            "name": "before",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Get session messages",
-        "description": "Retrieve all messages in a session, including user prompts and AI responses.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of messages",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -3571,37 +5569,40 @@
         ]
       },
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.prompt",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Send message",
-        "description": "Create and send a new message to a session, streaming the AI response.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Created message",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -3647,14 +5648,14 @@
           }
         },
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "messageID": {
-                    "type": "string",
-                    "pattern": "^msg.*"
+                    "type": "string"
                   },
                   "model": {
                     "type": "object",
@@ -3704,16 +5705,19 @@
                     "items": {
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/TextPartInput"
+                          "$ref": "#/components/schemas/AgentPartInput"
                         },
                         {
                           "$ref": "#/components/schemas/FilePartInput"
                         },
                         {
-                          "$ref": "#/components/schemas/AgentPartInput"
+                          "$ref": "#/components/schemas/SkillPartInput"
                         },
                         {
                           "$ref": "#/components/schemas/SubtaskPartInput"
+                        },
+                        {
+                          "$ref": "#/components/schemas/TextPartInput"
                         }
                       ]
                     }
@@ -3736,46 +5740,48 @@
     },
     "/session/{sessionID}/message/{messageID}": {
       "get": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.message",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
           },
           {
-            "in": "path",
             "name": "messageID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^msg.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Get message",
-        "description": "Retrieve a specific message from a session by its message ID.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Message",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -3828,46 +5834,48 @@
         ]
       },
       "delete": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.deleteMessage",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
           },
           {
-            "in": "path",
             "name": "messageID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^msg.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Delete message",
-        "description": "Permanently delete a specific message (and all of its parts) from a session. This does not revert any file changes that may have been made while processing the message.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Successfully deleted message",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -3895,6 +5903,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
           }
         },
         "x-codeSamples": [
@@ -3906,55 +5924,154 @@
       }
     },
     "/session/{sessionID}/message/{messageID}/part/{partID}": {
+      "patch": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "part.update",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "messageID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "partID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Part"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Part"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.part.update({\n  ...\n})"
+          }
+        ]
+      },
       "delete": {
+        "tags": [
+          "session"
+        ],
         "operationId": "part.delete",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
           },
           {
-            "in": "path",
             "name": "messageID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^msg.*"
+              "type": "string"
             },
             "required": true
           },
           {
-            "in": "path",
             "name": "partID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^prt.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "description": "Delete a part from a message",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Successfully deleted part",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -3990,60 +6107,48 @@
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.part.delete({\n  ...\n})"
           }
         ]
-      },
-      "patch": {
-        "operationId": "part.update",
+      }
+    },
+    "/session/{sessionID}/todo": {
+      "get": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.todo",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
           },
           {
-            "in": "path",
-            "name": "messageID",
+            "name": "directory",
+            "in": "query",
             "schema": {
-              "type": "string",
-              "pattern": "^msg.*"
+              "type": "string"
             },
-            "required": true
+            "required": false
           },
           {
-            "in": "path",
-            "name": "partID",
+            "name": "workspace",
+            "in": "query",
             "schema": {
-              "type": "string",
-              "pattern": "^prt.*"
+              "type": "string"
             },
-            "required": true
+            "required": false
           }
         ],
-        "description": "Update a part in a message",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Successfully updated part",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Part"
+                  "$ref": "#/components/schemas/TodoSnapshot"
                 }
               }
             }
@@ -4065,15 +6170,6 @@
                 "schema": {
                   "$ref": "#/components/schemas/NotFoundError"
                 }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Part"
               }
             }
           }
@@ -4081,44 +6177,47 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.part.update({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.todo({\n  ...\n})"
           }
         ]
       }
     },
     "/session/{sessionID}/prompt_async": {
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.prompt_async",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Send async message",
-        "description": "Create and send a new message to a session asynchronously, starting the session if needed and returning immediately.",
+        "security": [],
         "responses": {
-          "204": {
-            "description": "Prompt accepted"
+          "200": {
+            "description": "<No Content>"
           },
           "400": {
             "description": "Bad request",
@@ -4142,14 +6241,14 @@
           }
         },
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "messageID": {
-                    "type": "string",
-                    "pattern": "^msg.*"
+                    "type": "string"
                   },
                   "model": {
                     "type": "object",
@@ -4199,16 +6298,19 @@
                     "items": {
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/TextPartInput"
+                          "$ref": "#/components/schemas/AgentPartInput"
                         },
                         {
                           "$ref": "#/components/schemas/FilePartInput"
                         },
                         {
-                          "$ref": "#/components/schemas/AgentPartInput"
+                          "$ref": "#/components/schemas/SkillPartInput"
                         },
                         {
                           "$ref": "#/components/schemas/SubtaskPartInput"
+                        },
+                        {
+                          "$ref": "#/components/schemas/TextPartInput"
                         }
                       ]
                     }
@@ -4229,39 +6331,123 @@
         ]
       }
     },
+    "/session/{sessionID}/abort": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.abort",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.abort({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}/command": {
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.command",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Send command",
-        "description": "Send a new command to a session for execution by the AI assistant.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Created message",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -4307,14 +6493,14 @@
           }
         },
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "messageID": {
-                    "type": "string",
-                    "pattern": "^msg.*"
+                    "type": "string"
                   },
                   "agent": {
                     "type": "string"
@@ -4342,8 +6528,7 @@
                           "type": "object",
                           "properties": {
                             "id": {
-                              "type": "string",
-                              "pattern": "^prt.*"
+                              "type": "string"
                             },
                             "type": {
                               "type": "string",
@@ -4395,39 +6580,464 @@
         ]
       }
     },
+    "/session/{sessionID}/fork": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.fork",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messageID": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.fork({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/diff": {
+      "get": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.diff",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "messageID",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnChangeAggregate"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.diff({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/share": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.share",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Cloud sharing is disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionShareDisabledError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.share({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.unshare",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Cloud sharing is disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionShareDisabledError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.unshare({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/summarize": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.summarize",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "modelID": {
+                    "type": "string"
+                  },
+                  "providerID": {
+                    "type": "string"
+                  },
+                  "auto": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "modelID",
+                  "providerID"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.summarize({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}/shell": {
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.shell",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Run shell command",
-        "description": "Execute a shell command within the session context and return the AI's response.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Created message",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -4470,17 +7080,27 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
           }
         },
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "messageID": {
-                    "type": "string",
-                    "pattern": "^msg.*"
+                    "type": "string"
                   },
                   "agent": {
                     "type": "string"
@@ -4522,37 +7142,40 @@
     },
     "/session/{sessionID}/revert": {
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.revert",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Revert message",
-        "description": "Revert a specific message in a session, undoing its effects and restoring the previous state.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Updated session",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -4580,21 +7203,30 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
           }
         },
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "messageID": {
-                    "type": "string",
-                    "pattern": "^msg.*"
+                    "type": "string"
                   },
                   "partID": {
-                    "type": "string",
-                    "pattern": "^prt.*"
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -4614,37 +7246,40 @@
     },
     "/session/{sessionID}/unrevert": {
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "session.unrevert",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Restore reverted messages",
-        "description": "Restore all previously reverted messages in a session.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Updated session",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -4672,6 +7307,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
           }
         },
         "x-codeSamples": [
@@ -4684,47 +7329,48 @@
     },
     "/session/{sessionID}/permissions/{permissionID}": {
       "post": {
+        "tags": [
+          "session"
+        ],
         "operationId": "permission.respond",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "sessionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^ses.*"
+              "type": "string"
             },
             "required": true
           },
           {
-            "in": "path",
             "name": "permissionID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^per.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Respond to permission",
-        "deprecated": true,
-        "description": "Approve or deny a permission request from the AI assistant.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Permission processed successfully",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -4771,10 +7417,12 @@
                 },
                 "required": [
                   "response"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -4784,39 +7432,1050 @@
         ]
       }
     },
+    "/session/{sessionID}/artifacts": {
+      "get": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.artifacts",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SessionArtifact"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.artifacts({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/export": {
+      "get": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.export",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.export({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/tool/respond": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.toolRespond",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "ok"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "submit"
+                        ]
+                      },
+                      "messageID": {
+                        "type": "string"
+                      },
+                      "callID": {
+                        "type": "string"
+                      },
+                      "payload": {}
+                    },
+                    "required": [
+                      "kind",
+                      "messageID",
+                      "callID",
+                      "payload"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "dismiss"
+                        ]
+                      },
+                      "messageID": {
+                        "type": "string"
+                      },
+                      "callID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "messageID",
+                      "callID"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.toolRespond({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/turn-change/{messageID}": {
+      "get": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.turnChange",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "messageID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/TurnChangeDisplay"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.turnChange({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/turn-change/{messageID}/undo": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.turnChangeUndo",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "messageID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnChangeMutationResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.turnChangeUndo({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/turn-change/{messageID}/redo": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.turnChangeRedo",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "messageID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnChangeMutationResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.turnChangeRedo({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/turn/{userMessageID}/changes": {
+      "get": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.turnChangesAggregate",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "userMessageID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnChangeAggregate"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.turnChangesAggregate({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/turn/{userMessageID}/changes/undo": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.turnChangesAggregateUndo",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "userMessageID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnChangeMutationResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "force": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.turnChangesAggregateUndo({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/turn/{userMessageID}/changes/redo": {
+      "post": {
+        "tags": [
+          "session"
+        ],
+        "operationId": "session.turnChangesAggregateRedo",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "userMessageID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnChangeMutationResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Session conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionConflictError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "force": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.turnChangesAggregateRedo({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/permission": {
+      "get": {
+        "tags": [
+          "permission"
+        ],
+        "operationId": "permission.list",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "sessionID": {
+                        "type": "string"
+                      },
+                      "permission": {
+                        "type": "string"
+                      },
+                      "patterns": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "metadata": {
+                        "type": "object"
+                      },
+                      "always": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "tool": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "messageID": {
+                                "type": "string"
+                              },
+                              "callID": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "messageID",
+                              "callID"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "sessionID",
+                      "permission",
+                      "patterns",
+                      "metadata",
+                      "always"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get all pending permission requests across all sessions.",
+        "summary": "List pending permissions",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/permission/{requestID}/reply": {
       "post": {
+        "tags": [
+          "permission"
+        ],
         "operationId": "permission.reply",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "requestID",
+            "in": "path",
             "schema": {
-              "type": "string",
-              "pattern": "^per.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Respond to permission request",
-        "description": "Approve or deny a permission request from the AI assistant.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Permission processed successfully",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -4846,6 +8505,8 @@
             }
           }
         },
+        "description": "Approve or deny a permission request from the AI assistant.",
+        "summary": "Respond to permission request",
         "requestBody": {
           "content": {
             "application/json": {
@@ -4861,15 +8522,24 @@
                     ]
                   },
                   "message": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": [
                   "reply"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -4879,74 +8549,181 @@
         ]
       }
     },
-    "/permission": {
-      "get": {
-        "operationId": "permission.list",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
+    "/permission/__e2e/ask": {
+      "post": {
+        "tags": [
+          "permission"
         ],
-        "summary": "List pending permissions",
-        "description": "Get all pending permission requests across all sessions.",
+        "operationId": "permission.e2e.ask",
+        "parameters": [],
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of pending permissions",
+            "description": "<No Content>"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Test-only route gated by the OPENCODE_E2E_ENABLED and OPENCODE_E2E_LLM_URL environment flags.",
+        "summary": "Seed an e2e permission request",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string"
+                  },
+                  "permission": {
+                    "type": "string"
+                  },
+                  "patterns": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "metadata": {
+                    "anyOf": [
+                      {
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "always": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "sessionID",
+                  "permission",
+                  "patterns"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.e2e.ask({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/external-result": {
+      "get": {
+        "tags": [
+          "external-result"
+        ],
+        "operationId": "externalResult.list",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PermissionRequest"
+                    "type": "object",
+                    "properties": {
+                      "session": {},
+                      "message": {},
+                      "part": {}
+                    },
+                    "required": [
+                      "session",
+                      "message",
+                      "part"
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "Return the (session, message, part) trio for every external-result Deferred currently awaiting a user response.",
+        "summary": "List pending external-result tool calls",
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.list({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.externalResult.list({\n  ...\n})"
           }
         ]
       }
     },
     "/provider": {
       "get": {
+        "tags": [
+          "provider"
+        ],
         "operationId": "provider.list",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "List providers",
-        "description": "Get a list of all available AI providers, including both available and connected ones.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "List of providers",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -4960,9 +8737,6 @@
                     },
                     "default": {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string"
                       }
@@ -4978,12 +8752,15 @@
                     "all",
                     "default",
                     "connected"
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           }
         },
+        "description": "Get a list of all available AI providers, including both available and connected ones.",
+        "summary": "List providers",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -4994,35 +8771,36 @@
     },
     "/provider/auth": {
       "get": {
+        "tags": [
+          "provider"
+        ],
         "operationId": "provider.auth",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Get provider auth methods",
-        "description": "Retrieve available authentication methods for all AI providers.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Provider auth methods",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
                   "additionalProperties": {
                     "type": "array",
                     "items": {
@@ -5034,6 +8812,8 @@
             }
           }
         },
+        "description": "Retrieve available authentication methods for all AI providers.",
+        "summary": "Get provider auth methods",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5044,41 +8824,51 @@
     },
     "/provider/{providerID}/oauth/authorize": {
       "post": {
+        "tags": [
+          "provider"
+        ],
         "operationId": "provider.oauth.authorize",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "providerID",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "description": "Provider ID"
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "OAuth authorize",
-        "description": "Initiate OAuth authorization for a specific AI provider to get an authorization URL.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Authorization URL and method",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProviderAuthAuthorization"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ProviderAuthAuthorization"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -5094,6 +8884,8 @@
             }
           }
         },
+        "description": "Initiate OAuth authorization for a specific AI provider to get an authorization URL.",
+        "summary": "OAuth authorize",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5101,26 +8893,65 @@
                 "type": "object",
                 "properties": {
                   "method": {
-                    "description": "Auth method index",
-                    "type": "number"
+                    "anyOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "NaN"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "-Infinity"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "Infinity",
+                          "-Infinity",
+                          "NaN"
+                        ]
+                      }
+                    ]
                   },
                   "inputs": {
-                    "description": "Prompt inputs",
-                    "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
-                    "additionalProperties": {
-                      "type": "string"
-                    }
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Prompt inputs"
                   }
                 },
                 "required": [
                   "method"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -5132,37 +8963,40 @@
     },
     "/provider/{providerID}/oauth/callback": {
       "post": {
+        "tags": [
+          "provider"
+        ],
         "operationId": "provider.oauth.callback",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "providerID",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "required": true,
-            "description": "Provider ID"
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "OAuth callback",
-        "description": "Handle the OAuth callback from a provider after user authorization.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "OAuth callback processed successfully",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -5182,6 +9016,8 @@
             }
           }
         },
+        "description": "Handle the OAuth callback from a provider after user authorization.",
+        "summary": "OAuth callback",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5189,20 +9025,62 @@
                 "type": "object",
                 "properties": {
                   "method": {
-                    "description": "Auth method index",
-                    "type": "number"
+                    "anyOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "NaN"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "-Infinity"
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "Infinity",
+                          "-Infinity",
+                          "NaN"
+                        ]
+                      }
+                    ]
                   },
                   "code": {
-                    "description": "OAuth authorization code",
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "OAuth authorization code"
                   }
                 },
                 "required": [
                   "method"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -5212,38 +9090,1312 @@
         ]
       }
     },
+    "/provider/recent": {
+      "post": {
+        "tags": [
+          "provider"
+        ],
+        "operationId": "provider.recordRecent",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Persist the user's picked model as the recent default that model-less sessions (e.g. a Telegram /new) inherit. Called by the desktop model picker on an explicit pick.",
+        "summary": "Record recent model",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerID": {
+                    "type": "string"
+                  },
+                  "modelID": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerID",
+                  "modelID"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.provider.recordRecent({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/memory": {
+      "get": {
+        "tags": [
+          "memory"
+        ],
+        "operationId": "memory.get",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryState"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get PawWork memory",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.memory.get({\n  ...\n})"
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "memory"
+        ],
+        "operationId": "memory.update",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request | Invalid PawWork memory file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/BadRequestError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidMemoryFileError"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "summary": "Update raw PawWork memory",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.memory.update({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/memory/reset": {
+      "post": {
+        "tags": [
+          "memory"
+        ],
+        "operationId": "memory.reset",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryState"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Reset PawWork memory",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.memory.reset({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/memory/disabled": {
+      "patch": {
+        "tags": [
+          "memory"
+        ],
+        "operationId": "memory.disabled",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryState"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Disable or enable PawWork memory",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "disabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "disabled"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.memory.disabled({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/memory/entry/{id}": {
+      "delete": {
+        "tags": [
+          "memory"
+        ],
+        "operationId": "memory.deleteEntry",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryState"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Delete PawWork memory entry",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.memory.deleteEntry({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/automation": {
+      "get": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.list",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationListResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List automation definitions for the current project.",
+        "summary": "List automations",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.list({\n  ...\n})"
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.create",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Automation validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationValidationError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create an automation definition without executing it.",
+        "summary": "Create automation",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "oneshot"
+                      },
+                      "title": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 160
+                      },
+                      "prompt": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 20000
+                      },
+                      "context": {
+                        "type": "string",
+                        "enum": [
+                          "continue",
+                          "fresh"
+                        ]
+                      },
+                      "where": {
+                        "$ref": "#/components/schemas/AutomationWhere"
+                      },
+                      "timezone": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "model": {
+                        "$ref": "#/components/schemas/AutomationModel"
+                      },
+                      "variant": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "fireAt": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "title",
+                      "prompt",
+                      "context",
+                      "where",
+                      "timezone",
+                      "model",
+                      "fireAt"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "recurring"
+                      },
+                      "title": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 160
+                      },
+                      "prompt": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 20000
+                      },
+                      "context": {
+                        "type": "string",
+                        "enum": [
+                          "continue",
+                          "fresh"
+                        ]
+                      },
+                      "where": {
+                        "$ref": "#/components/schemas/AutomationWhere"
+                      },
+                      "timezone": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "model": {
+                        "$ref": "#/components/schemas/AutomationModel"
+                      },
+                      "variant": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "rhythm": {
+                        "$ref": "#/components/schemas/AutomationRhythm"
+                      },
+                      "stop": {
+                        "$ref": "#/components/schemas/AutomationStop"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "title",
+                      "prompt",
+                      "context",
+                      "where",
+                      "timezone",
+                      "model",
+                      "rhythm",
+                      "stop"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.create({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/automation/{automationID}": {
+      "get": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.get",
+        "parameters": [
+          {
+            "name": "automationID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^automation_(?!run_)"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get one automation definition.",
+        "summary": "Get automation",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.get({\n  ...\n})"
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.update",
+        "parameters": [
+          {
+            "name": "automationID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^automation_(?!run_)"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Automation update conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationConflictError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Automation validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationValidationError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update an automation definition.",
+        "summary": "Update automation",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 20000
+                  },
+                  "paused": {
+                    "type": "boolean"
+                  },
+                  "context": {
+                    "type": "string",
+                    "enum": [
+                      "continue",
+                      "fresh"
+                    ]
+                  },
+                  "where": {
+                    "$ref": "#/components/schemas/AutomationWhere"
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "fireAt": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "rhythm": {
+                    "$ref": "#/components/schemas/AutomationRhythm"
+                  },
+                  "stop": {
+                    "$ref": "#/components/schemas/AutomationStop"
+                  },
+                  "model": {
+                    "$ref": "#/components/schemas/AutomationModel"
+                  },
+                  "variant": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.update({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.delete",
+        "parameters": [
+          {
+            "name": "automationID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^automation_(?!run_)"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationDefinitionTombstone"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete an automation definition, cancel future scheduling, and return a tombstone. Already-started runs continue to completion.",
+        "summary": "Delete automation",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.delete({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/automation/{automationID}/runs": {
+      "get": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.runs",
+        "parameters": [
+          {
+            "name": "automationID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^automation_(?!run_)"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 100
+            },
+            "required": false
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^automation_run_"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationRunsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "List automation runs newest first.",
+        "summary": "List automation runs",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.runs({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/automation/{automationID}/run": {
+      "post": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.runNow",
+        "parameters": [
+          {
+            "name": "automationID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^automation_(?!run_)"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationRun"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a queued automation run, start execution in the background, and return the queued run immediately.",
+        "summary": "Run automation now",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.runNow({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/automation/{automationID}/pause": {
+      "post": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.pause",
+        "parameters": [
+          {
+            "name": "automationID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^automation_(?!run_)"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Automation update conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationConflictError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Pause an automation definition.",
+        "summary": "Pause automation",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.pause({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/automation/{automationID}/resume": {
+      "post": {
+        "tags": [
+          "automation"
+        ],
+        "operationId": "automation.resume",
+        "parameters": [
+          {
+            "name": "automationID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^automation_(?!run_)"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Automation update conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutomationConflictError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Resume a paused automation definition.",
+        "summary": "Resume automation",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.automation.resume({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/find": {
       "get": {
+        "tags": [
+          "file"
+        ],
         "operationId": "find.text",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "pattern",
+            "in": "query",
             "schema": {
               "type": "string"
             },
             "required": true
           }
         ],
-        "summary": "Find text",
-        "description": "Search for text patterns across files in the project using ripgrep.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Matches",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -5263,7 +10415,8 @@
                             },
                             "required": [
                               "text"
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "lines": {
                             "type": "object",
@@ -5274,13 +10427,82 @@
                             },
                             "required": [
                               "text"
-                            ]
+                            ],
+                            "additionalProperties": false
                           },
                           "line_number": {
-                            "type": "number"
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "NaN"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "Infinity"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "-Infinity"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity",
+                                  "-Infinity",
+                                  "NaN"
+                                ]
+                              }
+                            ]
                           },
                           "absolute_offset": {
-                            "type": "number"
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "NaN"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "Infinity"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "-Infinity"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity",
+                                  "-Infinity",
+                                  "NaN"
+                                ]
+                              }
+                            ]
                           },
                           "submatches": {
                             "type": "array",
@@ -5296,20 +10518,90 @@
                                   },
                                   "required": [
                                     "text"
-                                  ]
+                                  ],
+                                  "additionalProperties": false
                                 },
                                 "start": {
-                                  "type": "number"
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "NaN"
+                                          ]
+                                        },
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "Infinity"
+                                          ]
+                                        },
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "-Infinity"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "Infinity",
+                                        "-Infinity",
+                                        "NaN"
+                                      ]
+                                    }
+                                  ]
                                 },
                                 "end": {
-                                  "type": "number"
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "NaN"
+                                          ]
+                                        },
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "Infinity"
+                                          ]
+                                        },
+                                        {
+                                          "type": "string",
+                                          "enum": [
+                                            "-Infinity"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "Infinity",
+                                        "-Infinity",
+                                        "NaN"
+                                      ]
+                                    }
+                                  ]
                                 }
                               },
                               "required": [
                                 "match",
                                 "start",
                                 "end"
-                              ]
+                              ],
+                              "additionalProperties": false
                             }
                           }
                         },
@@ -5319,7 +10611,8 @@
                           "line_number",
                           "absolute_offset",
                           "submatches"
-                        ]
+                        ],
+                        "additionalProperties": false
                       }
                     },
                     "partial": {
@@ -5336,12 +10629,15 @@
                   "required": [
                     "items",
                     "partial"
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           }
         },
+        "description": "Search for text patterns across files in the project using ripgrep.",
+        "summary": "Find text",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5352,67 +10648,72 @@
     },
     "/find/file": {
       "get": {
+        "tags": [
+          "file"
+        ],
         "operationId": "find.files",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "query",
+            "in": "query",
             "schema": {
               "type": "string"
             },
             "required": true
           },
           {
-            "in": "query",
             "name": "dirs",
+            "in": "query",
             "schema": {
               "type": "string",
               "enum": [
                 "true",
                 "false"
               ]
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "type",
+            "in": "query",
             "schema": {
               "type": "string",
               "enum": [
                 "file",
                 "directory"
               ]
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "limit",
+            "in": "query",
             "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 200
-            }
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Find files",
-        "description": "Search for files or directories by name or pattern in the project directory.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "File paths",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -5425,6 +10726,8 @@
             }
           }
         },
+        "description": "Search for files or directories by name or pattern in the project directory.",
+        "summary": "Find files",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5435,36 +10738,40 @@
     },
     "/find/symbol": {
       "get": {
+        "tags": [
+          "file"
+        ],
         "operationId": "find.symbols",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "query",
+            "in": "query",
             "schema": {
               "type": "string"
             },
             "required": true
           }
         ],
-        "summary": "Find symbols",
-        "description": "Search for workspace symbols like functions, classes, and variables using LSP.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Symbols",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -5477,6 +10784,8 @@
             }
           }
         },
+        "description": "Search for workspace symbols like functions, classes, and variables using LSP.",
+        "summary": "Find symbols",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5487,48 +10796,83 @@
     },
     "/file": {
       "get": {
+        "tags": [
+          "file"
+        ],
         "operationId": "file.list",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "path",
+            "in": "query",
             "schema": {
               "type": "string"
             },
             "required": true
           }
         ],
-        "summary": "List files",
-        "description": "List files and directories in a specified path.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "Files and directories",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/FileNode"
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "absolute": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "file",
+                          "directory"
+                        ]
+                      },
+                      "ignored": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "path",
+                      "absolute",
+                      "type",
+                      "ignored"
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "List files and directories in a specified path.",
+        "summary": "List files",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5539,45 +10883,81 @@
     },
     "/file/content": {
       "get": {
+        "tags": [
+          "file"
+        ],
         "operationId": "file.read",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "path",
+            "in": "query",
             "schema": {
               "type": "string"
             },
             "required": true
           }
         ],
-        "summary": "Read file",
-        "description": "Read the content of a specified file.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "File content",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FileContent"
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "text",
+                        "binary"
+                      ]
+                    },
+                    "content": {
+                      "type": "string"
+                    },
+                    "diff": {
+                      "type": "string"
+                    },
+                    "patch": {},
+                    "encoding": {
+                      "type": "string",
+                      "enum": [
+                        "base64"
+                      ]
+                    },
+                    "mimeType": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "content"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           }
         },
+        "description": "Read the content of a specified file.",
+        "summary": "Read file",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5588,40 +10968,140 @@
     },
     "/file/status": {
       "get": {
+        "tags": [
+          "file"
+        ],
         "operationId": "file.status",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Get file status",
-        "description": "Get the git status of all files in the project.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "File status",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/File"
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "added": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      },
+                      "removed": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "NaN"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Infinity"
+                                ]
+                              },
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "-Infinity"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "Infinity",
+                              "-Infinity",
+                              "NaN"
+                            ]
+                          }
+                        ]
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": [
+                          "added",
+                          "deleted",
+                          "modified"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "added",
+                      "removed",
+                      "status"
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
             }
           }
         },
+        "description": "Get the git status of all files in the project.",
+        "summary": "Get file status",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5630,86 +11110,132 @@
         ]
       }
     },
-    "/event": {
-      "get": {
-        "operationId": "event.subscribe",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Subscribe to events",
-        "description": "Get events",
-        "responses": {
-          "200": {
-            "description": "Event stream",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "$ref": "#/components/schemas/Event"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.event.subscribe({\n  ...\n})"
-          }
-        ]
-      }
-    },
     "/mcp": {
       "get": {
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.status",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Get MCP status",
-        "description": "Get the status of all Model Context Protocol (MCP) servers.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "MCP server status",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
                   "additionalProperties": {
-                    "$ref": "#/components/schemas/MCPStatus"
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "connected"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "disabled"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "failed"
+                            ]
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "error"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "needs_auth"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "needs_client_registration"
+                            ]
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "error"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               }
             }
           }
         },
+        "description": "Get the status of all Model Context Protocol (MCP) servers.",
+        "summary": "Get MCP status",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5718,37 +11244,122 @@
         ]
       },
       "post": {
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.add",
         "parameters": [
           {
-            "in": "query",
             "name": "directory",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           },
           {
-            "in": "query",
             "name": "workspace",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "required": false
           }
         ],
-        "summary": "Add MCP server",
-        "description": "Dynamically add a new Model Context Protocol (MCP) server to the system.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "MCP server added successfully",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
                   "additionalProperties": {
-                    "$ref": "#/components/schemas/MCPStatus"
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "connected"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "disabled"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "failed"
+                            ]
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "error"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "needs_auth"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "needs_client_registration"
+                            ]
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "error"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               }
@@ -5765,6 +11376,8 @@
             }
           }
         },
+        "description": "Dynamically add a new Model Context Protocol (MCP) server to the system.",
+        "summary": "Add MCP server",
         "requestBody": {
           "content": {
             "application/json": {
@@ -5788,10 +11401,12 @@
                 "required": [
                   "name",
                   "config"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -5803,74 +11418,74 @@
     },
     "/mcp/{name}/auth": {
       "post": {
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.auth.start",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
+            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "name": "name",
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Start MCP OAuth",
-        "description": "Start OAuth authentication flow for a Model Context Protocol (MCP) server.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "OAuth flow started",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
                     "authorizationUrl": {
-                      "description": "URL to open in browser for authorization",
+                      "type": "string"
+                    },
+                    "oauthState": {
                       "type": "string"
                     }
                   },
                   "required": [
-                    "authorizationUrl"
-                  ]
+                    "authorizationUrl",
+                    "oauthState"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "MCP server does not support OAuth",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
+                  "$ref": "#/components/schemas/McpUnsupportedOAuthError"
                 }
               }
             }
           }
         },
+        "description": "Start OAuth authentication flow for a Model Context Protocol (MCP) server.",
+        "summary": "Start MCP OAuth",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5879,36 +11494,40 @@
         ]
       },
       "delete": {
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.auth.remove",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
+            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "name": "name",
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Remove MCP OAuth",
-        "description": "Remove OAuth credentials for an MCP server",
+        "security": [],
         "responses": {
           "200": {
-            "description": "OAuth credentials removed",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -5916,27 +11535,22 @@
                   "properties": {
                     "success": {
                       "type": "boolean",
-                      "const": true
+                      "enum": [
+                        true
+                      ]
                     }
                   },
                   "required": [
                     "success"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
+                  ],
+                  "additionalProperties": false
                 }
               }
             }
           }
         },
+        "description": "Remove OAuth credentials for an MCP server",
+        "summary": "Remove MCP OAuth",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -5947,40 +11561,128 @@
     },
     "/mcp/{name}/auth/callback": {
       "post": {
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.auth.callback",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
+            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "name": "name",
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Complete MCP OAuth",
-        "description": "Complete OAuth authentication for a Model Context Protocol (MCP) server using the authorization code.",
+        "security": [],
         "responses": {
           "200": {
-            "description": "OAuth authentication completed",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MCPStatus"
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "connected"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "disabled"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "failed"
+                          ]
+                        },
+                        "error": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "error"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "needs_auth"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "needs_client_registration"
+                          ]
+                        },
+                        "error": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "error"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
                 }
               }
             }
@@ -5994,18 +11696,10 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
-                }
-              }
-            }
           }
         },
+        "description": "Complete OAuth authentication for a Model Context Protocol (MCP) server using the authorization code.",
+        "summary": "Complete MCP OAuth",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6013,16 +11707,17 @@
                 "type": "object",
                 "properties": {
                   "code": {
-                    "description": "Authorization code from OAuth callback",
                     "type": "string"
                   }
                 },
                 "required": [
                   "code"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "required": true
         },
         "x-codeSamples": [
           {
@@ -6034,65 +11729,145 @@
     },
     "/mcp/{name}/auth/authenticate": {
       "post": {
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.auth.authenticate",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
+            "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "name": "name",
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "summary": "Authenticate MCP OAuth",
-        "description": "Start OAuth flow and wait for callback (opens browser)",
+        "security": [],
         "responses": {
           "200": {
-            "description": "OAuth authentication completed",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MCPStatus"
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "connected"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "disabled"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "failed"
+                          ]
+                        },
+                        "error": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "error"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "needs_auth"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "status"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "needs_client_registration"
+                          ]
+                        },
+                        "error": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "status",
+                        "error"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
                 }
               }
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "MCP server does not support OAuth",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BadRequestError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundError"
+                  "$ref": "#/components/schemas/McpUnsupportedOAuthError"
                 }
               }
             }
           }
         },
+        "description": "Start OAuth flow and wait for callback (opens browser)",
+        "summary": "Authenticate MCP OAuth",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -6103,35 +11878,40 @@
     },
     "/mcp/{name}/connect": {
       "post": {
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.connect",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "description": "Connect an MCP server",
+        "security": [],
         "responses": {
           "200": {
-            "description": "MCP server connected successfully",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -6141,6 +11921,7 @@
             }
           }
         },
+        "description": "Connect an MCP server",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -6151,35 +11932,40 @@
     },
     "/mcp/{name}/disconnect": {
       "post": {
+        "tags": [
+          "mcp"
+        ],
         "operationId": "mcp.disconnect",
         "parameters": [
           {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
             "name": "name",
+            "in": "path",
             "schema": {
               "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
           }
         ],
-        "description": "Disconnect an MCP server",
+        "security": [],
         "responses": {
           "200": {
-            "description": "MCP server disconnected successfully",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -6189,6 +11975,7 @@
             }
           }
         },
+        "description": "Disconnect an MCP server",
         "x-codeSamples": [
           {
             "lang": "js",
@@ -6197,50 +11984,11 @@
         ]
       }
     },
-    "/instance/dispose": {
-      "post": {
-        "operationId": "instance.dispose",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Dispose instance",
-        "description": "Clean up and dispose the current OpenCode instance, releasing all resources.",
-        "responses": {
-          "200": {
-            "description": "Instance disposed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "boolean"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.instance.dispose({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/path": {
+    "/event": {
       "get": {
-        "operationId": "path.get",
+        "operationId": "event.subscribe",
+        "summary": "Subscribe to events",
+        "description": "Get events",
         "parameters": [
           {
             "in": "query",
@@ -6257,15 +12005,13 @@
             }
           }
         ],
-        "summary": "Get paths",
-        "description": "Retrieve the current working directory and related path information for the OpenCode instance.",
         "responses": {
           "200": {
-            "description": "Path",
+            "description": "Event stream",
             "content": {
-              "application/json": {
+              "text/event-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/Path"
+                  "$ref": "#/components/schemas/Event"
                 }
               }
             }
@@ -6274,39 +12020,23 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.path.get({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.event.subscribe({\n  ...\n})"
           }
         ]
       }
     },
-    "/vcs": {
+    "/global/event": {
       "get": {
-        "operationId": "vcs.get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Get VCS info",
-        "description": "Retrieve version control system (VCS) information for the current project, such as git branch.",
+        "operationId": "global.event",
+        "summary": "Get global events",
+        "description": "Subscribe to global events from the OpenCode system using server-sent events.",
         "responses": {
           "200": {
-            "description": "VCS info",
+            "description": "Event stream",
             "content": {
-              "application/json": {
+              "text/event-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/VcsInfo"
+                  "$ref": "#/components/schemas/GlobalEvent"
                 }
               }
             }
@@ -6315,54 +12045,23 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.get({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.event({\n  ...\n})"
           }
         ]
       }
     },
-    "/vcs/diff": {
+    "/global/sync-event": {
       "get": {
-        "operationId": "vcs.diff",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "mode",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "git",
-                "branch"
-              ]
-            },
-            "required": true
-          }
-        ],
-        "summary": "Get VCS diff",
-        "description": "Retrieve the current working-tree diff. `git` compares the working tree against HEAD (covers staged and unstaged changes plus untracked files); `branch` compares the working tree against the merge base with the default branch.",
+        "operationId": "global.sync-event.subscribe",
+        "summary": "Subscribe to global sync events",
+        "description": "Get global sync events",
         "responses": {
           "200": {
-            "description": "VCS diff",
+            "description": "Event stream",
             "content": {
-              "application/json": {
+              "text/event-stream": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/VcsFileDiff"
-                  }
+                  "$ref": "#/components/schemas/SyncEvent"
                 }
               }
             }
@@ -6371,210 +12070,16 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.diff({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.sync-event.subscribe({\n  ...\n})"
           }
         ]
       }
     },
-    "/command": {
+    "/pty/{ptyID}/connect": {
       "get": {
-        "operationId": "command.list",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "List commands",
-        "description": "Get a list of all available commands in the OpenCode system.",
-        "responses": {
-          "200": {
-            "description": "List of commands",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Command"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.command.list({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/agent": {
-      "get": {
-        "operationId": "app.agents",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "List agents",
-        "description": "Get a list of all available AI agents in the OpenCode system.",
-        "responses": {
-          "200": {
-            "description": "List of agents",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Agent"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.app.agents({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/skill": {
-      "get": {
-        "operationId": "app.skills",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "List skills",
-        "description": "Get a list of all available skills in the OpenCode system.",
-        "responses": {
-          "200": {
-            "description": "List of skills",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "location": {
-                        "type": "string"
-                      },
-                      "content": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "description",
-                      "location",
-                      "content"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.app.skills({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/lsp": {
-      "get": {
-        "operationId": "lsp.status",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "directory",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "workspace",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "summary": "Get LSP status",
-        "description": "Get LSP server status",
-        "responses": {
-          "200": {
-            "description": "LSP server status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/LSPStatus"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.lsp.status({\n  ...\n})"
-          }
-        ]
-      }
-    },
-    "/pty/{ptyID}/connect-token": {
-      "post": {
-        "operationId": "pty.connectToken",
+        "operationId": "pty.connect",
+        "summary": "Connect to PTY session",
+        "description": "Establish a WebSocket connection to interact with a pseudo-terminal (PTY) session in real-time.",
         "parameters": [
           {
             "in": "query",
@@ -6594,24 +12099,28 @@
             "in": "path",
             "name": "ptyID",
             "schema": {
-              "type": "string",
-              "pattern": "^pty.*"
+              "type": "string"
             },
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ticket",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
-        "summary": "Create PTY WebSocket token",
-        "description": "Create a short-lived ticket for opening a PTY WebSocket connection.",
         "responses": {
-          "200": {
-            "description": "WebSocket connect token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PtyConnectToken"
-                }
-              }
-            }
+          "101": {
+            "description": "WebSocket protocol upgrade"
           },
           "404": {
             "description": "Not found",
@@ -6627,7 +12136,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.pty.connectToken({\n  ...\n})"
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.pty.connect({\n  ...\n})"
           }
         ]
       }
@@ -6635,1800 +12144,54 @@
   },
   "components": {
     "schemas": {
-      "Project": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "worktree": {
-            "type": "string"
-          },
-          "vcs": {
-            "type": "string",
-            "const": "git"
-          },
-          "name": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "object",
-            "properties": {
-              "url": {
-                "type": "string"
-              },
-              "override": {
-                "type": "string"
-              },
-              "color": {
-                "type": "string"
-              }
-            }
-          },
-          "commands": {
-            "type": "object",
-            "properties": {
-              "start": {
-                "description": "Startup script to run when creating a new workspace (worktree)",
-                "type": "string"
-              }
-            }
-          },
-          "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              },
-              "updated": {
-                "type": "number"
-              },
-              "initialized": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "created",
-              "updated"
-            ]
-          },
-          "sandboxes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "id",
-          "worktree",
-          "time",
-          "sandboxes"
-        ]
-      },
-      "Event.project.updated": {
+      "SyncEvent.message.part.removed": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "const": "project.updated"
+            "const": "message.part.removed.1"
           },
-          "properties": {
-            "$ref": "#/components/schemas/Project"
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.server.connected": {
-        "type": "object",
-        "properties": {
-          "type": {
+          "aggregate": {
             "type": "string",
-            "const": "server.connected"
+            "const": "sessionID"
           },
-          "properties": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.global.disposed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "global.disposed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.server.instance.disposed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "server.instance.disposed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "directory": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "directory"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.installation.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "installation.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "version": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "version"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.installation.update-available": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "installation.update-available"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "version": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "version"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.lsp.client.diagnostics": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "lsp.client.diagnostics"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "serverID": {
-                "type": "string"
-              },
-              "path": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "serverID",
-              "path"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.lsp.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "lsp.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.lsp.server.install.failed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "lsp.server.install.failed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "add": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "dir": {
-                "type": "string"
-              },
-              "error": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "add",
-              "dir",
-              "error"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.message.part.delta": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "message.part.delta"
-          },
-          "properties": {
+          "data": {
             "type": "object",
             "properties": {
               "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
+                "type": "string"
               },
               "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
+                "type": "string"
               },
               "partID": {
-                "type": "string",
-                "pattern": "^prt.*"
-              },
-              "field": {
-                "type": "string"
-              },
-              "delta": {
                 "type": "string"
               }
             },
             "required": [
               "sessionID",
               "messageID",
-              "partID",
-              "field",
-              "delta"
+              "partID"
             ]
           }
         },
         "required": [
           "type",
-          "properties"
-        ]
-      },
-      "PermissionRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^per.*"
-          },
-          "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
-          },
-          "permission": {
-            "type": "string"
-          },
-          "patterns": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "metadata": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {}
-          },
-          "always": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "tool": {
-            "type": "object",
-            "properties": {
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
-              },
-              "callID": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "messageID",
-              "callID"
-            ]
-          }
-        },
-        "required": [
-          "id",
-          "sessionID",
-          "permission",
-          "patterns",
-          "metadata",
-          "always"
-        ]
-      },
-      "Event.permission.asked": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "permission.asked"
-          },
-          "properties": {
-            "$ref": "#/components/schemas/PermissionRequest"
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.permission.replied": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "permission.replied"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "requestID": {
-                "type": "string",
-                "pattern": "^per.*"
-              },
-              "reply": {
-                "type": "string",
-                "enum": [
-                  "once",
-                  "always",
-                  "reject"
-                ]
-              }
-            },
-            "required": [
-              "sessionID",
-              "requestID",
-              "reply"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "SnapshotFileDiff": {
-        "type": "object",
-        "properties": {
-          "file": {
-            "type": "string"
-          },
-          "patch": {
-            "type": "string"
-          },
-          "additions": {
-            "type": "number"
-          },
-          "deletions": {
-            "type": "number"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "added",
-              "deleted",
-              "modified"
-            ]
-          }
-        },
-        "required": [
-          "file",
-          "patch",
-          "additions",
-          "deletions"
-        ]
-      },
-      "Event.session.diff": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.diff"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "diff": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/SnapshotFileDiff"
-                }
-              }
-            },
-            "required": [
-              "sessionID",
-              "diff"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "ProviderAuthError": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "const": "ProviderAuthError"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "providerID": {
-                "type": "string"
-              },
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "providerID",
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "name",
+          "aggregate",
           "data"
-        ]
-      },
-      "UnknownError": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "const": "UnknownError"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "name",
-          "data"
-        ]
-      },
-      "MessageOutputLengthError": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "const": "MessageOutputLengthError"
-          },
-          "data": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": [
-          "name",
-          "data"
-        ]
-      },
-      "MessageAbortedError": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "const": "MessageAbortedError"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "name",
-          "data"
-        ]
-      },
-      "StructuredOutputError": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "const": "StructuredOutputError"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              },
-              "retries": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "message",
-              "retries"
-            ]
-          }
-        },
-        "required": [
-          "name",
-          "data"
-        ]
-      },
-      "ContextOverflowError": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "const": "ContextOverflowError"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              },
-              "responseBody": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "name",
-          "data"
-        ]
-      },
-      "APIError": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "const": "APIError"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              },
-              "statusCode": {
-                "type": "number"
-              },
-              "isRetryable": {
-                "type": "boolean"
-              },
-              "responseHeaders": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                },
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
-              "responseBody": {
-                "type": "string"
-              },
-              "metadata": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                },
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "message",
-              "isRetryable"
-            ]
-          }
-        },
-        "required": [
-          "name",
-          "data"
-        ]
-      },
-      "Event.session.error": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.error"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "error": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/ProviderAuthError"
-                  },
-                  {
-                    "$ref": "#/components/schemas/UnknownError"
-                  },
-                  {
-                    "$ref": "#/components/schemas/MessageOutputLengthError"
-                  },
-                  {
-                    "$ref": "#/components/schemas/MessageAbortedError"
-                  },
-                  {
-                    "$ref": "#/components/schemas/StructuredOutputError"
-                  },
-                  {
-                    "$ref": "#/components/schemas/ContextOverflowError"
-                  },
-                  {
-                    "$ref": "#/components/schemas/APIError"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.file.edited": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "file.edited"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "file": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "file"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.file.watcher.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "file.watcher.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "file": {
-                "type": "string"
-              },
-              "event": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "const": "add"
-                  },
-                  {
-                    "type": "string",
-                    "const": "change"
-                  },
-                  {
-                    "type": "string",
-                    "const": "unlink"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "file",
-              "event"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.vcs.branch.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "vcs.branch.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "branch": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.mcp.tools.changed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "mcp.tools.changed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "server": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "server"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.mcp.browser.open.failed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "mcp.browser.open.failed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "mcpName": {
-                "type": "string"
-              },
-              "url": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "mcpName",
-              "url"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.command.executed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "command.executed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "arguments": {
-                "type": "string"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
-              }
-            },
-            "required": [
-              "name",
-              "sessionID",
-              "arguments",
-              "messageID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Todo": {
-        "type": "object",
-        "properties": {
-          "content": {
-            "description": "Brief description of the task",
-            "type": "string"
-          },
-          "status": {
-            "description": "Current status of the task: pending, in_progress, completed, cancelled",
-            "type": "string"
-          },
-          "priority": {
-            "description": "Priority level of the task: high, medium, low",
-            "type": "string"
-          }
-        },
-        "required": [
-          "content",
-          "status",
-          "priority"
-        ]
-      },
-      "TodoSnapshot": {
-        "type": "object",
-        "properties": {
-          "revision": {
-            "type": "number"
-          },
-          "todos": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Todo"
-            }
-          }
-        },
-        "required": [
-          "revision",
-          "todos"
-        ]
-      },
-      "Event.todo.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "todo.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "revision": {
-                "type": "number"
-              },
-              "todos": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Todo"
-                }
-              }
-            },
-            "required": [
-              "sessionID",
-              "revision",
-              "todos"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "SessionStatus": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "idle"
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "retry"
-              },
-              "attempt": {
-                "type": "number"
-              },
-              "message": {
-                "type": "string"
-              },
-              "next": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "type",
-              "attempt",
-              "message",
-              "next"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "busy"
-              }
-            },
-            "required": [
-              "type"
-            ]
-          }
-        ]
-      },
-      "Event.session.status": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.status"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "status": {
-                "$ref": "#/components/schemas/SessionStatus"
-              }
-            },
-            "required": [
-              "sessionID",
-              "status"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.session.idle": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.idle"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              }
-            },
-            "required": [
-              "sessionID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.session.compacted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.compacted"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              }
-            },
-            "required": [
-              "sessionID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.worktree.ready": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "worktree.ready"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "branch": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "branch"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.worktree.failed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "worktree.failed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Pty": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^pty.*"
-          },
-          "title": {
-            "type": "string"
-          },
-          "command": {
-            "type": "string"
-          },
-          "args": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "cwd": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "running",
-              "exited"
-            ]
-          },
-          "pid": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "id",
-          "title",
-          "command",
-          "args",
-          "cwd",
-          "status",
-          "pid"
-        ]
-      },
-      "Event.pty.created": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "pty.created"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "info": {
-                "$ref": "#/components/schemas/Pty"
-              }
-            },
-            "required": [
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.pty.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "pty.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "info": {
-                "$ref": "#/components/schemas/Pty"
-              }
-            },
-            "required": [
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.pty.exited": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "pty.exited"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "pattern": "^pty.*"
-              },
-              "exitCode": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "id",
-              "exitCode"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.pty.deleted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "pty.deleted"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "pattern": "^pty.*"
-              }
-            },
-            "required": [
-              "id"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.workspace.ready": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "workspace.ready"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.workspace.failed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "workspace.failed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "message"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.workspace.status": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "workspace.status"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "workspaceID": {
-                "type": "string",
-                "pattern": "^wrk.*"
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "connected",
-                  "connecting",
-                  "disconnected",
-                  "error"
-                ]
-              },
-              "error": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "workspaceID",
-              "status"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "OutputFormatText": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "text"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "JSONSchema": {
-        "type": "object",
-        "propertyNames": {
-          "type": "string"
-        },
-        "additionalProperties": {}
-      },
-      "OutputFormatJsonSchema": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "json_schema"
-          },
-          "schema": {
-            "$ref": "#/components/schemas/JSONSchema"
-          },
-          "retryCount": {
-            "default": 2,
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 9007199254740991
-          }
-        },
-        "required": [
-          "type",
-          "schema"
-        ]
-      },
-      "OutputFormat": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/OutputFormatText"
-          },
-          {
-            "$ref": "#/components/schemas/OutputFormatJsonSchema"
-          }
-        ]
-      },
-      "UserMessage": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^msg.*"
-          },
-          "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
-          },
-          "role": {
-            "type": "string",
-            "const": "user"
-          },
-          "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "created"
-            ]
-          },
-          "format": {
-            "$ref": "#/components/schemas/OutputFormat"
-          },
-          "summary": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "body": {
-                "type": "string"
-              },
-              "diffs": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/SnapshotFileDiff"
-                }
-              }
-            },
-            "required": [
-              "diffs"
-            ]
-          },
-          "agent": {
-            "type": "string"
-          },
-          "model": {
-            "type": "object",
-            "properties": {
-              "providerID": {
-                "type": "string"
-              },
-              "modelID": {
-                "type": "string"
-              },
-              "variant": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "providerID",
-              "modelID"
-            ]
-          },
-          "locale": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string"
-          },
-          "tools": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "type": "boolean"
-            }
-          }
-        },
-        "required": [
-          "id",
-          "sessionID",
-          "role",
-          "time",
-          "agent",
-          "model"
-        ]
-      },
-      "AssistantMessage": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^msg.*"
-          },
-          "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
-          },
-          "role": {
-            "type": "string",
-            "const": "assistant"
-          },
-          "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              },
-              "completed": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "created"
-            ]
-          },
-          "error": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ProviderAuthError"
-              },
-              {
-                "$ref": "#/components/schemas/UnknownError"
-              },
-              {
-                "$ref": "#/components/schemas/MessageOutputLengthError"
-              },
-              {
-                "$ref": "#/components/schemas/MessageAbortedError"
-              },
-              {
-                "$ref": "#/components/schemas/StructuredOutputError"
-              },
-              {
-                "$ref": "#/components/schemas/ContextOverflowError"
-              },
-              {
-                "$ref": "#/components/schemas/APIError"
-              }
-            ]
-          },
-          "parentID": {
-            "type": "string",
-            "pattern": "^msg.*"
-          },
-          "modelID": {
-            "type": "string"
-          },
-          "providerID": {
-            "type": "string"
-          },
-          "mode": {
-            "type": "string"
-          },
-          "agent": {
-            "type": "string"
-          },
-          "path": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "cwd": {
-                    "type": "string"
-                  },
-                  "root": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "cwd",
-                  "root"
-                ]
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "summary": {
-            "type": "boolean"
-          },
-          "cost": {
-            "type": "number"
-          },
-          "tokens": {
-            "type": "object",
-            "properties": {
-              "total": {
-                "type": "number"
-              },
-              "input": {
-                "type": "number"
-              },
-              "output": {
-                "type": "number"
-              },
-              "reasoning": {
-                "type": "number"
-              },
-              "cache": {
-                "type": "object",
-                "properties": {
-                  "read": {
-                    "type": "number"
-                  },
-                  "write": {
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "read",
-                  "write"
-                ]
-              }
-            },
-            "required": [
-              "input",
-              "output",
-              "reasoning",
-              "cache"
-            ]
-          },
-          "structured": {},
-          "variant": {
-            "type": "string"
-          },
-          "finish": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "sessionID",
-          "role",
-          "time",
-          "parentID",
-          "modelID",
-          "providerID",
-          "mode",
-          "agent",
-          "path",
-          "cost",
-          "tokens"
-        ]
-      },
-      "Message": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/UserMessage"
-          },
-          {
-            "$ref": "#/components/schemas/AssistantMessage"
-          }
-        ]
-      },
-      "Event.message.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "message.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "info": {
-                "$ref": "#/components/schemas/Message"
-              }
-            },
-            "required": [
-              "sessionID",
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.message.removed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "message.removed"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
-              }
-            },
-            "required": [
-              "sessionID",
-              "messageID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
         ]
       },
       "TextPart": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -8477,16 +12240,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -8769,16 +12529,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -8815,6 +12572,50 @@
           "messageID",
           "type",
           "text",
+          "time"
+        ]
+      },
+      "NoticePart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string"
+          },
+          "messageID": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "notice"
+          },
+          "kind": {
+            "type": "string",
+            "const": "safe_retry_failed"
+          },
+          "sideEffect": {
+            "type": "boolean"
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "created"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "kind",
           "time"
         ]
       },
@@ -8964,10 +12765,10 @@
             "$ref": "#/components/schemas/FileSource"
           },
           {
-            "$ref": "#/components/schemas/SymbolSource"
+            "$ref": "#/components/schemas/ResourceSource"
           },
           {
-            "$ref": "#/components/schemas/ResourceSource"
+            "$ref": "#/components/schemas/SymbolSource"
           }
         ]
       },
@@ -8975,16 +12776,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9163,6 +12961,14 @@
           "error": {
             "type": "string"
           },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "aborted",
+              "shutdown",
+              "tool_failure"
+            ]
+          },
           "metadata": {
             "type": "object",
             "propertyNames": {
@@ -9196,16 +13002,16 @@
       "ToolState": {
         "anyOf": [
           {
-            "$ref": "#/components/schemas/ToolStatePending"
-          },
-          {
-            "$ref": "#/components/schemas/ToolStateRunning"
-          },
-          {
             "$ref": "#/components/schemas/ToolStateCompleted"
           },
           {
             "$ref": "#/components/schemas/ToolStateError"
+          },
+          {
+            "$ref": "#/components/schemas/ToolStatePending"
+          },
+          {
+            "$ref": "#/components/schemas/ToolStateRunning"
           }
         ]
       },
@@ -9213,16 +13019,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9259,16 +13062,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9289,16 +13089,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9366,16 +13163,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9397,16 +13191,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9435,16 +13226,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9485,20 +13273,147 @@
           "name"
         ]
       },
+      "SkillPart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string"
+          },
+          "messageID": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "skill"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "start": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "end": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "value",
+              "start",
+              "end"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "name"
+        ]
+      },
+      "APIError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "APIError"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "statusCode": {
+                "type": "number"
+              },
+              "isRetryable": {
+                "type": "boolean"
+              },
+              "responseHeaders": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "responseBody": {
+                "type": "string"
+              },
+              "metadata": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "providerID": {
+                "type": "string"
+              },
+              "providerFailure": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "auth",
+                      "rate_limit",
+                      "quota_exhausted",
+                      "server_overload",
+                      "invalid_request",
+                      "transport_disconnect",
+                      "decompression",
+                      "unknown"
+                    ]
+                  },
+                  "code": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              }
+            },
+            "required": [
+              "message",
+              "isRetryable"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "data"
+        ]
+      },
       "RetryPart": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9536,16 +13451,13 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "sessionID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "messageID": {
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -9559,8 +13471,7 @@
           },
           "tail_start_id": {
             "description": "Message ID of the first retained message kept verbatim after compaction.",
-            "type": "string",
-            "pattern": "^msg.*"
+            "type": "string"
           }
         },
         "required": [
@@ -9574,56 +13485,65 @@
       "Part": {
         "anyOf": [
           {
-            "$ref": "#/components/schemas/TextPart"
+            "$ref": "#/components/schemas/AgentPart"
           },
           {
-            "$ref": "#/components/schemas/SubtaskPart"
-          },
-          {
-            "$ref": "#/components/schemas/ReasoningPart"
+            "$ref": "#/components/schemas/CompactionPart"
           },
           {
             "$ref": "#/components/schemas/FilePart"
           },
           {
-            "$ref": "#/components/schemas/ToolPart"
-          },
-          {
-            "$ref": "#/components/schemas/StepStartPart"
-          },
-          {
-            "$ref": "#/components/schemas/StepFinishPart"
-          },
-          {
-            "$ref": "#/components/schemas/SnapshotPart"
+            "$ref": "#/components/schemas/NoticePart"
           },
           {
             "$ref": "#/components/schemas/PatchPart"
           },
           {
-            "$ref": "#/components/schemas/AgentPart"
+            "$ref": "#/components/schemas/ReasoningPart"
           },
           {
             "$ref": "#/components/schemas/RetryPart"
           },
           {
-            "$ref": "#/components/schemas/CompactionPart"
+            "$ref": "#/components/schemas/SkillPart"
+          },
+          {
+            "$ref": "#/components/schemas/SnapshotPart"
+          },
+          {
+            "$ref": "#/components/schemas/StepFinishPart"
+          },
+          {
+            "$ref": "#/components/schemas/StepStartPart"
+          },
+          {
+            "$ref": "#/components/schemas/SubtaskPart"
+          },
+          {
+            "$ref": "#/components/schemas/TextPart"
+          },
+          {
+            "$ref": "#/components/schemas/ToolPart"
           }
         ]
       },
-      "Event.message.part.updated": {
+      "SyncEvent.message.part.updated": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "const": "message.part.updated"
+            "const": "message.part.updated.1"
           },
-          "properties": {
+          "aggregate": {
+            "type": "string",
+            "const": "sessionID"
+          },
+          "data": {
             "type": "object",
             "properties": {
               "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
+                "type": "string"
               },
               "part": {
                 "$ref": "#/components/schemas/Part"
@@ -9641,42 +13561,1147 @@
         },
         "required": [
           "type",
-          "properties"
+          "aggregate",
+          "data"
         ]
       },
-      "Event.message.part.removed": {
+      "SyncEvent.message.removed": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "const": "message.part.removed"
+            "const": "message.removed.1"
           },
-          "properties": {
+          "aggregate": {
+            "type": "string",
+            "const": "sessionID"
+          },
+          "data": {
             "type": "object",
             "properties": {
               "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
+                "type": "string"
               },
               "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
-              },
-              "partID": {
-                "type": "string",
-                "pattern": "^prt.*"
+                "type": "string"
               }
             },
             "required": [
               "sessionID",
-              "messageID",
-              "partID"
+              "messageID"
             ]
           }
         },
         "required": [
           "type",
-          "properties"
+          "aggregate",
+          "data"
+        ]
+      },
+      "OutputFormatText": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "text"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "JSONSchema": {
+        "type": "object",
+        "propertyNames": {
+          "type": "string"
+        },
+        "additionalProperties": {}
+      },
+      "OutputFormatJsonSchema": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "json_schema"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/JSONSchema"
+          },
+          "retryCount": {
+            "default": 2,
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "type",
+          "schema"
+        ]
+      },
+      "OutputFormat": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/OutputFormatJsonSchema"
+          },
+          {
+            "$ref": "#/components/schemas/OutputFormatText"
+          }
+        ]
+      },
+      "SnapshotFileDiff": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string"
+          },
+          "patch": {
+            "type": "string"
+          },
+          "additions": {
+            "type": "number"
+          },
+          "deletions": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "added",
+              "deleted",
+              "modified"
+            ]
+          }
+        },
+        "required": [
+          "file",
+          "patch",
+          "additions",
+          "deletions"
+        ]
+      },
+      "UserMessage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "const": "user"
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "created"
+            ]
+          },
+          "format": {
+            "$ref": "#/components/schemas/OutputFormat"
+          },
+          "summary": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "body": {
+                "type": "string"
+              },
+              "diffs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SnapshotFileDiff"
+                }
+              }
+            }
+          },
+          "agent": {
+            "type": "string"
+          },
+          "automationID": {
+            "type": "string"
+          },
+          "model": {
+            "type": "object",
+            "properties": {
+              "providerID": {
+                "type": "string"
+              },
+              "modelID": {
+                "type": "string"
+              },
+              "variant": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID",
+              "modelID"
+            ]
+          },
+          "locale": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string"
+          },
+          "tools": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "replay": {
+            "type": "boolean"
+          },
+          "diagnostics": {
+            "type": "object",
+            "properties": {
+              "run_lifecycle": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "session_id": {
+                      "type": "string"
+                    },
+                    "message_id": {
+                      "type": "string"
+                    },
+                    "assistant_message_id": {
+                      "type": "string"
+                    },
+                    "at": {
+                      "type": "number"
+                    },
+                    "duration_ms": {
+                      "type": "number"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "lifecycle": {
+                      "type": "object",
+                      "properties": {
+                        "action_id": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "initiated_at": {
+                          "type": "number"
+                        },
+                        "initiated_monotonic_ms": {
+                          "type": "number"
+                        },
+                        "affected_directory_keys": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "origin": {},
+                        "request": {}
+                      },
+                      "required": [
+                        "action_id",
+                        "kind"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "type",
+                    "session_id",
+                    "at"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "sessionID",
+          "role",
+          "time",
+          "agent",
+          "model"
+        ]
+      },
+      "ProviderAuthError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "ProviderAuthError"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "providerID": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID",
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "data"
+        ]
+      },
+      "UnknownError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "UnknownError"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "data"
+        ]
+      },
+      "MessageOutputLengthError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "MessageOutputLengthError"
+          },
+          "data": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": [
+          "name",
+          "data"
+        ]
+      },
+      "MessageAbortedError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "MessageAbortedError"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "data"
+        ]
+      },
+      "StructuredOutputError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "StructuredOutputError"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "retries": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "message",
+              "retries"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "data"
+        ]
+      },
+      "ContextOverflowError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "ContextOverflowError"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "responseBody": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "data"
+        ]
+      },
+      "AssistantMessage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "const": "assistant"
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              },
+              "completed": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "created"
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/APIError"
+              },
+              {
+                "$ref": "#/components/schemas/ContextOverflowError"
+              },
+              {
+                "$ref": "#/components/schemas/MessageAbortedError"
+              },
+              {
+                "$ref": "#/components/schemas/MessageOutputLengthError"
+              },
+              {
+                "$ref": "#/components/schemas/ProviderAuthError"
+              },
+              {
+                "$ref": "#/components/schemas/StructuredOutputError"
+              },
+              {
+                "$ref": "#/components/schemas/UnknownError"
+              }
+            ]
+          },
+          "parentID": {
+            "type": "string"
+          },
+          "modelID": {
+            "type": "string"
+          },
+          "providerID": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "agent": {
+            "type": "string"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "cwd": {
+                    "type": "string"
+                  },
+                  "root": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cwd",
+                  "root"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "summary": {
+            "type": "boolean"
+          },
+          "cost": {
+            "type": "number"
+          },
+          "tokens": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "number"
+              },
+              "input": {
+                "type": "number"
+              },
+              "output": {
+                "type": "number"
+              },
+              "reasoning": {
+                "type": "number"
+              },
+              "cache": {
+                "type": "object",
+                "properties": {
+                  "read": {
+                    "type": "number"
+                  },
+                  "write": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "read",
+                  "write"
+                ]
+              }
+            },
+            "required": [
+              "input",
+              "output",
+              "reasoning",
+              "cache"
+            ]
+          },
+          "tokensCumulative": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "number"
+              },
+              "input": {
+                "type": "number"
+              },
+              "output": {
+                "type": "number"
+              },
+              "reasoning": {
+                "type": "number"
+              },
+              "cache": {
+                "type": "object",
+                "properties": {
+                  "read": {
+                    "type": "number"
+                  },
+                  "write": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "read",
+                  "write"
+                ]
+              }
+            },
+            "required": [
+              "input",
+              "output",
+              "reasoning",
+              "cache"
+            ]
+          },
+          "structured": {},
+          "variant": {
+            "type": "string"
+          },
+          "finish": {
+            "type": "string"
+          },
+          "diagnostics": {
+            "type": "object",
+            "properties": {
+              "llm_trace": {
+                "type": "object",
+                "properties": {
+                  "schema_version": {
+                    "type": "number",
+                    "const": 1
+                  },
+                  "trace_id": {
+                    "type": "string"
+                  },
+                  "session_id": {
+                    "type": "string"
+                  },
+                  "message_id": {
+                    "type": "string"
+                  },
+                  "parent_message_id": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "agent": {
+                    "type": "string"
+                  },
+                  "variant": {
+                    "type": "string"
+                  },
+                  "request": {
+                    "type": "object",
+                    "properties": {
+                      "streaming": {
+                        "type": "boolean",
+                        "const": true
+                      },
+                      "tool_count": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "tool_choice": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "required",
+                          "none"
+                        ]
+                      },
+                      "small": {
+                        "type": "boolean"
+                      },
+                      "reasoning_capability": {
+                        "type": "boolean"
+                      },
+                      "interleaved_field": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "properties": {
+                          "temperature": {
+                            "type": "number"
+                          },
+                          "top_p": {
+                            "type": "number"
+                          },
+                          "top_k": {
+                            "type": "number"
+                          },
+                          "max_output_tokens": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "streaming",
+                      "tool_count",
+                      "small",
+                      "reasoning_capability"
+                    ]
+                  },
+                  "stream_events": {
+                    "type": "object",
+                    "properties": {
+                      "start": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "start_step": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "finish_step": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "finish": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "text_start": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "text_delta": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "text_end": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "reasoning_start": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "reasoning_delta": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "reasoning_end": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "tool_input_start": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "tool_input_delta": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "tool_input_end": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "tool_call": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "tool_result": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "tool_error": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "error": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "finish_reason": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "start",
+                      "start_step",
+                      "finish_step",
+                      "finish",
+                      "text_start",
+                      "text_delta",
+                      "text_end",
+                      "reasoning_start",
+                      "reasoning_delta",
+                      "reasoning_end",
+                      "tool_input_start",
+                      "tool_input_delta",
+                      "tool_input_end",
+                      "tool_call",
+                      "tool_result",
+                      "tool_error",
+                      "error"
+                    ]
+                  },
+                  "stored_parts": {
+                    "type": "object",
+                    "properties": {
+                      "text": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "reasoning": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "tool": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "step_start": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "step_finish": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "patch": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "file": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "other": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "text",
+                      "reasoning",
+                      "tool",
+                      "step_start",
+                      "step_finish",
+                      "patch",
+                      "file",
+                      "other"
+                    ]
+                  },
+                  "tokens": {
+                    "type": "object",
+                    "properties": {
+                      "input": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "output": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "reasoning": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "cache_read": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "cache_write": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "input",
+                      "output",
+                      "reasoning",
+                      "cache_read",
+                      "cache_write"
+                    ]
+                  },
+                  "flags": {
+                    "type": "object",
+                    "properties": {
+                      "empty_completion": {
+                        "type": "boolean"
+                      },
+                      "stream_error": {
+                        "type": "boolean"
+                      },
+                      "aborted": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "empty_completion"
+                    ]
+                  },
+                  "created_at": {
+                    "type": "number"
+                  },
+                  "completed_at": {
+                    "type": "number"
+                  },
+                  "stream": {}
+                },
+                "required": [
+                  "schema_version",
+                  "trace_id",
+                  "session_id",
+                  "message_id",
+                  "provider",
+                  "model",
+                  "agent",
+                  "stream_events",
+                  "stored_parts",
+                  "flags",
+                  "created_at"
+                ]
+              },
+              "run_observability": {},
+              "run_lifecycle": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "schema_version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "session_id": {
+                      "type": "string"
+                    },
+                    "message_id": {
+                      "type": "string"
+                    },
+                    "assistant_message_id": {
+                      "type": "string"
+                    },
+                    "at": {
+                      "type": "number"
+                    },
+                    "duration_ms": {
+                      "type": "number"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "lifecycle": {
+                      "type": "object",
+                      "properties": {
+                        "action_id": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "initiated_at": {
+                          "type": "number"
+                        },
+                        "initiated_monotonic_ms": {
+                          "type": "number"
+                        },
+                        "affected_directory_keys": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "origin": {},
+                        "request": {}
+                      },
+                      "required": [
+                        "action_id",
+                        "kind"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "schema_version",
+                    "type",
+                    "session_id",
+                    "at"
+                  ]
+                }
+              },
+              "abort": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  },
+                  "title_generation_state": {
+                    "type": "string",
+                    "enum": [
+                      "not_started",
+                      "in_flight",
+                      "completed_before_abort",
+                      "completed_after_abort"
+                    ]
+                  },
+                  "propagation_point": {
+                    "type": "string"
+                  },
+                  "error_name": {
+                    "type": "string"
+                  },
+                  "error_message": {
+                    "type": "string"
+                  },
+                  "via_ctx_abort": {
+                    "type": "boolean"
+                  },
+                  "recorded_at": {
+                    "type": "number"
+                  }
+                }
+              },
+              "title_generation": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "parent_message_id": {
+                    "type": "string"
+                  },
+                  "started_at": {
+                    "type": "number"
+                  },
+                  "completed_at": {
+                    "type": "number"
+                  },
+                  "success": {
+                    "type": "boolean"
+                  },
+                  "applied": {
+                    "type": "boolean"
+                  },
+                  "error_name": {
+                    "type": "string"
+                  },
+                  "error_message": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "started_at",
+                  "success"
+                ]
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "sessionID",
+          "role",
+          "time",
+          "parentID",
+          "modelID",
+          "providerID",
+          "mode",
+          "agent",
+          "path",
+          "cost",
+          "tokens"
+        ]
+      },
+      "Message": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/AssistantMessage"
+          },
+          {
+            "$ref": "#/components/schemas/UserMessage"
+          }
+        ]
+      },
+      "SyncEvent.message.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "message.updated.1"
+          },
+          "aggregate": {
+            "type": "string",
+            "const": "sessionID"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "info": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "required": [
+              "sessionID",
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "aggregate",
+          "data"
         ]
       },
       "PermissionAction": {
@@ -9716,8 +14741,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "slug": {
             "type": "string"
@@ -9726,15 +14750,13 @@
             "type": "string"
           },
           "workspaceID": {
-            "type": "string",
-            "pattern": "^wrk.*"
+            "type": "string"
           },
           "directory": {
             "type": "string"
           },
           "parentID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "createdByAgentTool": {
             "default": false,
@@ -9824,12 +14846,10 @@
             "type": "object",
             "properties": {
               "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
+                "type": "string"
               },
               "partID": {
-                "type": "string",
-                "pattern": "^prt.*"
+                "type": "string"
               },
               "snapshot": {
                 "type": "string"
@@ -9900,385 +14920,6 @@
           "executionContext"
         ]
       },
-      "Event.session.created": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.created"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "info": {
-                "$ref": "#/components/schemas/Session"
-              }
-            },
-            "required": [
-              "sessionID",
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.session.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "info": {
-                "$ref": "#/components/schemas/Session"
-              }
-            },
-            "required": [
-              "sessionID",
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.session.deleted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "session.deleted"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "info": {
-                "$ref": "#/components/schemas/Session"
-              }
-            },
-            "required": [
-              "sessionID",
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/Event.project.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.server.connected"
-          },
-          {
-            "$ref": "#/components/schemas/Event.global.disposed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.server.instance.disposed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.installation.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.installation.update-available"
-          },
-          {
-            "$ref": "#/components/schemas/Event.lsp.client.diagnostics"
-          },
-          {
-            "$ref": "#/components/schemas/Event.lsp.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.lsp.server.install.failed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.part.delta"
-          },
-          {
-            "$ref": "#/components/schemas/Event.permission.asked"
-          },
-          {
-            "$ref": "#/components/schemas/Event.permission.replied"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.diff"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.error"
-          },
-          {
-            "$ref": "#/components/schemas/Event.file.edited"
-          },
-          {
-            "$ref": "#/components/schemas/Event.file.watcher.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.vcs.branch.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.mcp.tools.changed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.mcp.browser.open.failed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.command.executed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.todo.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.status"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.idle"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.compacted"
-          },
-          {
-            "$ref": "#/components/schemas/Event.worktree.ready"
-          },
-          {
-            "$ref": "#/components/schemas/Event.worktree.failed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.pty.created"
-          },
-          {
-            "$ref": "#/components/schemas/Event.pty.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.pty.exited"
-          },
-          {
-            "$ref": "#/components/schemas/Event.pty.deleted"
-          },
-          {
-            "$ref": "#/components/schemas/Event.workspace.ready"
-          },
-          {
-            "$ref": "#/components/schemas/Event.workspace.failed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.workspace.status"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.removed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.part.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.message.part.removed"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.created"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.updated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.session.deleted"
-          }
-        ]
-      },
-      "GlobalEvent": {
-        "type": "object",
-        "properties": {
-          "directory": {
-            "type": "string"
-          },
-          "project": {
-            "type": "string"
-          },
-          "workspace": {
-            "type": "string"
-          },
-          "payload": {
-            "$ref": "#/components/schemas/Event"
-          }
-        },
-        "required": [
-          "directory",
-          "payload"
-        ]
-      },
-      "SyncEvent.message.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "message.updated.1"
-          },
-          "aggregate": {
-            "type": "string",
-            "const": "sessionID"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "info": {
-                "$ref": "#/components/schemas/Message"
-              }
-            },
-            "required": [
-              "sessionID",
-              "info"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "aggregate",
-          "data"
-        ]
-      },
-      "SyncEvent.message.removed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "message.removed.1"
-          },
-          "aggregate": {
-            "type": "string",
-            "const": "sessionID"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
-              }
-            },
-            "required": [
-              "sessionID",
-              "messageID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "aggregate",
-          "data"
-        ]
-      },
-      "SyncEvent.message.part.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "message.part.updated.1"
-          },
-          "aggregate": {
-            "type": "string",
-            "const": "sessionID"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "part": {
-                "$ref": "#/components/schemas/Part"
-              },
-              "time": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "sessionID",
-              "part",
-              "time"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "aggregate",
-          "data"
-        ]
-      },
-      "SyncEvent.message.part.removed": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "message.part.removed.1"
-          },
-          "aggregate": {
-            "type": "string",
-            "const": "sessionID"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
-              },
-              "partID": {
-                "type": "string",
-                "pattern": "^prt.*"
-              }
-            },
-            "required": [
-              "sessionID",
-              "messageID",
-              "partID"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "aggregate",
-          "data"
-        ]
-      },
       "SyncEvent.session.created": {
         "type": "object",
         "properties": {
@@ -10294,8 +14935,40 @@
             "type": "object",
             "properties": {
               "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
+                "type": "string"
+              },
+              "info": {
+                "$ref": "#/components/schemas/Session"
+              }
+            },
+            "required": [
+              "sessionID",
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "aggregate",
+          "data"
+        ]
+      },
+      "SyncEvent.session.deleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.deleted.1"
+          },
+          "aggregate": {
+            "type": "string",
+            "const": "sessionID"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
               },
               "info": {
                 "$ref": "#/components/schemas/Session"
@@ -10328,8 +15001,7 @@
             "type": "object",
             "properties": {
               "sessionID": {
-                "type": "string",
-                "pattern": "^ses.*"
+                "type": "string"
               },
               "info": {
                 "type": "object",
@@ -10337,8 +15009,7 @@
                   "id": {
                     "anyOf": [
                       {
-                        "type": "string",
-                        "pattern": "^ses.*"
+                        "type": "string"
                       },
                       {
                         "type": "null"
@@ -10368,8 +15039,7 @@
                   "workspaceID": {
                     "anyOf": [
                       {
-                        "type": "string",
-                        "pattern": "^wrk.*"
+                        "type": "string"
                       },
                       {
                         "type": "null"
@@ -10389,8 +15059,7 @@
                   "parentID": {
                     "anyOf": [
                       {
-                        "type": "string",
-                        "pattern": "^ses.*"
+                        "type": "string"
                       },
                       {
                         "type": "null"
@@ -10573,12 +15242,10 @@
                         "type": "object",
                         "properties": {
                           "messageID": {
-                            "type": "string",
-                            "pattern": "^msg.*"
+                            "type": "string"
                           },
                           "partID": {
-                            "type": "string",
-                            "pattern": "^prt.*"
+                            "type": "string"
                           },
                           "snapshot": {
                             "type": "string"
@@ -10681,23 +15348,1881 @@
           "data"
         ]
       },
-      "SyncEvent.session.deleted": {
+      "SyncEvent": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "$ref": "#/components/schemas/SyncEvent"
+          }
+        },
+        "required": [
+          "payload"
+        ]
+      },
+      "AutomationDefinitionTombstone": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean",
+            "const": true
+          },
+          "revision": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "id",
+          "deleted",
+          "revision"
+        ],
+        "additionalProperties": false
+      },
+      "Event.automation.definition.deleted": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "const": "session.deleted.1"
+            "const": "automation.definition.deleted"
           },
-          "aggregate": {
+          "properties": {
+            "$ref": "#/components/schemas/AutomationDefinitionTombstone"
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "AutomationWhere": {
+        "type": "object",
+        "properties": {
+          "projectID": {
+            "type": "string"
+          },
+          "worktree": {
             "type": "string",
-            "const": "sessionID"
+            "minLength": 1
+          }
+        },
+        "required": [
+          "projectID"
+        ],
+        "additionalProperties": false
+      },
+      "AutomationModel": {
+        "type": "object",
+        "properties": {
+          "providerID": {
+            "type": "string"
           },
-          "data": {
+          "modelID": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "providerID",
+          "modelID"
+        ],
+        "additionalProperties": false
+      },
+      "AutomationRhythm": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "interval"
+              },
+              "everyMs": {
+                "type": "integer",
+                "minimum": 30000,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "kind",
+              "everyMs"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "cron"
+              },
+              "expression": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "kind",
+              "expression"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "AutomationStop": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "count"
+              },
+              "count": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "kind",
+              "count"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "condition"
+              },
+              "condition": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 4000
+              }
+            },
+            "required": [
+              "kind",
+              "condition"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "never"
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "AutomationDefinition": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "oneshot"
+              },
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 160
+              },
+              "prompt": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 20000
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "paused": {
+                "type": "boolean"
+              },
+              "context": {
+                "type": "string",
+                "enum": [
+                  "continue",
+                  "fresh"
+                ]
+              },
+              "where": {
+                "$ref": "#/components/schemas/AutomationWhere"
+              },
+              "createdAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "updatedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "timezone": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sourceSessionID": {
+                "type": "string"
+              },
+              "normalizationWarnings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "model": {
+                "$ref": "#/components/schemas/AutomationModel"
+              },
+              "variant": {
+                "type": "string",
+                "minLength": 1
+              },
+              "fireAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "kind",
+              "id",
+              "title",
+              "prompt",
+              "revision",
+              "paused",
+              "context",
+              "where",
+              "createdAt",
+              "updatedAt",
+              "timezone",
+              "normalizationWarnings",
+              "model",
+              "fireAt"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "recurring"
+              },
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 160
+              },
+              "prompt": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 20000
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "paused": {
+                "type": "boolean"
+              },
+              "context": {
+                "type": "string",
+                "enum": [
+                  "continue",
+                  "fresh"
+                ]
+              },
+              "where": {
+                "$ref": "#/components/schemas/AutomationWhere"
+              },
+              "createdAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "updatedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "timezone": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sourceSessionID": {
+                "type": "string"
+              },
+              "normalizationWarnings": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "model": {
+                "$ref": "#/components/schemas/AutomationModel"
+              },
+              "variant": {
+                "type": "string",
+                "minLength": 1
+              },
+              "rhythm": {
+                "$ref": "#/components/schemas/AutomationRhythm"
+              },
+              "stop": {
+                "$ref": "#/components/schemas/AutomationStop"
+              },
+              "nextFireAt": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "nextFires": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "failureStreak": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "kind",
+              "id",
+              "title",
+              "prompt",
+              "revision",
+              "paused",
+              "context",
+              "where",
+              "createdAt",
+              "updatedAt",
+              "timezone",
+              "normalizationWarnings",
+              "model",
+              "rhythm",
+              "stop",
+              "nextFireAt",
+              "nextFires",
+              "failureStreak"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Event.automation.definition.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "automation.definition.updated"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/AutomationDefinition"
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "AutomationRunBlocker": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "permission"
+              },
+              "requestID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "requestID"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "question"
+              },
+              "callID": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "kind",
+              "callID"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "AutomationRunError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "needs_user_input",
+              "execution_failed",
+              "step_cap",
+              "loop_gate"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "AutomationRun": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "automationID": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "definitionRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "triggeredAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "cost": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "state": {
+                "type": "string",
+                "const": "scheduled"
+              },
+              "sessionID": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "startedAt": {
+                "type": "null"
+              },
+              "completedAt": {
+                "type": "null"
+              },
+              "result": {
+                "type": "null"
+              },
+              "error": {
+                "type": "null"
+              }
+            },
+            "required": [
+              "id",
+              "automationID",
+              "revision",
+              "definitionRevision",
+              "triggeredAt",
+              "cost",
+              "state",
+              "sessionID",
+              "startedAt",
+              "completedAt",
+              "result",
+              "error"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "automationID": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "definitionRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "triggeredAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "cost": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "startedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "completedAt": {
+                "type": "null"
+              },
+              "result": {
+                "type": "null"
+              },
+              "error": {
+                "type": "null"
+              },
+              "state": {
+                "type": "string",
+                "const": "running"
+              }
+            },
+            "required": [
+              "id",
+              "automationID",
+              "revision",
+              "definitionRevision",
+              "triggeredAt",
+              "cost",
+              "sessionID",
+              "startedAt",
+              "completedAt",
+              "result",
+              "error",
+              "state"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "automationID": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "definitionRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "triggeredAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "cost": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "startedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "completedAt": {
+                "type": "null"
+              },
+              "result": {
+                "type": "null"
+              },
+              "error": {
+                "type": "null"
+              },
+              "state": {
+                "type": "string",
+                "const": "awaiting_input"
+              },
+              "blocker": {
+                "$ref": "#/components/schemas/AutomationRunBlocker"
+              }
+            },
+            "required": [
+              "id",
+              "automationID",
+              "revision",
+              "definitionRevision",
+              "triggeredAt",
+              "cost",
+              "sessionID",
+              "startedAt",
+              "completedAt",
+              "result",
+              "error",
+              "state",
+              "blocker"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "automationID": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "definitionRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "triggeredAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "cost": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "startedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "completedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "result": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "error": {
+                "type": "null"
+              },
+              "state": {
+                "type": "string",
+                "const": "succeeded"
+              }
+            },
+            "required": [
+              "id",
+              "automationID",
+              "revision",
+              "definitionRevision",
+              "triggeredAt",
+              "cost",
+              "sessionID",
+              "startedAt",
+              "completedAt",
+              "result",
+              "error",
+              "state"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "automationID": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "definitionRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "triggeredAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "cost": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "startedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "completedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "result": {
+                "type": "null"
+              },
+              "error": {
+                "$ref": "#/components/schemas/AutomationRunError"
+              },
+              "state": {
+                "type": "string",
+                "const": "failed"
+              }
+            },
+            "required": [
+              "id",
+              "automationID",
+              "revision",
+              "definitionRevision",
+              "triggeredAt",
+              "cost",
+              "sessionID",
+              "startedAt",
+              "completedAt",
+              "result",
+              "error",
+              "state"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "automationID": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "definitionRevision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "triggeredAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "cost": {
+                "anyOf": [
+                  {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "state": {
+                "type": "string",
+                "const": "stopped"
+              },
+              "sessionID": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "startedAt": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "completedAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "result": {
+                "type": "null"
+              },
+              "error": {
+                "type": "null"
+              },
+              "stopReason": {
+                "type": "string",
+                "enum": [
+                  "previous_run_awaiting_input",
+                  "missed_schedule",
+                  "cancelled",
+                  "expired",
+                  "blocker_lost"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "automationID",
+              "revision",
+              "definitionRevision",
+              "triggeredAt",
+              "cost",
+              "state",
+              "sessionID",
+              "startedAt",
+              "completedAt",
+              "result",
+              "error",
+              "stopReason"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Event.automation.run.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "automation.run.updated"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/AutomationRun"
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.command.executed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "command.executed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "arguments": {
+                "type": "string"
+              },
+              "messageID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "sessionID",
+              "arguments",
+              "messageID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.file.edited": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file.edited"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "file"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.file.watcher.rescan": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file.watcher.rescan"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "directory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "directory"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.file.watcher.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file.watcher.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string"
+              },
+              "event": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "const": "add"
+                  },
+                  {
+                    "type": "string",
+                    "const": "change"
+                  },
+                  {
+                    "type": "string",
+                    "const": "unlink"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "file",
+              "event"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.global.disposed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "global.disposed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.installation.update-available": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "installation.update-available"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "version"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.installation.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "installation.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "version"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.lsp.client.diagnostics": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "lsp.client.diagnostics"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "serverID": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "serverID",
+              "path"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.lsp.server.install.failed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "lsp.server.install.failed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "add": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "dir": {
+                "type": "string"
+              },
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "add",
+              "dir",
+              "error"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.lsp.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "lsp.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.mcp.browser.open.failed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "mcp.browser.open.failed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "mcpName": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "mcpName",
+              "url"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.mcp.tools.changed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "mcp.tools.changed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "server": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "server"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.message.part.delta": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "message.part.delta"
+          },
+          "properties": {
             "type": "object",
             "properties": {
               "sessionID": {
+                "type": "string"
+              },
+              "messageID": {
+                "type": "string"
+              },
+              "partID": {
+                "type": "string"
+              },
+              "field": {
+                "type": "string"
+              },
+              "delta": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionID",
+              "messageID",
+              "partID",
+              "field",
+              "delta"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.message.part.removed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "message.part.removed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "messageID": {
+                "type": "string"
+              },
+              "partID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionID",
+              "messageID",
+              "partID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.message.part.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "message.part.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "part": {
+                "$ref": "#/components/schemas/Part"
+              },
+              "time": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "sessionID",
+              "part",
+              "time"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.message.removed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "message.removed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "messageID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionID",
+              "messageID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.message.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "message.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "info": {
+                "$ref": "#/components/schemas/Message"
+              }
+            },
+            "required": [
+              "sessionID",
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "PermissionRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string"
+          },
+          "permission": {
+            "type": "string"
+          },
+          "patterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          },
+          "always": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tool": {
+            "type": "object",
+            "properties": {
+              "messageID": {
+                "type": "string"
+              },
+              "callID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "messageID",
+              "callID"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "sessionID",
+          "permission",
+          "patterns",
+          "metadata",
+          "always"
+        ]
+      },
+      "Event.permission.asked": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "permission.asked"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/PermissionRequest"
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.permission.replied": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "permission.replied"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "requestID": {
+                "type": "string"
+              },
+              "reply": {
                 "type": "string",
-                "pattern": "^ses.*"
+                "enum": [
+                  "once",
+                  "always",
+                  "reject"
+                ]
+              }
+            },
+            "required": [
+              "sessionID",
+              "requestID",
+              "reply"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Project": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "worktree": {
+            "type": "string"
+          },
+          "vcs": {
+            "type": "string",
+            "const": "git"
+          },
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "override": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "commands": {
+            "type": "object",
+            "properties": {
+              "start": {
+                "description": "Startup script to run when creating a new workspace (worktree)",
+                "type": "string"
+              }
+            }
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              },
+              "updated": {
+                "type": "number"
+              },
+              "initialized": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "created",
+              "updated"
+            ]
+          },
+          "sandboxes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "worktree",
+          "time",
+          "sandboxes"
+        ]
+      },
+      "Event.project.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "project.updated"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/Project"
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Pty": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "running",
+              "exited"
+            ]
+          },
+          "pid": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "command",
+          "args",
+          "cwd",
+          "status",
+          "pid"
+        ]
+      },
+      "Event.pty.created": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "pty.created"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "info": {
+                "$ref": "#/components/schemas/Pty"
+              }
+            },
+            "required": [
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.pty.deleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "pty.deleted"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.pty.exited": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "pty.exited"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "exitCode": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "exitCode"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.pty.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "pty.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "info": {
+                "$ref": "#/components/schemas/Pty"
+              }
+            },
+            "required": [
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.server.connected": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "server.connected"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.server.instance.disposed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "server.instance.disposed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "directory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "directory"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.compacted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.compacted"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.created": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.created"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
               },
               "info": {
                 "$ref": "#/components/schemas/Session"
@@ -10711,62 +17236,909 @@
         },
         "required": [
           "type",
-          "aggregate",
-          "data"
+          "properties"
         ]
       },
-      "SyncEvent": {
+      "Event.session.deleted": {
         "type": "object",
         "properties": {
-          "payload": {
-            "$ref": "#/components/schemas/SyncEvent"
+          "type": {
+            "type": "string",
+            "const": "session.deleted"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "info": {
+                "$ref": "#/components/schemas/Session"
+              }
+            },
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
         "required": [
-          "payload"
+          "type",
+          "properties"
         ]
       },
-      "LogLevel": {
-        "description": "Log level",
-        "type": "string",
-        "enum": [
-          "DEBUG",
-          "INFO",
-          "WARN",
-          "ERROR"
-        ]
-      },
-      "ServerConfig": {
-        "description": "Server configuration for opencode serve and web commands",
+      "Event.session.diff": {
         "type": "object",
         "properties": {
-          "port": {
-            "description": "Port to listen on",
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991
+          "type": {
+            "type": "string",
+            "const": "session.diff"
           },
-          "hostname": {
-            "description": "Hostname to listen on",
-            "type": "string"
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "diff": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SnapshotFileDiff"
+                }
+              }
+            },
+            "required": [
+              "sessionID",
+              "diff"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.error": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.error"
           },
-          "mdns": {
-            "description": "Enable mDNS service discovery",
-            "type": "boolean"
-          },
-          "mdnsDomain": {
-            "description": "Custom domain name for mDNS service (default: opencode.local)",
-            "type": "string"
-          },
-          "cors": {
-            "description": "Additional domains to allow for CORS",
-            "type": "array",
-            "items": {
-              "type": "string"
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/APIError"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContextOverflowError"
+                  },
+                  {
+                    "$ref": "#/components/schemas/MessageAbortedError"
+                  },
+                  {
+                    "$ref": "#/components/schemas/MessageOutputLengthError"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ProviderAuthError"
+                  },
+                  {
+                    "$ref": "#/components/schemas/StructuredOutputError"
+                  },
+                  {
+                    "$ref": "#/components/schemas/UnknownError"
+                  }
+                ]
+              }
             }
           }
         },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.idle": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.idle"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "RetryClassification": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "free_quota_exhausted"
+              },
+              "providerID": {
+                "type": "string"
+              },
+              "raw": {
+                "type": "string"
+              },
+              "statusCode": {
+                "type": "number"
+              },
+              "retryAfterMs": {
+                "type": "number"
+              },
+              "resetAt": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "kind",
+              "providerID",
+              "raw"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "unknown"
+              },
+              "raw": {
+                "type": "string"
+              },
+              "statusCode": {
+                "type": "number"
+              },
+              "retryAfterMs": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "kind",
+              "raw"
+            ]
+          }
+        ]
+      },
+      "SessionStatus": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "idle"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "retry"
+              },
+              "attempt": {
+                "type": "number"
+              },
+              "message": {
+                "type": "string"
+              },
+              "next": {
+                "type": "number"
+              },
+              "presentation": {
+                "type": "string",
+                "enum": [
+                  "recovery",
+                  "safe_recovery"
+                ]
+              },
+              "reason": {
+                "type": "string",
+                "const": "network_connection_dropped"
+              },
+              "classification": {
+                "$ref": "#/components/schemas/RetryClassification"
+              }
+            },
+            "required": [
+              "type",
+              "attempt",
+              "message",
+              "next"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "busy"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "rate_limit_blocked"
+              },
+              "classification": {
+                "$ref": "#/components/schemas/RetryClassification"
+              }
+            },
+            "required": [
+              "type",
+              "classification"
+            ]
+          }
+        ]
+      },
+      "Event.session.status": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.status"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "status": {
+                "$ref": "#/components/schemas/SessionStatus"
+              }
+            },
+            "required": [
+              "sessionID",
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.turn_change_invalidated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.turn_change_invalidated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "info": {
+                "$ref": "#/components/schemas/Session"
+              }
+            },
+            "required": [
+              "sessionID",
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Todo": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "content": {
+            "description": "Brief description of the task",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current status of the task: pending, in_progress, completed, cancelled",
+            "type": "string"
+          },
+          "priority": {
+            "description": "Priority level of the task: high, medium, low",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "content",
+          "status",
+          "priority"
+        ]
+      },
+      "Event.todo.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "todo.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "todos": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Todo"
+                }
+              }
+            },
+            "required": [
+              "sessionID",
+              "revision",
+              "todos"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.vcs.branch.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "vcs.branch.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "branch": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.workspace.failed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "workspace.failed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.workspace.ready": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "workspace.ready"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.workspace.status": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "workspace.status"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "workspaceID": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "connected",
+                  "connecting",
+                  "disconnected",
+                  "error"
+                ]
+              },
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "workspaceID",
+              "status"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.worktree.failed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "worktree.failed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.worktree.ready": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "worktree.ready"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "branch": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "branch"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Event.automation.definition.deleted"
+          },
+          {
+            "$ref": "#/components/schemas/Event.automation.definition.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.automation.run.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.command.executed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.file.edited"
+          },
+          {
+            "$ref": "#/components/schemas/Event.file.watcher.rescan"
+          },
+          {
+            "$ref": "#/components/schemas/Event.file.watcher.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.global.disposed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.installation.update-available"
+          },
+          {
+            "$ref": "#/components/schemas/Event.installation.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.lsp.client.diagnostics"
+          },
+          {
+            "$ref": "#/components/schemas/Event.lsp.server.install.failed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.lsp.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.mcp.browser.open.failed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.mcp.tools.changed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.part.delta"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.part.removed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.part.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.removed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.message.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.permission.asked"
+          },
+          {
+            "$ref": "#/components/schemas/Event.permission.replied"
+          },
+          {
+            "$ref": "#/components/schemas/Event.project.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.pty.created"
+          },
+          {
+            "$ref": "#/components/schemas/Event.pty.deleted"
+          },
+          {
+            "$ref": "#/components/schemas/Event.pty.exited"
+          },
+          {
+            "$ref": "#/components/schemas/Event.pty.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.server.connected"
+          },
+          {
+            "$ref": "#/components/schemas/Event.server.instance.disposed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.compacted"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.created"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.deleted"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.diff"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.error"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.idle"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.status"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.turn_change_invalidated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.todo.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.vcs.branch.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.workspace.failed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.workspace.ready"
+          },
+          {
+            "$ref": "#/components/schemas/Event.workspace.status"
+          },
+          {
+            "$ref": "#/components/schemas/Event.worktree.failed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.worktree.ready"
+          }
+        ]
+      },
+      "GlobalEvent": {
+        "type": "object",
+        "properties": {
+          "directory": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          },
+          "workspace": {
+            "type": "string"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/Event"
+          }
+        },
+        "required": [
+          "directory",
+          "payload"
+        ]
+      },
+      "OAuth": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "oauth"
+            ]
+          },
+          "refresh": {
+            "type": "string"
+          },
+          "access": {
+            "type": "string"
+          },
+          "expires": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "NaN"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Infinity"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "-Infinity"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ]
+              }
+            ]
+          },
+          "accountId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enterpriseUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "refresh",
+          "access",
+          "expires"
+        ],
         "additionalProperties": false
+      },
+      "ApiAuth": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "api"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "key"
+        ],
+        "additionalProperties": false
+      },
+      "WellKnownAuth": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "wellknown"
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "key",
+          "token"
+        ],
+        "additionalProperties": false
+      },
+      "Auth": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ApiAuth"
+          },
+          {
+            "$ref": "#/components/schemas/OAuth"
+          },
+          {
+            "$ref": "#/components/schemas/WellKnownAuth"
+          }
+        ]
+      },
+      "BadRequestError": {
+        "type": "object",
+        "properties": {
+          "data": {},
+          "error": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {}
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "const": false
+          }
+        },
+        "required": [
+          "data",
+          "error",
+          "success"
+        ]
       },
       "SkillsConfig": {
         "description": "Additional skill folder paths",
@@ -10787,191 +18159,6 @@
             }
           }
         }
-      },
-      "PermissionActionConfig": {
-        "type": "string",
-        "enum": [
-          "ask",
-          "allow",
-          "deny"
-        ]
-      },
-      "PermissionObjectConfig": {
-        "type": "object",
-        "propertyNames": {
-          "type": "string"
-        },
-        "additionalProperties": {
-          "$ref": "#/components/schemas/PermissionActionConfig"
-        }
-      },
-      "PermissionRuleConfig": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/PermissionActionConfig"
-          },
-          {
-            "$ref": "#/components/schemas/PermissionObjectConfig"
-          }
-        ]
-      },
-      "PermissionConfig": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/PermissionActionConfig"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "read": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "edit": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "glob": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "grep": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "list": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "bash": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "agent": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "task": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "external_directory": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "todowrite": {
-                "$ref": "#/components/schemas/PermissionActionConfig"
-              },
-              "question": {
-                "$ref": "#/components/schemas/PermissionActionConfig"
-              },
-              "webfetch": {
-                "$ref": "#/components/schemas/PermissionActionConfig"
-              },
-              "websearch": {
-                "$ref": "#/components/schemas/PermissionActionConfig"
-              },
-              "lsp": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              },
-              "doom_loop": {
-                "$ref": "#/components/schemas/PermissionActionConfig"
-              },
-              "skill": {
-                "$ref": "#/components/schemas/PermissionRuleConfig"
-              }
-            },
-            "additionalProperties": {
-              "$ref": "#/components/schemas/PermissionRuleConfig"
-            }
-          }
-        ]
-      },
-      "AgentConfig": {
-        "type": "object",
-        "properties": {
-          "model": {
-            "type": "string",
-            "pattern": "^[^/]+\\/[^/].*$"
-          },
-          "variant": {
-            "description": "Default model variant for this agent (applies only when using the agent's configured model).",
-            "type": "string"
-          },
-          "temperature": {
-            "type": "number"
-          },
-          "top_p": {
-            "type": "number"
-          },
-          "prompt": {
-            "type": "string"
-          },
-          "tools": {
-            "description": "@deprecated Use 'permission' field instead",
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "type": "boolean"
-            }
-          },
-          "disable": {
-            "type": "boolean"
-          },
-          "description": {
-            "description": "Description of when to use the agent",
-            "type": "string"
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "subagent",
-              "primary",
-              "all"
-            ]
-          },
-          "hidden": {
-            "description": "Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)",
-            "type": "boolean"
-          },
-          "options": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {}
-          },
-          "color": {
-            "description": "Hex color code (e.g., #FF5733) or theme color (e.g., primary)",
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^#[0-9a-fA-F]{6}$"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "primary",
-                  "secondary",
-                  "accent",
-                  "success",
-                  "warning",
-                  "error",
-                  "info"
-                ]
-              }
-            ]
-          },
-          "steps": {
-            "description": "Maximum number of agentic iterations before forcing text-only response",
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991
-          },
-          "maxSteps": {
-            "description": "@deprecated Use 'steps' field instead.",
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991
-          },
-          "permission": {
-            "$ref": "#/components/schemas/PermissionConfig"
-          }
-        },
-        "additionalProperties": {}
       },
       "ProviderConfig": {
         "type": "object",
@@ -11190,11 +18377,7 @@
                         ]
                       }
                     }
-                  },
-                  "required": [
-                    "input",
-                    "output"
-                  ]
+                  }
                 },
                 "experimental": {
                   "type": "boolean"
@@ -11204,7 +18387,8 @@
                   "enum": [
                     "alpha",
                     "beta",
-                    "deprecated"
+                    "deprecated",
+                    "active"
                   ]
                 },
                 "provider": {
@@ -11375,6 +18559,99 @@
         "enum": [
           "auto",
           "stretch"
+        ]
+      },
+      "PermissionActionConfig": {
+        "type": "string",
+        "enum": [
+          "ask",
+          "allow",
+          "deny"
+        ]
+      },
+      "PermissionObjectConfig": {
+        "type": "object",
+        "propertyNames": {
+          "type": "string"
+        },
+        "additionalProperties": {
+          "$ref": "#/components/schemas/PermissionActionConfig"
+        }
+      },
+      "PermissionRuleConfig": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PermissionActionConfig"
+          },
+          {
+            "$ref": "#/components/schemas/PermissionObjectConfig"
+          }
+        ]
+      },
+      "PermissionConfig": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PermissionActionConfig"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "read": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "edit": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "glob": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "grep": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "list": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "bash": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "agent": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "task": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "external_directory": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "todowrite": {
+                "$ref": "#/components/schemas/PermissionActionConfig"
+              },
+              "question": {
+                "$ref": "#/components/schemas/PermissionActionConfig"
+              },
+              "webfetch": {
+                "$ref": "#/components/schemas/PermissionActionConfig"
+              },
+              "websearch": {
+                "$ref": "#/components/schemas/PermissionActionConfig"
+              },
+              "lsp": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "doom_loop": {
+                "$ref": "#/components/schemas/PermissionActionConfig"
+              },
+              "skill": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "browser": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              }
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PermissionRuleConfig"
+            }
+          }
         ]
       },
       "Config": {
@@ -11783,187 +19060,138 @@
         },
         "additionalProperties": false
       },
-      "BadRequestError": {
+      "GlobalUpgradeBadRequest": {
         "type": "object",
         "properties": {
-          "data": {},
-          "errors": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
-              "additionalProperties": {}
-            }
-          },
           "success": {
             "type": "boolean",
-            "const": false
-          }
-        },
-        "required": [
-          "data",
-          "errors",
-          "success"
-        ]
-      },
-      "OAuth": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "oauth"
-          },
-          "refresh": {
-            "type": "string"
-          },
-          "access": {
-            "type": "string"
-          },
-          "expires": {
-            "type": "number"
-          },
-          "accountId": {
-            "type": "string"
-          },
-          "enterpriseUrl": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "refresh",
-          "access",
-          "expires"
-        ]
-      },
-      "ApiAuth": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "api"
-          },
-          "key": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "type",
-          "key"
-        ]
-      },
-      "WellKnownAuth": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "wellknown"
-          },
-          "key": {
-            "type": "string"
-          },
-          "token": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "key",
-          "token"
-        ]
-      },
-      "Auth": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/OAuth"
-          },
-          {
-            "$ref": "#/components/schemas/ApiAuth"
-          },
-          {
-            "$ref": "#/components/schemas/WellKnownAuth"
-          }
-        ]
-      },
-      "Workspace": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^wrk.*"
-          },
-          "type": {
-            "type": "string"
-          },
-          "branch": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
+            "enum": [
+              false
             ]
           },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "directory": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "extra": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "projectID": {
+          "error": {
             "type": "string"
           }
         },
         "required": [
-          "id",
-          "type",
-          "branch",
-          "name",
-          "directory",
-          "extra",
-          "projectID"
-        ]
+          "success",
+          "error"
+        ],
+        "additionalProperties": false,
+        "description": "Global upgrade request cannot be fulfilled"
+      },
+      "GlobalUpgradeServerError": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              false
+            ]
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "error"
+        ],
+        "additionalProperties": false,
+        "description": "Global upgrade failed"
+      },
+      "VcsDiffRawFailure": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "vcs_diff_raw_failed"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "too-large"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "reason",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "Raw VCS diff is too large"
+      },
+      "VcsApplyFailure": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "vcs_apply_failed"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "non-git",
+              "not-clean",
+              "too-large",
+              "invalid-input"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "reason",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "VCS patch apply failure"
+      },
+      "VcsApplyTooLargeFailure": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "vcs_apply_failed"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "too-large"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "reason",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "VCS patch apply request is too large"
       },
       "NotFoundError": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
-            "const": "NotFoundError"
+            "enum": [
+              "NotFoundError"
+            ]
           },
           "data": {
             "type": "object",
@@ -11974,13 +19202,16 @@
             },
             "required": [
               "message"
-            ]
+            ],
+            "additionalProperties": false
           }
         },
         "required": [
           "name",
           "data"
-        ]
+        ],
+        "additionalProperties": false,
+        "description": "Not found"
       },
       "Model": {
         "type": "object",
@@ -12317,108 +19548,366 @@
             }
           },
           "activeOrgName": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "switchableOrgCount": {
             "type": "integer",
-            "minimum": 0,
-            "maximum": 9007199254740991
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           }
         },
         "required": [
           "consoleManagedProviders",
           "switchableOrgCount"
-        ]
+        ],
+        "additionalProperties": false
       },
-      "ToolIDs": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "ToolListItem": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "parameters": {}
-        },
-        "required": [
-          "id",
-          "description",
-          "parameters"
-        ]
-      },
-      "ToolList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/ToolListItem"
-        }
-      },
-      "Worktree": {
+      "SessionConflictError": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "branch": {
-            "type": "string"
-          },
-          "directory": {
-            "type": "string"
-          },
-          "source": {
-            "default": "created",
-            "type": "string",
-            "enum": [
-              "created",
-              "existing"
-            ]
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ],
+            "additionalProperties": false
           }
         },
         "required": [
           "name",
-          "branch",
-          "directory"
-        ]
+          "data"
+        ],
+        "additionalProperties": false,
+        "description": "Session conflict"
       },
-      "WorktreeCreateInput": {
+      "SessionShareDisabledError": {
         "type": "object",
         "properties": {
-          "name": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "cloud_share_disabled"
+            ]
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "additionalProperties": false,
+        "description": "Cloud sharing is disabled"
+      },
+      "ProviderAuthMethod": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "oauth",
+              "api"
+            ]
+          },
+          "label": {
             "type": "string"
           },
-          "startCommand": {
-            "description": "Additional startup script to run after the project's start command",
-            "type": "string"
+          "prompts": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "text"
+                          ]
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "placeholder": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "when": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "type": "string",
+                                  "enum": [
+                                    "eq",
+                                    "neq"
+                                  ]
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "op",
+                                "value"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "key",
+                        "message"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "select"
+                          ]
+                        },
+                        "key": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "hint": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label",
+                              "value"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "when": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "type": "string",
+                                  "enum": [
+                                    "eq",
+                                    "neq"
+                                  ]
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "op",
+                                "value"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "key",
+                        "message",
+                        "options"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
-        }
+        },
+        "required": [
+          "type",
+          "label"
+        ],
+        "additionalProperties": false
       },
-      "WorktreeRemoveInput": {
+      "ProviderAuthAuthorization": {
         "type": "object",
         "properties": {
-          "directory": {
+          "url": {
+            "type": "string"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "code"
+            ]
+          },
+          "instructions": {
             "type": "string"
           }
         },
         "required": [
-          "directory"
-        ]
+          "url",
+          "method",
+          "instructions"
+        ],
+        "additionalProperties": false
       },
-      "WorktreeResetInput": {
+      "InvalidMemoryFileError": {
         "type": "object",
         "properties": {
-          "directory": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "invalid_memory_file"
+            ]
+          },
+          "reason": {
             "type": "string"
           }
         },
         "required": [
-          "directory"
-        ]
+          "error",
+          "reason"
+        ],
+        "additionalProperties": false,
+        "description": "Invalid PawWork memory file"
+      },
+      "AutomationValidationError": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "invalid_automation"
+            ]
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "field",
+                "message"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "error",
+          "details"
+        ],
+        "additionalProperties": false,
+        "description": "Automation validation failed"
+      },
+      "AutomationConflictError": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "automation_conflict"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "Automation update conflict"
+      },
+      "McpUnsupportedOAuthError": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "additionalProperties": false,
+        "description": "MCP server does not support OAuth"
       },
       "ProjectSummary": {
         "type": "object",
@@ -12442,8 +19931,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "slug": {
             "type": "string"
@@ -12452,15 +19940,13 @@
             "type": "string"
           },
           "workspaceID": {
-            "type": "string",
-            "pattern": "^wrk.*"
+            "type": "string"
           },
           "directory": {
             "type": "string"
           },
           "parentID": {
-            "type": "string",
-            "pattern": "^ses.*"
+            "type": "string"
           },
           "createdByAgentTool": {
             "default": false,
@@ -12550,12 +20036,10 @@
             "type": "object",
             "properties": {
               "messageID": {
-                "type": "string",
-                "pattern": "^msg.*"
+                "type": "string"
               },
               "partID": {
-                "type": "string",
-                "pattern": "^prt.*"
+                "type": "string"
               },
               "snapshot": {
                 "type": "string"
@@ -12623,6 +20107,12 @@
                 "type": "null"
               }
             ]
+          },
+          "activityAt": {
+            "type": "number"
+          },
+          "lastUserMessageAt": {
+            "type": "number"
           }
         },
         "required": [
@@ -12635,31 +20125,6 @@
           "time",
           "executionContext",
           "project"
-        ]
-      },
-      "McpResource": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "uri": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "mimeType": {
-            "type": "string"
-          },
-          "client": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "uri",
-          "client"
         ]
       },
       "SessionArtifact": {
@@ -12681,12 +20146,636 @@
           "kind"
         ]
       },
+      "Symbol": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "number"
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "uri": {
+                "type": "string"
+              },
+              "range": {
+                "$ref": "#/components/schemas/Range"
+              }
+            },
+            "required": [
+              "uri",
+              "range"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "kind",
+          "location"
+        ]
+      },
+      "AutomationListResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AutomationDefinition"
+            }
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "additionalProperties": false
+      },
+      "AutomationRunsResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AutomationRun"
+            }
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "items",
+          "nextCursor"
+        ],
+        "additionalProperties": false
+      },
+      "TodoSnapshot": {
+        "type": "object",
+        "properties": {
+          "revision": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "todos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Todo"
+            }
+          }
+        },
+        "required": [
+          "revision",
+          "todos"
+        ]
+      },
+      "TurnChangeDisplay": {
+        "type": "object",
+        "properties": {
+          "sessionID": {
+            "type": "string"
+          },
+          "turnID": {
+            "type": "string"
+          },
+          "messageID": {
+            "type": "string"
+          },
+          "undoAvailable": {
+            "type": "boolean"
+          },
+          "redoAvailable": {
+            "type": "boolean"
+          },
+          "truncated": {
+            "type": "boolean"
+          },
+          "omittedCount": {
+            "type": "number"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "openPath": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "added",
+                    "modified",
+                    "deleted"
+                  ]
+                },
+                "additions": {
+                  "type": "number"
+                },
+                "deletions": {
+                  "type": "number"
+                },
+                "patch": {
+                  "type": "string"
+                },
+                "sensitive": {
+                  "type": "boolean"
+                },
+                "binary": {
+                  "type": "boolean"
+                },
+                "large": {
+                  "type": "boolean"
+                },
+                "restoreAvailable": {
+                  "type": "boolean"
+                },
+                "expandable": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "path",
+                "status",
+                "expandable"
+              ]
+            }
+          }
+        },
+        "required": [
+          "sessionID",
+          "turnID",
+          "messageID",
+          "undoAvailable",
+          "redoAvailable",
+          "files"
+        ]
+      },
+      "TurnChangeMutationResult": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "const": "applied"
+              },
+              "display": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string"
+                  },
+                  "turnID": {
+                    "type": "string"
+                  },
+                  "messageID": {
+                    "type": "string"
+                  },
+                  "undoAvailable": {
+                    "type": "boolean"
+                  },
+                  "redoAvailable": {
+                    "type": "boolean"
+                  },
+                  "truncated": {
+                    "type": "boolean"
+                  },
+                  "omittedCount": {
+                    "type": "number"
+                  },
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "path": {
+                          "type": "string"
+                        },
+                        "openPath": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "added",
+                            "modified",
+                            "deleted"
+                          ]
+                        },
+                        "additions": {
+                          "type": "number"
+                        },
+                        "deletions": {
+                          "type": "number"
+                        },
+                        "patch": {
+                          "type": "string"
+                        },
+                        "sensitive": {
+                          "type": "boolean"
+                        },
+                        "binary": {
+                          "type": "boolean"
+                        },
+                        "large": {
+                          "type": "boolean"
+                        },
+                        "restoreAvailable": {
+                          "type": "boolean"
+                        },
+                        "expandable": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "path",
+                        "status",
+                        "expandable"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "sessionID",
+                  "turnID",
+                  "messageID",
+                  "undoAvailable",
+                  "redoAvailable",
+                  "files"
+                ]
+              },
+              "skipped": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "messageID": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "enum": [
+                        "conflict",
+                        "permission_denied"
+                      ]
+                    },
+                    "files": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "reason"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "messageID",
+                    "reason",
+                    "files"
+                  ]
+                }
+              },
+              "mutatedPaths": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "status",
+              "display"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "const": "blocked"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "conflict",
+                  "restore_missing",
+                  "permission_denied",
+                  "unsupported_size",
+                  "write_failed",
+                  "rollback_failed"
+                ]
+              },
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "omittedCount": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "reason"
+                  ]
+                }
+              },
+              "skipped": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "messageID": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "enum": [
+                        "conflict",
+                        "permission_denied"
+                      ]
+                    },
+                    "files": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "reason"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "messageID",
+                    "reason",
+                    "files"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "status",
+              "reason",
+              "files"
+            ]
+          }
+        ]
+      },
+      "AutomationCreateInput": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "oneshot"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 160
+              },
+              "prompt": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 20000
+              },
+              "context": {
+                "type": "string",
+                "enum": [
+                  "continue",
+                  "fresh"
+                ]
+              },
+              "where": {
+                "$ref": "#/components/schemas/AutomationWhere"
+              },
+              "timezone": {
+                "type": "string",
+                "minLength": 1
+              },
+              "model": {
+                "$ref": "#/components/schemas/AutomationModel"
+              },
+              "variant": {
+                "type": "string",
+                "minLength": 1
+              },
+              "fireAt": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "kind",
+              "title",
+              "prompt",
+              "context",
+              "where",
+              "timezone",
+              "model",
+              "fireAt"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "recurring"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 160
+              },
+              "prompt": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 20000
+              },
+              "context": {
+                "type": "string",
+                "enum": [
+                  "continue",
+                  "fresh"
+                ]
+              },
+              "where": {
+                "$ref": "#/components/schemas/AutomationWhere"
+              },
+              "timezone": {
+                "type": "string",
+                "minLength": 1
+              },
+              "model": {
+                "$ref": "#/components/schemas/AutomationModel"
+              },
+              "variant": {
+                "type": "string",
+                "minLength": 1
+              },
+              "rhythm": {
+                "$ref": "#/components/schemas/AutomationRhythm"
+              },
+              "stop": {
+                "$ref": "#/components/schemas/AutomationStop"
+              }
+            },
+            "required": [
+              "kind",
+              "title",
+              "prompt",
+              "context",
+              "where",
+              "timezone",
+              "model",
+              "rhythm",
+              "stop"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "AutomationUpdateInput": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20000
+          },
+          "paused": {
+            "type": "boolean"
+          },
+          "context": {
+            "type": "string",
+            "enum": [
+              "continue",
+              "fresh"
+            ]
+          },
+          "where": {
+            "$ref": "#/components/schemas/AutomationWhere"
+          },
+          "timezone": {
+            "type": "string",
+            "minLength": 1
+          },
+          "fireAt": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "rhythm": {
+            "$ref": "#/components/schemas/AutomationRhythm"
+          },
+          "stop": {
+            "$ref": "#/components/schemas/AutomationStop"
+          },
+          "model": {
+            "$ref": "#/components/schemas/AutomationModel"
+          },
+          "variant": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "MemoryState": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "safe_mode"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "profile": {
+            "type": "string"
+          },
+          "profileTooLarge": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "path",
+          "disabled",
+          "status",
+          "content"
+        ]
+      },
       "TextPartInput": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -12732,8 +20821,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -12769,8 +20857,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -12808,12 +20895,53 @@
           "name"
         ]
       },
+      "SkillPartInput": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "skill"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "start": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "end": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "value",
+              "start",
+              "end"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ]
+      },
       "SubtaskPartInput": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^prt.*"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -13089,510 +21217,86 @@
           "agent"
         ]
       },
-      "ProviderAuthMethod": {
+      "PromptBody": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "oauth",
-              "api"
-            ]
-          },
-          "label": {
+          "messageID": {
             "type": "string"
           },
-          "prompts": {
+          "model": {
+            "type": "object",
+            "properties": {
+              "providerID": {
+                "type": "string"
+              },
+              "modelID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID",
+              "modelID"
+            ]
+          },
+          "agent": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "noReply": {
+            "type": "boolean"
+          },
+          "tools": {
+            "description": "@deprecated tools and permissions have been merged, you can set permissions on the session itself now",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "format": {
+            "$ref": "#/components/schemas/OutputFormat"
+          },
+          "system": {
+            "type": "string"
+          },
+          "variant": {
+            "type": "string"
+          },
+          "parts": {
             "type": "array",
             "items": {
               "anyOf": [
                 {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "const": "text"
-                    },
-                    "key": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "placeholder": {
-                      "type": "string"
-                    },
-                    "when": {
-                      "type": "object",
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "op": {
-                          "type": "string",
-                          "enum": [
-                            "eq",
-                            "neq"
-                          ]
-                        },
-                        "value": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "key",
-                        "op",
-                        "value"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "key",
-                    "message"
-                  ]
+                  "$ref": "#/components/schemas/AgentPartInput"
                 },
                 {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "const": "select"
-                    },
-                    "key": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "options": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "label": {
-                            "type": "string"
-                          },
-                          "value": {
-                            "type": "string"
-                          },
-                          "hint": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "label",
-                          "value"
-                        ]
-                      }
-                    },
-                    "when": {
-                      "type": "object",
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "op": {
-                          "type": "string",
-                          "enum": [
-                            "eq",
-                            "neq"
-                          ]
-                        },
-                        "value": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "key",
-                        "op",
-                        "value"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "key",
-                    "message",
-                    "options"
-                  ]
+                  "$ref": "#/components/schemas/FilePartInput"
+                },
+                {
+                  "$ref": "#/components/schemas/SkillPartInput"
+                },
+                {
+                  "$ref": "#/components/schemas/SubtaskPartInput"
+                },
+                {
+                  "$ref": "#/components/schemas/TextPartInput"
                 }
               ]
             }
           }
         },
         "required": [
-          "type",
-          "label"
+          "parts"
         ]
       },
-      "ProviderAuthAuthorization": {
+      "CommandBody": {
         "type": "object",
         "properties": {
-          "url": {
-            "type": "string"
-          },
-          "method": {
-            "type": "string",
-            "enum": [
-              "auto",
-              "code"
-            ]
-          },
-          "instructions": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "url",
-          "method",
-          "instructions"
-        ]
-      },
-      "Symbol": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "number"
-          },
-          "location": {
-            "type": "object",
-            "properties": {
-              "uri": {
-                "type": "string"
-              },
-              "range": {
-                "$ref": "#/components/schemas/Range"
-              }
-            },
-            "required": [
-              "uri",
-              "range"
-            ]
-          }
-        },
-        "required": [
-          "name",
-          "kind",
-          "location"
-        ]
-      },
-      "FileNode": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
-          },
-          "absolute": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "file",
-              "directory"
-            ]
-          },
-          "ignored": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "name",
-          "path",
-          "absolute",
-          "type",
-          "ignored"
-        ]
-      },
-      "FileContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "text",
-              "binary"
-            ]
-          },
-          "content": {
-            "type": "string"
-          },
-          "diff": {
-            "type": "string"
-          },
-          "patch": {
-            "type": "object",
-            "properties": {
-              "oldFileName": {
-                "type": "string"
-              },
-              "newFileName": {
-                "type": "string"
-              },
-              "oldHeader": {
-                "type": "string"
-              },
-              "newHeader": {
-                "type": "string"
-              },
-              "hunks": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "oldStart": {
-                      "type": "number"
-                    },
-                    "oldLines": {
-                      "type": "number"
-                    },
-                    "newStart": {
-                      "type": "number"
-                    },
-                    "newLines": {
-                      "type": "number"
-                    },
-                    "lines": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "required": [
-                    "oldStart",
-                    "oldLines",
-                    "newStart",
-                    "newLines",
-                    "lines"
-                  ]
-                }
-              },
-              "index": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "oldFileName",
-              "newFileName",
-              "hunks"
-            ]
-          },
-          "encoding": {
-            "type": "string",
-            "const": "base64"
-          },
-          "mimeType": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "content"
-        ]
-      },
-      "File": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string"
-          },
-          "added": {
-            "type": "integer",
-            "minimum": -9007199254740991,
-            "maximum": 9007199254740991
-          },
-          "removed": {
-            "type": "integer",
-            "minimum": -9007199254740991,
-            "maximum": 9007199254740991
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "added",
-              "deleted",
-              "modified"
-            ]
-          }
-        },
-        "required": [
-          "path",
-          "added",
-          "removed",
-          "status"
-        ]
-      },
-      "MCPStatusConnected": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "const": "connected"
-          }
-        },
-        "required": [
-          "status"
-        ]
-      },
-      "MCPStatusDisabled": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "const": "disabled"
-          }
-        },
-        "required": [
-          "status"
-        ]
-      },
-      "MCPStatusFailed": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "const": "failed"
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "status",
-          "error"
-        ]
-      },
-      "MCPStatusNeedsAuth": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "const": "needs_auth"
-          }
-        },
-        "required": [
-          "status"
-        ]
-      },
-      "MCPStatusNeedsClientRegistration": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "const": "needs_client_registration"
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "status",
-          "error"
-        ]
-      },
-      "MCPStatus": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/MCPStatusConnected"
-          },
-          {
-            "$ref": "#/components/schemas/MCPStatusDisabled"
-          },
-          {
-            "$ref": "#/components/schemas/MCPStatusFailed"
-          },
-          {
-            "$ref": "#/components/schemas/MCPStatusNeedsAuth"
-          },
-          {
-            "$ref": "#/components/schemas/MCPStatusNeedsClientRegistration"
-          }
-        ]
-      },
-      "Path": {
-        "type": "object",
-        "properties": {
-          "home": {
-            "type": "string"
-          },
-          "state": {
-            "type": "string"
-          },
-          "config": {
-            "type": "string"
-          },
-          "worktree": {
-            "type": "string"
-          },
-          "directory": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "home",
-          "state",
-          "config",
-          "worktree",
-          "directory"
-        ]
-      },
-      "VcsInfo": {
-        "type": "object",
-        "properties": {
-          "branch": {
-            "type": "string"
-          },
-          "default_branch": {
-            "type": "string"
-          }
-        }
-      },
-      "VcsFileDiff": {
-        "type": "object",
-        "properties": {
-          "file": {
-            "type": "string"
-          },
-          "patch": {
-            "type": "string"
-          },
-          "additions": {
-            "type": "number"
-          },
-          "deletions": {
-            "type": "number"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "added",
-              "deleted",
-              "modified"
-            ]
-          }
-        },
-        "required": [
-          "file",
-          "patch",
-          "additions",
-          "deletions"
-        ]
-      },
-      "Command": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
+          "messageID": {
             "type": "string"
           },
           "agent": {
@@ -13601,47 +21305,466 @@
           "model": {
             "type": "string"
           },
-          "source": {
-            "type": "string",
-            "enum": [
-              "command",
-              "mcp",
-              "skill"
+          "locale": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "variant": {
+            "type": "string"
+          },
+          "parts": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "file"
+                    },
+                    "mime": {
+                      "type": "string"
+                    },
+                    "filename": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "$ref": "#/components/schemas/FilePartSource"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "mime",
+                    "url"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "arguments",
+          "command"
+        ]
+      },
+      "ShellBody": {
+        "type": "object",
+        "properties": {
+          "messageID": {
+            "type": "string"
+          },
+          "agent": {
+            "type": "string"
+          },
+          "model": {
+            "type": "object",
+            "properties": {
+              "providerID": {
+                "type": "string"
+              },
+              "modelID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerID",
+              "modelID"
             ]
           },
-          "template": {
+          "command": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent",
+          "command"
+        ]
+      },
+      "SessionCreateBody": {
+        "type": "object",
+        "properties": {
+          "parentID": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "skill": {
+            "type": "string"
+          },
+          "permission": {
+            "$ref": "#/components/schemas/PermissionRuleset"
+          },
+          "workspaceID": {
+            "type": "string"
+          },
+          "createdByAgentTool": {
+            "type": "boolean"
+          },
+          "subagentType": {
             "anyOf": [
               {
                 "type": "string"
               },
               {
-                "type": "string"
+                "type": "null"
               }
             ]
+          }
+        }
+      },
+      "SessionForkBody": {
+        "type": "object",
+        "properties": {
+          "messageID": {
+            "type": "string"
+          }
+        }
+      },
+      "SessionRevertBody": {
+        "type": "object",
+        "properties": {
+          "messageID": {
+            "type": "string"
           },
-          "subtask": {
+          "partID": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "messageID"
+        ]
+      },
+      "TurnChangeAggregate": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "empty"
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "turnID": {
+                "type": "string"
+              },
+              "messageID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "sessionID"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "captured"
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "turnID": {
+                "type": "string"
+              },
+              "messageID": {
+                "type": "string"
+              },
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "openPath": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "added",
+                        "modified",
+                        "deleted"
+                      ]
+                    },
+                    "additions": {
+                      "type": "number"
+                    },
+                    "deletions": {
+                      "type": "number"
+                    },
+                    "patch": {
+                      "type": "string"
+                    },
+                    "sensitive": {
+                      "type": "boolean"
+                    },
+                    "binary": {
+                      "type": "boolean"
+                    },
+                    "large": {
+                      "type": "boolean"
+                    },
+                    "restoreAvailable": {
+                      "type": "boolean"
+                    },
+                    "expandable": {
+                      "type": "boolean"
+                    },
+                    "restoreState": {
+                      "type": "string",
+                      "enum": [
+                        "applied",
+                        "undone",
+                        "redo_invalidated"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "status",
+                    "expandable",
+                    "restoreState"
+                  ]
+                }
+              },
+              "truncated": {
+                "type": "boolean"
+              },
+              "omittedCount": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "kind",
+              "sessionID",
+              "files"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "uncaptured"
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "turnID": {
+                "type": "string"
+              },
+              "messageID": {
+                "type": "string"
+              },
+              "count": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "kind",
+              "sessionID",
+              "count"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "mixed"
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "turnID": {
+                "type": "string"
+              },
+              "messageID": {
+                "type": "string"
+              },
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "openPath": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "added",
+                        "modified",
+                        "deleted"
+                      ]
+                    },
+                    "additions": {
+                      "type": "number"
+                    },
+                    "deletions": {
+                      "type": "number"
+                    },
+                    "patch": {
+                      "type": "string"
+                    },
+                    "sensitive": {
+                      "type": "boolean"
+                    },
+                    "binary": {
+                      "type": "boolean"
+                    },
+                    "large": {
+                      "type": "boolean"
+                    },
+                    "restoreAvailable": {
+                      "type": "boolean"
+                    },
+                    "expandable": {
+                      "type": "boolean"
+                    },
+                    "restoreState": {
+                      "type": "string",
+                      "enum": [
+                        "applied",
+                        "undone",
+                        "redo_invalidated"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "status",
+                    "expandable",
+                    "restoreState"
+                  ]
+                }
+              },
+              "count": {
+                "type": "number"
+              },
+              "truncated": {
+                "type": "boolean"
+              },
+              "omittedCount": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "kind",
+              "sessionID",
+              "files",
+              "count"
+            ]
+          }
+        ]
+      },
+      "LogLevel": {
+        "description": "Log level",
+        "type": "string",
+        "enum": [
+          "DEBUG",
+          "INFO",
+          "WARN",
+          "ERROR"
+        ]
+      },
+      "ServerConfig": {
+        "description": "Server configuration for opencode serve and web commands",
+        "type": "object",
+        "properties": {
+          "port": {
+            "description": "Port to listen on",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "hostname": {
+            "description": "Hostname to listen on",
+            "type": "string"
+          },
+          "mdns": {
+            "description": "Enable mDNS service discovery",
             "type": "boolean"
           },
-          "hints": {
+          "mdnsDomain": {
+            "description": "Custom domain name for mDNS service (default: opencode.local)",
+            "type": "string"
+          },
+          "cors": {
+            "description": "Additional domains to allow for CORS",
             "type": "array",
             "items": {
               "type": "string"
             }
           }
         },
-        "required": [
-          "name",
-          "template",
-          "hints"
-        ]
+        "additionalProperties": false
       },
-      "Agent": {
+      "AgentConfig": {
         "type": "object",
         "properties": {
-          "name": {
+          "model": {
+            "type": "string",
+            "pattern": "^[^/]+\\/[^/].*$"
+          },
+          "variant": {
+            "description": "Default model variant for this agent (applies only when using the agent's configured model).",
             "type": "string"
           },
+          "temperature": {
+            "type": "number"
+          },
+          "top_p": {
+            "type": "number"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "tools": {
+            "description": "@deprecated Use 'permission' field instead",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "disable": {
+            "type": "boolean"
+          },
           "description": {
+            "description": "Description of when to use the agent",
             "type": "string"
           },
           "mode": {
@@ -13652,44 +21775,9 @@
               "all"
             ]
           },
-          "native": {
-            "type": "boolean"
-          },
           "hidden": {
+            "description": "Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)",
             "type": "boolean"
-          },
-          "topP": {
-            "type": "number"
-          },
-          "temperature": {
-            "type": "number"
-          },
-          "color": {
-            "type": "string"
-          },
-          "permission": {
-            "$ref": "#/components/schemas/PermissionRuleset"
-          },
-          "model": {
-            "type": "object",
-            "properties": {
-              "modelID": {
-                "type": "string"
-              },
-              "providerID": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "modelID",
-              "providerID"
-            ]
-          },
-          "variant": {
-            "type": "string"
-          },
-          "prompt": {
-            "type": "string"
           },
           "options": {
             "type": "object",
@@ -13698,68 +21786,113 @@
             },
             "additionalProperties": {}
           },
-          "steps": {
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991
-          }
-        },
-        "required": [
-          "name",
-          "mode",
-          "permission",
-          "options"
-        ]
-      },
-      "LSPStatus": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "root": {
-            "type": "string"
-          },
-          "status": {
+          "color": {
+            "description": "Hex color code (e.g., #FF5733) or theme color (e.g., primary)",
             "anyOf": [
               {
                 "type": "string",
-                "const": "connected"
+                "pattern": "^#[0-9a-fA-F]{6}$"
               },
               {
                 "type": "string",
-                "const": "error"
+                "enum": [
+                  "primary",
+                  "secondary",
+                  "accent",
+                  "success",
+                  "warning",
+                  "error",
+                  "info"
+                ]
               }
             ]
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "root",
-          "status"
-        ]
-      },
-      "PtyConnectToken": {
-        "type": "object",
-        "properties": {
-          "ticket": {
-            "type": "string"
           },
-          "expires_in": {
+          "steps": {
+            "description": "Maximum number of agentic iterations before forcing text-only response",
             "type": "integer",
             "exclusiveMinimum": 0,
             "maximum": 9007199254740991
+          },
+          "maxSteps": {
+            "description": "@deprecated Use 'steps' field instead.",
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "permission": {
+            "$ref": "#/components/schemas/PermissionConfig"
           }
         },
-        "required": [
-          "ticket",
-          "expires_in"
-        ]
+        "additionalProperties": {}
       }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": [
+    {
+      "name": "control",
+      "description": "HttpApi control-plane JSON routes."
+    },
+    {
+      "name": "global",
+      "description": "HttpApi global control routes."
+    },
+    {
+      "name": "workspace",
+      "description": "HttpApi experimental workspace routes."
+    },
+    {
+      "name": "root",
+      "description": "HttpApi root instance routes."
+    },
+    {
+      "name": "project",
+      "description": "HttpApi project routes."
+    },
+    {
+      "name": "pty",
+      "description": "HttpApi PTY JSON and connect-token routes."
+    },
+    {
+      "name": "config",
+      "description": "HttpApi config routes."
+    },
+    {
+      "name": "experimental",
+      "description": "HttpApi experimental JSON routes."
+    },
+    {
+      "name": "session",
+      "description": "HttpApi session JSON routes."
+    },
+    {
+      "name": "permission",
+      "description": "HttpApi permission routes."
+    },
+    {
+      "name": "external-result",
+      "description": "HttpApi external-result routes."
+    },
+    {
+      "name": "provider",
+      "description": "HttpApi provider routes."
+    },
+    {
+      "name": "memory",
+      "description": "HttpApi PawWork memory routes."
+    },
+    {
+      "name": "automation",
+      "description": "HttpApi automation routes."
+    },
+    {
+      "name": "file",
+      "description": "HttpApi file routes."
+    },
+    {
+      "name": "mcp",
+      "description": "HttpApi MCP routes."
     }
-  }
+  ]
 }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1058,11 +1058,7 @@
             "name": "ensureConfig",
             "in": "query",
             "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
+              "type": "boolean"
             },
             "required": false
           }
@@ -2118,182 +2114,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "worktree": {
-                        "type": "string"
-                      },
-                      "vcs": {
-                        "type": "string",
-                        "enum": [
-                          "git"
-                        ]
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "icon": {
-                        "type": "object",
-                        "properties": {
-                          "url": {
-                            "type": "string"
-                          },
-                          "override": {
-                            "type": "string"
-                          },
-                          "color": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      "commands": {
-                        "type": "object",
-                        "properties": {
-                          "start": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      "time": {
-                        "type": "object",
-                        "properties": {
-                          "created": {
-                            "anyOf": [
-                              {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "NaN"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "Infinity"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "-Infinity"
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "Infinity",
-                                  "-Infinity",
-                                  "NaN"
-                                ]
-                              }
-                            ]
-                          },
-                          "updated": {
-                            "anyOf": [
-                              {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "NaN"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "Infinity"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "-Infinity"
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "Infinity",
-                                  "-Infinity",
-                                  "NaN"
-                                ]
-                              }
-                            ]
-                          },
-                          "initialized": {
-                            "anyOf": [
-                              {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "NaN"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "Infinity"
-                                    ]
-                                  },
-                                  {
-                                    "type": "string",
-                                    "enum": [
-                                      "-Infinity"
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "string",
-                                "enum": [
-                                  "Infinity",
-                                  "-Infinity",
-                                  "NaN"
-                                ]
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "created",
-                          "updated"
-                        ],
-                        "additionalProperties": false
-                      },
-                      "sandboxes": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "worktree",
-                      "time",
-                      "sandboxes"
-                    ],
-                    "additionalProperties": false
+                    "$ref": "#/components/schemas/Project"
                   }
                 }
               }
@@ -2341,182 +2162,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "worktree": {
-                      "type": "string"
-                    },
-                    "vcs": {
-                      "type": "string",
-                      "enum": [
-                        "git"
-                      ]
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "icon": {
-                      "type": "object",
-                      "properties": {
-                        "url": {
-                          "type": "string"
-                        },
-                        "override": {
-                          "type": "string"
-                        },
-                        "color": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "commands": {
-                      "type": "object",
-                      "properties": {
-                        "start": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "time": {
-                      "type": "object",
-                      "properties": {
-                        "created": {
-                          "anyOf": [
-                            {
-                              "anyOf": [
-                                {
-                                  "type": "number"
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "NaN"
-                                  ]
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "Infinity"
-                                  ]
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "-Infinity"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "string",
-                              "enum": [
-                                "Infinity",
-                                "-Infinity",
-                                "NaN"
-                              ]
-                            }
-                          ]
-                        },
-                        "updated": {
-                          "anyOf": [
-                            {
-                              "anyOf": [
-                                {
-                                  "type": "number"
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "NaN"
-                                  ]
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "Infinity"
-                                  ]
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "-Infinity"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "string",
-                              "enum": [
-                                "Infinity",
-                                "-Infinity",
-                                "NaN"
-                              ]
-                            }
-                          ]
-                        },
-                        "initialized": {
-                          "anyOf": [
-                            {
-                              "anyOf": [
-                                {
-                                  "type": "number"
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "NaN"
-                                  ]
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "Infinity"
-                                  ]
-                                },
-                                {
-                                  "type": "string",
-                                  "enum": [
-                                    "-Infinity"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "type": "string",
-                              "enum": [
-                                "Infinity",
-                                "-Infinity",
-                                "NaN"
-                              ]
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "created",
-                        "updated"
-                      ],
-                      "additionalProperties": false
-                    },
-                    "sandboxes": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "worktree",
-                    "time",
-                    "sandboxes"
-                  ],
-                  "additionalProperties": false
+                  "$ref": "#/components/schemas/Project"
                 }
               }
             }
@@ -4349,11 +3995,7 @@
             "name": "roots",
             "in": "query",
             "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
+              "type": "boolean"
             },
             "required": false
           },
@@ -4361,7 +4003,7 @@
             "name": "start",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "number"
             },
             "required": false
           },
@@ -4385,7 +4027,7 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "number"
             },
             "required": false
           },
@@ -4393,11 +4035,7 @@
             "name": "archived",
             "in": "query",
             "schema": {
-              "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
+              "type": "boolean"
             },
             "required": false
           },
@@ -4447,7 +4085,22 @@
           "experimental"
         ],
         "operationId": "worktree.create",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -4498,30 +4151,14 @@
         "description": "Create a new git worktree for the current project and run any configured startup scripts.",
         "summary": "Create worktree",
         "requestBody": {
+          "required": false,
           "content": {
             "application/json": {
               "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "startCommand": {
-                        "type": "string"
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "$ref": "#/components/schemas/WorktreeCreateInput"
               }
             }
-          },
-          "required": true
+          }
         },
         "x-codeSamples": [
           {
@@ -4535,7 +4172,22 @@
           "experimental"
         ],
         "operationId": "worktree.list",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -4590,7 +4242,22 @@
           "experimental"
         ],
         "operationId": "worktree.remove",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -4617,23 +4284,14 @@
         "description": "Remove a git worktree and delete its branch.",
         "summary": "Remove worktree",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "directory": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "directory"
-                ],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/WorktreeRemoveInput"
               }
             }
-          },
-          "required": true
+          }
         },
         "x-codeSamples": [
           {
@@ -4649,7 +4307,22 @@
           "experimental"
         ],
         "operationId": "worktree.reset",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -4676,23 +4349,14 @@
         "description": "Reset a worktree branch to the primary default branch.",
         "summary": "Reset worktree",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "directory": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "directory"
-                ],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/WorktreeResetInput"
               }
             }
-          },
-          "required": true
+          }
         },
         "x-codeSamples": [
           {
@@ -5497,7 +5161,7 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "number"
             },
             "required": false
           },
@@ -8365,65 +8029,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "sessionID": {
-                        "type": "string"
-                      },
-                      "permission": {
-                        "type": "string"
-                      },
-                      "patterns": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "metadata": {
-                        "type": "object"
-                      },
-                      "always": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "tool": {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "messageID": {
-                                "type": "string"
-                              },
-                              "callID": {
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "messageID",
-                              "callID"
-                            ],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "sessionID",
-                      "permission",
-                      "patterns",
-                      "metadata",
-                      "always"
-                    ],
-                    "additionalProperties": false
+                    "$ref": "#/components/schemas/PermissionRequest"
                   }
                 }
               }
@@ -8668,18 +8274,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "session": {},
-                      "message": {},
-                      "part": {}
-                    },
-                    "required": [
-                      "session",
-                      "message",
-                      "part"
-                    ],
-                    "additionalProperties": false
+                    "$ref": "#/components/schemas/PendingExternalResult"
                   }
                 }
               }
@@ -9270,23 +8865,14 @@
         },
         "summary": "Update raw PawWork memory",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "content": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "content"
-                ],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/MemoryRawInput"
               }
             }
-          },
-          "required": true
+          }
         },
         "x-codeSamples": [
           {
@@ -9391,23 +8977,14 @@
         },
         "summary": "Disable or enable PawWork memory",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "disabled": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "disabled"
-                ],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/MemoryDisabledInput"
               }
             }
-          },
-          "required": true
+          }
         },
         "x-codeSamples": [
           {
@@ -9580,122 +9157,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "anyOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "kind": {
-                        "type": "string",
-                        "const": "oneshot"
-                      },
-                      "title": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 160
-                      },
-                      "prompt": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 20000
-                      },
-                      "context": {
-                        "type": "string",
-                        "enum": [
-                          "continue",
-                          "fresh"
-                        ]
-                      },
-                      "where": {
-                        "$ref": "#/components/schemas/AutomationWhere"
-                      },
-                      "timezone": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "model": {
-                        "$ref": "#/components/schemas/AutomationModel"
-                      },
-                      "variant": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "fireAt": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "maximum": 9007199254740991
-                      }
-                    },
-                    "required": [
-                      "kind",
-                      "title",
-                      "prompt",
-                      "context",
-                      "where",
-                      "timezone",
-                      "model",
-                      "fireAt"
-                    ],
-                    "additionalProperties": false
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "kind": {
-                        "type": "string",
-                        "const": "recurring"
-                      },
-                      "title": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 160
-                      },
-                      "prompt": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 20000
-                      },
-                      "context": {
-                        "type": "string",
-                        "enum": [
-                          "continue",
-                          "fresh"
-                        ]
-                      },
-                      "where": {
-                        "$ref": "#/components/schemas/AutomationWhere"
-                      },
-                      "timezone": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "model": {
-                        "$ref": "#/components/schemas/AutomationModel"
-                      },
-                      "variant": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "rhythm": {
-                        "$ref": "#/components/schemas/AutomationRhythm"
-                      },
-                      "stop": {
-                        "$ref": "#/components/schemas/AutomationStop"
-                      }
-                    },
-                    "required": [
-                      "kind",
-                      "title",
-                      "prompt",
-                      "context",
-                      "where",
-                      "timezone",
-                      "model",
-                      "rhythm",
-                      "stop"
-                    ],
-                    "additionalProperties": false
-                  }
-                ]
+                "$ref": "#/components/schemas/AutomationCreateInput"
               }
             }
           }
@@ -9875,62 +9337,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 160
-                  },
-                  "prompt": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 20000
-                  },
-                  "paused": {
-                    "type": "boolean"
-                  },
-                  "context": {
-                    "type": "string",
-                    "enum": [
-                      "continue",
-                      "fresh"
-                    ]
-                  },
-                  "where": {
-                    "$ref": "#/components/schemas/AutomationWhere"
-                  },
-                  "timezone": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "fireAt": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 9007199254740991
-                  },
-                  "rhythm": {
-                    "$ref": "#/components/schemas/AutomationRhythm"
-                  },
-                  "stop": {
-                    "$ref": "#/components/schemas/AutomationStop"
-                  },
-                  "model": {
-                    "$ref": "#/components/schemas/AutomationModel"
-                  },
-                  "variant": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  }
-                },
-                "additionalProperties": false
+                "$ref": "#/components/schemas/AutomationUpdateInput"
               }
             }
           }
@@ -10705,7 +10112,7 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "number"
             },
             "required": false
           }
@@ -10920,37 +10327,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "text",
-                        "binary"
-                      ]
-                    },
-                    "content": {
-                      "type": "string"
-                    },
-                    "diff": {
-                      "type": "string"
-                    },
-                    "patch": {},
-                    "encoding": {
-                      "type": "string",
-                      "enum": [
-                        "base64"
-                      ]
-                    },
-                    "mimeType": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "type",
-                    "content"
-                  ],
-                  "additionalProperties": false
+                  "$ref": "#/components/schemas/FileContent"
                 }
               }
             }
@@ -20769,6 +20146,170 @@
           "disabled",
           "status",
           "content"
+        ]
+      },
+      "MemoryRawInput": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ]
+      },
+      "MemoryDisabledInput": {
+        "type": "object",
+        "properties": {
+          "disabled": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "disabled"
+        ]
+      },
+      "WorktreeCreateInput": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "startCommand": {
+            "type": "string",
+            "description": "Additional startup script to run after the project's start command"
+          }
+        }
+      },
+      "WorktreeRemoveInput": {
+        "type": "object",
+        "properties": {
+          "directory": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "directory"
+        ]
+      },
+      "WorktreeResetInput": {
+        "type": "object",
+        "properties": {
+          "directory": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "directory"
+        ]
+      },
+      "FileContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "text",
+              "binary"
+            ]
+          },
+          "content": {
+            "type": "string"
+          },
+          "diff": {
+            "type": "string"
+          },
+          "patch": {
+            "type": "object",
+            "properties": {
+              "oldFileName": {
+                "type": "string"
+              },
+              "newFileName": {
+                "type": "string"
+              },
+              "oldHeader": {
+                "type": "string"
+              },
+              "newHeader": {
+                "type": "string"
+              },
+              "hunks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "oldStart": {
+                      "type": "number"
+                    },
+                    "oldLines": {
+                      "type": "number"
+                    },
+                    "newStart": {
+                      "type": "number"
+                    },
+                    "newLines": {
+                      "type": "number"
+                    },
+                    "lines": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "oldStart",
+                    "oldLines",
+                    "newStart",
+                    "newLines",
+                    "lines"
+                  ]
+                }
+              },
+              "index": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "oldFileName",
+              "newFileName",
+              "hunks"
+            ]
+          },
+          "encoding": {
+            "type": "string",
+            "enum": [
+              "base64"
+            ]
+          },
+          "mimeType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content"
+        ]
+      },
+      "PendingExternalResult": {
+        "type": "object",
+        "properties": {
+          "session": {
+            "$ref": "#/components/schemas/Session"
+          },
+          "message": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "part": {
+            "$ref": "#/components/schemas/Part"
+          }
+        },
+        "required": [
+          "session",
+          "message",
+          "part"
         ]
       },
       "TextPartInput": {


### PR DESCRIPTION
## Summary

Switch SDK/OpenAPI generation to the production Effect `ProductionApi` source and refresh the checked-in OpenAPI plus v2 SDK artifacts.

## Why

The SDK generation chain still depended on the legacy Hono documentation tree, leaving checked-in OpenAPI and generated SDK coverage behind the production HTTP boundary. Related to #936.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

- Confirm `Server.openapi()` and `bun dev generate` now use `controlOpenApi()` from the production `ProductionApi` source.
- Review the narrow OpenAPI schema patches for session, automation, memory, artifacts, symbols, VCS failure responses, and special SSE/WebSocket surfaces.
- Confirm generated `packages/sdk/openapi.json` and v2 SDK artifacts are expected and do not hide drift.

## Risk Notes

Residual risk: `session.export` remains a debug export snapshot without a hand-authored zod schema, so its generated response type is still broad. I did not hand-write that large schema in this PR because it would broaden the migration beyond the SDK generation source closeout. No visible UI changed, and no platform/packaging surface changed.

## How To Verify

```text
packages/opencode: bun test test/server/vcs-routes.test.ts test/server/openapi-generation-source.test.ts -> 28 passed
packages/opencode: bun test test/server/openapi-generation-source.test.ts test/server/production-boundary.test.ts test/server/route-inventory-harness.test.ts -> passed before the VCS CI fix
packages/opencode: bun test test/server/production-boundary.test.ts test/server/route-inventory-harness.test.ts -> 34 passed after the VCS CI fix
packages/opencode: bun run route:inventory -> passed; Hono 128, checked-in OpenAPI 125, v2 SDK 124, local HttpApi 122; special surfaces remain classified honestly
packages/sdk/js: bun run build -> passed and regenerated packages/sdk/openapi.json plus v2 SDK artifacts
packages/sdk/js: bun test test/v2-generated-core.test.ts test/v2-client-error-interceptor.test.ts -> 16 passed
packages/opencode: GOMAXPROCS=2 bun run typecheck -> passed
root: bun turbo typecheck -> passed before the VCS CI fix
root: git diff --check -> passed
fresh-eye review: final pre-PR round reported No P0/P1 findings; post-CI-fix VCS round reported No P0-P3 findings and no P0/P1 blockers
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded OpenAPI API documentation generation to include additional routes and comprehensive schema definitions.
  
* **Documentation**
  * Enhanced TypeScript type exports in JavaScript SDK for improved type support and better IDE autocompletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->