### PR TITLE
refactor(opencode): remove TurnChange facades

### DIFF
--- a/packages/opencode/src/session/turn-change.ts
+++ b/packages/opencode/src/session/turn-change.ts
@@ -22,7 +22,6 @@ import { Global } from "@/global"
 import * as Bom from "@/util/bom"
 import { Log } from "@opencode-ai/core/util/log"
 import { Context, Effect, Layer } from "effect"
-import { makeRuntime } from "@/effect/run-service"
 
 export type FileState =
   | {
@@ -1497,49 +1496,4 @@ export namespace TurnChange {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
-  const runtime = makeRuntime(Service, defaultLayer)
-
-  export function recordWrite(input: RecordWriteInput) {
-    return runtime.runSync((svc) => svc.recordWrite(input))
-  }
-
-  export function recordUncaptured(input: RecordUncapturedInput) {
-    return runtime.runSync((svc) => svc.recordUncaptured(input))
-  }
-
-  export function finalize(input: { sessionID: SessionID; messageID: MessageID }) {
-    return runtime.runSync((svc) => svc.finalize(input))
-  }
-
-  export function get(input: { sessionID: SessionID; messageID: MessageID }) {
-    return runtime.runSync((svc) => svc.get(input))
-  }
-
-  export function aggregateTurn(input: { sessionID: SessionID; userMessageID: MessageID }) {
-    return runtime.runSync((svc) => svc.aggregateTurn(input))
-  }
-
-  export function aggregateTurnUnion(input: { sessionID: SessionID; userMessageID: MessageID }) {
-    return runtime.runSync((svc) => svc.aggregateTurnUnion(input))
-  }
-
-  export function aggregateSessionFromTurns(input: { sessionID: SessionID }) {
-    return runtime.runSync((svc) => svc.aggregateSessionFromTurns(input))
-  }
-
-  export function undo(input: { sessionID: SessionID; messageID: MessageID }) {
-    return runtime.runPromise((svc) => svc.undo(input))
-  }
-
-  export function redo(input: { sessionID: SessionID; messageID: MessageID }) {
-    return runtime.runPromise((svc) => svc.redo(input))
-  }
-
-  export function aggregateTurnUndo(input: { sessionID: SessionID; userMessageID: MessageID; force?: boolean }) {
-    return runtime.runPromise((svc) => svc.aggregateTurnUndo(input))
-  }
-
-  export function aggregateTurnRedo(input: { sessionID: SessionID; userMessageID: MessageID; force?: boolean }) {
-    return runtime.runPromise((svc) => svc.aggregateTurnRedo(input))
-  }
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -106,3 +106,24 @@ test("session summary/revert/compaction services do not expose Promise facades",
     for (const facade of facades) expect(text).not.toContain(facade)
   }
 })
+
+test("TurnChange service does not expose sync or Promise facades", async () => {
+  const text = await readFile(path.join(srcRoot, "session/turn-change.ts"), "utf8")
+  const facades = [
+    "export function recordWrite",
+    "export function recordUncaptured",
+    "export function finalize",
+    "export function get",
+    "export function aggregateTurn",
+    "export function aggregateTurnUnion",
+    "export function aggregateSessionFromTurns",
+    "export function undo",
+    "export function redo",
+    "export function aggregateTurnUndo",
+    "export function aggregateTurnRedo",
+  ]
+
+  expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+  expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+  for (const facade of facades) expect(text).not.toContain(facade)
+})

--- a/packages/opencode/test/server/turn-change-aggregate-routes.test.ts
+++ b/packages/opencode/test/server/turn-change-aggregate-routes.test.ts
@@ -9,10 +9,15 @@ import { TurnChange } from "../../src/session/turn-change"
 import { MessageID, type SessionID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Log } from "@opencode-ai/core/util/log"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { tmpdir } from "../fixture/fixture"
 import { resetDatabase } from "../fixture/db"
 
 void Log.init({ print: false })
