### PR TITLE
refactor(opencode): move websocket Hono host out of server entrypoint

### DIFF
--- a/packages/opencode/src/server/production-special.ts
+++ b/packages/opencode/src/server/production-special.ts
@@ -1,4 +1,3 @@
-import type { Hono } from "hono"
 import { AsyncQueue } from "@/util/queue"
 import { handleInstanceEventStream } from "./instance/event"
 import {
@@ -9,6 +8,7 @@ import {
 import { handleUIRequest } from "./ui"
 import { requestContextFromRequest, withRequestContext } from "./request-context"
 import { SyncEvent } from "@/sync"
+import type { WebSocketCompatibilityApp } from "./websocket-compatibility"
 
 export type ProductionSpecialHandler = {
   handle(request: Request, env?: unknown): Promise<Response | undefined>
@@ -29,7 +29,7 @@ export function isInstanceSpecialRequest(method: string, pathname: string) {
 }
 
 export function createProductionSpecialHandler(input: {
-  websocketCompatibilityApp: Hono
+  websocketCompatibilityApp: WebSocketCompatibilityApp
   globalRoutes?: GlobalRoutesOptions
 }): ProductionSpecialHandler {
   const globalRoutes = input.globalRoutes ?? {}

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,5 +1,4 @@
 import { adapter } from "#hono"
-import { Hono } from "hono"
 import { HTTPException } from "hono/http-exception"
 import { Option, Redacted } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -15,7 +14,7 @@ import { ServerAuth } from "./auth"
 import { initProjectors } from "./projectors"
 import { createProductionHttpApiDispatcher, isProductionHttpApiRequest } from "./production-httpapi"
 import { createProductionSpecialHandler } from "./production-special"
-import { createWebSocketCompatibilityApp } from "./websocket-compatibility"
+import { createWebSocketCompatibilityHost } from "./websocket-compatibility"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -165,7 +164,7 @@ async function maybeCompress(request: Request, response: Response) {
 }
 
 function create(opts: { cors?: string[] }) {
-  const websocketApp = new Hono()
+  const websocketCompatibilityHost = createWebSocketCompatibilityHost()
   let app: ServerApp
   const runtime = adapter.create(
     {
@@ -173,14 +172,13 @@ function create(opts: { cors?: string[] }) {
         return app.fetch(request, env)
       },
     },
-    websocketApp,
+    websocketCompatibilityHost.app,
   )
-  const websocketCompatibility = createWebSocketCompatibilityApp(runtime.upgradeWebSocket)
+  const websocketCompatibility = websocketCompatibilityHost.mount(runtime.upgradeWebSocket)
   const special = createProductionSpecialHandler({ websocketCompatibilityApp: websocketCompatibility })
   const dispatcher = createProductionHttpApiDispatcher(runtime.upgradeWebSocket, {
     specialHandler: special,
   })
-  websocketApp.route("/", websocketCompatibility)
 
   app = {
     async fetch(request, env) {

--- a/packages/opencode/src/server/websocket-compatibility.ts
+++ b/packages/opencode/src/server/websocket-compatibility.ts
@@ -4,10 +4,26 @@ import { PtyConnectCompatibilityRoutes } from "./instance/pty"
 import { AuthMiddleware, ErrorMiddleware } from "./middleware"
 import { WorkspaceWebSocketCompatibilityRoutes } from "./proxy"
 
+export type WebSocketCompatibilityApp = {
+  fetch: (request: Request, env?: unknown) => Response | Promise<Response>
+}
+
 export function createWebSocketCompatibilityApp(upgradeWebSocket: UpgradeWebSocket) {
   return new Hono()
     .onError(ErrorMiddleware)
     .use(AuthMiddleware)
     .route("/", WorkspaceWebSocketCompatibilityRoutes(upgradeWebSocket))
     .route("/pty", PtyConnectCompatibilityRoutes(upgradeWebSocket))
+}
+
+export function createWebSocketCompatibilityHost() {
+  const app = new Hono()
+  return {
+    app,
+    mount(upgradeWebSocket: UpgradeWebSocket): WebSocketCompatibilityApp {
+      const compatibilityApp = createWebSocketCompatibilityApp(upgradeWebSocket)
+      app.route("/", compatibilityApp)
+      return compatibilityApp
+    },
+  }
 }

--- a/packages/opencode/test/server/production-boundary.test.ts
+++ b/packages/opencode/test/server/production-boundary.test.ts
@@ -107,6 +107,19 @@ describe("production server boundary", () => {
     expect(server).not.toContain("compatibility.fetch")
   })
 
+  test("keeps the production server entrypoint free of direct Hono host construction", async () => {
+    const server = await readFile(path.join(import.meta.dir, "../../src/server/server.ts"), "utf8")
+    const websocketCompatibility = await readFile(
+      path.join(import.meta.dir, "../../src/server/websocket-compatibility.ts"),
+      "utf8",
+    )
+
+    expect(server).not.toMatch(/from\s+["']hono["']/)
+    expect(server).not.toMatch(/\bnew\s+Hono\s*\(/)
+    expect(websocketCompatibility).toMatch(/from\s+["']hono["']/)
+    expect(websocketCompatibility).toMatch(/\bnew\s+Hono\s*\(/)
+  })
+
   test("does not keep a legacy Hono documentation route tree", () => {
     const openapi = path.join(import.meta.dir, "../../src/server/openapi.ts")
 


### PR DESCRIPTION
## Summary

Moves the production WebSocket Hono placeholder host out of `server.ts` and into the WebSocket compatibility island.

## Why

The production server now dispatches ordinary HTTP/API requests through the Effect HttpApi dispatcher, but `server.ts` still directly imported Hono and constructed a Hono app only to host real WebSocket upgrade compatibility routes. This keeps that Hono construction in the WebSocket compatibility boundary while preserving the existing PTY and workspace WebSocket upgrade behavior.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the two-step WebSocket host construction: `server.ts` should remain free of direct Hono imports/construction, while `/pty/:ptyID/connect` and `/__workspace_ws` still mount through the compatibility app passed to the adapter.

## Risk Notes

No visible UI or copy changed, so the UI screenshot checklist item is left unticked. Runtime risk is limited to WebSocket compatibility host wiring; adapter code, ordinary HttpApi dispatch, SSE handling, and UI fallback behavior were not changed.

## How To Verify

```text
Boundary RED: the new production-boundary assertion failed before implementation on server.ts direct Hono import/construction.
bun test test/server/production-boundary.test.ts test/server/route-inventory-harness.test.ts: 35 pass.
bun test test/server/pty-routes.test.ts test/server/workspace-router.test.ts: 35 pass.
GOMAXPROCS=2 bun run typecheck: pass.
git diff --check: pass.
Fresh-eye review: Findings: none; no P0/P1/P2/P3 follow-up required.
```

## Screenshots or Recordings

Not required; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
