### PR TITLE
refactor(opencode): narrow websocket adapter host boundary

### DIFF
--- a/packages/opencode/src/server/adapter.bun.ts
+++ b/packages/opencode/src/server/adapter.bun.ts
@@ -6,6 +6,7 @@ export const adapter: Adapter = {
     const ws = createBunWebSocket()
     return {
       upgradeWebSocket: ws.upgradeWebSocket,
+      mountWebSocketApp() {},
       async listen(opts) {
         const args = {
           fetch: app.fetch,

--- a/packages/opencode/src/server/adapter.node.ts
+++ b/packages/opencode/src/server/adapter.node.ts
@@ -1,14 +1,20 @@
 import { createAdaptorServer, type ServerType } from "@hono/node-server"
 import { createNodeWebSocket } from "@hono/node-ws"
-import type { Hono } from "hono"
+import { Hono } from "hono"
 import type { Socket } from "node:net"
-import type { Adapter } from "./adapter"
+import type { Adapter, FetchApp } from "./adapter"
 
 export const adapter: Adapter = {
-  create(app, websocketApp?: Hono) {
-    const ws = createNodeWebSocket({ app: websocketApp ?? (app as Hono) })
+  create(app) {
+    let websocketApp: FetchApp | undefined
+    const websocketHost = new Hono()
+    websocketHost.all("*", (c) => websocketApp?.fetch(c.req.raw, c.env) ?? c.notFound())
+    const ws = createNodeWebSocket({ app: websocketHost })
     return {
       upgradeWebSocket: ws.upgradeWebSocket,
+      mountWebSocketApp(app) {
+        websocketApp = app
+      },
       async listen(opts) {
         const start = (port: number) =>
           new Promise<ServerType>((resolve, reject) => {

--- a/packages/opencode/src/server/adapter.ts
+++ b/packages/opencode/src/server/adapter.ts
@@ -1,4 +1,3 @@
-import type { Hono } from "hono"
 import type { UpgradeWebSocket } from "hono/ws"
 
 export type Opts = {
@@ -13,6 +12,7 @@ export type Listener = {
 
 export interface Runtime {
   upgradeWebSocket: UpgradeWebSocket
+  mountWebSocketApp(app: FetchApp): void
   listen(opts: Opts): Promise<Listener>
 }
 
@@ -21,6 +21,5 @@ export type FetchApp = {
 }
 
 export interface Adapter {
-  create(app: FetchApp, websocketApp: Hono): Runtime
-  create(app: Hono): Runtime
+  create(app: FetchApp): Runtime
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -14,7 +14,7 @@ import { ServerAuth } from "./auth"
 import { initProjectors } from "./projectors"
 import { createProductionHttpApiDispatcher, isProductionHttpApiRequest } from "./production-httpapi"
 import { createProductionSpecialHandler } from "./production-special"
-import { createWebSocketCompatibilityHost } from "./websocket-compatibility"
+import { createWebSocketCompatibilityApp } from "./websocket-compatibility"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -164,17 +164,14 @@ async function maybeCompress(request: Request, response: Response) {
 }
 
 function create(opts: { cors?: string[] }) {
-  const websocketCompatibilityHost = createWebSocketCompatibilityHost()
   let app: ServerApp
-  const runtime = adapter.create(
-    {
-      fetch(request: Request, env?: unknown) {
-        return app.fetch(request, env)
-      },
+  const runtime = adapter.create({
+    fetch(request: Request, env?: unknown) {
+      return app.fetch(request, env)
     },
-    websocketCompatibilityHost.app,
-  )
-  const websocketCompatibility = websocketCompatibilityHost.mount(runtime.upgradeWebSocket)
+  })
+  const websocketCompatibility = createWebSocketCompatibilityApp(runtime.upgradeWebSocket)
+  runtime.mountWebSocketApp(websocketCompatibility)
   const special = createProductionSpecialHandler({ websocketCompatibilityApp: websocketCompatibility })
   const dispatcher = createProductionHttpApiDispatcher(runtime.upgradeWebSocket, {
     specialHandler: special,

--- a/packages/opencode/src/server/websocket-compatibility.ts
+++ b/packages/opencode/src/server/websocket-compatibility.ts
@@ -15,15 +15,3 @@ export function createWebSocketCompatibilityApp(upgradeWebSocket: UpgradeWebSock
     .route("/", WorkspaceWebSocketCompatibilityRoutes(upgradeWebSocket))
     .route("/pty", PtyConnectCompatibilityRoutes(upgradeWebSocket))
 }
-
-export function createWebSocketCompatibilityHost() {
-  const app = new Hono()
-  return {
-    app,
-    mount(upgradeWebSocket: UpgradeWebSocket): WebSocketCompatibilityApp {
-      const compatibilityApp = createWebSocketCompatibilityApp(upgradeWebSocket)
-      app.route("/", compatibilityApp)
-      return compatibilityApp
-    },
-  }
-}

--- a/packages/opencode/test/server/adapter-node-shutdown.test.ts
+++ b/packages/opencode/test/server/adapter-node-shutdown.test.ts
@@ -7,10 +7,15 @@ describe("node server adapter shutdown", () => {
       import { Hono } from "hono"
       import { adapter } from "./src/server/adapter.node.ts"
 
-      const app = new Hono()
+      const app = {
+        fetch() {
+          return new Response("not found", { status: 404 })
+        },
+      }
       const runtime = adapter.create(app)
 
-      app.get(
+      const websocketApp = new Hono()
+      websocketApp.get(
         "/ws",
         runtime.upgradeWebSocket(() => ({
           onOpen(_event, ws) {
@@ -18,6 +23,7 @@ describe("node server adapter shutdown", () => {
           },
         })),
       )
+      runtime.mountWebSocketApp(websocketApp)
 
       const listener = await runtime.listen({ port: 0, hostname: "127.0.0.1" })
       const socket = new WebSocket(\`ws://127.0.0.1:\${listener.port}/ws\`)

--- a/packages/opencode/test/server/adapter-node-shutdown.test.ts
+++ b/packages/opencode/test/server/adapter-node-shutdown.test.ts
@@ -8,8 +8,8 @@ describe("node server adapter shutdown", () => {
       import { adapter } from "./src/server/adapter.node.ts"
 
       const app = {
-        fetch() {
-          return new Response("not found", { status: 404 })
+        fetch(request) {
+          return new Response(\`main-fetch:\${new URL(request.url).pathname}\`)
         },
       }
       const runtime = adapter.create(app)
@@ -26,6 +26,12 @@ describe("node server adapter shutdown", () => {
       runtime.mountWebSocketApp(websocketApp)
 
       const listener = await runtime.listen({ port: 0, hostname: "127.0.0.1" })
+      const http = await fetch(\`http://127.0.0.1:\${listener.port}/health\`)
+      const httpText = await http.text()
+      if (http.status !== 200 || httpText !== "main-fetch:/health") {
+        throw new Error(\`HTTP listener did not use main FetchApp: \${http.status} \${httpText}\`)
+      }
+
       const socket = new WebSocket(\`ws://127.0.0.1:\${listener.port}/ws\`)
       const opened = new Promise((resolve, reject) => {
         socket.addEventListener("message", (event) => {

--- a/packages/opencode/test/server/production-boundary.test.ts
+++ b/packages/opencode/test/server/production-boundary.test.ts
@@ -120,16 +120,18 @@ describe("production server boundary", () => {
     expect(websocketCompatibility).toMatch(/\bnew\s+Hono\s*\(/)
   })
 
-  test("keeps the normal adapter app contract at the Web Fetch boundary", async () => {
+  test("keeps the adapter app contract at the Web Fetch boundary", async () => {
     const adapter = await readFile(path.join(import.meta.dir, "../../src/server/adapter.ts"), "utf8")
     const nodeAdapter = await readFile(path.join(import.meta.dir, "../../src/server/adapter.node.ts"), "utf8")
     const bunAdapter = await readFile(path.join(import.meta.dir, "../../src/server/adapter.bun.ts"), "utf8")
 
-    expect(adapter).toMatch(/create\(app:\s*FetchApp,\s*websocketApp:\s*Hono\):\s*Runtime/)
-    expect(adapter).toMatch(/create\(app:\s*Hono\):\s*Runtime/)
-    expect(adapter).not.toMatch(/create\(app:\s*Hono\s*\|\s*FetchApp/)
-    expect(adapter).not.toMatch(/create\(app:\s*FetchApp,\s*websocketApp\?:\s*Hono/)
-    expect(nodeAdapter).toMatch(/websocketApp\?:\s*Hono/)
+    expect(adapter).not.toMatch(/from\s+["']hono["']/)
+    expect(adapter).toMatch(/create\(app:\s*FetchApp\):\s*Runtime/)
+    expect(adapter).toMatch(/mountWebSocketApp\(app:\s*FetchApp\):\s*void/)
+    expect(adapter).not.toMatch(/create\(app:\s*Hono/)
+    expect(adapter).not.toMatch(/websocketApp:\s*Hono/)
+    expect(nodeAdapter).toMatch(/\bnew\s+Hono\s*\(/)
+    expect(nodeAdapter).not.toMatch(/create\(app,\s*websocketApp\?/)
     expect(bunAdapter).not.toMatch(/from\s+["']hono["']/)
     expect(bunAdapter).not.toMatch(/create\(app:\s*Hono/)
   })


### PR DESCRIPTION
## Summary

Move the production WebSocket compatibility host out of the server entrypoint and adapter public contract. The production server now registers a fetch-only WebSocket compatibility app with the runtime, while the Node adapter keeps the Hono host required by `@hono/node-ws` as a private implementation detail.

## Why

Related to #936.

The remaining production WebSocket compatibility surfaces (`/__workspace_ws` and `/pty/:ptyID/connect`) still need Hono's `upgradeWebSocket` helper, but ordinary production HTTP fetch should not depend on a Hono adapter host. This narrows the compatibility seam to the Node adapter instead of making `server.ts` construct and pass a Hono host app.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

Please focus on the Node adapter boundary: ordinary HTTP requests should continue to use the main `FetchApp`, while upgrade requests should resolve through the mounted WebSocket compatibility app. Also check that Bun keeps its existing fetch path behavior.

## Risk Notes

Platform behavior is relevant because the Node adapter owns desktop/server WebSocket upgrades. The remaining Hono dependency is intentional and limited to the Node adapter because `@hono/node-ws` requires a Hono `app.request()` host. No UI, docs, dependencies, permissions, generated files, or API/SDK contracts changed. The visible UI checklist item is left unticked because there is no UI or copy change.

## How To Verify

```text
Focused RED: production-boundary and adapter-node-shutdown failed before implementation because the adapter still exposed a Hono host contract and mountWebSocketApp did not exist.
Focused tests: 13 passed in test/server/production-boundary.test.ts and test/server/adapter-node-shutdown.test.ts.
Related tests: 100 passed across production-boundary, adapter-node-shutdown, auth, pty-routes, proxy, route-inventory-harness, workspace-router, and workspace-routing-decision.
Typecheck: GOMAXPROCS=2 bun run typecheck passed from packages/opencode.
Diff check: git diff --check passed from the repo root.
Fresh-eye review: no P0/P1; one P2 test-hardening suggestion was fixed in f0d8aa5309.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved server adapter architecture to enable more flexible WebSocket integration and reduce framework-specific type dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->