### PR TITLE
refactor(opencode): use session service for worktree binding checks

### DIFF
--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -179,7 +179,12 @@ export namespace Worktree {
   export const layer: Layer.Layer<
     Service,
     never,
-    AppFileSystem.Service | Path.Path | ChildProcessSpawner.ChildProcessSpawner | Git.Service | Project.Service
+    | AppFileSystem.Service
+    | Path.Path
+    | ChildProcessSpawner.ChildProcessSpawner
+    | Git.Service
+    | Project.Service
+    | Session.Service
   > = Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -189,6 +194,7 @@ export namespace Worktree {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
       const gitSvc = yield* Git.Service
       const project = yield* Project.Service
+      const sessions = yield* Session.Service
       const registryLocks = new Map<ProjectID, Semaphore.Semaphore>()
       const ensureIgnored = (root: string) =>
         ensureWorktreesIgnoredEffect(root).pipe(
@@ -548,7 +554,7 @@ export namespace Worktree {
         }
 
         const directory = yield* canonical(input.directory)
-        const bound = yield* Effect.promise(() => Session.findActiveWorktreeBinding(directory))
+        const bound = yield* sessions.findActiveWorktreeBinding(directory)
         if (bound) {
           throw new RemoveFailedError({
             message: `Worktree is in use by session "${bound.title}". Call ExitWorktree from that session first.`,
@@ -729,7 +735,7 @@ export namespace Worktree {
           throw new ResetFailedError({ message: "Cannot reset the primary workspace" })
         }
 
-        const bound = yield* Effect.promise(() => Session.findActiveWorktreeBinding(directory))
+        const bound = yield* sessions.findActiveWorktreeBinding(directory)
         if (bound) {
           throw new ResetFailedError({
             message: `Worktree is in use by session "${bound.title}". Call ExitWorktree from that session first.`,
@@ -832,6 +838,7 @@ export namespace Worktree {
     Layer.provide(Git.defaultLayer),
     Layer.provide(CrossSpawnSpawner.defaultLayer),
     Layer.provide(Project.defaultLayer),
+    Layer.provide(Layer.suspend(() => Session.defaultLayer)),
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),
   )

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -68,3 +68,9 @@ test("Worktree service uses the Effect-native gitignore guard boundary", async (
   expect(text).not.toContain("Effect.promise(() => ensureWorktreesIgnored")
   expect(text).not.toContain("Effect.promise(() => restoreWorktreesIgnored")
 })
+
+test("Worktree service uses the Effect-native session active binding boundary", async () => {
+  const text = await readFile(path.join(srcRoot, "worktree/index.ts"), "utf8")
+
+  expect(text).not.toContain("Session.findActiveWorktreeBinding(")
+})

--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -13,6 +13,7 @@ import { Git } from "../../src/git"
 import { Instance } from "../../src/project/instance"
 import { Project } from "../../src/project/project"
 import { ProjectTable } from "../../src/project/project.sql"
+import { Session } from "../../src/session"
 import { Database, eq } from "../../src/storage/db"
 import { Worktree } from "../../src/worktree"
 import { tmpdir } from "../fixture/fixture"
@@ -71,6 +72,7 @@ function worktreeLayerWithStartCommandProbe(probe: StartCommandProbe) {
   return Worktree.layer.pipe(
     Layer.provide(Git.defaultLayer),
     Layer.provide(Project.defaultLayer),
+    Layer.provide(Session.defaultLayer),
     Layer.provide(startCommandSpawnProbe(probe)),
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),


### PR DESCRIPTION
## Summary

Move Worktree remove/reset active-binding checks onto the Effect-native `Session.Service` path.

## Why

`Worktree.Service` still crossed through the public Promise facade with `Effect.promise(() => Session.findActiveWorktreeBinding(...))` when blocking remove/reset for active worktree sessions. This keeps the public facade for compatibility while making the production service boundary Effect-native.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the Worktree/Session layer wiring, especially whether `Worktree.defaultLayer` remains safe for the compatibility facades while `AppRuntime` also provides `Session.defaultLayer`.

## Risk Notes

The active-bound-session behavior and error message are intended to stay unchanged. Fresh-eye review had no P0/P1/P2 findings; its only P3 suggestion was to replace `Layer.suspend(() => Session.defaultLayer)` with direct `Session.defaultLayer`, but direct provide was tested and failed module initialization with `Cannot access 'defaultLayer' before initialization`, so the lazy layer is retained.

Skipped conditional checklist items: no visible UI or copy changes; no docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes beyond the tested worktree service behavior.

## How To Verify

```text
RED: bun test test/effect/legacy-boundaries.test.ts failed on the new Worktree Session facade guard because worktree/index.ts still called Session.findActiveWorktreeBinding(...).
Guardrail: bun test test/effect/legacy-boundaries.test.ts passed, 6 tests.
Focused behavior: bun test test/project/worktree.test.ts test/session/session.test.ts passed, 45 tests.
Focused remove/reset and guard: bun test test/project/worktree-remove.test.ts test/worktree/gitignore-guard.test.ts passed, 9 tests and 1 Windows-only skip.
Typecheck: GOMAXPROCS=2 bun run typecheck passed.
Diff check: git diff --check passed.
Fresh-eye review: no P0/P1/P2 findings; P3 direct-layer simplification not applied because it reproduced a module-initialization failure.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal session management architecture for worktree operations.

* **Tests**
  * Enhanced test coverage to ensure proper session boundary handling for worktree operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->