### PR TITLE
refactor(opencode): use ModelsDev service in provider list

### DIFF
--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -15,6 +15,7 @@ import { Storage } from "@/storage/storage"
 import { Snapshot } from "@/snapshot"
 import { Plugin } from "@/plugin"
 import { ModelState } from "@/provider/model-state"
+import { ModelsDev } from "@/provider/models"
 import { Provider } from "@/provider/provider"
 import { ProviderAuth } from "@/provider/auth"
 import { Agent } from "@/agent/agent"
@@ -70,6 +71,7 @@ export const AppLayer = Layer.mergeAll(
   Snapshot.defaultLayer,
   Plugin.defaultLayer,
   ModelState.defaultLayer,
+  ModelsDev.defaultLayer,
   Provider.defaultLayer,
   ProviderAuth.defaultLayer,
   Agent.defaultLayer,

--- a/packages/opencode/src/server/instance/provider-actions.ts
+++ b/packages/opencode/src/server/instance/provider-actions.ts
@@ -3,17 +3,20 @@ import { mapValues } from "remeda"
 import { Config } from "../../config/config"
 import { ModelState } from "../../provider/model-state"
 import { ModelsDev } from "../../provider/models"
+import { withPawWorkProviders } from "../../provider/pawwork-providers"
 import { ProviderAuth } from "../../provider/auth"
 import { Provider } from "../../provider/provider"
 import { ModelID, ProviderID } from "../../provider/schema"
 
 export const listProviders = Effect.fn("ProviderRoutes.list")(function* () {
   const config = yield* Config.Service
+  const modelsDev = yield* ModelsDev.Service
   const provider = yield* Provider.Service
-  const [configInfo, allProviders, connected] = yield* Effect.all(
-    [config.get(), Effect.promise(() => ModelsDev.get()), provider.list()],
-    { concurrency: 3 },
+  const [configInfo, modelsDevProviders, connected] = yield* Effect.all(
+    [config.get(), modelsDev.data().pipe(Effect.orDie), provider.list()],
+    { concurrency: "unbounded" },
   )
+  const allProviders = withPawWorkProviders(modelsDevProviders)
   const disabled = new Set(configInfo.disabled_providers ?? [])
   const enabled = configInfo.enabled_providers ? new Set(configInfo.enabled_providers) : undefined
 

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -74,3 +74,10 @@ test("Worktree service uses the Effect-native session active binding boundary", 
 
   expect(text).not.toContain("Session.findActiveWorktreeBinding(")
 })
+
+test("provider list route uses the ModelsDev service instead of the Promise facade", async () => {
+  const text = await readFile(path.join(srcRoot, "server/instance/provider-actions.ts"), "utf8")
+
+  expect(text).not.toContain("Effect.promise(() => ModelsDev.get())")
+  expect(text).not.toContain("ModelsDev.get()")
+})

--- a/packages/opencode/test/server/provider-routes.test.ts
+++ b/packages/opencode/test/server/provider-routes.test.ts
@@ -7,6 +7,7 @@ import { Effect, Layer } from "effect"
 import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiTest, OpenApi } from "effect/unstable/httpapi"
 import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
+import { VOLCENGINE_PLAN_DEFAULT_MODEL_ID, VOLCENGINE_PLAN_PROVIDER_ID } from "@opencode-ai/util/volcengine-plan"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { ProviderRoutes } from "../../src/server/instance/provider"
@@ -200,6 +201,8 @@ describe("provider routes", () => {
         expect(body.all).toBeArray()
         expect(body.default).toBeObject()
         expect(body.connected).toBeArray()
+        expect(body.all.some((provider: { id: string }) => provider.id === VOLCENGINE_PLAN_PROVIDER_ID)).toBe(true)
+        expect(body.default[VOLCENGINE_PLAN_PROVIDER_ID]).toBe(VOLCENGINE_PLAN_DEFAULT_MODEL_ID)
       },
     })
   })


### PR DESCRIPTION
## Summary

- Route provider listing through `ModelsDev.Service.data()` instead of the `ModelsDev.get()` Promise facade.
- Preserve PawWork provider overlays and default model mapping in the provider route output.
- Add guard coverage so the provider list route cannot regress to the ModelsDev Promise facade.

## Why

Related to #936.

The provider list route was already inside an Effect boundary, but still reached back to the ModelsDev async facade. This keeps the route effect-native while preserving existing config enabled/disabled filtering, connected provider merge, and PawWork local provider behavior.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

- Confirm the explicit `withPawWorkProviders(...)` overlay is the right behavior match for the old `ModelsDev.get()` facade.
- Confirm `ModelsDev.defaultLayer` belongs in `AppRuntime` now that the route yields `ModelsDev.Service`.
- Fresh-eye result: no P0/P1 findings and no P2/P3 changes recommended.

## Risk Notes

No visible UI/copy changes, platform/packaging changes, or docs/release/dependency/permission/generated/local file surfaces were touched; the related conditional checklist items are intentionally left unticked.

The main behavior risk is provider catalog parity. Provider route tests now assert the PawWork provider overlay and default model mapping, and the existing config/provider route suites still pass.

## How To Verify

```text
Focused route/boundary tests: 28 passed across provider-routes.test.ts, config-routes.test.ts, and legacy-boundaries.test.ts
Typecheck: GOMAXPROCS=2 bun run typecheck passed in packages/opencode
Diff check: git diff --check passed from the repository root
Fresh-eye review: no P0/P1 findings; no P2/P3 changes recommended
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
