### PR TITLE
refactor(opencode): remove session service Promise facades

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -15,8 +15,6 @@ import { Storage } from "@/storage/storage"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect, Layer, Context, Schema } from "effect"
 import { isOverflow as overflow, usable } from "./overflow"
-import { makeRuntime } from "@/effect/run-service"
-import { fn } from "@/util/fn"
 
 const log = Log.create({ service: "session.compaction" })
 
@@ -765,27 +763,6 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(Bus.layer),
     Layer.provide(Config.defaultLayer),
   ),
-)
-
-const { runPromise } = makeRuntime(Service, defaultLayer)
-
-export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
-  return runPromise((svc) => svc.isOverflow(input))
-}
-
-export async function prune(input: { sessionID: SessionID }) {
-  return runPromise((svc) => svc.prune(input))
-}
-
-export const create = fn(
-  z.object({
-    sessionID: SessionID.zod,
-    agent: z.string(),
-    model: z.object({ providerID: ProviderID.zod, modelID: ModelID.zod }),
-    auto: z.boolean(),
-    overflow: z.boolean().optional(),
-  }),
-  (input) => runPromise((svc) => svc.create(input)),
 )
 
 export * as SessionCompaction from "./compaction"

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -1,6 +1,5 @@
 import z from "zod"
 import { Effect, Layer, Context } from "effect"
-import { makeRuntime } from "@/effect/run-service"
 import { Bus } from "../bus"
 import { Snapshot } from "../snapshot"
 import { SyncEvent } from "../sync"
@@ -170,12 +169,5 @@ export const defaultLayer: Layer.Layer<Service, never, never> = Layer.suspend(()
     Layer.provide(Bus.layer),
   ),
 )
-
-const { runPromise } = makeRuntime(Service, defaultLayer)
-
-export const revert = (input: RevertInput) => runPromise((svc) => svc.revert(RevertInput.parse(input)))
-export const unrevert = (input: z.infer<typeof UnrevertInput>) =>
-  runPromise((svc) => svc.unrevert(UnrevertInput.parse(input)))
-export const cleanup = (session: Session.Info) => runPromise((svc) => svc.cleanup(Session.Info.parse(session)))
 
 export * as SessionRevert from "./revert"

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -1,6 +1,5 @@
 import z from "zod"
 import { Effect, Layer, Context } from "effect"
-import { makeRuntime } from "@/effect/run-service"
 import { Snapshot } from "@/snapshot"
 import { MessageV2 } from "./message-v2"
 import { SessionID, MessageID } from "./schema"
