### PR TITLE
fix(opencode): retire legacy Hono doc source

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -465,6 +465,7 @@ function classify(input: {
   if (input.hono && input.v2Sdk && !input.openapi) return "hono-v2-sdk"
   if (input.hono && !input.openapi) return "hono-only"
   if (!input.hono && input.localHttpApi && input.upstreamHttpApi) return "local-httpapi-upstream-only"
+  if (!input.hono && input.localHttpApi) return "local-httpapi-only"
   if (!input.hono && input.upstreamHttpApi) return "onlyHttpApi"
   if (input.openapi && !input.hono) return "openapi-only"
   if (input.legacySdk || input.v2Sdk) return "sdk-only"

--- a/packages/opencode/src/server/control/index.ts
+++ b/packages/opencode/src/server/control/index.ts
@@ -2,7 +2,7 @@ import { Auth } from "@/auth"
 import { Log } from "@opencode-ai/core/util/log"
 import { ProviderID } from "@/provider/schema"
 import { Hono } from "hono"
-import { describeRoute, resolver, validator, openAPIRouteHandler } from "hono-openapi"
+import { describeRoute, resolver, validator } from "hono-openapi"
 import z from "zod"
 import { errors } from "../error"
 import { GlobalRoutes } from "../instance/global"
@@ -72,19 +72,6 @@ export function ControlPlaneRoutes(): Hono {
         await Auth.remove(providerID)
         return c.json(true)
       },
-    )
-    .get(
-      "/doc",
-      openAPIRouteHandler(app, {
-        documentation: {
-          info: {
-            title: "opencode",
-            version: "0.0.3",
-            description: "opencode api",
-          },
-          openapi: "3.1.1",
-        },
-      }),
     )
     .use(
       validator(

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -259,11 +259,13 @@ describe("route inventory harness", () => {
       specialSurface: "PTY websocket",
       compatibilityBoundary: true,
     })
-    expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/doc")).toMatchObject({
-      hono: true,
+    const doc = inventory.rows.find((row) => row.method === "GET" && row.path === "/doc")
+    expect(doc).toMatchObject({
+      hono: false,
       localHttpApi: true,
       specialSurface: "OpenAPI source",
     })
+    expect(doc?.classification).toMatch(/^local-httpapi-(?:only|upstream-only)$/)
     expect(
       inventory.rows.find((row) => row.method === "POST" && row.path === "/permission/__e2e/ask"),
     ).toMatchObject({


### PR DESCRIPTION
## Summary

- Remove the legacy Hono `GET /doc` handler from `ControlPlaneRoutes` so the documentation route no longer has an old Hono source boundary.
- Keep production `/doc` served by `ProductionApi` / `controlOpenApi()` and classify the inventory row as a local HttpApi-only OpenAPI source.

## Why

`GET /doc` already serves the production OpenAPI document through the Effect HttpApi path, but the old Hono route declaration kept route inventory reporting it as `hono-only`. This closes that source-boundary mismatch without regenerating SDK artifacts or touching unrelated MCP, UI, WebSocket, SSE, or ordinary JSON routes.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

- Confirm `/doc` still returns the same production OpenAPI JSON through `ProductionApi` / `controlOpenApi()`.
- Confirm route inventory now treats `/doc` as local HttpApi-only and no longer as `hono-only`.
- Confirm this stays limited to the `/doc` source boundary and does not change SDK generation or MCP parser behavior.

## Risk Notes

Low. This removes a stale Hono documentation handler that production no longer mounts and keeps the existing production Effect HttpApi handler intact. No UI, copy, platform, dependency, generated SDK, release note, credential, permission, deletion, or committed docs surface changed. `bun run route:inventory` regenerated the local ignored research report for verification only; it is not staged.

Skipped conditional checklist items:
- Visible UI or copy check: no visible UI or copy changed.
- macOS/Windows platform check: no platform, packaging, updater, signing, path, shell, or permission surface changed.
- Docs/release/dependency/generated-content callout: no committed docs, release notes, dependency, or generated content changed.

## How To Verify

```text
Focused server tests: `bun test test/server/openapi-generation-source.test.ts test/server/production-boundary.test.ts test/server/route-inventory-harness.test.ts` passed, 45 pass / 0 fail.
Route inventory: `bun run route:inventory` passed; `/doc` is now Hono=no, Local HttpApi=yes, classification=`local-httpapi-only`, special surface=`OpenAPI source`.
Typecheck: `GOMAXPROCS=2 bun run typecheck` passed.
Whitespace: `git diff --check` passed.
Fresh-eye review: independent reviewer reported no P0/P1 findings and no P2/P3 findings.
```

## Screenshots or Recordings

Not applicable. No visible UI changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
