### PR TITLE
refactor(opencode): retire memory external-result Hono sources

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -68,11 +68,9 @@ const honoRouteSources = [
   ["packages/opencode/src/server/instance/config.ts", "/config"],
   ["packages/opencode/src/server/instance/event.ts", ""],
   ["packages/opencode/src/server/instance/experimental.ts", "/experimental"],
-  ["packages/opencode/src/server/instance/external-result.ts", "/external-result"],
   ["packages/opencode/src/server/instance/file.ts", ""],
   ["packages/opencode/src/server/instance/index.ts", ""],
   ["packages/opencode/src/server/instance/mcp.ts", "/mcp"],
-  ["packages/opencode/src/server/instance/memory.ts", "/memory"],
   ["packages/opencode/src/server/instance/permission.ts", "/permission"],
   ["packages/opencode/src/server/instance/project.ts", "/project"],
   ["packages/opencode/src/server/instance/provider.ts", "/provider"],
@@ -456,6 +454,7 @@ function classify(input: {
     return "adapter-compatibility-boundary"
   }
   if (explicitlyDeferred.some((pattern) => pattern.test(key) || pattern.test(input.path))) return "explicitly-deferred"
+  if (pawworkOwned.has(key) && !input.hono && input.localHttpApi) return "pawwork-owned"
   if (pawworkOwned.has(key) && input.hono && !input.openapi && !input.legacySdk && input.v2Sdk) {
     return "pawwork-owned-sdk-v2-only"
   }

--- a/packages/opencode/src/server/instance/external-result.ts
+++ b/packages/opencode/src/server/instance/external-result.ts
@@ -1,14 +1,9 @@
-import { Hono } from "hono"
-import { describeRoute, resolver } from "hono-openapi"
 import { Cause, Effect } from "effect"
-import z from "zod"
 import { Session } from "@/session"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionID, MessageID } from "@/session/schema"
 import { ExternalResult } from "@/tool/external-result"
-import { lazy } from "../../util/lazy"
 import { Log } from "@opencode-ai/core/util/log"
-import { AppRuntime } from "@/effect/app-runtime"
 
 const log = Log.create({ service: "server" })
 
@@ -19,13 +14,11 @@ const log = Log.create({ service: "server" })
 // `message.part.updated` SSE event, which is intentionally not in the
 // event-replay buffer (high-volume streaming type), so any reload past the
 // SSE cursor loses the dock. Served at `GET /external-result`.
-const PendingExternalResult = z.object({
-  session: Session.Info,
-  message: MessageV2.Info,
-  part: MessageV2.Part,
-})
-
-const runExternalResultRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
+type PendingExternalResult = {
+  session: Session.Info
+  message: MessageV2.Info
+  part: MessageV2.Part
+}
 
 const readMessage = Effect.fn("ExternalResultRoutes.message.get")(function* (input: {
   sessionID: SessionID
@@ -77,12 +70,12 @@ const hydratePendingExternalResult = Effect.fn("ExternalResultRoutes.hydrate")(f
   // reducer does not upsert session info).
   const pending = yield* readMessageWithPendingToolPart({ sessionID, messageID, callID: snap.callID })
   if (!pending) return
-  return { session, message: pending.message.info, part: pending.part } satisfies z.infer<typeof PendingExternalResult>
+  return { session, message: pending.message.info, part: pending.part } satisfies PendingExternalResult
 })
 
 export const listPendingExternalResults = Effect.fn("ExternalResultRoutes.list")(function* () {
   const sessions = yield* Session.Service
-  const out: Array<z.infer<typeof PendingExternalResult>> = []
+  const out: PendingExternalResult[] = []
   for (const snap of ExternalResult.list()) {
     const result = yield* hydratePendingExternalResult(sessions, snap).pipe(
       Effect.catchCause((cause) =>
@@ -105,29 +98,3 @@ export const listPendingExternalResults = Effect.fn("ExternalResultRoutes.list")
   }
   return out
 })
-
-export const ExternalResultRoutes = lazy(() =>
-  new Hono().get(
-    "/",
-    describeRoute({
-      summary: "List pending external-result tool calls",
-      description:
-        "Return the (session, message, part) trio for every external-result Deferred currently awaiting a user response. Used by the app to hydrate the dock after reload / cold-open.",
-      operationId: "externalResult.list",
-      responses: {
-        200: {
-          description: "Pending external-result tool calls",
-          content: {
-            "application/json": {
-              schema: resolver(PendingExternalResult.array()),
-            },
-          },
-        },
-      },
-    }),
-    async (c) => {
-      const out = await runExternalResultRoute(listPendingExternalResults())
-      return c.json(out)
-    },
-  ),
-)

--- a/packages/opencode/src/server/instance/index.ts
+++ b/packages/opencode/src/server/instance/index.ts
@@ -13,7 +13,6 @@ import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Runtime } from "@opencode-ai/core/runtime"
 import { LSP } from "../../lsp"
 import { Command } from "../../command"
-import { ExternalResultRoutes } from "./external-result"
 import { PermissionRoutes } from "./permission"
 import { ProjectRoutes } from "./project"
 import { SessionRoutes } from "./session"
@@ -23,7 +22,6 @@ import { FileRoutes } from "./file"
 import { ConfigRoutes } from "./config"
 import { ExperimentalRoutes } from "./experimental"
 import { ProviderRoutes } from "./provider"
-import { MemoryRoutes } from "./memory"
 import { AutomationRoutes } from "./automation"
 import { WorkspaceRouterMiddleware } from "./middleware"
 import { AppRuntime } from "@/effect/app-runtime"
@@ -136,9 +134,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono =>
     .route("/experimental", ExperimentalRoutes())
     .route("/session", SessionRoutes())
     .route("/permission", PermissionRoutes())
-    .route("/external-result", ExternalResultRoutes())
     .route("/provider", ProviderRoutes())
-    .route("/memory", MemoryRoutes())
     .route("/automation", AutomationRoutes())
     .route("/", FileRoutes())
     .route("/mcp", McpRoutes())

--- a/packages/opencode/src/server/instance/memory.ts
+++ b/packages/opencode/src/server/instance/memory.ts
@@ -1,17 +1,6 @@
-import { Hono } from "hono"
-import { describeRoute, resolver, validator } from "hono-openapi"
 import { Effect } from "effect"
-import z from "zod"
 import { Instance } from "@/project/instance"
 import { MemoryService } from "@/memory/service"
-import { AppRuntime } from "@/effect/app-runtime"
-
-const MemoryRawInput = z.object({ content: z.string() }).meta({ ref: "MemoryRawInput" })
-const MemoryDisabledInput = z.object({ disabled: z.boolean() }).meta({ ref: "MemoryDisabledInput" })
-
-const MemoryState = z.any().meta({ ref: "MemoryState" })
-
-const runMemoryRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
 
 function createMemoryService() {
   return MemoryService.create({ workspacePath: Instance.directory })
@@ -45,83 +34,3 @@ export const deleteMemoryEntry = Effect.fn("MemoryRoutes.deleteEntry")(function*
   yield* Effect.promise(() => memory.deleteEntry(id))
   return yield* Effect.promise(() => memory.read())
 })
-
-export const MemoryRoutes = () =>
-  new Hono()
-    .get(
-      "/",
-      describeRoute({
-        summary: "Get PawWork memory",
-        operationId: "memory.get",
-        responses: {
-          200: { description: "Memory state", content: { "application/json": { schema: resolver(MemoryState) } } },
-        },
-      }),
-      async (c) => c.json(await runMemoryRoute(readMemory())),
-    )
-    .patch(
-      "/",
-      describeRoute({
-        summary: "Update raw PawWork memory",
-        operationId: "memory.update",
-        responses: {
-          200: { description: "Memory state", content: { "application/json": { schema: resolver(MemoryState) } } },
-          400: { description: "Invalid memory file" },
-        },
-      }),
-      validator("json", MemoryRawInput),
-      async (c) => {
-        try {
-          const content = c.req.valid("json").content
-          const state = await runMemoryRoute(updateRawMemory(content))
-          return c.json(state)
-        } catch (error) {
-          return c.json({ error: "invalid_memory_file", reason: error instanceof Error ? error.message : String(error) }, 400)
-        }
-      },
-    )
-    .post(
-      "/reset",
-      describeRoute({
-        summary: "Reset PawWork memory",
-        operationId: "memory.reset",
-        responses: {
-          200: { description: "Memory state", content: { "application/json": { schema: resolver(MemoryState) } } },
-        },
-      }),
-      async (c) => {
-        const state = await runMemoryRoute(resetMemory())
-        return c.json(state)
-      },
-    )
-    .patch(
-      "/disabled",
-      describeRoute({
-        summary: "Disable or enable PawWork memory",
-        operationId: "memory.disabled",
-        responses: {
-          200: { description: "Memory state", content: { "application/json": { schema: resolver(MemoryState) } } },
-        },
-      }),
-      validator("json", MemoryDisabledInput),
-      async (c) => {
-        const disabled = c.req.valid("json").disabled
-        const state = await runMemoryRoute(setMemoryDisabled(disabled))
-        return c.json(state)
-      },
-    )
-    .delete(
-      "/entry/:id",
-      describeRoute({
-        summary: "Delete PawWork memory entry",
-        operationId: "memory.deleteEntry",
-        responses: {
-          200: { description: "Memory state", content: { "application/json": { schema: resolver(MemoryState) } } },
-        },
-      }),
-      async (c) => {
-        const id = c.req.param("id")
-        const state = await runMemoryRoute(deleteMemoryEntry(id))
-        return c.json(state)
-      },
-    )

--- a/packages/opencode/test/server/external-result-routes.test.ts
+++ b/packages/opencode/test/server/external-result-routes.test.ts
@@ -3,10 +3,9 @@ import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-nod
 import { Effect, Layer } from "effect"
 import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
-import { Hono } from "hono"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
-import { ExternalResultRoutes } from "../../src/server/instance/external-result"
+import { Server } from "../../src/server/server"
 import { ExternalResultApi } from "../../src/server/routes/instance/httpapi/groups/external-result"
 import { externalResultHandlers } from "../../src/server/routes/instance/httpapi/handlers/external-result"
 import { Session } from "../../src/session"
@@ -21,8 +20,10 @@ afterEach(async () => {
 })
 
 describe("external-result routes", () => {
-  function app() {
-    return new Hono().route("/external-result", ExternalResultRoutes())
+  function requestExternalResult(directory: string, routePath: string, init: RequestInit = {}) {
+    const headers = new Headers(init.headers)
+    headers.set("x-opencode-directory", directory)
+    return Server.Default().app.request(routePath, { ...init, headers })
   }
 
   function requestExternalResultHttpApi(routePath: string, init?: RequestInit) {
@@ -49,7 +50,7 @@ describe("external-result routes", () => {
     expect(spec.paths["/external-result"]).toHaveProperty("get")
   })
 
-  test("skips stale pending external-result entries through the route runtime", async () => {
+  test("skips stale pending external-result entries through the production route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
     ExternalResult.__resetForTests()
 
@@ -65,14 +66,14 @@ describe("external-result routes", () => {
           }),
         )
 
-        const response = await app().request("/external-result")
+        const response = await requestExternalResult(tmp.path, "/external-result")
         expect(response.status).toBe(200)
         expect(await response.json()).toEqual([])
       },
     })
   })
 
-  test("hydrates pending external-result tool calls through the route runtime", async () => {
+  test("hydrates pending external-result tool calls through the production route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
     ExternalResult.__resetForTests()
 
@@ -153,7 +154,7 @@ describe("external-result routes", () => {
           }),
         )
 
-        const response = await app().request("/external-result")
+        const response = await requestExternalResult(tmp.path, "/external-result")
         expect(response.status).toBe(200)
         expect(await response.json()).toEqual([
           expect.objectContaining({

--- a/packages/opencode/test/server/memory-routes.test.ts
+++ b/packages/opencode/test/server/memory-routes.test.ts
@@ -3,11 +3,10 @@ import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-nod
 import { Effect, Layer } from "effect"
 import { Etag, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, OpenApi } from "effect/unstable/httpapi"
-import { Hono } from "hono"
 import { Log } from "@opencode-ai/core/util/log"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
-import { MemoryRoutes } from "../../src/server/instance/memory"
+import { Server } from "../../src/server/server"
 import { MemoryApi } from "../../src/server/routes/instance/httpapi/groups/memory"
 import { memoryHandlers } from "../../src/server/routes/instance/httpapi/handlers/memory"
 import { tmpdir } from "../fixture/fixture"
@@ -23,8 +22,10 @@ afterEach(async () => {
 })
 
 describe("memory routes", () => {
-  function app() {
-    return new Hono().route("/memory", MemoryRoutes())
+  function requestMemory(directory: string, routePath: string, init: RequestInit = {}) {
+    const headers = new Headers(init.headers)
+    headers.set("x-opencode-directory", directory)
+    return Server.Default().app.request(routePath, { ...init, headers })
   }
 
   function requestMemoryHttpApi(routePath: string, init?: RequestInit) {
@@ -67,40 +68,35 @@ describe("memory routes", () => {
     })
   })
 
-  test("reads and updates memory through the route runtime", async () => {
+  test("reads and updates memory through the production route runtime", async () => {
     await using tmp = await tmpdir({ git: true })
     await using home = await tmpdir()
     process.env.PAWWORK_HOME = home.path
 
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const initial = await app().request("/memory")
-        expect(initial.status).toBe(200)
-        expect(await initial.json()).toMatchObject({ disabled: false, status: "ok" })
+    const initial = await requestMemory(tmp.path, "/memory")
+    expect(initial.status).toBe(200)
+    expect(await initial.json()).toMatchObject({ disabled: false, status: "ok" })
 
-        const content = "# PawWork Memory\n\n## Profile\n\n- PawWork Memory is enabled.\n\n## Archive\n\n### First id:first\n\nStored note.\n"
-        const updated = await app().request("/memory", {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ content }),
-        })
-        expect(updated.status).toBe(200)
-        expect(await updated.json()).toMatchObject({ content })
-
-        const disabled = await app().request("/memory/disabled", {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ disabled: true }),
-        })
-        expect(disabled.status).toBe(200)
-        expect(await disabled.json()).toMatchObject({ disabled: true })
-
-        const deleted = await app().request("/memory/entry/first", { method: "DELETE" })
-        expect(deleted.status).toBe(200)
-        expect((await deleted.json()).content).not.toContain("Stored note.")
-      },
+    const content = "# PawWork Memory\n\n## Profile\n\n- PawWork Memory is enabled.\n\n## Archive\n\n### First id:first\n\nStored note.\n"
+    const updated = await requestMemory(tmp.path, "/memory", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content }),
     })
+    expect(updated.status).toBe(200)
+    expect(await updated.json()).toMatchObject({ content })
+
+    const disabled = await requestMemory(tmp.path, "/memory/disabled", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ disabled: true }),
+    })
+    expect(disabled.status).toBe(200)
+    expect(await disabled.json()).toMatchObject({ disabled: true })
+
+    const deleted = await requestMemory(tmp.path, "/memory/entry/first", { method: "DELETE" })
+    expect(deleted.status).toBe(200)
+    expect((await deleted.json()).content).not.toContain("Stored note.")
   })
 
   test("PATCH with invalid content returns a clean safe-mode reason", async () => {
@@ -108,22 +104,17 @@ describe("memory routes", () => {
     await using home = await tmpdir()
     process.env.PAWWORK_HOME = home.path
 
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const response = await app().request("/memory", {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ content: "garbage with no profile or archive sections" }),
-        })
-
-        expect(response.status).toBe(400)
-        const body = await response.json()
-        // The original error must surface cleanly through the Effect runtime,
-        // not as a wrapped FiberFailure trace.
-        expect(body).toMatchObject({ error: "invalid_memory_file", reason: "missing_profile" })
-      },
+    const response = await requestMemory(tmp.path, "/memory", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "garbage with no profile or archive sections" }),
     })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    // The original error must surface cleanly through the Effect runtime,
+    // not as a wrapped FiberFailure trace.
+    expect(body).toMatchObject({ error: "invalid_memory_file", reason: "missing_profile" })
   })
 
   test("reads, updates, disables, deletes, and rejects invalid content through the HttpApi handlers", async () => {

--- a/packages/opencode/test/server/production-boundary.test.ts
+++ b/packages/opencode/test/server/production-boundary.test.ts
@@ -179,4 +179,22 @@ describe("production server boundary", () => {
     expect(globalEvents).toContain("handleGlobalEventStream")
     expect(globalEvents).toContain("handleGlobalSyncEventStream")
   })
+
+  test("does not retain retired memory or external-result legacy Hono route sources", async () => {
+    const instanceRoutes = await readFile(path.join(import.meta.dir, "../../src/server/instance/index.ts"), "utf8")
+    const memory = await readFile(path.join(import.meta.dir, "../../src/server/instance/memory.ts"), "utf8")
+    const externalResult = await readFile(
+      path.join(import.meta.dir, "../../src/server/instance/external-result.ts"),
+      "utf8",
+    )
+
+    expect(instanceRoutes).not.toContain("MemoryRoutes")
+    expect(instanceRoutes).not.toContain("ExternalResultRoutes")
+    for (const source of [memory, externalResult]) {
+      expect(source).not.toMatch(/from\s+["']hono["']/)
+      expect(source).not.toMatch(/\bnew\s+Hono\s*\(/)
+    }
+    expect(memory).not.toContain("export const MemoryRoutes")
+    expect(externalResult).not.toContain("export const ExternalResultRoutes")
+  })
 })

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -34,12 +34,12 @@ function hasRoute(routes: ReadonlyArray<{ method: string; path: string }>, metho
 }
 
 describe("route inventory harness", () => {
-  test("discovers PawWork-owned Hono routes now covered by the checked-in OpenAPI surface", async () => {
+  test("tracks PawWork-owned routes covered by the checked-in OpenAPI surface", async () => {
     const inventory = await buildRouteInventory({ root, requireUpstream: false })
 
-    expect(hasRoute(inventory.hono.routes, "GET", "/external-result")).toBe(true)
-    expect(hasRoute(inventory.hono.routes, "GET", "/memory")).toBe(true)
-    expect(hasRoute(inventory.hono.routes, "PATCH", "/memory/disabled")).toBe(true)
+    expect(hasRoute(inventory.hono.routes, "GET", "/external-result")).toBe(false)
+    expect(hasRoute(inventory.hono.routes, "GET", "/memory")).toBe(false)
+    expect(hasRoute(inventory.hono.routes, "PATCH", "/memory/disabled")).toBe(false)
     expect(hasRoute(inventory.hono.routes, "POST", "/session/:sessionID/tool/respond")).toBe(true)
     expect(hasRoute(inventory.hono.routes, "GET", "/session/:sessionID/turn/:userMessageID/changes")).toBe(true)
 
@@ -48,15 +48,16 @@ describe("route inventory harness", () => {
     expect(hasRoute(inventory.v2Sdk.routes, "GET", "/external-result")).toBe(true)
   })
 
-  test("classifies compatibility gaps by source instead of treating every missing SDK route as a server gap", async () => {
+  test("classifies retired PawWork-owned routes by their remaining production sources", async () => {
     const inventory = await buildRouteInventory({ root, requireUpstream: false })
 
     const externalResult = inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")
     expect(externalResult).toMatchObject({
-      hono: true,
+      hono: false,
       openapi: true,
       legacySdk: false,
       v2Sdk: true,
+      localHttpApi: true,
       classification: "pawwork-owned",
     })
 
@@ -113,7 +114,7 @@ describe("route inventory harness", () => {
       classification: "all-public-surfaces",
     })
     expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")).toMatchObject({
-      hono: true,
+      hono: false,
       localHttpApi: true,
       classification: "pawwork-owned",
     })
@@ -129,7 +130,7 @@ describe("route inventory harness", () => {
     })
   })
 
-  test("tracks local HttpApi migration coverage for ordinary JSON file, project, memory, and external-result routes", async () => {
+  test("tracks local HttpApi migration coverage for ordinary JSON file and project routes", async () => {
     const inventory = await buildRouteInventory({ root, requireUpstream: false })
 
     for (const [method, routePath] of [
@@ -143,6 +144,18 @@ describe("route inventory harness", () => {
       ["GET", "/project/current"],
       ["POST", "/project/git/init"],
       ["PATCH", "/project/:projectID"],
+    ] as const) {
+      expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
+        hono: true,
+        localHttpApi: true,
+      })
+    }
+  })
+
+  test("keeps retired memory and external-result routes on the HttpApi production surface only", async () => {
+    const inventory = await buildRouteInventory({ root, requireUpstream: false })
+
+    for (const [method, routePath] of [
       ["GET", "/memory"],
       ["PATCH", "/memory"],
       ["POST", "/memory/reset"],
@@ -151,15 +164,13 @@ describe("route inventory harness", () => {
       ["GET", "/external-result"],
     ] as const) {
       expect(inventory.rows.find((row) => row.method === method && row.path === routePath)).toMatchObject({
-        hono: true,
+        hono: false,
+        openapi: true,
+        v2Sdk: true,
         localHttpApi: true,
+        classification: "pawwork-owned",
       })
     }
-
-    expect(inventory.rows.find((row) => row.method === "GET" && row.path === "/external-result")).toMatchObject({
-      openapi: true,
-      classification: "pawwork-owned",
-    })
   })
 
   test("tracks local HttpApi migration coverage for ordinary experimental JSON routes", async () => {


### PR DESCRIPTION
## Summary

Retire the legacy Hono route sources for `GET /external-result` and the PawWork-owned `/memory*` routes now that production serves the same HTTP surface through Effect HttpApi handlers.

## Why

These routes already had local HttpApi declarations and handlers, but the old `ExternalResultRoutes()` and `MemoryRoutes()` Hono implementations remained as parallel source code. Removing those legacy route trees makes the Effect HttpApi handlers the source of truth for this slice.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please check that the legacy Hono sources are fully retired while the production behavior still goes through the existing Effect HttpApi route functions.

Fresh-eye result: no P0/P1/P2/P3 findings. I applied this review question before opening the PR: `本次的所有改动已经是最优解了吗？是否是最简洁、最优雅、最安心、最彻底的方案？用奥卡姆剃刀大胆思考。` The only issue found during the pass was preserving the `pawwork-owned` inventory classification after Hono retirement, and that is included in this diff.

## Risk Notes

Low runtime risk: production already routes these paths through `production-httpapi.ts`, and the tests now hit `Server.Default().app` plus the direct HttpApi handlers. No SDK generated files, dependencies, UI, platform, docs, release notes, permissions, credentials, or generated tracked content changed.

Skipped conditional checklist items: no visible UI or copy changed; no platform, packaging, updater, signing, paths, shell, or permissions surface changed; no tracked docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes were introduced.

## How To Verify

```text
Focused route tests: bun test test/server/memory-routes.test.ts test/server/external-result-routes.test.ts test/server/production-boundary.test.ts test/server/route-inventory-harness.test.ts -> 50 pass, 0 fail
Route inventory: bun run route:inventory -> memory/external-result rows are Hono=no, OpenAPI=yes, v2 SDK=yes, Local HttpApi=yes, classification=pawwork-owned
Typecheck: GOMAXPROCS=2 bun run typecheck -> pass
Diff check: git diff --check -> pass
Fresh-eye review: no P0/P1/P2/P3 findings after the retained-classification fix
```

## Screenshots or Recordings

Not required: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