@@ -87,8 +86,6 @@ export namespace SessionSummary {
     layer.pipe(Layer.provide(Snapshot.defaultLayer), Layer.provide(TurnChange.defaultLayer)),
   )
 
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
   export const summarize = (_input: { sessionID: SessionID; messageID: MessageID }) => undefined
 
   export const DiffInput = z.object({
@@ -99,12 +96,4 @@ export namespace SessionSummary {
   export const ArtifactsInput = z.object({
     sessionID: SessionID.zod,
   })
-
-  export async function diff(input: z.infer<typeof DiffInput>) {
-    return runPromise((svc) => svc.diff(input))
-  }
-
-  export async function artifacts(input: z.infer<typeof ArtifactsInput>) {
-    return runPromise((svc) => svc.artifacts(input))
-  }
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -91,3 +91,18 @@ test("ModelState recent writes stay on the Effect service boundary", async () =>
   expect(service).not.toContain("export async function recordRecent")
   expect(providerTest).not.toContain("ModelState.recordRecent(")
 })
+
+test("session summary/revert/compaction services do not expose Promise facades", async () => {
+  const files = {
+    "session/summary.ts": ["export async function diff", "export async function artifacts"],
+    "session/revert.ts": ["export const revert =", "export const unrevert =", "export const cleanup ="],
+    "session/compaction.ts": ["export async function isOverflow", "export async function prune", "export const create ="],
+  }
+
+  for (const [file, facades] of Object.entries(files)) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+    for (const facade of facades) expect(text).not.toContain(facade)
+  }
+})

--- a/packages/opencode/test/session/session-artifacts.test.ts
+++ b/packages/opencode/test/session/session-artifacts.test.ts
@@ -1,17 +1,22 @@
-import { describe, expect, test } from "bun:test"
-import { Instance } from "../../src/project/instance"
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { SessionSummary } from "../../src/session/summary"
 import { TurnChange } from "../../src/session/turn-change"
-import { tmpdir } from "../fixture/fixture"
+import { provideTmpdirInstance } from "../fixture/fixture"
 import { resetDatabase } from "../fixture/db"
+import { testEffect } from "../lib/effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 
-async function makeUser(sessionID: SessionID, suffix: string) {
+const it = testEffect(Layer.mergeAll(Session.defaultLayer, SessionSummary.defaultLayer, CrossSpawnSpawner.defaultLayer))
+
+const makeUser = Effect.fn("test.makeUser")(function* (sessionID: SessionID, suffix: string) {
+  const session = yield* Session.Service
   const id = MessageID.make(`msg_artifact_user_${suffix}`)
-  await Session.updateMessage({
+  yield* session.updateMessage({
     id,
     sessionID,
     role: "user",
@@ -21,11 +26,16 @@ async function makeUser(sessionID: SessionID, suffix: string) {
     tools: {},
   } as unknown as MessageV2.Info)
   return id
-}
+})
 
-async function makeAssistant(sessionID: SessionID, parentID: MessageID, suffix: string) {
+const makeAssistant = Effect.fn("test.makeAssistant")(function* (
+  sessionID: SessionID,
+  parentID: MessageID,
+  suffix: string,
+) {
+  const session = yield* Session.Service
   const id = MessageID.make(`msg_artifact_assistant_${suffix}`)
-  await Session.updateMessage({
+  yield* session.updateMessage({
     id,
     sessionID,
     role: "assistant",
@@ -40,65 +50,71 @@ async function makeAssistant(sessionID: SessionID, parentID: MessageID, suffix: 
     tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
   } as unknown as MessageV2.Info)
   return id
-}
+})
 
 describe("session artifacts", () => {
-  test("returns artifacts from captured and mixed aggregates while ignoring deleted and uncaptured-only changes", async () => {
-    await resetDatabase()
-    await using tmp = await tmpdir({ git: true })
+  it.live(
+    "returns artifacts from captured and mixed aggregates while ignoring deleted and uncaptured-only changes",
+    Effect.gen(function* () {
+      yield* Effect.promise(() => resetDatabase())
+      return yield* provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const summary = yield* SessionSummary.Service
 
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const session = await Session.create({ title: "Artifacts" })
-        const user = await makeUser(session.id, "captured")
-        const assistant = await makeAssistant(session.id, user, "captured")
+          const info = yield* session.create({ title: "Artifacts" })
+          const user = yield* makeUser(info.id, "captured")
+          const assistant = yield* makeAssistant(info.id, user, "captured")
 
-        TurnChange.recordWrite({
-          sessionID: session.id,
-          messageID: assistant,
-          path: `${tmp.path}/artifact-report.md`,
-          before: { exists: false },
-          after: { exists: true, content: "report\n" },
-        })
-        TurnChange.recordWrite({
-          sessionID: session.id,
-          messageID: assistant,
-          path: `${tmp.path}/deleted.md`,
-          before: { exists: true, content: "delete\n" },
-          after: { exists: false },
-        })
-        TurnChange.recordUncaptured({ sessionID: session.id, messageID: assistant })
-        TurnChange.finalize({ sessionID: session.id, messageID: assistant })
+          TurnChange.recordWrite({
+            sessionID: info.id,
+            messageID: assistant,
+            path: `${dir}/artifact-report.md`,
+            before: { exists: false },
+            after: { exists: true, content: "report\n" },
+          })
+          TurnChange.recordWrite({
+            sessionID: info.id,
+            messageID: assistant,
+            path: `${dir}/deleted.md`,
+            before: { exists: true, content: "delete\n" },
+            after: { exists: false },
+          })
+          TurnChange.recordUncaptured({ sessionID: info.id, messageID: assistant })
+          TurnChange.finalize({ sessionID: info.id, messageID: assistant })
 
-        const artifacts = await SessionSummary.artifacts({ sessionID: session.id })
-        expect(artifacts).toEqual([
-          {
-            file: "artifact-report.md",
-            kind: "added",
-          },
-        ])
-      },
-    })
-  })
+          const artifacts = yield* summary.artifacts({ sessionID: info.id })
+          expect(artifacts).toEqual([
+            {
+              file: "artifact-report.md",
+              kind: "added",
+            },
+          ])
+        }),
+      )
+    }),
+  )
 
-  test("returns no artifacts for empty and uncaptured-only aggregates", async () => {
-    await resetDatabase()
-    await using tmp = await tmpdir({ git: true })
+  it.live(
+    "returns no artifacts for empty and uncaptured-only aggregates",
+    Effect.gen(function* () {
+      yield* Effect.promise(() => resetDatabase())
+      return yield* provideTmpdirInstance(() =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const summary = yield* SessionSummary.Service
 
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const empty = await Session.create({ title: "Empty artifacts" })
-        expect(await SessionSummary.artifacts({ sessionID: empty.id })).toEqual([])
+          const empty = yield* session.create({ title: "Empty artifacts" })
+          expect(yield* summary.artifacts({ sessionID: empty.id })).toEqual([])
 
-        const uncaptured = await Session.create({ title: "Uncaptured artifacts" })
-        const user = await makeUser(uncaptured.id, "uncaptured")
-        const assistant = await makeAssistant(uncaptured.id, user, "uncaptured")
-        TurnChange.recordUncaptured({ sessionID: uncaptured.id, messageID: assistant })
-        TurnChange.finalize({ sessionID: uncaptured.id, messageID: assistant })
-        expect(await SessionSummary.artifacts({ sessionID: uncaptured.id })).toEqual([])
-      },
-    })
-  })
+          const uncaptured = yield* session.create({ title: "Uncaptured artifacts" })
+          const user = yield* makeUser(uncaptured.id, "uncaptured")
+          const assistant = yield* makeAssistant(uncaptured.id, user, "uncaptured")
+          TurnChange.recordUncaptured({ sessionID: uncaptured.id, messageID: assistant })
+          TurnChange.finalize({ sessionID: uncaptured.id, messageID: assistant })
+          expect(yield* summary.artifacts({ sessionID: uncaptured.id })).toEqual([])
+        }),
+      )
+    }),
+  )
 })