+const turnChange = await AppRuntime.runPromise(TurnChange.Service)
+const recordWrite = (input: Parameters<typeof turnChange.recordWrite>[0]) =>
+  AppRuntime.runSync(turnChange.recordWrite(input))
+const finalize = (input: Parameters<typeof turnChange.finalize>[0]) => AppRuntime.runSync(turnChange.finalize(input))
 
 afterEach(async () => {
   mock.restore()
@@ -66,14 +71,14 @@ describe("turn-change aggregate HTTP routes (#428)", () => {
         const file = path.join(fixture.path, "legacy.txt")
         await fs.writeFile(file, "legacy\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: assistantID,
           path: file,
           before: { exists: false },
           after: { exists: true, content: "legacy\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: assistantID })
+        finalize({ sessionID: session.id, messageID: assistantID })
 
         const app = Server.Default().app
 
@@ -107,22 +112,22 @@ describe("turn-change aggregate HTTP routes (#428)", () => {
         await fs.writeFile(fileA, "A\n", "utf-8")
         await fs.writeFile(fileB, "B\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: fileA,
           before: { exists: false },
           after: { exists: true, content: "A\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: fileB,
           before: { exists: false },
           after: { exists: true, content: "B\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
         const app = Server.Default().app
 
@@ -189,22 +194,22 @@ describe("turn-change aggregate HTTP routes (#428)", () => {
         await fs.writeFile(ok, "ok\n", "utf-8")
         await fs.writeFile(conflict, "tampered\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: ok,
           before: { exists: false },
           after: { exists: true, content: "ok\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: conflict,
           before: { exists: false },
           after: { exists: true, content: "expected\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
         const app = Server.Default().app
 

--- a/packages/opencode/test/session/session-artifacts.test.ts
+++ b/packages/opencode/test/session/session-artifacts.test.ts
@@ -6,12 +6,19 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { SessionSummary } from "../../src/session/summary"
 import { TurnChange } from "../../src/session/turn-change"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { resetDatabase } from "../fixture/db"
 import { testEffect } from "../lib/effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 
 const it = testEffect(Layer.mergeAll(Session.defaultLayer, SessionSummary.defaultLayer, CrossSpawnSpawner.defaultLayer))
+const turnChange = await AppRuntime.runPromise(TurnChange.Service)
+const recordWrite = (input: Parameters<typeof turnChange.recordWrite>[0]) =>
+  AppRuntime.runSync(turnChange.recordWrite(input))
+const recordUncaptured = (input: Parameters<typeof turnChange.recordUncaptured>[0]) =>
+  AppRuntime.runSync(turnChange.recordUncaptured(input))
+const finalize = (input: Parameters<typeof turnChange.finalize>[0]) => AppRuntime.runSync(turnChange.finalize(input))
 
 const makeUser = Effect.fn("test.makeUser")(function* (sessionID: SessionID, suffix: string) {
   const session = yield* Session.Service
@@ -66,22 +73,22 @@ describe("session artifacts", () => {
           const user = yield* makeUser(info.id, "captured")
           const assistant = yield* makeAssistant(info.id, user, "captured")
 
-          TurnChange.recordWrite({
+          recordWrite({
             sessionID: info.id,
             messageID: assistant,
             path: `${dir}/artifact-report.md`,
             before: { exists: false },
             after: { exists: true, content: "report\n" },
           })
-          TurnChange.recordWrite({
+          recordWrite({
             sessionID: info.id,
             messageID: assistant,
             path: `${dir}/deleted.md`,
             before: { exists: true, content: "delete\n" },
             after: { exists: false },
           })
-          TurnChange.recordUncaptured({ sessionID: info.id, messageID: assistant })
-          TurnChange.finalize({ sessionID: info.id, messageID: assistant })
+          recordUncaptured({ sessionID: info.id, messageID: assistant })
+          finalize({ sessionID: info.id, messageID: assistant })
 
           const artifacts = yield* summary.artifacts({ sessionID: info.id })
           expect(artifacts).toEqual([
@@ -110,8 +117,8 @@ describe("session artifacts", () => {
           const uncaptured = yield* session.create({ title: "Uncaptured artifacts" })
           const user = yield* makeUser(uncaptured.id, "uncaptured")
           const assistant = yield* makeAssistant(uncaptured.id, user, "uncaptured")
-          TurnChange.recordUncaptured({ sessionID: uncaptured.id, messageID: assistant })
-          TurnChange.finalize({ sessionID: uncaptured.id, messageID: assistant })
+          recordUncaptured({ sessionID: uncaptured.id, messageID: assistant })
+          finalize({ sessionID: uncaptured.id, messageID: assistant })
           expect(yield* summary.artifacts({ sessionID: uncaptured.id })).toEqual([])
         }),
       )

--- a/packages/opencode/test/session/turn-change-aggregate.test.ts
+++ b/packages/opencode/test/session/turn-change-aggregate.test.ts
@@ -10,8 +10,27 @@ import { ModelID, ProviderID } from "../../src/provider/schema"
 import { SessionTable } from "../../src/session/session.sql"
 import { Database, eq } from "../../src/storage/db"
 import { Bus } from "../../src/bus"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { tmpdir } from "../fixture/fixture"
 import { resetDatabase } from "../fixture/db"
+
+const turnChange = await AppRuntime.runPromise(TurnChange.Service)
+const recordWrite = (input: Parameters<typeof turnChange.recordWrite>[0]) =>
+  AppRuntime.runSync(turnChange.recordWrite(input))
+const recordUncaptured = (input: Parameters<typeof turnChange.recordUncaptured>[0]) =>
+  AppRuntime.runSync(turnChange.recordUncaptured(input))
+const finalize = (input: Parameters<typeof turnChange.finalize>[0]) => AppRuntime.runSync(turnChange.finalize(input))
+const aggregateTurn = (input: Parameters<typeof turnChange.aggregateTurn>[0]) =>
+  AppRuntime.runSync(turnChange.aggregateTurn(input))
+const aggregateTurnUnion = (input: Parameters<typeof turnChange.aggregateTurnUnion>[0]) =>
+  AppRuntime.runSync(turnChange.aggregateTurnUnion(input))
+const aggregateSessionFromTurns = (input: Parameters<typeof turnChange.aggregateSessionFromTurns>[0]) =>
+  AppRuntime.runSync(turnChange.aggregateSessionFromTurns(input))
+const undo = (input: Parameters<typeof turnChange.undo>[0]) => AppRuntime.runPromise(turnChange.undo(input))
+const aggregateTurnUndo = (input: Parameters<typeof turnChange.aggregateTurnUndo>[0]) =>
+  AppRuntime.runPromise(turnChange.aggregateTurnUndo(input))
+const aggregateTurnRedo = (input: Parameters<typeof turnChange.aggregateTurnRedo>[0]) =>
+  AppRuntime.runPromise(turnChange.aggregateTurnRedo(input))
 
 async function makeAssistant(sessionID: SessionID, parentID: MessageID, suffix: string) {
   const id = MessageID.make(`msg_assistant_${suffix}`)
@@ -71,25 +90,25 @@ describe("TurnChange.aggregateTurn", () => {
         const a1 = await makeAssistant(session.id, userMessageID, "a1")
         const a2 = await makeAssistant(session.id, userMessageID, "a2")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: path.join(fixture.path, "alpha.txt"),
           before: { exists: false },
           after: { exists: true, content: "A\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
+        finalize({ sessionID: session.id, messageID: a1 })
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: path.join(fixture.path, "beta.txt"),
           before: { exists: false },
           after: { exists: true, content: "B\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const display = TurnChange.aggregateTurn({ sessionID: session.id, userMessageID })
+        const display = aggregateTurn({ sessionID: session.id, userMessageID })
         expect(display?.files.map((f) => f.path)).toEqual(["alpha.txt", "beta.txt"])
         expect(display?.undoAvailable).toBe(true)
         expect(display?.turnID).toBe(userMessageID)
@@ -111,25 +130,25 @@ describe("TurnChange.aggregateTurn", () => {
         const target = path.join(fixture.path, "f.txt")
         await fs.writeFile(target, "one\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: target,
           before: { exists: true, content: "one\n" },
           after: { exists: true, content: "two\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
+        finalize({ sessionID: session.id, messageID: a1 })
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: target,
           before: { exists: true, content: "two\n" },
           after: { exists: true, content: "three\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const display = TurnChange.aggregateTurn({ sessionID: session.id, userMessageID })
+        const display = aggregateTurn({ sessionID: session.id, userMessageID })
         expect(display?.files).toHaveLength(1)
         expect(display?.files[0].patch).toContain("-one")
         expect(display?.files[0].patch).toContain("+three")
@@ -150,25 +169,25 @@ describe("TurnChange.aggregateTurn", () => {
         const a2 = await makeAssistant(session.id, userMessageID, "wb2")
         const target = path.join(fixture.path, "ghost.txt")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: target,
           before: { exists: false },
           after: { exists: true, content: "g\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
+        finalize({ sessionID: session.id, messageID: a1 })
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: target,
           before: { exists: true, content: "g\n" },
           after: { exists: false },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const display = TurnChange.aggregateTurn({ sessionID: session.id, userMessageID })
+        const display = aggregateTurn({ sessionID: session.id, userMessageID })
         expect(display?.files ?? []).toEqual([])
       },
     })
@@ -182,7 +201,7 @@ describe("TurnChange.aggregateTurn", () => {
       fn: async () => {
         const session = await SessionNs.create({ title: "empty" })
         const userMessageID = await makeUser(session.id, "empty")
-        const display = TurnChange.aggregateTurn({ sessionID: session.id, userMessageID })
+        const display = aggregateTurn({ sessionID: session.id, userMessageID })
         expect(display).toBeUndefined()
       },
     })
@@ -199,24 +218,24 @@ describe("TurnChange.aggregateTurn", () => {
         const userB = await makeUser(session.id, "scopeB")
         const a1 = await makeAssistant(session.id, userA, "p1")
         const a2 = await makeAssistant(session.id, userB, "p2")
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: path.join(fixture.path, "in.txt"),
           before: { exists: false },
           after: { exists: true, content: "in\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: path.join(fixture.path, "out.txt"),
           before: { exists: false },
           after: { exists: true, content: "out\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const display = TurnChange.aggregateTurn({ sessionID: session.id, userMessageID: userA })
+        const display = aggregateTurn({ sessionID: session.id, userMessageID: userA })
         expect(display?.files.map((f) => f.path)).toEqual(["in.txt"])
       },
     })
@@ -233,7 +252,7 @@ describe("TurnChange aggregate union", () => {
         const session = await SessionNs.create({ title: "union-empty" })
         const userMessageID = await makeUser(session.id, "union-empty")
 
-        const result = TurnChange.aggregateTurnUnion({ sessionID: session.id, userMessageID })
+        const result = aggregateTurnUnion({ sessionID: session.id, userMessageID })
 
         expect(result).toMatchObject({ kind: "empty" })
       },
@@ -254,7 +273,7 @@ describe("TurnChange aggregate union", () => {
           events.push(event.properties.sessionID)
         })
         try {
-          TurnChange.recordUncaptured({ sessionID: session.id, messageID: assistantID })
+          recordUncaptured({ sessionID: session.id, messageID: assistantID })
           await new Promise((resolve) => setTimeout(resolve, 20))
 
           expect(events).toEqual([session.id])
@@ -279,14 +298,14 @@ describe("TurnChange aggregate union", () => {
           events.push(event.properties.sessionID)
         })
         try {
-          TurnChange.recordWrite({
+          recordWrite({
             sessionID: session.id,
             messageID: assistantID,
             path: path.join(fixture.path, "captured.txt"),
             before: { exists: false },
             after: { exists: true, content: "captured\n" },
           })
-          TurnChange.finalize({ sessionID: session.id, messageID: assistantID })
+          finalize({ sessionID: session.id, messageID: assistantID })
           await new Promise((resolve) => setTimeout(resolve, 20))
 
           expect(events).toEqual([session.id])
@@ -307,16 +326,16 @@ describe("TurnChange aggregate union", () => {
         const userMessageID = await makeUser(session.id, "union-captured")
         const assistantID = await makeAssistant(session.id, userMessageID, "union-captured")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: assistantID,
           path: path.join(fixture.path, "captured.txt"),
           before: { exists: false },
           after: { exists: true, content: "captured\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: assistantID })
+        finalize({ sessionID: session.id, messageID: assistantID })
 
-        const result = TurnChange.aggregateTurnUnion({ sessionID: session.id, userMessageID })
+        const result = aggregateTurnUnion({ sessionID: session.id, userMessageID })
 
         expect(result).toMatchObject({ kind: "captured", files: [{ path: "captured.txt", restoreState: "applied" }] })
       },
@@ -335,17 +354,17 @@ describe("TurnChange aggregate union", () => {
         const target = path.join(fixture.path, "undone.txt")
         await fs.writeFile(target, "after\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: assistantID,
           path: target,
           before: { exists: false },
           after: { exists: true, content: "after\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: assistantID })
-        await TurnChange.undo({ sessionID: session.id, messageID: assistantID })
+        finalize({ sessionID: session.id, messageID: assistantID })
+        await undo({ sessionID: session.id, messageID: assistantID })
 
-        const result = TurnChange.aggregateTurnUnion({ sessionID: session.id, userMessageID })
+        const result = aggregateTurnUnion({ sessionID: session.id, userMessageID })
 
         expect(result).toMatchObject({ kind: "captured", files: [{ path: "undone.txt", restoreState: "undone" }] })
       },
@@ -366,25 +385,25 @@ describe("TurnChange aggregate union", () => {
         const appliedFile = path.join(fixture.path, "applied-file.txt")
         await fs.writeFile(undoneFile, "after undone\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: undoneAssistant,
           path: undoneFile,
           before: { exists: false },
           after: { exists: true, content: "after undone\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: undoneAssistant })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: undoneAssistant })
+        recordWrite({
           sessionID: session.id,
           messageID: appliedAssistant,
           path: appliedFile,
           before: { exists: false },
           after: { exists: true, content: "after applied\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: appliedAssistant })
-        await TurnChange.undo({ sessionID: session.id, messageID: undoneAssistant })
+        finalize({ sessionID: session.id, messageID: appliedAssistant })
+        await undo({ sessionID: session.id, messageID: undoneAssistant })
 
-        const result = TurnChange.aggregateTurnUnion({ sessionID: session.id, userMessageID })
+        const result = aggregateTurnUnion({ sessionID: session.id, userMessageID })
 
         expect(result).toMatchObject({ kind: "captured" })
         if (result.kind !== "captured") return
@@ -409,7 +428,7 @@ describe("TurnChange aggregate union", () => {
         const assistantID = await makeAssistant(session.id, userMessageID, "union-truncated")
 
         for (let index = 0; index < 201; index++) {
-          TurnChange.recordWrite({
+          recordWrite({
             sessionID: session.id,
             messageID: assistantID,
             path: path.join(fixture.path, `truncated-${index}.txt`),
@@ -417,9 +436,9 @@ describe("TurnChange aggregate union", () => {
             after: { exists: true, content: `${index}\n` },
           })
         }
-        TurnChange.finalize({ sessionID: session.id, messageID: assistantID })
+        finalize({ sessionID: session.id, messageID: assistantID })
 
-        const result = TurnChange.aggregateTurnUnion({ sessionID: session.id, userMessageID })
+        const result = aggregateTurnUnion({ sessionID: session.id, userMessageID })
 
         expect(result).toMatchObject({ kind: "captured", truncated: true, omittedCount: 1 })
       },
@@ -444,26 +463,26 @@ describe("TurnChange aggregate union", () => {
         await fs.writeFile(target, "A\n", "utf-8")
 
         await fs.writeFile(target, "B\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: firstAssistant,
           path: target,
           before: { exists: true, content: "A\n" },
           after: { exists: true, content: "B\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: firstAssistant })
+        finalize({ sessionID: session.id, messageID: firstAssistant })
         await fs.writeFile(target, "C\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: secondAssistant,
           path: target,
           before: { exists: true, content: "B\n" },
           after: { exists: true, content: "C\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: secondAssistant })
-        await TurnChange.undo({ sessionID: session.id, messageID: secondAssistant })
+        finalize({ sessionID: session.id, messageID: secondAssistant })
+        await undo({ sessionID: session.id, messageID: secondAssistant })
 
-        const result = TurnChange.aggregateTurnUnion({ sessionID: session.id, userMessageID })
+        const result = aggregateTurnUnion({ sessionID: session.id, userMessageID })
 
         expect(await fs.readFile(target, "utf-8")).toBe("B\n")
         expect(result).toMatchObject({ kind: "captured" })
@@ -487,9 +506,9 @@ describe("TurnChange aggregate union", () => {
         const userMessageID = await makeUser(session.id, "union-uncaptured")
         const assistantID = await makeAssistant(session.id, userMessageID, "union-uncaptured")
 
-        TurnChange.recordUncaptured({ sessionID: session.id, messageID: assistantID })
+        recordUncaptured({ sessionID: session.id, messageID: assistantID })
 
-        const result = TurnChange.aggregateTurnUnion({ sessionID: session.id, userMessageID })
+        const result = aggregateTurnUnion({ sessionID: session.id, userMessageID })
 
         expect(result).toMatchObject({ kind: "uncaptured", count: 1 })
       },
@@ -506,17 +525,17 @@ describe("TurnChange aggregate union", () => {
         const userMessageID = await makeUser(session.id, "union-mixed")
         const assistantID = await makeAssistant(session.id, userMessageID, "union-mixed")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: assistantID,
           path: path.join(fixture.path, "mixed.txt"),
           before: { exists: false },
           after: { exists: true, content: "mixed\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: assistantID })
-        TurnChange.recordUncaptured({ sessionID: session.id, messageID: assistantID })
+        finalize({ sessionID: session.id, messageID: assistantID })
+        recordUncaptured({ sessionID: session.id, messageID: assistantID })
 
-        const result = TurnChange.aggregateTurnUnion({ sessionID: session.id, userMessageID })
+        const result = aggregateTurnUnion({ sessionID: session.id, userMessageID })
 
         expect(result).toMatchObject({
           kind: "mixed",
@@ -539,22 +558,22 @@ describe("TurnChange aggregate union", () => {
         const secondUser = await makeUser(session.id, "union-session-second")
         const secondAssistant = await makeAssistant(session.id, secondUser, "union-session-second")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: firstAssistant,
           path: path.join(fixture.path, "kept.txt"),
           before: { exists: false },
           after: { exists: true, content: "kept\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: firstAssistant })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: firstAssistant })
+        recordWrite({
           sessionID: session.id,
           messageID: secondAssistant,
           path: path.join(fixture.path, "reverted.txt"),
           before: { exists: false },
           after: { exists: true, content: "reverted\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: secondAssistant })
+        finalize({ sessionID: session.id, messageID: secondAssistant })
         Database.use((db) =>
           db
             .update(SessionTable)
@@ -563,7 +582,7 @@ describe("TurnChange aggregate union", () => {
             .run(),
         )
 
-        const result = TurnChange.aggregateSessionFromTurns({ sessionID: session.id })
+        const result = aggregateSessionFromTurns({ sessionID: session.id })
 
         expect(result).toMatchObject({ kind: "captured", files: [{ path: "kept.txt" }] })
         expect(
@@ -583,14 +602,14 @@ describe("TurnChange aggregate union", () => {
         const firstUser = await makeUser(session.id, "union-session-part-revert-first")
         const firstAssistant = await makeAssistant(session.id, firstUser, "union-session-part-revert-first")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: firstAssistant,
           path: path.join(fixture.path, "part-kept.txt"),
           before: { exists: false },
           after: { exists: true, content: "part kept\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: firstAssistant })
+        finalize({ sessionID: session.id, messageID: firstAssistant })
         Database.use((db) =>
           db
             .update(SessionTable)
@@ -599,7 +618,7 @@ describe("TurnChange aggregate union", () => {
             .run(),
         )
 
-        const result = TurnChange.aggregateSessionFromTurns({ sessionID: session.id })
+        const result = aggregateSessionFromTurns({ sessionID: session.id })
 
         expect(result).toMatchObject({ kind: "captured", files: [{ path: "part-kept.txt" }] })
       },
@@ -617,22 +636,22 @@ describe("TurnChange aggregate union", () => {
         const firstAssistant = await makeAssistant(session.id, userMessageID, "part-cutoff-a1")
         const secondAssistant = await makeAssistant(session.id, userMessageID, "part-cutoff-a2")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: firstAssistant,
           path: path.join(fixture.path, "part-a1.txt"),
           before: { exists: false },
           after: { exists: true, content: "a1\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: firstAssistant })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: firstAssistant })
+        recordWrite({
           sessionID: session.id,
           messageID: secondAssistant,
           path: path.join(fixture.path, "part-a2.txt"),
           before: { exists: false },
           after: { exists: true, content: "a2\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: secondAssistant })
+        finalize({ sessionID: session.id, messageID: secondAssistant })
         Database.use((db) =>
           db
             .update(SessionTable)
@@ -641,7 +660,7 @@ describe("TurnChange aggregate union", () => {
             .run(),
         )
 
-        const result = TurnChange.aggregateSessionFromTurns({ sessionID: session.id })
+        const result = aggregateSessionFromTurns({ sessionID: session.id })
 
         expect(result).toMatchObject({ kind: "captured", files: [{ path: "part-a1.txt" }] })
         expect(
@@ -664,24 +683,24 @@ describe("TurnChange aggregate union", () => {
         const secondAssistant = await makeAssistant(session.id, secondUser, "union-session-same-path-second")
         const target = path.join(fixture.path, "same.txt")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: firstAssistant,
           path: target,
           before: { exists: true, content: "one\n" },
           after: { exists: true, content: "two\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: firstAssistant })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: firstAssistant })
+        recordWrite({
           sessionID: session.id,
           messageID: secondAssistant,
           path: target,
           before: { exists: true, content: "two\n" },
           after: { exists: true, content: "three\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: secondAssistant })
+        finalize({ sessionID: session.id, messageID: secondAssistant })
 
-        const result = TurnChange.aggregateSessionFromTurns({ sessionID: session.id })
+        const result = aggregateSessionFromTurns({ sessionID: session.id })
 
         expect(result).toMatchObject({ kind: "captured" })
         if (result.kind !== "captured") return
@@ -713,26 +732,26 @@ describe("TurnChange aggregate union", () => {
         await fs.writeFile(target, "A\n", "utf-8")
 
         await fs.writeFile(target, "B\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: firstAssistant,
           path: target,
           before: { exists: true, content: "A\n" },
           after: { exists: true, content: "B\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: firstAssistant })
+        finalize({ sessionID: session.id, messageID: firstAssistant })
         await fs.writeFile(target, "C\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: secondAssistant,
           path: target,
           before: { exists: true, content: "B\n" },
           after: { exists: true, content: "C\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: secondAssistant })
-        await TurnChange.undo({ sessionID: session.id, messageID: secondAssistant })
+        finalize({ sessionID: session.id, messageID: secondAssistant })
+        await undo({ sessionID: session.id, messageID: secondAssistant })
 
-        const result = TurnChange.aggregateSessionFromTurns({ sessionID: session.id })
+        const result = aggregateSessionFromTurns({ sessionID: session.id })
 
         expect(await fs.readFile(target, "utf-8")).toBe("B\n")
         expect(result).toMatchObject({ kind: "captured" })
@@ -763,24 +782,24 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         await fs.writeFile(fileA, "newA\n", "utf-8")
         await fs.writeFile(fileB, "newB\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: fileA,
           before: { exists: false },
           after: { exists: true, content: "newA\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: fileB,
           before: { exists: false },
           after: { exists: true, content: "newB\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const result = await TurnChange.aggregateTurnUndo({ sessionID: session.id, userMessageID })
+        const result = await aggregateTurnUndo({ sessionID: session.id, userMessageID })
         expect(result.status).toBe("applied")
         if (result.status !== "applied") return
         expect(result.display.undoAvailable).toBe(false)
@@ -814,18 +833,18 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         const fileA = path.join(fixture.path, "r-a.txt")
         await fs.writeFile(fileA, "newA\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: fileA,
           before: { exists: false },
           after: { exists: true, content: "newA\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
+        finalize({ sessionID: session.id, messageID: a1 })
 
-        const undoResult = await TurnChange.aggregateTurnUndo({ sessionID: session.id, userMessageID })
+        const undoResult = await aggregateTurnUndo({ sessionID: session.id, userMessageID })
         expect(undoResult.status).toBe("applied")
-        const redoResult = await TurnChange.aggregateTurnRedo({ sessionID: session.id, userMessageID })
+        const redoResult = await aggregateTurnRedo({ sessionID: session.id, userMessageID })
         expect(redoResult.status).toBe("applied")
         if (redoResult.status !== "applied") return
         expect(redoResult.display.undoAvailable).toBe(true)
@@ -850,24 +869,24 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         await fs.writeFile(ok, "newOK\n", "utf-8")
         await fs.writeFile(conflict, "tampered\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: ok,
           before: { exists: false },
           after: { exists: true, content: "newOK\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: conflict,
           before: { exists: false },
           after: { exists: true, content: "expectedConflict\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const result = await TurnChange.aggregateTurnUndo({ sessionID: session.id, userMessageID })
+        const result = await aggregateTurnUndo({ sessionID: session.id, userMessageID })
         expect(result.status).toBe("blocked")
         if (result.status !== "blocked") return
         expect(result.reason).toBe("conflict")
@@ -890,26 +909,26 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         const target = path.join(fixture.path, "chain.txt")
 
         await fs.writeFile(target, "two\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: target,
           before: { exists: false },
           after: { exists: true, content: "two\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
+        finalize({ sessionID: session.id, messageID: a1 })
 
         await fs.writeFile(target, "three\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: target,
           before: { exists: true, content: "two\n" },
           after: { exists: true, content: "three\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const result = await TurnChange.aggregateTurnUndo({ sessionID: session.id, userMessageID })
+        const result = await aggregateTurnUndo({ sessionID: session.id, userMessageID })
         expect(result.status).toBe("applied")
         if (result.status !== "applied") return
         expect(result.skipped ?? []).toEqual([])
@@ -920,7 +939,7 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
             .catch(() => false),
         ).toBe(false)
 
-        const redo = await TurnChange.aggregateTurnRedo({ sessionID: session.id, userMessageID })
+        const redo = await aggregateTurnRedo({ sessionID: session.id, userMessageID })
         expect(redo.status).toBe("applied")
         if (redo.status !== "applied") return
         expect(await fs.readFile(target, "utf-8")).toBe("three\n")
@@ -945,24 +964,24 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         const fileA = path.join(dirA, "shared.txt")
         const fileB = path.join(dirB, "shared.txt")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: fileA,
           before: { exists: false },
           after: { exists: true, content: "A\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: fileB,
           before: { exists: false },
           after: { exists: true, content: "B\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const display = TurnChange.aggregateTurn({ sessionID: session.id, userMessageID })
+        const display = aggregateTurn({ sessionID: session.id, userMessageID })
         expect(display?.files).toHaveLength(2)
         const openPaths = (display?.files ?? []).map((f) => f.openPath).sort()
         expect(openPaths).toEqual([fileA, fileB].sort())
@@ -985,27 +1004,27 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         await fs.writeFile(fileA, "A\n", "utf-8")
         await fs.writeFile(fileB, "B\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: fileA,
           before: { exists: false },
           after: { exists: true, content: "A\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: fileB,
           before: { exists: false },
           after: { exists: true, content: "B\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const undoSecond = await TurnChange.undo({ sessionID: session.id, messageID: a2 })
+        const undoSecond = await undo({ sessionID: session.id, messageID: a2 })
         expect(undoSecond.status).toBe("applied")
 
-        const display = TurnChange.aggregateTurn({ sessionID: session.id, userMessageID })
+        const display = aggregateTurn({ sessionID: session.id, userMessageID })
         expect(display?.undoAvailable).toBe(true)
         expect(display?.redoAvailable).toBe(true)
       },
@@ -1027,24 +1046,24 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         await fs.writeFile(ok, "OK\n", "utf-8")
         await fs.writeFile(conflict, "tampered\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: ok,
           before: { exists: false },
           after: { exists: true, content: "OK\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: conflict,
           before: { exists: false },
           after: { exists: true, content: "expectedConflict\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const result = await TurnChange.aggregateTurnUndo({
+        const result = await aggregateTurnUndo({
           sessionID: session.id,
           userMessageID,
           force: true,
@@ -1072,24 +1091,24 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         const externalA = "/tmp/pawwork-fixture-A/config.json"
         const externalB = "/tmp/pawwork-fixture-B/config.json"
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: externalA,
           before: { exists: false },
           after: { exists: true, content: '{"a":1}\n' },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: externalB,
           before: { exists: false },
           after: { exists: true, content: '{"b":1}\n' },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const display = TurnChange.aggregateTurn({ sessionID: session.id, userMessageID })
+        const display = aggregateTurn({ sessionID: session.id, userMessageID })
         expect(display?.files).toHaveLength(2)
         const paths = (display?.files ?? []).map((f) => f.path)
         // Distinct displayPaths after the second-pass disambiguation.
@@ -1115,33 +1134,33 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         const big = path.join(fixture.path, "u-big.bin")
         await fs.writeFile(ok, "OK\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: ok,
           before: { exists: false },
           after: { exists: true, content: "OK\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
+        finalize({ sessionID: session.id, messageID: a1 })
         // Mark the second message's `before` as non-restorable (oversized).
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: big,
           before: { exists: true, restorable: false, hash: "large:99999999", large: true },
           after: { exists: true, content: "after\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
         // Default (force=false): fatal unsupported_size, ok file untouched.
-        const blocked = await TurnChange.aggregateTurnUndo({ sessionID: session.id, userMessageID })
+        const blocked = await aggregateTurnUndo({ sessionID: session.id, userMessageID })
         expect(blocked.status).toBe("blocked")
         if (blocked.status !== "blocked") return
         expect(blocked.reason).toBe("unsupported_size")
         expect(await fs.readFile(ok, "utf-8")).toBe("OK\n")
 
         // force=true must not partially mutate either; still fatal unsupported_size.
-        const forced = await TurnChange.aggregateTurnUndo({
+        const forced = await aggregateTurnUndo({
           sessionID: session.id,
           userMessageID,
           force: true,
@@ -1169,24 +1188,24 @@ describe("TurnChange.aggregateTurnUndo / aggregateTurnRedo", () => {
         await fs.writeFile(ok, "newOK\n", "utf-8")
         await fs.writeFile(conflict, "tampered\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           sessionID: session.id,
           messageID: a1,
           path: ok,
           before: { exists: false },
           after: { exists: true, content: "newOK\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a1 })
-        TurnChange.recordWrite({
+        finalize({ sessionID: session.id, messageID: a1 })
+        recordWrite({
           sessionID: session.id,
           messageID: a2,
           path: conflict,
           before: { exists: false },
           after: { exists: true, content: "expectedConflict\n" },
         })
-        TurnChange.finalize({ sessionID: session.id, messageID: a2 })
+        finalize({ sessionID: session.id, messageID: a2 })
 
-        const result = await TurnChange.aggregateTurnUndo({
+        const result = await aggregateTurnUndo({
           sessionID: session.id,
           userMessageID,
           force: true,

--- a/packages/opencode/test/session/turn-change.test.ts
+++ b/packages/opencode/test/session/turn-change.test.ts
@@ -8,10 +8,18 @@ import { TurnChange } from "../../src/session/turn-change"
 import { MessageID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Database } from "../../src/storage/db"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { tmpdir } from "../fixture/fixture"
 import { resetDatabase } from "../fixture/db"
 
 const messageID = MessageID.make("msg_turn_change")
+const turnChange = await AppRuntime.runPromise(TurnChange.Service)
+const recordWrite = (input: Parameters<typeof turnChange.recordWrite>[0]) =>
+  AppRuntime.runSync(turnChange.recordWrite(input))
+const finalize = (input: Parameters<typeof turnChange.finalize>[0]) => AppRuntime.runSync(turnChange.finalize(input))
+const get = (input: Parameters<typeof turnChange.get>[0]) => AppRuntime.runSync(turnChange.get(input))
+const undo = (input: Parameters<typeof turnChange.undo>[0]) => AppRuntime.runPromise(turnChange.undo(input))
+const redo = (input: Parameters<typeof turnChange.redo>[0]) => AppRuntime.runPromise(turnChange.redo(input))
 
 async function createTurn() {
   const session = await SessionNs.create({ title: "turn change" })
@@ -43,20 +51,20 @@ describe("TurnChange", () => {
         const target = path.join(fixture.path, "file.txt")
         await fs.writeFile(target, "one\n", "utf-8")
 
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: true, content: "one\n" },
           after: { exists: true, content: "two\n" },
         })
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: true, content: "two\n" },
           after: { exists: true, content: "three\n" },
         })
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
 
         expect(display?.files).toHaveLength(1)
         expect(display?.files[0]).toMatchObject({
@@ -82,14 +90,14 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, ".env")
 
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: false },
           after: { exists: true, content: "TOKEN=new-secret\n" },
         })
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
         const serialized = JSON.stringify(display)
 
         expect(display?.undoAvailable).toBe(true)
@@ -117,26 +125,26 @@ describe("TurnChange", () => {
         const second = path.join(fixture.path, "second.txt")
         const first = path.join(fixture.path, "first.txt")
 
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: second,
           before: { exists: false },
           after: { exists: true, content: "second\n" },
         })
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: first,
           before: { exists: false },
           after: { exists: true, content: "first\n" },
         })
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: second,
           before: { exists: true, content: "second\n" },
           after: { exists: true, content: "second updated\n" },
         })
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
 
         expect(display?.files.map((file) => file.path)).toEqual(["second.txt", "first.txt"])
       },
@@ -152,18 +160,18 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const external = path.join(path.dirname(fixture.path), "outside-project", "external.txt")
 
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: external,
           before: { exists: false },
           after: { exists: true, content: "external\n" },
         })
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
 
         expect(display?.files[0]?.path).toBe("external.txt")
         expect(JSON.stringify(display)).not.toContain(path.dirname(fixture.path))
-        expect(TurnChange.get(turn)?.files[0]?.openPath).toBe(external)
+        expect(get(turn)?.files[0]?.openPath).toBe(external)
       },
     })
   })
@@ -177,14 +185,14 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const external = path.join(path.dirname(fixture.path), "my-secrets", "config.json")
 
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: external,
           before: { exists: false },
           after: { exists: true, content: "token=hidden\n" },
         })
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
         const serialized = JSON.stringify(display)
 
         expect(display?.files).toEqual([
@@ -212,23 +220,23 @@ describe("TurnChange", () => {
         const first = path.join(path.dirname(fixture.path), "outside-a", "config.json")
         const second = path.join(path.dirname(fixture.path), "outside-b", "config.json")
 
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: first,
           before: { exists: false },
           after: { exists: true, content: "first\n" },
         })
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: second,
           before: { exists: false },
           after: { exists: true, content: "second\n" },
         })
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
 
         expect(display?.files.map((file) => file.path)).toEqual(["config.json", "config.json · external #2"])
-        expect(TurnChange.get(turn)?.files.map((file) => file.openPath)).toEqual([first, second])
+        expect(get(turn)?.files.map((file) => file.openPath)).toEqual([first, second])
       },
     })
   })
@@ -241,7 +249,7 @@ describe("TurnChange", () => {
       fn: async () => {
         const turn = await createTurn()
         for (let index = 0; index < 201; index++) {
-          TurnChange.recordWrite({
+          recordWrite({
             ...turn,
             path: path.join(fixture.path, `file-${index}.txt`),
             before: { exists: false },
@@ -249,13 +257,13 @@ describe("TurnChange", () => {
           })
         }
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
 
         expect(display?.files).toHaveLength(200)
         expect(display?.truncated).toBe(true)
         expect(display?.omittedCount).toBe(1)
         expect(display?.undoAvailable).toBe(false)
-        expect(TurnChange.get(turn)?.undoAvailable).toBe(false)
+        expect(get(turn)?.undoAvailable).toBe(false)
       },
     })
   })
@@ -268,21 +276,21 @@ describe("TurnChange", () => {
       fn: async () => {
         const turn = await createTurn()
         for (let index = 0; index < 200; index++) {
-          TurnChange.recordWrite({
+          recordWrite({
             ...turn,
             path: path.join(fixture.path, `noop-${index}.txt`),
             before: { exists: true, content: "same\n" },
             after: { exists: true, content: "same\n" },
           })
         }
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: path.join(fixture.path, "omitted.txt"),
           before: { exists: false },
           after: { exists: true, content: "omitted\n" },
         })
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
 
         expect(display).toMatchObject({
           truncated: true,
@@ -291,7 +299,7 @@ describe("TurnChange", () => {
           redoAvailable: false,
           files: [],
         })
-        expect(TurnChange.get(turn)).toMatchObject({
+        expect(get(turn)).toMatchObject({
           truncated: true,
           omittedCount: 1,
           undoAvailable: false,
@@ -312,16 +320,16 @@ describe("TurnChange", () => {
         for (let index = 0; index < 201; index++) {
           const target = path.join(fixture.path, `file-${index}.txt`)
           await fs.writeFile(target, "after\n", "utf-8")
-          TurnChange.recordWrite({
+          recordWrite({
             ...turn,
             path: target,
             before: { exists: false },
             after: { exists: true, content: "after\n" },
           })
         }
-        TurnChange.finalize(turn)
+        finalize(turn)
 
-        const result = await TurnChange.undo(turn)
+        const result = await undo(turn)
 
         expect(result).toMatchObject({
           status: "blocked",
@@ -345,14 +353,14 @@ describe("TurnChange", () => {
         const large = "x".repeat(20 * 1024 * 1024 + 1)
         await fs.rm(target, { force: true })
 
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: true, content: large },
           after: { exists: false },
         })
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
         expect(display?.files).toEqual([
           {
             path: "large.txt",
@@ -363,7 +371,7 @@ describe("TurnChange", () => {
           },
         ])
 
-        const result = await TurnChange.undo(turn)
+        const result = await undo(turn)
         expect(result).toMatchObject({
           status: "blocked",
           reason: "unsupported_size",
@@ -383,13 +391,13 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, "medium.txt")
         const medium = "a".repeat(3 * 1024 * 1024)
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: false },
           after: { exists: true, content: medium },
         })
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
         expect(display?.files).toHaveLength(1)
         expect(display?.files[0]).toMatchObject({
           path: "medium.txt",
@@ -401,7 +409,7 @@ describe("TurnChange", () => {
         expect(display?.undoAvailable).toBe(true)
 
         await fs.writeFile(target, medium, "utf-8")
-        const result = await TurnChange.undo(turn)
+        const result = await undo(turn)
         expect(result.status).toBe("applied")
         await expect(fs.readFile(target, "utf-8")).rejects.toThrow()
       },
@@ -417,13 +425,13 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, "huge.txt")
         const huge = "a".repeat(20 * 1024 * 1024 + 1)
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: false },
           after: { exists: true, content: huge },
         })
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
         expect(display?.files).toHaveLength(1)
         expect(display?.files[0]).toMatchObject({
           large: true,
@@ -443,20 +451,20 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, "bom.txt")
         await fs.writeFile(target, "after\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: true, content: "before\n", bom: true },
           after: { exists: true, content: "after\n", bom: false },
         })
-        TurnChange.finalize(turn)
+        finalize(turn)
 
-        expect((await TurnChange.undo(turn)).status).toBe("applied")
+        expect((await undo(turn)).status).toBe("applied")
         const bytes = await fs.readFile(target)
         expect([...bytes.slice(0, 3)]).toEqual([0xef, 0xbb, 0xbf])
         expect(bytes.toString("utf-8")).toBe("\uFEFFbefore\n")
 
-        expect((await TurnChange.redo(turn)).status).toBe("applied")
+        expect((await redo(turn)).status).toBe("applied")
         const redoBytes = await fs.readFile(target)
         expect([...redoBytes.slice(0, 3)]).not.toEqual([0xef, 0xbb, 0xbf])
         expect(redoBytes.toString("utf-8")).toBe("after\n")
@@ -473,16 +481,16 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, "file.txt")
         await fs.writeFile(target, "after\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: true, content: "before\n" },
           after: { exists: true, content: "after\n" },
         })
-        TurnChange.finalize(turn)
+        finalize(turn)
         await fs.writeFile(target, "user edit\n", "utf-8")
 
-        const result = await TurnChange.undo(turn)
+        const result = await undo(turn)
 
         expect(result.status).toBe("blocked")
         expect(await fs.readFile(target, "utf-8")).toBe("user edit\n")
@@ -499,18 +507,18 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, "file.txt")
         await fs.writeFile(target, "after\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: true, content: "before\n" },
           after: { exists: true, content: "after\n" },
         })
-        TurnChange.finalize(turn)
+        finalize(turn)
         await fs.writeFile(target, "x".repeat(20 * 1024 * 1024 + 1), "utf-8")
 
         const readFile = spyOn(fs, "readFile")
         try {
-          const result = await TurnChange.undo(turn)
+          const result = await undo(turn)
 
           expect(result).toMatchObject({
             status: "blocked",
@@ -533,7 +541,7 @@ describe("TurnChange", () => {
       fn: async () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, "file.txt")
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: false },
@@ -543,8 +551,8 @@ describe("TurnChange", () => {
           throw new Error("db unavailable")
         })
         try {
-          expect(() => TurnChange.finalize(turn)).not.toThrow()
-          expect(TurnChange.get(turn)).toBeUndefined()
+          expect(() => finalize(turn)).not.toThrow()
+          expect(get(turn)).toBeUndefined()
         } finally {
           transaction.mockRestore()
         }
@@ -561,13 +569,13 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, "file.txt")
         await fs.writeFile(target, "after\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: true, content: "before\n" },
           after: { exists: true, content: "after\n" },
         })
-        TurnChange.finalize(turn)
+        finalize(turn)
 
         const writeFile = spyOn(fs, "writeFile").mockImplementation(() => {
           const err = new Error("permission denied") as NodeJS.ErrnoException
@@ -575,7 +583,7 @@ describe("TurnChange", () => {
           throw err
         })
         try {
-          const result = await TurnChange.undo(turn)
+          const result = await undo(turn)
 
           expect(result).toMatchObject({
             status: "blocked",
@@ -598,13 +606,13 @@ describe("TurnChange", () => {
         const turn = await createTurn()
         const target = path.join(fixture.path, "file.txt")
         await fs.writeFile(target, "after\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           ...turn,
           path: target,
           before: { exists: true, content: "before\n" },
           after: { exists: true, content: "after\n" },
         })
-        TurnChange.finalize(turn)
+        finalize(turn)
 
         const original = Database.use
         let calls = 0
@@ -614,7 +622,7 @@ describe("TurnChange", () => {
           return original(fn)
         }) as typeof Database.use)
         try {
-          const result = await TurnChange.undo(turn)
+          const result = await undo(turn)
 
           expect(result).toMatchObject({
             status: "blocked",
@@ -622,7 +630,7 @@ describe("TurnChange", () => {
             files: [{ path: "file.txt", reason: "state_persist_failed" }],
           })
           expect(await fs.readFile(target, "utf-8")).toBe("after\n")
-          expect(TurnChange.get(turn)?.undoAvailable).toBe(true)
+          expect(get(turn)?.undoAvailable).toBe(true)
         } finally {
           use.mockRestore()
         }
@@ -639,15 +647,15 @@ describe("TurnChange", () => {
         const first = await createTurn()
         const target = path.join(fixture.path, "file.txt")
         await fs.writeFile(target, "after\n", "utf-8")
-        TurnChange.recordWrite({
+        recordWrite({
           ...first,
           path: target,
           before: { exists: true, content: "before\n" },
           after: { exists: true, content: "after\n" },
         })
-        TurnChange.finalize(first)
-        expect((await TurnChange.undo(first)).status).toBe("applied")
-        expect(TurnChange.get(first)?.redoAvailable).toBe(true)
+        finalize(first)
+        expect((await undo(first)).status).toBe("applied")
+        expect(get(first)?.redoAvailable).toBe(true)
 
         const second = { sessionID: first.sessionID, messageID: MessageID.make("msg_turn_change_2") }
         await SessionNs.updateMessage({
@@ -664,15 +672,15 @@ describe("TurnChange", () => {
           cost: 0,
           tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
         } as unknown as MessageV2.Info)
-        TurnChange.recordWrite({
+        recordWrite({
           ...second,
           path: target,
           before: { exists: true, content: "before\n" },
           after: { exists: true, content: "new turn\n" },
         })
-        TurnChange.finalize(second)
+        finalize(second)
 
-        expect(TurnChange.get(first)?.redoAvailable).toBe(false)
+        expect(get(first)?.redoAvailable).toBe(false)
       },
     })
   })

--- a/packages/opencode/test/share/share-next.test.ts
+++ b/packages/opencode/test/share/share-next.test.ts
@@ -21,6 +21,7 @@ import { ShareRuntime } from "../../src/share/runtime"
 import { Storage } from "../../src/storage/storage"
 import { SessionShareTable } from "../../src/share/share.sql"
 import { Database, eq } from "../../src/storage/db"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { resetDatabase } from "../fixture/db"
 import { testEffect } from "../lib/effect"
@@ -34,6 +35,10 @@ const env = Layer.mergeAll(
 )
 const it = testEffect(env)
 const enabledGate = Layer.succeed(ShareRuntime.CloudShareGate, { isEnabled: () => true })
+const turnChange = await AppRuntime.runPromise(TurnChange.Service)
+const recordWrite = (input: Parameters<typeof turnChange.recordWrite>[0]) =>
+  AppRuntime.runSync(turnChange.recordWrite(input))
+const finalize = (input: Parameters<typeof turnChange.finalize>[0]) => AppRuntime.runSync(turnChange.finalize(input))
 
 const json = (req: Parameters<typeof HttpClientResponse.fromWeb>[0], body: unknown, status = 200) =>
   HttpClientResponse.fromWeb(
@@ -389,22 +394,22 @@ describe("ShareNext", () => {
           )
 
           yield* Effect.sync(() => {
-            TurnChange.recordWrite({
+            recordWrite({
               sessionID: info.id,
               messageID: firstAssistant,
               path: "/repo/part-a1.txt",
               before: { exists: false },
               after: { exists: true, content: "a1\n" },
             })
-            TurnChange.finalize({ sessionID: info.id, messageID: firstAssistant })
-            TurnChange.recordWrite({
+            finalize({ sessionID: info.id, messageID: firstAssistant })
+            recordWrite({
               sessionID: info.id,
               messageID: secondAssistant,
               path: "/repo/part-a2.txt",
               before: { exists: false },
               after: { exists: true, content: "a2\n" },
             })
-            TurnChange.finalize({ sessionID: info.id, messageID: secondAssistant })
+            finalize({ sessionID: info.id, messageID: secondAssistant })
             Database.use((db) =>
               db
                 .update(SessionTable)

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -26,6 +26,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { resetDatabase } from "../fixture/db"
 import { testEffect } from "../lib/effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
 
 const testLayer = Layer.mergeAll(
   CrossSpawnSpawner.defaultLayer,
@@ -36,6 +37,10 @@ const testLayer = Layer.mergeAll(
   TurnChange.defaultLayer,
 )
 const it = testEffect(testLayer)
+const turnChange = await AppRuntime.runPromise(TurnChange.Service)
+const finalize = (input: Parameters<typeof turnChange.finalize>[0]) => AppRuntime.runSync(turnChange.finalize(input))
+const aggregateTurnUnion = (input: Parameters<typeof turnChange.aggregateTurnUnion>[0]) =>
+  AppRuntime.runSync(turnChange.aggregateTurnUnion(input))
 
 const initBashEffect = Effect.gen(function* () {
   const info = yield* ShellTool
@@ -324,7 +329,7 @@ describe("tool.bash expected_outputs", () => {
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
 
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
         expect(display?.files).toEqual([
           {
             path: "report.docx",
@@ -369,7 +374,7 @@ describe("tool.bash expected_outputs", () => {
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true }])
 
-        expect(TurnChange.finalize(turn)?.files).toMatchObject([
+        expect(finalize(turn)?.files).toMatchObject([
           {
             path: "notes.txt",
             status: "added",
@@ -413,7 +418,7 @@ describe("tool.bash expected_outputs", () => {
           (result.metadata as { artifacts?: Array<{ path: string; exists: boolean; changed: boolean }> }).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true }])
 
-        expect(TurnChange.finalize(turn)?.files).toMatchObject([
+        expect(finalize(turn)?.files).toMatchObject([
           {
             path: "notes-bom.txt",
             status: "added",
@@ -453,7 +458,7 @@ describe("tool.bash expected_outputs", () => {
         )
 
         expect(result.metadata.exit).toBe(1)
-        const display = TurnChange.finalize(turn)
+        const display = finalize(turn)
         expect(display?.files[0]).toMatchObject({
           path: "partial.docx",
           status: "added",
@@ -501,7 +506,7 @@ describe("tool.bash expected_outputs", () => {
           (result.metadata as { artifacts?: Array<{ path: string; exists: boolean; changed: boolean }> }).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true }])
         expect(
-          TurnChange.finalize(turn)?.files?.some(
+          finalize(turn)?.files?.some(
             (file) => file.path === "nested/report.txt" && file.status === "added",
           ),
         ).toBe(true)
@@ -532,7 +537,7 @@ describe("tool.bash expected_outputs", () => {
           ),
         )
 
-        expect(TurnChange.finalize(turn)).toBeUndefined()
+        expect(finalize(turn)).toBeUndefined()
       },
     })
   })
@@ -563,9 +568,9 @@ describe("tool.bash expected_outputs", () => {
 
         expect(result.metadata.exit).toBe(0)
         expect((result.metadata as { artifacts?: unknown[] }).artifacts).toBeUndefined()
-        expect(TurnChange.finalize(turn)).toBeUndefined()
+        expect(finalize(turn)).toBeUndefined()
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "uncaptured",
           count: 1,
@@ -612,7 +617,7 @@ describe("tool.bash expected_outputs", () => {
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
 
-        expect(TurnChange.finalize(turn)?.files).toEqual([
+        expect(finalize(turn)?.files).toEqual([
           {
             path: "Report.DOCX",
             status: "added",
@@ -663,7 +668,7 @@ describe("tool.bash expected_outputs", () => {
             }
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
-        expect(TurnChange.finalize(turn)?.files).toEqual([
+        expect(finalize(turn)?.files).toEqual([
           {
             path: "report.docx",
             status: "modified",
@@ -706,9 +711,9 @@ describe("tool.bash expected_outputs", () => {
         )
 
         expect(result.metadata.exit).toBe(0)
-        TurnChange.finalize(turn)
+        finalize(turn)
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "mixed",
           count: 1,
@@ -763,7 +768,7 @@ describe("tool.bash expected_outputs", () => {
             }
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
-        expect(TurnChange.finalize(turn)?.files?.[0]).toMatchObject({
+        expect(finalize(turn)?.files?.[0]).toMatchObject({
           path: "nested/Report.XLSX",
           status: "added",
           binary: true,
@@ -804,9 +809,9 @@ describe("tool.bash expected_outputs", () => {
 
         expect(result.metadata.exit).toBe(0)
         expect((result.metadata as { artifacts?: unknown[] }).artifacts).toBeUndefined()
-        expect(TurnChange.finalize(turn)).toBeUndefined()
+        expect(finalize(turn)).toBeUndefined()
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "uncaptured",
           count: 1,
@@ -848,9 +853,9 @@ describe("tool.bash expected_outputs", () => {
         expect(result.metadata.exit).toBe(0)
         expect(fs.existsSync(target)).toBe(true)
         expect((result.metadata as { artifacts?: unknown[] }).artifacts).toBeUndefined()
-        expect(TurnChange.finalize(turn)).toBeUndefined()
+        expect(finalize(turn)).toBeUndefined()
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "uncaptured",
           count: 1,
@@ -894,9 +899,9 @@ describe("tool.bash expected_outputs", () => {
 
         expect(result.metadata.exit).toBe(0)
         expect((result.metadata as { artifacts?: unknown[] }).artifacts).toBeUndefined()
-        expect(TurnChange.finalize(turn)).toBeUndefined()
+        expect(finalize(turn)).toBeUndefined()
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "uncaptured",
           count: 1,
@@ -971,7 +976,7 @@ describe("tool.bash expected_outputs", () => {
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "mixed",
           count: 1,
@@ -1007,7 +1012,7 @@ describe("tool.bash expected_outputs", () => {
 
         expect(result.metadata.exit).toBe(0)
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "empty",
         })
@@ -1048,9 +1053,9 @@ describe("tool.bash expected_outputs", () => {
 
         expect(result.metadata.exit).toBe(0)
         expect((result.metadata as { artifacts?: unknown[] }).artifacts).toBeUndefined()
-        expect(TurnChange.finalize(turn)).toBeUndefined()
+        expect(finalize(turn)).toBeUndefined()
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "empty",
         })
@@ -1116,7 +1121,7 @@ describe("tool.bash expected_outputs", () => {
             }
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
-        expect(TurnChange.finalize(turn)?.files).toEqual([
+        expect(finalize(turn)?.files).toEqual([
           {
             path: "report.docx",
             status: "modified",
@@ -1190,7 +1195,7 @@ describe("tool.bash expected_outputs", () => {
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "mixed",
           count: 1,
@@ -1269,7 +1274,7 @@ describe("tool.bash expected_outputs", () => {
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "mixed",
           count: 1,
@@ -1345,7 +1350,7 @@ describe("tool.bash expected_outputs", () => {
             }
           ).artifacts,
         ).toEqual([{ path: target, exists: true, changed: true, binary: true }])
-        expect(TurnChange.finalize(turn)?.files).toEqual([
+        expect(finalize(turn)?.files).toEqual([
           {
             path: "report.xlsx",
             status: "modified",
@@ -1406,9 +1411,9 @@ describe("tool.bash expected_outputs", () => {
 
         expect(result.metadata.exit).toBe(0)
         expect((result.metadata as { artifacts?: unknown[] }).artifacts).toBeUndefined()
-        expect(TurnChange.finalize(turn)).toBeUndefined()
+        expect(finalize(turn)).toBeUndefined()
         expect(
-          TurnChange.aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
+          aggregateTurnUnion({ sessionID: turn.sessionID, userMessageID: MessageID.make("msg_user") }),
         ).toMatchObject({
           kind: "empty",
         })
@@ -1464,7 +1469,7 @@ describe("tool.bash expected_outputs", () => {
               }
             ).artifacts,
           ).toEqual([{ path: target, exists: false, changed: false, comparable: false, errorCode: "EACCES" }])
-          expect(TurnChange.finalize(turn)).toBeUndefined()
+          expect(finalize(turn)).toBeUndefined()
         } finally {
           readSpy.mockRestore()
         }


### PR DESCRIPTION
## Summary

Remove the remaining `TurnChange` sync/Promise facade exports and their per-service runtime. Test callers now exercise `TurnChange.Service` through a service runtime, and the legacy-boundaries guardrail rejects reintroducing these facades.

## Why

Related to #936.

`TurnChange` is already part of the shared `AppRuntime` layer, so its private `makeRuntime(Service, defaultLayer)` compatibility runtime is no longer needed. Keeping it would leave another service-specific facade after the migration tail is supposed to move callers onto Effect services.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether the converted tests still cover the same record/finalize/aggregate/undo/redo behavior through the service boundary, and whether the guardrail is specific enough to block the removed `TurnChange` facades without expanding this PR beyond the TurnChange cleanup.

## Risk Notes

No product behavior is intended to change. The touched server route test is test-only and was updated solely because it created TurnChange fixture data through the removed facade. No UI, copy, dependency, generated output, docs, release-note, credential, deletion, or platform/packaging surface changed.

Fresh-eye result: no P0/P1 findings. One P3 cleanup was found and fixed by removing an unused local test helper. The remaining local test helpers intentionally keep this PR scoped to facade removal instead of rewriting older async tests into a larger harness migration.

## How To Verify

```text
Legacy-boundary RED: added TurnChange facade guardrail and confirmed it failed before removing the runtime/facade block.
Focused tests: bun test test/session/turn-change.test.ts test/session/turn-change-aggregate.test.ts test/session/session-artifacts.test.ts test/share/share-next.test.ts test/tool/write.test.ts test/tool/edit.test.ts test/tool/apply_patch.test.ts test/tool/shell.test.ts test/session/processor-effect.test.ts test/session/processor-rate-limit.test.ts test/session/snapshot-tool-race.test.ts test/effect/legacy-boundaries.test.ts -> 260 pass, 0 fail.
Extra touched test: bun test test/server/turn-change-aggregate-routes.test.ts -> 3 pass, 0 fail.
Typecheck: GOMAXPROCS=2 bun run typecheck -> passed.
Diff check: git diff --check -> passed.
Direct-call grep: no remaining TurnChange facade caller hits outside service method names and test titles.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.