### PR TITLE
refactor(opencode): narrow SSE event native boundary

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -450,7 +450,7 @@ function classify(input: {
   upstreamHttpApi: boolean
 }) {
   const key = `${input.method} ${input.path}`
-  if (isNativeSpecial(input.method, input.path) && input.hono && !input.localHttpApi) {
+  if (isNativeSpecial(input.method, input.path) && !input.localHttpApi) {
     return "production-native-special-surface"
   }
   if (isCompatibilityBoundary(input.method, input.path) && input.hono && !input.localHttpApi) {

--- a/packages/opencode/src/server/instance/event.ts
+++ b/packages/opencode/src/server/instance/event.ts
@@ -1,7 +1,4 @@
-import { Hono } from "hono"
-import { describeRoute, resolver } from "hono-openapi"
 import { Log } from "@opencode-ai/core/util/log"
-import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { AsyncQueue } from "../../util/queue"
 import { createSseResponse } from "../sse"
@@ -11,32 +8,6 @@ const DEFAULT_HEARTBEAT_MS = 10_000
 
 function normalizeHeartbeatMs(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : DEFAULT_HEARTBEAT_MS
-}
-
-export const EventRoutes = (options: { heartbeatMs?: number } = {}) => {
-  const heartbeatMs = normalizeHeartbeatMs(options.heartbeatMs)
-
-  return new Hono().get(
-    "/event",
-    describeRoute({
-      summary: "Subscribe to events",
-      description: "Get events",
-      operationId: "event.subscribe",
-      responses: {
-        200: {
-          description: "Event stream",
-          content: {
-            "text/event-stream": {
-              schema: resolver(BusEvent.payloads()),
-            },
-          },
-        },
-      },
-    }),
-    async (c) => {
-      return handleInstanceEventStream(c.req.raw, { heartbeatMs })
-    },
-  )
 }
 
 export function handleInstanceEventStream(request: Request, options: { heartbeatMs?: number } = {}) {

--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -3,7 +3,6 @@ import { describeRoute, resolver, validator } from "hono-openapi"
 import { Effect } from "effect"
 import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
-import { SyncEvent } from "@/sync"
 import { GlobalBus } from "@/bus/global"
 import { AppRuntime } from "@/effect/app-runtime"
 import { AsyncQueue } from "@/util/queue"
@@ -14,7 +13,6 @@ import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
 import { errors } from "../error"
 import { EventReplayStore, type GlobalEventEnvelope, type ReplayRecord } from "../event-replay"
-import { globalEventOpenApiSchema, globalSyncEventOpenApiSchema } from "../global-openapi-schema"
 import { requestContextFromHono, withRequestContext } from "@/server/request-context"
 import { createSseResponse } from "../sse"
 
@@ -343,26 +341,7 @@ export function handleGlobalSyncEventStream(
   return streamEvents(request, subscribe, heartbeatMs)
 }
 
-export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
-  const replayBridge = options.replayBridge ?? globalEventReplay
-  const heartbeatMs = normalizeHeartbeatMs(options.heartbeatMs)
-  const syncSubscribe =
-    options.syncSubscribe ??
-    ((q: AsyncQueue<string | null>) => {
-      return SyncEvent.subscribeAll(({ def, event }) => {
-        // TODO: don't pass def, just pass the type (and it should
-        // be versioned)
-        q.push(
-          JSON.stringify({
-            payload: {
-              ...event,
-              type: SyncEvent.versionedType(def.type, def.version),
-            },
-          }),
-        )
-      })
-    })
-
+export function createGlobalRoutes() {
   return new Hono()
     .use((c, next) => withRequestContext(requestContextFromHono(c, {}), () => next()))
     .get(
@@ -384,48 +363,6 @@ export function createGlobalRoutes(options: GlobalRoutesOptions = {}) {
       }),
       async (c) => {
         return c.json({ healthy: true, version: Installation.VERSION })
-      },
-    )
-    .get(
-      "/event",
-      describeRoute({
-        summary: "Get global events",
-        description: "Subscribe to global events from the OpenCode system using server-sent events.",
-        operationId: "global.event",
-        responses: {
-          200: {
-            description: "Event stream",
-            content: {
-              "text/event-stream": {
-                schema: resolver(globalEventOpenApiSchema()),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        return handleGlobalEventStream(c.req.raw, replayBridge, heartbeatMs)
-      },
-    )
-    .get(
-      "/sync-event",
-      describeRoute({
-        summary: "Subscribe to global sync events",
-        description: "Get global sync events",
-        operationId: "global.sync-event.subscribe",
-        responses: {
-          200: {
-            description: "Event stream",
-            content: {
-              "text/event-stream": {
-                schema: resolver(globalSyncEventOpenApiSchema()),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        return handleGlobalSyncEventStream(c.req.raw, syncSubscribe, heartbeatMs)
       },
     )
     .get(

--- a/packages/opencode/src/server/instance/index.ts
+++ b/packages/opencode/src/server/instance/index.ts
@@ -23,7 +23,6 @@ import { FileRoutes } from "./file"
 import { ConfigRoutes } from "./config"
 import { ExperimentalRoutes } from "./experimental"
 import { ProviderRoutes } from "./provider"
-import { EventRoutes } from "./event"
 import { MemoryRoutes } from "./memory"
 import { AutomationRoutes } from "./automation"
 import { WorkspaceRouterMiddleware } from "./middleware"
@@ -142,7 +141,6 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono =>
     .route("/memory", MemoryRoutes())
     .route("/automation", AutomationRoutes())
     .route("/", FileRoutes())
-    .route("/", EventRoutes())
     .route("/mcp", McpRoutes())
     .post(
       "/instance/dispose",

--- a/packages/opencode/src/server/routes/instance/event.ts
+++ b/packages/opencode/src/server/routes/instance/event.ts
@@ -1,1 +1,0 @@
-export { EventRoutes } from "../../instance/event"

--- a/packages/opencode/test/server/event-stream-routes.test.ts
+++ b/packages/opencode/test/server/event-stream-routes.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { Hono } from "hono"
 import z from "zod"
 import { Bus } from "../../src/bus"
 import { BusEvent } from "../../src/bus/bus-event"
 import { Instance } from "../../src/project/instance"
 import { EventReplayStore } from "../../src/server/event-replay"
-import { EventRoutes } from "../../src/server/instance/event"
-import { createGlobalEventReplayBridge, createGlobalRoutes } from "../../src/server/instance/global"
+import { handleInstanceEventStream } from "../../src/server/instance/event"
+import {
+  createGlobalEventReplayBridge,
+  handleGlobalEventStream,
+  handleGlobalSyncEventStream,
+} from "../../src/server/instance/global"
 import type { AsyncQueue } from "../../src/util/queue"
 import { tmpdir } from "../fixture/fixture"
 
@@ -116,13 +119,19 @@ async function readSseFrames(response: Response, count: number, timeoutMs = 2_00
   }
 }
 
+function globalEventResponse(
+  bridge: ReturnType<typeof createGlobalEventReplayBridge>,
+  init?: RequestInit,
+) {
+  return handleGlobalEventStream(new Request("http://localhost/global/event", init), bridge, 5)
+}
+
 describe("SSE event routes", () => {
   test("global event fresh connect seeds a replay cursor through the real route", async () => {
     const bridge = createGlobalEventReplayBridge({ replayStore: new EventReplayStore({ bootID: "boot" }) })
     bridge.append(envelope("permission.asked", "q1"))
-    const app = new Hono().route("/global", createGlobalRoutes({ replayBridge: bridge, heartbeatMs: 5 }))
 
-    const response = await app.request("/global/event")
+    const response = globalEventResponse(bridge)
 
     expectSseHeaders(response)
     const [connected] = await readSseFrames(response, 1)
@@ -135,9 +144,8 @@ describe("SSE event routes", () => {
     const bridge = createGlobalEventReplayBridge({ replayStore: new EventReplayStore({ bootID: "boot" }) })
     bridge.append(envelope("permission.asked", "q1"))
     bridge.append(envelope("permission.replied", "q1"))
-    const app = new Hono().route("/global", createGlobalRoutes({ replayBridge: bridge, heartbeatMs: 5 }))
 
-    const response = await app.request("/global/event", {
+    const response = globalEventResponse(bridge, {
       headers: { "Last-Event-ID": "boot:1" },
     })
 
@@ -156,9 +164,8 @@ describe("SSE event routes", () => {
     const bridge = createGlobalEventReplayBridge({ replayStore: new EventReplayStore({ bootID: "boot" }) })
     bridge.append(envelope("permission.asked", "q1"))
     bridge.append(envelope("permission.replied", "q1"))
-    const app = new Hono().route("/global", createGlobalRoutes({ replayBridge: bridge, heartbeatMs: 5 }))
 
-    const response = await app.request("/global/event", {
+    const response = globalEventResponse(bridge, {
       headers: { "last-event-id": "boot:1" },
     })
 
@@ -171,9 +178,8 @@ describe("SSE event routes", () => {
   test("global event stale cursor sends only a connected fence", async () => {
     const bridge = createGlobalEventReplayBridge({ replayStore: new EventReplayStore({ bootID: "boot" }) })
     bridge.append(envelope("permission.asked", "q1"))
-    const app = new Hono().route("/global", createGlobalRoutes({ replayBridge: bridge, heartbeatMs: 5 }))
 
-    const response = await app.request("/global/event", {
+    const response = globalEventResponse(bridge, {
       headers: { "Last-Event-ID": "old:1" },
     })
 
@@ -193,9 +199,8 @@ describe("SSE event routes", () => {
     })
     bridge.append(envelope("permission.asked", "q1"))
     bridge.append(envelope("permission.replied", "q1"))
-    const app = new Hono().route("/global", createGlobalRoutes({ replayBridge: bridge, heartbeatMs: 5 }))
 
-    const response = await app.request("/global/event", {
+    const response = globalEventResponse(bridge, {
       headers: { "Last-Event-ID": "boot:0" },
     })
 
@@ -212,8 +217,7 @@ describe("SSE event routes", () => {
 
   test("global event live replayable packets carry ids and heartbeat packets do not", async () => {
     const bridge = createGlobalEventReplayBridge({ replayStore: new EventReplayStore({ bootID: "boot" }) })
-    const app = new Hono().route("/global", createGlobalRoutes({ replayBridge: bridge, heartbeatMs: 5 }))
-    const response = await app.request("/global/event")
+    const response = globalEventResponse(bridge)
 
     const reader = createSseReader(response)
     try {
@@ -250,8 +254,7 @@ describe("SSE event routes", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const app = EventRoutes({ heartbeatMs: 5 })
-        const response = await app.request("/event")
+        const response = handleInstanceEventStream(new Request("http://localhost/event"), { heartbeatMs: 5 })
 
         expectSseHeaders(response)
         const reader = createSseReader(response)
@@ -276,18 +279,14 @@ describe("SSE event routes", () => {
   })
 
   test("global sync event route uses enveloped frames", async () => {
-    const app = new Hono().route(
-      "/global",
-      createGlobalRoutes({
-        heartbeatMs: 5,
-        syncSubscribe: (q: AsyncQueue<string | null>) => {
-          q.push(JSON.stringify({ payload: { type: "sync.fixture.1", id: "evt_1" } }))
-          return () => {}
-        },
-      }),
+    const response = handleGlobalSyncEventStream(
+      new Request("http://localhost/global/sync-event"),
+      (q: AsyncQueue<string | null>) => {
+        q.push(JSON.stringify({ payload: { type: "sync.fixture.1", id: "evt_1" } }))
+        return () => {}
+      },
+      5,
     )
-
-    const response = await app.request("/global/sync-event")
 
     expectSseHeaders(response)
     const [connected, fixture, heartbeat] = await readSseFrames(response, 3)

--- a/packages/opencode/test/server/global-event-replay.test.ts
+++ b/packages/opencode/test/server/global-event-replay.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test"
-import { Hono } from "hono"
 import { EventReplayStore } from "../../src/server/event-replay"
 import {
   createGlobalEventReplayBridge,
@@ -178,13 +177,15 @@ describe("createGlobalEventReplayBridge", () => {
   test("route reads Last-Event-ID and writes replay ids into SSE output", async () => {
     const bridge = createGlobalEventReplayBridge({ replayStore: new EventReplayStore({ bootID: "boot" }) })
     bridge.append(envelope("permission.asked", "q1"))
-    const app = new Hono().get("/event", (c) => handleGlobalEventStream(c.req.raw, bridge))
     const controller = new AbortController()
 
-    const response = await app.request("/event", {
-      headers: { "Last-Event-ID": "boot:0" },
-      signal: controller.signal,
-    })
+    const response = handleGlobalEventStream(
+      new Request("http://localhost/global/event", {
+        headers: { "Last-Event-ID": "boot:0" },
+        signal: controller.signal,
+      }),
+      bridge,
+    )
     expect(response.status).toBe(200)
     const text = await readSseUntil(response, (value) => value.includes("permission.asked"))
     controller.abort()

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -454,10 +454,9 @@ describe("route inventory harness", () => {
       ["GET", "/event", "SSE/event"],
       ["GET", "/global/event", "SSE/event"],
       ["GET", "/global/sync-event", "SSE/event"],
-      ["ALL", "/*", "UI static route"],
     ] as const) {
       expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
-        hono: true,
+        hono: false,
         localHttpApi: false,
         nativeSpecial: true,
         compatibilityBoundary: false,
@@ -465,6 +464,15 @@ describe("route inventory harness", () => {
         specialSurface,
       })
     }
+
+    expect(inventory.rows.find((row) => row.method === "ALL" && row.path === "/*")).toMatchObject({
+      hono: true,
+      localHttpApi: false,
+      nativeSpecial: true,
+      compatibilityBoundary: false,
+      classification: "production-native-special-surface",
+      specialSurface: "UI static route",
+    })
 
     for (const [method, routePath, specialSurface] of [
       ["GET", "/pty/:ptyID/connect", "PTY websocket"],


### PR DESCRIPTION
## Summary

Remove the legacy Hono route wrappers for the three SSE event streams and keep them as explicit production-native special surfaces.

## Why

The production server already serves `/event`, `/global/event`, and `/global/sync-event` through direct native SSE handlers. Keeping the old Hono route definitions made the route inventory report these streams as Hono-owned HTTP boundaries, which blurred the #936 migration state.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please check that the SSE handlers remain direct native special boundaries, not fake HttpApi wrappers, and that the route inventory continues to distinguish SSE from UI static routing and WebSocket compatibility.

Fresh-eye result: independent read-only review found no P0/P1/P2 issues. One P3 suggested removing an unused legacy wrapper, which is included in this PR and reverified.

## Risk Notes

The main risk is accidentally dropping SSE compatibility while removing the legacy Hono route shells. Focused SSE, production-boundary, OpenAPI-source, route-inventory, and typecheck coverage passed on the final diff.

Skipped conditional checklist items:

- Visible UI/copy check: not applicable; this PR has no visible UI or copy change.
- Platform/packaging check: not applicable; this PR does not touch platform, packaging, updater, signing, paths, shell, or permissions behavior.
- Docs/release/dependency/credential/generated-content check: not applicable; no tracked docs, release notes, dependencies, permissions, credentials, or generated files changed.

## How To Verify

```text
Focused server tests: 88 passed
  bun test test/server/route-inventory-harness.test.ts test/server/event-stream-routes.test.ts test/server/global-event-replay.test.ts test/server/production-boundary.test.ts test/server/control-routes.test.ts test/server/global-config-routes.test.ts test/session/run-state.test.ts

OpenAPI event coverage: 8 passed
  bun test test/server/openapi-generation-source.test.ts test/server/control-routes.test.ts --test-name-pattern "event|OpenAPI|generated"

Route inventory: ok, regenerated local ignored report
  bun run route:inventory

Typecheck: ok
  bun run typecheck

Diff check: no whitespace errors
  git diff --check
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