### PR DESCRIPTION
## Summary

Remove the legacy Promise facade exports from `SessionSummary`, `SessionRevert`, and `SessionCompaction`, while keeping their service definitions, layers, schema exports, and namespace re-exports intact.

## Why

Related to #936.

The app runtime now composes these services through the shared Effect layer graph, so the old per-service `makeRuntime(Service, defaultLayer)` bridges are no longer needed for this slice.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the direct test caller migration uses the service runtime cleanly and whether the guardrail is narrow enough to protect only the three removed session service facades.

## Risk Notes

No product behavior, persistence semantics, generated files, dependencies, or platform surfaces changed. Conditional checklist skips: no visible UI/copy changes, no platform/packaging surface, and no docs/release/dependency/permission/credential/generated-content surface.

Fresh-eye result: P0/P1 none. P3 guardrail robustness was addressed by matching the `makeRuntime` import and call with regex instead of a single exact string.

## How To Verify

```text
RED guardrail: bun test test/effect/legacy-boundaries.test.ts failed before cleanup on SessionSummary makeRuntime(Service, defaultLayer)
Focused tests: bun test test/session/session-artifacts.test.ts test/session/revert-compact.test.ts test/session/compaction.test.ts test/session/snapshot-tool-race.test.ts test/session/processor-effect.test.ts test/session/processor-rate-limit.test.ts test/effect/legacy-boundaries.test.ts -> 121 passed, 0 failed
Typecheck: GOMAXPROCS=2 bun run typecheck -> tsgo --noEmit passed
Diff check: git diff --check -> passed
```

## Screenshots or Recordings

Not applicable, no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
