### PR TITLE
refactor(opencode): effectify worktree gitignore guard

### DIFF
--- a/packages/opencode/src/worktree/gitignore-guard.ts
+++ b/packages/opencode/src/worktree/gitignore-guard.ts
@@ -1,8 +1,8 @@
-import { promises as fs } from "fs"
-import path from "path"
+import { Effect, Path } from "effect"
 import { NamedError } from "@opencode-ai/util/error"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import z from "zod"
-import { Process } from "../util/process"
+import { Git } from "@/git"
 
 export const GitignoreGuardError = NamedError.create(
   "WorktreeGitignoreGuardError",
@@ -12,15 +12,6 @@ export const GitignoreGuardError = NamedError.create(
 )
 
 const ENTRY = ".worktrees/"
-
-async function git(root: string, args: string[]) {
-  const result = await Process.text(["git", ...args], { cwd: root, nothrow: true })
-  return {
-    code: result.code,
-    stdout: result.text,
-    stderr: result.stderr.toString(),
-  }
-}
 
 function hasWorktreesIgnore(text: string) {
   return text
@@ -32,50 +23,67 @@ function hasWorktreesIgnore(text: string) {
     )
 }
 
-export async function ensureWorktreesIgnored(
-  root: string,
-): Promise<{ changed: boolean; file: string; before?: string }> {
+export type GitignoreGuardChange = { changed: boolean; file: string; before?: string }
+
+export const ensureWorktreesIgnoredEffect = Effect.fn("Worktree.ensureWorktreesIgnored")(function* (root: string) {
+  const fs = yield* AppFileSystem.Service
+  const path = yield* Path.Path
+  const git = yield* Git.Service
   const file = path.join(root, ".gitignore")
-  const before = await fs.readFile(file, "utf8").catch((error: unknown) => {
-    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return undefined
-    throw error
-  })
+  const before = yield* fs.readFileString(file).pipe(
+    Effect.catchIf(
+      (error) => error.reason._tag === "NotFound",
+      () => Effect.succeed(undefined),
+    ),
+  )
 
   if (before && hasWorktreesIgnore(before)) return { changed: false, file }
 
-  const status = await git(root, [
-    "-c",
-    "core.fsmonitor=false",
-    "-c",
-    "status.showUntrackedFiles=all",
-    "status",
-    "--porcelain=v1",
-    "--no-renames",
-    "--",
-    ".gitignore",
-  ])
-  if (status.code !== 0) {
-    throw new GitignoreGuardError({
-      message: status.stderr || status.stdout || "Failed to inspect .gitignore status",
-    })
+  const status = yield* git.run(
+    [
+      "-c",
+      "core.fsmonitor=false",
+      "-c",
+      "status.showUntrackedFiles=all",
+      "status",
+      "--porcelain=v1",
+      "--no-renames",
+      "--",
+      ".gitignore",
+    ],
+    { cwd: root },
+  )
+  const stdout = status.text()
+  const stderr = status.stderr.toString()
+  if (status.exitCode !== 0) {
+    return yield* Effect.fail(
+      new GitignoreGuardError({
+        message: stderr || stdout || "Failed to inspect .gitignore status",
+      }),
+    )
   }
-  if (status.stdout.trim()) {
-    throw new GitignoreGuardError({
-      message: ".gitignore has local changes. Commit or discard them before creating a PawWork worktree.",
-    })
+  if (stdout.trim()) {
+    return yield* Effect.fail(
+      new GitignoreGuardError({
+        message: ".gitignore has local changes. Commit or discard them before creating a PawWork worktree.",
+      }),
+    )
   }
 
   const prefix = before && before.length > 0 && !before.endsWith("\n") ? "\n" : ""
   const next = `${before ?? ""}${prefix}${ENTRY}\n`
-  await fs.writeFile(file, next)
+  yield* fs.writeFileString(file, next)
   return { changed: true, file, before }
-}
+})
 
-export async function restoreWorktreesIgnored(change: { changed: boolean; file: string; before?: string }) {
+export const restoreWorktreesIgnoredEffect = Effect.fn("Worktree.restoreWorktreesIgnored")(function* (
+  change: GitignoreGuardChange,
+) {
   if (!change.changed) return
+  const fs = yield* AppFileSystem.Service
   if (change.before === undefined) {
-    await fs.rm(change.file, { force: true })
+    yield* fs.remove(change.file, { force: true })
     return
   }
-  await fs.writeFile(change.file, change.before)
-}
+  yield* fs.writeFileString(change.file, change.before)
+})

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -12,7 +12,8 @@ import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
 import { Git } from "@/git"
 import { Deferred, Effect, Layer, Path, Scope, Context, Stream, Semaphore } from "effect"
-import { ensureWorktreesIgnored, restoreWorktreesIgnored } from "./gitignore-guard"
+import type { GitignoreGuardChange } from "./gitignore-guard"
+import { ensureWorktreesIgnoredEffect, restoreWorktreesIgnoredEffect } from "./gitignore-guard"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -189,6 +190,14 @@ export namespace Worktree {
       const gitSvc = yield* Git.Service
       const project = yield* Project.Service
       const registryLocks = new Map<ProjectID, Semaphore.Semaphore>()
+      const ensureIgnored = (root: string) =>
+        ensureWorktreesIgnoredEffect(root).pipe(
+          Effect.provideService(AppFileSystem.Service, fs),
+          Effect.provideService(Path.Path, pathSvc),
+          Effect.provideService(Git.Service, gitSvc),
+        )
+      const restoreIgnored = (change: GitignoreGuardChange) =>
+        restoreWorktreesIgnoredEffect(change).pipe(Effect.provideService(AppFileSystem.Service, fs))
 
       const registryLock = (projectID: ProjectID) => {
         const hit = registryLocks.get(projectID)
@@ -387,12 +396,12 @@ export namespace Worktree {
 
       const setup = Effect.fnUntraced(function* (info: Info) {
         const ctx = yield* InstanceState.context
-        const ignoreChange = yield* Effect.promise(() => ensureWorktreesIgnored(ctx.worktree))
+        const ignoreChange = yield* ensureIgnored(ctx.worktree).pipe(Effect.orDie)
         const created = yield* git(["worktree", "add", "--no-checkout", "-b", info.branch, info.directory], {
           cwd: ctx.worktree,
         })
         if (created.code !== 0) {
-          yield* Effect.promise(() => restoreWorktreesIgnored(ignoreChange))
+          yield* restoreIgnored(ignoreChange).pipe(Effect.orDie)
           throw new CreateFailedError({ message: created.stderr || created.text || "Failed to create git worktree" })
         }
 

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -61,3 +61,10 @@ test("worktree adaptor does not call Worktree Promise facades", async () => {
   expect(text).not.toContain("Worktree.createFromInfo")
   expect(text).not.toContain("Worktree.remove")
 })
+
+test("Worktree service uses the Effect-native gitignore guard boundary", async () => {
+  const text = await readFile(path.join(srcRoot, "worktree/index.ts"), "utf8")
+
+  expect(text).not.toContain("Effect.promise(() => ensureWorktreesIgnored")
+  expect(text).not.toContain("Effect.promise(() => restoreWorktreesIgnored")
+})

--- a/packages/opencode/test/worktree/gitignore-guard.test.ts
+++ b/packages/opencode/test/worktree/gitignore-guard.test.ts
@@ -1,55 +1,106 @@
-import { $ } from "bun"
-import { describe, expect, test } from "bun:test"
-import fs from "fs/promises"
-import path from "path"
-import { ensureWorktreesIgnored } from "../../src/worktree/gitignore-guard"
-import { tmpdir } from "../fixture/fixture"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { NodePath } from "@effect/platform-node"
+import { describe, expect } from "bun:test"
+import { Cause, Effect, Exit, Layer, Path } from "effect"
+import { Git } from "../../src/git"
+import { ensureWorktreesIgnoredEffect } from "../../src/worktree/gitignore-guard"
+import { tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  Layer.mergeAll(AppFileSystem.defaultLayer, Git.defaultLayer, NodePath.layer, CrossSpawnSpawner.defaultLayer),
+)
+
+function guardFailsWithName(exit: Exit.Exit<unknown, unknown>, name: string) {
+  if (Exit.isSuccess(exit)) return false
+  return Cause.prettyErrors(exit.cause).some(
+    (error) => error instanceof Error && (error.name === name || error.message.includes(name)),
+  )
+}
+
+const gitOk = Effect.fnUntraced(function* (root: string, args: string[]) {
+  const git = yield* Git.Service
+  const result = yield* git.run(args, { cwd: root })
+  expect(result.exitCode).toBe(0)
+})
 
 describe("worktree gitignore guard", () => {
-  test("creates .gitignore with .worktrees entry when missing", async () => {
-    await using tmp = await tmpdir({ git: true })
+  it.live("creates .gitignore with .worktrees entry when missing", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const fs = yield* AppFileSystem.Service
+      const path = yield* Path.Path
 
-    const result = await ensureWorktreesIgnored(tmp.path)
+      const result = yield* ensureWorktreesIgnoredEffect(tmp)
 
-    expect(result.changed).toBe(true)
-    expect(await fs.readFile(path.join(tmp.path, ".gitignore"), "utf8")).toBe(".worktrees/\n")
-  })
+      expect(result.changed).toBe(true)
+      expect(yield* fs.readFileString(path.join(tmp, ".gitignore"))).toBe(".worktrees/\n")
+    }),
+  )
 
-  test("does not duplicate existing .worktrees entry", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await Bun.write(path.join(tmp.path, ".gitignore"), "node_modules\n/.worktrees/\n")
-    await $`git add .gitignore && git commit -m ignore-worktrees`.cwd(tmp.path).quiet()
+  it.live("does not duplicate existing .worktrees entry", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const fs = yield* AppFileSystem.Service
+      const path = yield* Path.Path
+      const file = path.join(tmp, ".gitignore")
+      yield* fs.writeFileString(file, "node_modules\n/.worktrees/\n")
+      yield* gitOk(tmp, ["add", ".gitignore"])
+      yield* gitOk(tmp, ["commit", "-m", "ignore-worktrees"])
 
-    const result = await ensureWorktreesIgnored(tmp.path)
+      const result = yield* ensureWorktreesIgnoredEffect(tmp)
 
-    expect(result.changed).toBe(false)
-    expect(await fs.readFile(path.join(tmp.path, ".gitignore"), "utf8")).toBe("node_modules\n/.worktrees/\n")
-  })
+      expect(result.changed).toBe(false)
+      expect(yield* fs.readFileString(file)).toBe("node_modules\n/.worktrees/\n")
+    }),
+  )
 
-  test("refuses to append when .gitignore has local changes", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await Bun.write(path.join(tmp.path, ".gitignore"), "node_modules\n")
-    await $`git add .gitignore && git commit -m initial-gitignore`.cwd(tmp.path).quiet()
-    await Bun.write(path.join(tmp.path, ".gitignore"), "node_modules\ndist\n")
+  it.live("refuses to append when .gitignore has local changes", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const fs = yield* AppFileSystem.Service
+      const path = yield* Path.Path
+      const file = path.join(tmp, ".gitignore")
+      yield* fs.writeFileString(file, "node_modules\n")
+      yield* gitOk(tmp, ["add", ".gitignore"])
+      yield* gitOk(tmp, ["commit", "-m", "initial-gitignore"])
+      yield* fs.writeFileString(file, "node_modules\ndist\n")
 
-    await expect(ensureWorktreesIgnored(tmp.path)).rejects.toThrow("WorktreeGitignoreGuardError")
-  })
+      const exit = yield* Effect.exit(ensureWorktreesIgnoredEffect(tmp))
 
-  test("refuses to append when untracked .gitignore is hidden by git config", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await $`git config status.showUntrackedFiles no`.cwd(tmp.path).quiet()
-    await Bun.write(path.join(tmp.path, ".gitignore"), "node_modules\n")
+      expect(guardFailsWithName(exit, "WorktreeGitignoreGuardError")).toBe(true)
+    }),
+  )
 
-    await expect(ensureWorktreesIgnored(tmp.path)).rejects.toThrow("WorktreeGitignoreGuardError")
-  })
+  it.live("refuses to append when untracked .gitignore is hidden by git config", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const fs = yield* AppFileSystem.Service
+      const path = yield* Path.Path
+      yield* gitOk(tmp, ["config", "status.showUntrackedFiles", "no"])
+      yield* fs.writeFileString(path.join(tmp, ".gitignore"), "node_modules\n")
 
-  test("refuses to recreate a locally deleted tracked .gitignore", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const file = path.join(tmp.path, ".gitignore")
-    await Bun.write(file, "node_modules\n")
-    await $`git add .gitignore && git commit -m initial-gitignore`.cwd(tmp.path).quiet()
-    await fs.unlink(file)
+      const exit = yield* Effect.exit(ensureWorktreesIgnoredEffect(tmp))
 
-    await expect(ensureWorktreesIgnored(tmp.path)).rejects.toThrow("WorktreeGitignoreGuardError")
-  })
+      expect(guardFailsWithName(exit, "WorktreeGitignoreGuardError")).toBe(true)
+    }),
+  )
+
+  it.live("refuses to recreate a locally deleted tracked .gitignore", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const fs = yield* AppFileSystem.Service
+      const path = yield* Path.Path
+      const file = path.join(tmp, ".gitignore")
+      yield* fs.writeFileString(file, "node_modules\n")
+      yield* gitOk(tmp, ["add", ".gitignore"])
+      yield* gitOk(tmp, ["commit", "-m", "initial-gitignore"])
+      yield* fs.remove(file)
+
+      const exit = yield* Effect.exit(ensureWorktreesIgnoredEffect(tmp))
+
+      expect(guardFailsWithName(exit, "WorktreeGitignoreGuardError")).toBe(true)
+    }),
+  )
 })


### PR DESCRIPTION
## Summary
- move the worktree .gitignore guard onto Effect-native helpers backed by AppFileSystem, Path, and Git services
- call the guard directly from Worktree.Service setup without the Promise facade bridge
- convert the guard tests to the Effect path and add a legacy-boundary guardrail

Related to #936

## Verification
- bun test test/worktree/gitignore-guard.test.ts
- bun test test/project/worktree.test.ts
- bun test test/effect/legacy-boundaries.test.ts
- GOMAXPROCS=2 bun run typecheck
- git diff --check

## Review
- Fresh-eye review: no P0/P1/P2/P3 findings; reviewer agreed this is the smallest correct boundary for this slice.