### PR TITLE
fix(opencode): parse multiline SDK route calls

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -315,7 +315,7 @@ async function readOpenApiRoutes(root: string): Promise<Route[]> {
 
 export function parseSdkRoutesFromText(text: string, source: string): Route[] {
   const routes: Route[] = []
-  const routePattern = /\.(get|post|put|patch|delete)(?:\.sse)?<[^>]*>\(\{\s*url:\s*(["'`])([^"'`]+)\2/g
+  const routePattern = /\.(get|post|put|patch|delete)(?:\.sse)?<[^>]*>\(\s*\{\s*url:\s*(["'`])([^"'`]+)\2/g
   for (const match of text.matchAll(routePattern)) {
     routes.push({ method: match[1]!.toUpperCase(), path: normalizePath(match[3]!), source })
   }

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -117,6 +117,16 @@ describe("route inventory harness", () => {
       localHttpApi: true,
       classification: "pawwork-owned",
     })
+    expect(
+      inventory.rows.find((row) => row.method === "POST" && row.path === "/mcp/:name/auth/authenticate"),
+    ).toMatchObject({
+      hono: true,
+      openapi: true,
+      legacySdk: true,
+      v2Sdk: true,
+      localHttpApi: true,
+      classification: "all-public-surfaces",
+    })
   })
 
   test("tracks local HttpApi migration coverage for ordinary JSON file, project, memory, and external-result routes", async () => {
@@ -420,6 +430,11 @@ describe("route inventory harness", () => {
       client.delete<Response>({
         url: \`/pty/{id}\`,
       })
+      client.post<Response, Error>(
+        {
+          url: "/mcp/{name}/auth/authenticate",
+        },
+      )
       `,
       "fixture.ts",
     )
@@ -427,6 +442,11 @@ describe("route inventory harness", () => {
     expect(routes).toContainEqual({ method: "GET", path: "/config", source: "fixture.ts" })
     expect(routes).toContainEqual({ method: "POST", path: "/session/:sessionID/message", source: "fixture.ts" })
     expect(routes).toContainEqual({ method: "DELETE", path: "/pty/:ptyID", source: "fixture.ts" })
+    expect(routes).toContainEqual({
+      method: "POST",
+      path: "/mcp/:name/auth/authenticate",
+      source: "fixture.ts",
+    })
   })
 
   test("distinguishes non-product Hono and v2 SDK routes from Hono-only routes", async () => {


### PR DESCRIPTION
## Summary

Fix the route inventory SDK parser so it counts generated SDK calls whose request object starts on the line after the HTTP method call. This makes `POST /mcp/:name/auth/authenticate` show as covered by both legacy and v2 SDK surfaces instead of `unknown`.

## Why

The MCP authenticate route already exists in Hono, the checked-in OpenAPI document, local HttpApi, upstream HttpApi, and both generated SDKs. The inventory parser only matched SDK calls written as `.post<...>({ url: ... })`, so it missed the generated `.post<...>(\n  { url: ... }\n)` shape and reported a false coverage gap.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the SDK parser broadening is narrow enough and whether the MCP authenticate inventory assertion correctly proves the route is no longer an unknown coverage gap.

## Risk Notes

No product, OAuth, request/response, dependency, generated artifact, or UI behavior changes. Conditional checklist items skipped because this PR does not touch visible UI/copy, platform/packaging behavior, or generated outputs.

Fresh-eye result: independent reviewer found no P0/P1/P2/P3 issues and agreed this is the smallest correct fix. The reviewer verified that both SDK files already contain the MCP authenticate helper and the old parser only missed the multiline object form.

## How To Verify

```text
RED: bun test test/server/route-inventory-harness.test.ts failed on the new parser fixture because POST /mcp/:name/auth/authenticate was not parsed from method<...>(\n  { url }) format.
MCP routes: bun test test/server/mcp-routes.test.ts -> 9 pass.
Harness/source: bun test test/server/route-inventory-harness.test.ts test/server/openapi-generation-source.test.ts -> 33 pass.
Inventory: bun run route:inventory -> target row reports legacy SDK yes, v2 SDK yes, classification all-public-surfaces.
Typecheck: GOMAXPROCS=2 bun run typecheck -> tsgo --noEmit passed.
Diff check: git diff --check -> passed.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MCP authentication endpoint (POST /mcp/:name/auth/authenticate).

* **Tests**
  * Enhanced test coverage for SDK route detection and endpoint registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->