### PR TITLE
refactor(opencode): retire ModelState recent facade

### DIFF
--- a/packages/opencode/src/provider/model-state.test.ts
+++ b/packages/opencode/src/provider/model-state.test.ts
@@ -1,8 +1,8 @@
-import fs from "fs/promises"
 import path from "path"
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Global } from "@opencode-ai/core/global"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import { testEffect } from "../../test/lib/effect"
 import { ModelState } from "./model-state"
 
@@ -48,65 +48,67 @@ describe("applyRecent", () => {
   })
 })
 
-describe("recordRecent", () => {
-  // Global.Path.state is the process-wide state dir (isolated per test process by
-  // the XDG override in test/preload.ts). Clear model.json around each test.
-  const modelFile = () => path.join(Global.Path.state, "model.json")
-
-  beforeEach(async () => {
-    await fs.mkdir(Global.Path.state, { recursive: true })
-    await fs.rm(modelFile(), { force: true })
-  })
-  afterEach(async () => await fs.rm(modelFile(), { force: true }))
-
-  test("promotes the model while preserving sibling state on a normal file", async () => {
-    await fs.writeFile(modelFile(), JSON.stringify({ recent: [other], favorite: ["x"], variant: { agent: "fast" } }))
-    await ModelState.recordRecent(model)
-    const after = JSON.parse(await fs.readFile(modelFile(), "utf8"))
-    expect(after.recent[0]).toEqual(model)
-    expect(after.favorite).toEqual(["x"])
-    expect(after.variant).toEqual({ agent: "fast" })
-  })
-
-  test("creates the file from empty when it is missing (ENOENT)", async () => {
-    await ModelState.recordRecent(model)
-    const after = JSON.parse(await fs.readFile(modelFile(), "utf8"))
-    expect(after.recent).toEqual([model])
-  })
-
-  test("does NOT overwrite a file it cannot parse, so sibling state survives", async () => {
-    // A non-ENOENT read failure (here, corrupt JSON) must skip the write rather
-    // than clobber a file that may still hold favorite/variant under the damage.
-    await fs.writeFile(modelFile(), "{ not valid json")
-    await ModelState.recordRecent(model)
-    expect(await fs.readFile(modelFile(), "utf8")).toBe("{ not valid json")
-  })
-})
-
 describe("ModelState.Service.recordRecent", () => {
   const modelFile = () => path.join(Global.Path.state, "model.json")
-  const run = testEffect(ModelState.defaultLayer)
+  const run = testEffect(Layer.merge(ModelState.defaultLayer, AppFileSystem.defaultLayer))
 
-  beforeEach(async () => {
-    await fs.mkdir(Global.Path.state, { recursive: true })
-    await fs.rm(modelFile(), { force: true })
-  })
-  afterEach(async () => await fs.rm(modelFile(), { force: true }))
+  const withCleanModelFile = <A, E, R>(body: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      yield* fs.makeDirectory(Global.Path.state, { recursive: true })
+      yield* fs.remove(modelFile()).pipe(Effect.ignore)
+      yield* Effect.addFinalizer(() => fs.remove(modelFile()).pipe(Effect.ignore))
+      return yield* body
+    })
 
   run.live(
-    "promotes the model through the Effect service while preserving sibling state",
-    Effect.gen(function* () {
-      yield* Effect.promise(() =>
-        fs.writeFile(modelFile(), JSON.stringify({ recent: [other], favorite: ["x"], variant: { agent: "fast" } })),
-      )
+    "promotes the model while preserving sibling state on a normal file",
+    withCleanModelFile(
+      Effect.gen(function* () {
+        const fs = yield* AppFileSystem.Service
+        yield* fs.writeWithDirs(
+          modelFile(),
+          JSON.stringify({ recent: [other], favorite: ["x"], variant: { agent: "fast" } }),
+        )
 
-      const service = yield* ModelState.Service
-      yield* service.recordRecent(model)
+        const service = yield* ModelState.Service
+        yield* service.recordRecent(model)
 
-      const after = yield* Effect.promise(() => fs.readFile(modelFile(), "utf8").then(JSON.parse))
-      expect(after.recent[0]).toEqual(model)
-      expect(after.favorite).toEqual(["x"])
-      expect(after.variant).toEqual({ agent: "fast" })
-    }),
+        const after = JSON.parse(yield* fs.readFileString(modelFile()))
+        expect(after.recent[0]).toEqual(model)
+        expect(after.favorite).toEqual(["x"])
+        expect(after.variant).toEqual({ agent: "fast" })
+      }),
+    ),
+  )
+
+  run.live(
+    "creates the file from empty when it is missing (ENOENT)",
+    withCleanModelFile(
+      Effect.gen(function* () {
+        const fs = yield* AppFileSystem.Service
+        const service = yield* ModelState.Service
+
+        yield* service.recordRecent(model)
+
+        const after = JSON.parse(yield* fs.readFileString(modelFile()))
+        expect(after.recent).toEqual([model])
+      }),
+    ),
+  )
+
+  run.live(
+    "does NOT overwrite a file it cannot parse, so sibling state survives",
+    withCleanModelFile(
+      Effect.gen(function* () {
+        const fs = yield* AppFileSystem.Service
+        yield* fs.writeWithDirs(modelFile(), "{ not valid json")
+
+        const service = yield* ModelState.Service
+        yield* service.recordRecent(model)
+
+        expect(yield* fs.readFileString(modelFile())).toBe("{ not valid json")
+      }),
+    ),
   )
 })

