### PR TITLE
refactor(opencode): narrow adapter app contract

### DIFF
--- a/packages/opencode/src/server/adapter.bun.ts
+++ b/packages/opencode/src/server/adapter.bun.ts
@@ -1,9 +1,8 @@
-import type { Hono } from "hono"
 import { createBunWebSocket } from "hono/bun"
 import type { Adapter } from "./adapter"
 
 export const adapter: Adapter = {
-  create(app: Hono) {
+  create(app) {
     const ws = createBunWebSocket()
     return {
       upgradeWebSocket: ws.upgradeWebSocket,

--- a/packages/opencode/src/server/adapter.ts
+++ b/packages/opencode/src/server/adapter.ts
@@ -21,5 +21,6 @@ export type FetchApp = {
 }
 
 export interface Adapter {
-  create(app: Hono | FetchApp, websocketApp?: Hono): Runtime
+  create(app: FetchApp, websocketApp: Hono): Runtime
+  create(app: Hono): Runtime
 }

--- a/packages/opencode/test/server/production-boundary.test.ts
+++ b/packages/opencode/test/server/production-boundary.test.ts
@@ -120,6 +120,20 @@ describe("production server boundary", () => {
     expect(websocketCompatibility).toMatch(/\bnew\s+Hono\s*\(/)
   })
 
+  test("keeps the normal adapter app contract at the Web Fetch boundary", async () => {
+    const adapter = await readFile(path.join(import.meta.dir, "../../src/server/adapter.ts"), "utf8")
+    const nodeAdapter = await readFile(path.join(import.meta.dir, "../../src/server/adapter.node.ts"), "utf8")
+    const bunAdapter = await readFile(path.join(import.meta.dir, "../../src/server/adapter.bun.ts"), "utf8")
+
+    expect(adapter).toMatch(/create\(app:\s*FetchApp,\s*websocketApp:\s*Hono\):\s*Runtime/)
+    expect(adapter).toMatch(/create\(app:\s*Hono\):\s*Runtime/)
+    expect(adapter).not.toMatch(/create\(app:\s*Hono\s*\|\s*FetchApp/)
+    expect(adapter).not.toMatch(/create\(app:\s*FetchApp,\s*websocketApp\?:\s*Hono/)
+    expect(nodeAdapter).toMatch(/websocketApp\?:\s*Hono/)
+    expect(bunAdapter).not.toMatch(/from\s+["']hono["']/)
+    expect(bunAdapter).not.toMatch(/create\(app:\s*Hono/)
+  })
+
   test("does not keep a legacy Hono documentation route tree", () => {
     const openapi = path.join(import.meta.dir, "../../src/server/openapi.ts")
 


### PR DESCRIPTION
## Summary

Narrow the server adapter normal app contract from `Hono | FetchApp` to explicit Web Fetch overloads.

## Why

The production HTTP app already dispatches through Web Fetch. The adapter interface still exposed the normal app as `Hono | FetchApp`, which made the Hono compatibility boundary look wider than it is.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether the overloads express the intended boundary clearly: production HTTP uses `FetchApp + Hono websocket host`, while the `Hono` single-argument path remains only for real compatibility fallback.

## Risk Notes

Low. This is a type-contract cleanup with no route behavior change.

Skipped conditional checklist items:
- Visible UI/copy check: no visible UI or copy changed.
- Docs/release/dependencies/permissions/generated/local-file surfaces: none changed.

## How To Verify

```text
Focused server tests: 13 passed in bun test test/server/production-boundary.test.ts test/server/adapter-node-shutdown.test.ts
Typecheck: passed with GOMAXPROCS=2 bun run typecheck
Diff check: passed with git diff --check
Fresh-eye review: final pass reported No findings and no P0/P1/P2/P3
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