--- a/packages/opencode/src/provider/model-state.ts
+++ b/packages/opencode/src/provider/model-state.ts
@@ -3,7 +3,6 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Global } from "@opencode-ai/core/global"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { Context, Effect, Layer } from "effect"
-import { makeRuntime } from "../effect/run-service"
 import { isRecord } from "../util/record"
 
 /**
@@ -87,17 +86,4 @@ export namespace ModelState {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(EffectFlock.defaultLayer), Layer.provide(AppFileSystem.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  /**
-   * Best-effort, locked read-modify-write. Only a missing file (ENOENT) starts
-   * from empty; any other read failure skips the write so sibling state (favorite,
-   * variant, …) is never clobbered. The temp-file + rename keeps the unlocked
-   * `defaultModel()` reader from ever seeing a half-written file, and failures
-   * never reach the caller.
-   */
-  export async function recordRecent(model: ModelRef): Promise<void> {
-    return runPromise((svc) => svc.recordRecent(model))
-  }
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -3,6 +3,7 @@ import { readdir, readFile } from "fs/promises"
 import path from "path"
 
 const srcRoot = path.resolve(import.meta.dir, "../../src")
+const testRoot = path.resolve(import.meta.dir, "..")
 
 async function sourceFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true })
@@ -80,4 +81,13 @@ test("provider list route uses the ModelsDev service instead of the Promise faca
 
   expect(text).not.toContain("Effect.promise(() => ModelsDev.get())")
   expect(text).not.toContain("ModelsDev.get()")
+})
+
+test("ModelState recent writes stay on the Effect service boundary", async () => {
+  const service = await readFile(path.join(srcRoot, "provider/model-state.ts"), "utf8")
+  const providerTest = await readFile(path.join(testRoot, "provider/provider.test.ts"), "utf8")
+
+  expect(service).not.toContain("makeRuntime(Service, defaultLayer)")
+  expect(service).not.toContain("export async function recordRecent")
+  expect(providerTest).not.toContain("ModelState.recordRecent(")
 })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -76,6 +76,10 @@ async function defaultModel() {
   return run((provider) => provider.defaultModel())
 }
 
+async function recordRecent(model: ModelState.ModelRef) {
+  return AppRuntime.runPromise(ModelState.Service.use((modelState) => modelState.recordRecent(model)))
+}
+
 async function readAuthSnapshot() {
   try {
     return await Filesystem.readText(path.join(Global.Path.data, "auth.json"))
@@ -757,7 +761,7 @@ test("defaultModel returns a model seeded into recent via recordRecent (model.js
         const fallback = await defaultModel()
         // Seed the OTHER model — the one defaultModel would not pick on its own.
         const other = String(fallback.modelID) === "model-a" ? "model-b" : "model-a"
-        await ModelState.recordRecent({ providerID: ProviderID.make("custom-openai"), modelID: ModelID.make(other) })
+        await recordRecent({ providerID: ProviderID.make("custom-openai"), modelID: ModelID.make(other) })
         const after = await defaultModel()
         expect(String(after.providerID)).toBe("custom-openai")
         expect(String(after.modelID)).toBe(other)


### PR DESCRIPTION
## Summary

Retire the `ModelState.recordRecent(...)` Promise facade now that the production route helper uses `ModelState.Service` directly.

- Remove the per-service `makeRuntime(Service, defaultLayer)` bridge from `provider/model-state.ts`.
- Convert direct tests to the Effect service runtime/harness.
- Add a legacy-boundary guardrail so the ModelState recent write path stays service-native.

## Why

Related to #936.

`AppRuntime` now owns the service DAG, and `server/instance/provider-actions.ts` already records recent model picks through `ModelState.Service`. The remaining async facade was only keeping test callers on the old Promise boundary.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please check that the cleanup stays limited to the ModelState recent-write facade and that `ModelState.Service.recordRecent(...)` still preserves the existing best-effort write behavior: missing-file handling, corrupt-file no-clobber behavior, locked temp write/rename, sibling state preservation, recent dedupe, and cap semantics.

## Risk Notes

Behavior risk is limited to recent-model state writes, covered by direct service tests, the provider default-model round-trip, and the live `/provider/recent` route test. No visible UI/copy, platform/packaging, docs/release notes, dependencies, permissions, credentials, generated files, or deletion behavior changed.

Fresh-eye result: no P0, P1, or P2 findings. One P3 readability issue was fixed by wrapping a long test fixture line before PR creation.

Skipped conditional checklist items: visible UI/copy manual check is not applicable; platform/packaging impact is not applicable; docs/release notes/dependencies/permissions/credentials/deletion/generated-content callouts are not applicable.

## How To Verify

```text
RED guardrail: bun test test/effect/legacy-boundaries.test.ts failed before implementation because provider/model-state.ts still contained makeRuntime(Service, defaultLayer).
Focused tests: bun test src/provider/model-state.test.ts test/provider/provider.test.ts test/server/provider-recent-route.test.ts test/effect/legacy-boundaries.test.ts -> 129 pass, 0 fail.
Typecheck: GOMAXPROCS=2 bun run typecheck -> tsgo --noEmit passed.
Diff check: git diff --check -> passed with no whitespace errors.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal model state management to use effect-driven architecture with improved service boundaries and cleaner separation of concerns.

* **Tests**
  * Updated test suite to align with new effect-based approach; added boundary tests to enforce architectural constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->