### PR TITLE
refactor(opencode): remove agent settings facades

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -40,6 +40,7 @@ import type { ACPConfig } from "./types"
 import { Provider } from "../provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
 import { Agent as AgentModule } from "../agent/agent"
+import { AppRuntime } from "../effect/app-runtime"
 import { Installation } from "@/installation"
 import { MessageV2 } from "@/session/message-v2"
 import { Config } from "@/config/config"
@@ -56,6 +57,10 @@ const DEFAULT_VARIANT_VALUE = "default"
 
 export namespace ACP {
   const log = Log.create({ service: "acp-agent" })
+
+  function defaultAgent() {
+    return AppRuntime.runPromise(AgentModule.Service.use((agent) => agent.defaultAgent()))
+  }
 
   async function getContextLimit(
     sdk: OpencodeClient,
@@ -1101,7 +1106,7 @@ export namespace ACP {
         this.sessionManager.get(sessionId).modeId ||
         (await (async () => {
           if (!availableModes.length) return undefined
-          const defaultAgentName = await AgentModule.defaultAgent()
+          const defaultAgentName = await defaultAgent()
           const resolvedModeId =
             availableModes.find((mode) => mode.name === defaultAgentName)?.id ?? availableModes[0].id
           this.sessionManager.setMode(sessionId, resolvedModeId)
@@ -1302,7 +1307,7 @@ export namespace ACP {
       if (!current) {
         this.sessionManager.setModel(session.id, model)
       }
-      const agent = session.modeId ?? (await AgentModule.defaultAgent())
+      const agent = session.modeId ?? (await defaultAgent())
 
       const parts: Array<
         | { type: "text"; text: string; synthetic?: boolean; ignored?: boolean }

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -18,7 +18,6 @@ import { mergeDeep, pipe, sortBy, values } from "remeda"
 import { Plugin } from "@/plugin"
 import { Effect, Context, Layer } from "effect"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { Global } from "@opencode-ai/core/global"
 import { aiSdkTracer } from "@opencode-ai/core/effect/observability"
 import path from "path"
@@ -399,22 +398,4 @@ export namespace Agent {
     Layer.provide(Auth.defaultLayer),
     Layer.provide(Config.defaultLayer),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function get(agent: string) {
-    return runPromise((svc) => svc.get(agent))
-  }
-
-  export async function list() {
-    return runPromise((svc) => svc.list())
-  }
-
-  export async function defaultAgent() {
-    return runPromise((svc) => svc.defaultAgent())
-  }
-
-  export async function generate(input: { description: string; model?: { providerID: ProviderID; modelID: ModelID } }) {
-    return runPromise((svc) => svc.generate(input))
-  }
 }

--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -2,6 +2,7 @@ import { EOL } from "os"
 import { basename } from "path"
 import { Effect } from "effect"
 import { Agent } from "../../../agent/agent"
+import { AppRuntime } from "../../../effect/app-runtime"
 import { Provider } from "../../../provider/provider"
 import { Session } from "../../../session"
 import type { MessageV2 } from "../../../session/message-v2"
@@ -34,7 +35,7 @@ export const AgentCommand = cmd({
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
       const agentName = args.name as string
-      const agent = await Agent.get(agentName)
+      const agent = await AppRuntime.runPromise(Agent.Service.use((svc) => svc.get(agentName)))
       if (!agent) {
         process.stderr.write(
           `Agent ${agentName} not found, run '${basename(process.execPath)} agent list' to get an agent list` + EOL,

--- a/packages/opencode/src/settings/index.ts
+++ b/packages/opencode/src/settings/index.ts
@@ -1,5 +1,4 @@
 import { Context, Effect, Layer, Ref, Semaphore } from "effect"
-import { makeRuntime } from "../effect/run-service"
 import { Storage } from "../storage/storage"
 
 export namespace Settings {
@@ -47,11 +46,4 @@ export namespace Settings {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Storage.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export const lspEnabled = async () => runPromise((svc) => svc.lspEnabled())
-  export const setLspEnabled = async (value: boolean) => runPromise((svc) => svc.setLspEnabled(value))
-  export const webSearchEnabled = async () => runPromise((svc) => svc.webSearchEnabled())
-  export const setWebSearchEnabled = async (value: boolean) => runPromise((svc) => svc.setWebSearchEnabled(value))
 }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -221,7 +221,7 @@ export namespace ToolRegistry {
                     worktree: ctx.worktree,
                   }
                   const result = yield* Effect.promise(() => def.execute(args as any, pluginCtx))
-                  const agent = yield* Effect.promise(() => Agent.get(toolCtx.agent))
+                  const agent = yield* agents.get(toolCtx.agent)
                   const out = yield* truncate.output(result, {}, agent)
                   return {
                     title: "",

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -5,6 +5,12 @@ import { Instance } from "../../src/project/instance"
 import { Agent } from "../../src/agent/agent"
 import { Permission } from "../../src/permission"
 import { Global } from "@opencode-ai/core/global"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
+
+function runAgent<A>(fn: (svc: Agent.Interface) => Effect.Effect<A>) {
+  return AppRuntime.runPromise(Agent.Service.use(fn))
+}
 
 // Helper to evaluate permission for a tool with wildcard pattern
 function evalPerm(agent: Agent.Info | undefined, permission: string): Permission.Action | undefined {
@@ -21,7 +27,7 @@ test("returns default native agents when no config", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const agents = await Agent.list()
+      const agents = await runAgent((svc) => svc.list())
       const names = agents.map((a) => a.name)
       expect(names).toContain("build")
       // plan agent removed in #239
@@ -40,7 +46,7 @@ test("build agent has correct default properties", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(build).toBeDefined()
       expect(build?.mode).toBe("primary")
       expect(build?.native).toBe(true)
@@ -55,7 +61,7 @@ test("explore agent denies edit and write", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const explore = await Agent.get("explore")
+      const explore = await runAgent((svc) => svc.get("explore"))
       expect(explore).toBeDefined()
       expect(explore?.mode).toBe("subagent")
       expect(evalPerm(explore, "edit")).toBe("deny")
@@ -71,7 +77,7 @@ test("explore agent allows external directories and Truncate.GLOB", async () => 
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const explore = await Agent.get("explore")
+      const explore = await runAgent((svc) => svc.get("explore"))
       expect(explore).toBeDefined()
       expect(Permission.evaluate("external_directory", "/some/other/path", explore!.permission).action).toBe("allow")
       expect(Permission.evaluate("external_directory", Truncate.GLOB, explore!.permission).action).toBe("allow")
@@ -84,7 +90,7 @@ test("general agent denies todo tools", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const general = await Agent.get("general")
+      const general = await runAgent((svc) => svc.get("general"))
       expect(general).toBeDefined()
       expect(general?.mode).toBe("subagent")
       expect(general?.hidden).toBeUndefined()
@@ -98,7 +104,7 @@ test("compaction agent denies all permissions", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const compaction = await Agent.get("compaction")
+      const compaction = await runAgent((svc) => svc.get("compaction"))
       expect(compaction).toBeDefined()
       expect(compaction?.hidden).toBe(true)
       expect(evalPerm(compaction, "bash")).toBe("deny")
@@ -124,7 +130,7 @@ test("custom agent from config creates new agent", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const custom = await Agent.get("my_custom_agent")
+      const custom = await runAgent((svc) => svc.get("my_custom_agent"))
       expect(custom).toBeDefined()
       expect(String(custom?.model?.providerID)).toBe("openai")
       expect(String(custom?.model?.modelID)).toBe("gpt-4")
@@ -153,7 +159,7 @@ test("custom agent config overrides native agent properties", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(build).toBeDefined()
       expect(String(build?.model?.providerID)).toBe("anthropic")
       expect(String(build?.model?.modelID)).toBe("claude-3")
@@ -176,9 +182,9 @@ test("agent disable removes agent from list", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const explore = await Agent.get("explore")
+      const explore = await runAgent((svc) => svc.get("explore"))
       expect(explore).toBeUndefined()
-      const agents = await Agent.list()
+      const agents = await runAgent((svc) => svc.list())
       const names = agents.map((a) => a.name)
       expect(names).not.toContain("explore")
     },
@@ -202,7 +208,7 @@ test("agent permission config merges with defaults", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(build).toBeDefined()
       // Specific pattern is denied
       expect(Permission.evaluate("bash", "rm -rf *", build!.permission).action).toBe("deny")
@@ -223,7 +229,7 @@ test("global permission config applies to all agents", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(build).toBeDefined()
       expect(evalPerm(build, "bash")).toBe("deny")
     },
@@ -242,8 +248,8 @@ test("agent steps/maxSteps config sets steps property", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
-      const general = await Agent.get("general")
+      const build = await runAgent((svc) => svc.get("build"))
+      const general = await runAgent((svc) => svc.get("general"))
       expect(build?.steps).toBe(50)
       expect(general?.steps).toBe(100)
     },
@@ -261,7 +267,7 @@ test("agent mode can be overridden", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const explore = await Agent.get("explore")
+      const explore = await runAgent((svc) => svc.get("explore"))
       expect(explore?.mode).toBe("primary")
     },
   })
@@ -278,7 +284,7 @@ test("agent name can be overridden", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(build?.name).toBe("Builder")
     },
   })
@@ -295,7 +301,7 @@ test("agent prompt can be set from config", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(build?.prompt).toBe("Custom system prompt")
     },
   })
@@ -315,7 +321,7 @@ test("unknown agent properties are placed into options", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(build?.options.random_property).toBe("hello")
       expect(build?.options.another_random).toBe(123)
     },
@@ -338,7 +344,7 @@ test("agent options merge correctly", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(build?.options.custom_option).toBe(true)
       expect(build?.options.another_option).toBe("value")
     },
@@ -363,8 +369,8 @@ test("multiple custom agents can be defined", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const agentA = await Agent.get("agent_a")
-      const agentB = await Agent.get("agent_b")
+      const agentA = await runAgent((svc) => svc.get("agent_a"))
+      const agentB = await runAgent((svc) => svc.get("agent_b"))
       expect(agentA?.description).toBe("Agent A")
       expect(agentA?.mode).toBe("subagent")
       expect(agentB?.description).toBe("Agent B")
@@ -378,7 +384,7 @@ test("Agent.get returns undefined for non-existent agent", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const nonExistent = await Agent.get("does_not_exist")
+      const nonExistent = await runAgent((svc) => svc.get("does_not_exist"))
       expect(nonExistent).toBeUndefined()
     },
   })
@@ -389,7 +395,7 @@ test("default permission asks for doom_loop and allows external_directory", asyn
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(evalPerm(build, "doom_loop")).toBe("ask")
       expect(evalPerm(build, "external_directory")).toBe("allow")
     },
@@ -401,7 +407,7 @@ test("webfetch is allowed by default", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(evalPerm(build, "webfetch")).toBe("allow")
     },
   })
@@ -412,7 +418,7 @@ test("websearch is allowed by default", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(evalPerm(build, "websearch")).toBe("allow")
     },
   })
@@ -434,7 +440,7 @@ test("legacy tools config converts to permissions", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(evalPerm(build, "bash")).toBe("deny")
       expect(evalPerm(build, "read")).toBe("deny")
     },
@@ -456,7 +462,7 @@ test("legacy tools.write config maps to edit permission", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(evalPerm(build, "edit")).toBe("deny")
     },
   })
@@ -474,7 +480,7 @@ test("Truncate.GLOB is allowed even when user denies external_directory globally
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(Permission.evaluate("external_directory", Truncate.GLOB, build!.permission).action).toBe("allow")
       expect(Permission.evaluate("external_directory", Truncate.DIR, build!.permission).action).toBe("deny")
       expect(Permission.evaluate("external_directory", "/some/other/path", build!.permission).action).toBe("deny")
@@ -498,7 +504,7 @@ test("Truncate.GLOB is allowed even when user denies external_directory per-agen
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(Permission.evaluate("external_directory", Truncate.GLOB, build!.permission).action).toBe("allow")
       expect(Permission.evaluate("external_directory", Truncate.DIR, build!.permission).action).toBe("deny")
       expect(Permission.evaluate("external_directory", "/some/other/path", build!.permission).action).toBe("deny")
@@ -521,7 +527,7 @@ test("explicit Truncate.GLOB deny is respected", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       expect(Permission.evaluate("external_directory", Truncate.GLOB, build!.permission).action).toBe("deny")
       expect(Permission.evaluate("external_directory", Truncate.DIR, build!.permission).action).toBe("deny")
     },
@@ -553,7 +559,7 @@ description: Permission skill.
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const build = await Agent.get("build")
+        const build = await runAgent((svc) => svc.get("build"))
         const skillDir = path.join(tmp.path, ".opencode", "skill", "perm-skill")
         const target = path.join(skillDir, "reference", "notes.md")
         expect(Permission.evaluate("external_directory", target, build!.permission).action).toBe("allow")
@@ -577,7 +583,7 @@ test("opencode tmp directory is allowed for external_directory", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await runAgent((svc) => svc.get("build"))
       const target = path.join(Global.Path.tmp, "agent-work", "scratch.txt")
       expect(Permission.evaluate("external_directory", target, build!.permission).action).toBe("allow")
       expect(
@@ -592,7 +598,7 @@ test("defaultAgent returns build by default", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const agent = await Agent.defaultAgent()
+      const agent = await runAgent((svc) => svc.defaultAgent())
       expect(agent).toBe("build")
     },
   })
@@ -613,7 +619,7 @@ test("defaultAgent picks a custom primary when build is disabled", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const agent = await Agent.defaultAgent()
+      const agent = await runAgent((svc) => svc.defaultAgent())
       // build is disabled, the next primary visible agent is the custom one
       expect(agent).toBe("my_primary")
     },
@@ -631,7 +637,7 @@ test("defaultAgent throws when build is disabled and no other primary visible ex
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      await expect(Agent.defaultAgent()).rejects.toThrow("no primary visible agent found")
+      await expect(runAgent((svc) => svc.defaultAgent())).rejects.toThrow("no primary visible agent found")
     },
   })
 })

--- a/packages/opencode/test/agent/no-plan-agent.test.ts
+++ b/packages/opencode/test/agent/no-plan-agent.test.ts
@@ -7,12 +7,13 @@ test("plan agent is not registered after #239", async () => {
   await using tmp = await tmpdir()
   await Effect.runPromise(
     provideInstance(tmp.path)(
-      Effect.promise(async () => {
-        const agents = await Agent.list()
+      Effect.gen(function* () {
+        const agent = yield* Agent.Service
+        const agents = yield* agent.list()
         const names = agents.map((a) => a.name)
         expect(names).not.toContain("plan")
         expect(names).toContain("build") // build remains as the hidden default
       }),
-    ),
+    ).pipe(Effect.provide(Agent.defaultLayer)),
   )
 })

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -127,3 +127,27 @@ test("TurnChange service does not expose sync or Promise facades", async () => {
   expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
   for (const facade of facades) expect(text).not.toContain(facade)
 })
+
+test("Agent and Settings services do not expose Promise facades", async () => {
+  const services = {
+    "agent/agent.ts": [
+      "export async function get",
+      "export async function list",
+      "export async function defaultAgent",
+      "export async function generate",
+    ],
+    "settings/index.ts": [
+      "export const lspEnabled = async",
+      "export const setLspEnabled = async",
+      "export const webSearchEnabled = async",
+      "export const setWebSearchEnabled = async",
+    ],
+  }
+
+  for (const [file, facades] of Object.entries(services)) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+    for (const facade of facades) expect(text).not.toContain(facade)
+  }
+})

--- a/packages/opencode/test/lsp/index.test.ts
+++ b/packages/opencode/test/lsp/index.test.ts
@@ -1,17 +1,23 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+import { Effect } from "effect"
 import path from "path"
 import * as Lsp from "../../src/lsp/index"
 import { LSPServer } from "../../src/lsp/server"
 import { Settings } from "../../src/settings"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
+function settings<A, E>(fn: (svc: Settings.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(Settings.Service.use(fn))
+}
+
 describe("lsp.spawn", () => {
   beforeEach(async () => {
-    await Settings.setLspEnabled(true)
+    await settings((svc) => svc.setLspEnabled(true))
   })
   afterEach(async () => {
-    await Settings.setLspEnabled(false)
+    await settings((svc) => svc.setLspEnabled(false))
   })
 
   test("does not spawn builtin LSP for files outside instance", async () => {

--- a/packages/opencode/test/lsp/lifecycle.test.ts
+++ b/packages/opencode/test/lsp/lifecycle.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test"
+import { Effect } from "effect"
 import path from "path"
 import * as Lsp from "../../src/lsp/index"
 import { LSPServer } from "../../src/lsp/server"
 import { Settings } from "../../src/settings"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
+
+function settings<A, E>(fn: (svc: Settings.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(Settings.Service.use(fn))
+}
 
 function withInstance(fn: (dir: string) => Promise<void>) {
   return async () => {
@@ -24,13 +30,13 @@ describe("LSP service lifecycle", () => {
   let spawnSpy: ReturnType<typeof spyOn>
 
   beforeEach(async () => {
-    await Settings.setLspEnabled(true)
+    await settings((svc) => svc.setLspEnabled(true))
     spawnSpy = spyOn(LSPServer.Typescript, "spawn").mockResolvedValue(undefined)
   })
 
   afterEach(async () => {
     spawnSpy.mockRestore()
-    await Settings.setLspEnabled(false)
+    await settings((svc) => svc.setLspEnabled(false))
   })
 
   test(

--- a/packages/opencode/test/permission/pawwork-defaults.test.ts
+++ b/packages/opencode/test/permission/pawwork-defaults.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, expect, test } from "bun:test"
+import { Effect } from "effect"
 import { Agent } from "../../src/agent/agent"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Permission } from "../../src/permission"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
+
+function agent<A>(fn: (svc: Agent.Interface) => Effect.Effect<A>) {
+  return AppRuntime.runPromise(Agent.Service.use(fn))
+}
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -13,7 +19,7 @@ test("build agent uses PawWork permission defaults", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const build = await Agent.get("build")
+      const build = await agent((svc) => svc.get("build"))
 
       expect(build).toBeDefined()
       expect(Permission.evaluate("read", "notes.txt", build!.permission).action).toBe("allow")

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -12,6 +12,7 @@ import { ProviderTransform } from "../../src/provider"
 import { localToolImportSpec, ToolRegistry } from "../../src/tool/registry"
 import { deferredGroupMembers } from "../../src/tool/tool-info"
 import { Settings } from "../../src/settings"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { MessageID, SessionID } from "../../src/session/schema"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { LLM } from "../../src/session/llm"
@@ -22,6 +23,10 @@ import { Permission } from "../../src/permission"
 afterEach(async () => {
   await Instance.disposeAll()
 })
+
+function settings<A, E>(fn: (svc: Settings.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(Settings.Service.use(fn))
+}
 
 async function withMockedConfigInstall<T>(fn: () => Promise<T>): Promise<T> {
   return await withConfigDepsLock(async () => {
@@ -950,7 +955,7 @@ describe("tool.registry", () => {
 
   test("excludes lsp tool when Settings.lspEnabled=false", async () => {
     await using tmp = await tmpdir()
-    await Settings.setLspEnabled(false)
+    await settings((svc) => svc.setLspEnabled(false))
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
@@ -973,7 +978,7 @@ describe("tool.registry", () => {
 
   test("registers lsp when Settings.lspEnabled=true but defers it out of the default model surface", async () => {
     await using tmp = await tmpdir()
-    await Settings.setLspEnabled(true)
+    await settings((svc) => svc.setLspEnabled(true))
     try {
       await Instance.provide({
         directory: tmp.path,
@@ -993,7 +998,7 @@ describe("tool.registry", () => {
         },
       })
     } finally {
-      await Settings.setLspEnabled(false)
+      await settings((svc) => svc.setLspEnabled(false))
     }
   })
 
@@ -1003,31 +1008,31 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          await Settings.setLspEnabled(true)
+          await settings((svc) => svc.setLspEnabled(true))
           const before = await ToolRegistry.ids()
           expect(before).toContain("lsp")
 
-          await Settings.setLspEnabled(false)
+          await settings((svc) => svc.setLspEnabled(false))
           await ToolRegistry.invalidate()
           const off = await ToolRegistry.ids()
           expect(off).not.toContain("lsp")
 
-          await Settings.setLspEnabled(true)
+          await settings((svc) => svc.setLspEnabled(true))
           await ToolRegistry.invalidate()
           const on = await ToolRegistry.ids()
           expect(on).toContain("lsp")
         },
       })
     } finally {
-      await Settings.setLspEnabled(false)
+      await settings((svc) => svc.setLspEnabled(false))
     }
   })
 
   test("exposes websearch for non-opencode providers without codesearch", async () => {
     await using tmp = await tmpdir()
-    const previous = await Settings.webSearchEnabled()
+    const previous = await settings((svc) => svc.webSearchEnabled())
     try {
-      await Settings.setWebSearchEnabled(true)
+      await settings((svc) => svc.setWebSearchEnabled(true))
 
       await Instance.provide({
         directory: tmp.path,
@@ -1045,7 +1050,7 @@ describe("tool.registry", () => {
         },
       })
     } finally {
-      await Settings.setWebSearchEnabled(previous)
+      await settings((svc) => svc.setWebSearchEnabled(previous))
     }
   })
 
@@ -1055,7 +1060,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          await Settings.setWebSearchEnabled(true)
+          await settings((svc) => svc.setWebSearchEnabled(true))
           await ToolRegistry.invalidate()
 
           const visibleIds = await ToolRegistry.ids()
@@ -1068,7 +1073,7 @@ describe("tool.registry", () => {
           })
           expect(visible.map((tool) => tool.id)).toContain("websearch")
 
-          await Settings.setWebSearchEnabled(false)
+          await settings((svc) => svc.setWebSearchEnabled(false))
           await ToolRegistry.invalidate()
 
           const hiddenRegistryIds = await ToolRegistry.ids()
@@ -1085,13 +1090,13 @@ describe("tool.registry", () => {
         },
       })
     } finally {
-      await Settings.setWebSearchEnabled(true)
+      await settings((svc) => svc.setWebSearchEnabled(true))
     }
   })
 
   test("does not advertise lsp as deferred when Settings.lspEnabled=false", async () => {
     await using tmp = await tmpdir()
-    await Settings.setLspEnabled(false)
+    await settings((svc) => svc.setLspEnabled(false))
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
@@ -1159,7 +1164,7 @@ describe("tool.registry", () => {
 
   test("rejects direct tool_info activation for lsp when Settings.lspEnabled=false", async () => {
     await using tmp = await tmpdir()
-    await Settings.setLspEnabled(false)
+    await settings((svc) => svc.setLspEnabled(false))
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
@@ -1189,7 +1194,7 @@ describe("tool.registry", () => {
 
   test("omits deferred repair hint for lsp when Settings.lspEnabled=false", async () => {
     await using tmp = await tmpdir()
-    await Settings.setLspEnabled(false)
+    await settings((svc) => svc.setLspEnabled(false))
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
@@ -1217,7 +1222,7 @@ describe("tool.registry", () => {
 
   test("omits deferred repair hint for lsp after it is activated", async () => {
     await using tmp = await tmpdir()
-    await Settings.setLspEnabled(true)
+    await settings((svc) => svc.setLspEnabled(true))
     try {
       await Instance.provide({
         directory: tmp.path,
@@ -1244,13 +1249,13 @@ describe("tool.registry", () => {
         },
       })
     } finally {
-      await Settings.setLspEnabled(false)
+      await settings((svc) => svc.setLspEnabled(false))
     }
   })
 
   test("defers lsp and worktree tools until activated, and advertises them via tool_info", async () => {
     await using tmp = await tmpdir()
-    await Settings.setLspEnabled(true)
+    await settings((svc) => svc.setLspEnabled(true))
     try {
       await Instance.provide({
         directory: tmp.path,
@@ -1312,7 +1317,7 @@ describe("tool.registry", () => {
         },
       })
     } finally {
-      await Settings.setLspEnabled(false)
+      await settings((svc) => svc.setLspEnabled(false))
     }
   })
 


### PR DESCRIPTION
## Summary

Remove the remaining Agent and Settings Promise facades and move their callers onto Effect service access.

## Why

Related to #936. Agent and Settings still built per-service runtimes with exported Promise helpers after the app runtime layer became the shared service boundary.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether every Agent and Settings caller now goes through `Agent.Service` / `Settings.Service` or `AppRuntime`, and whether the test helpers preserve the same runtime semantics without reintroducing a production facade.

## Risk Notes

No visible UI or copy changed, so no screenshot check was needed. No platform, packaging, dependency, credential, generated output, or deletion surface changed. Residual risk is limited to runtime wiring at the Agent/Settings service boundary; focused tests and typecheck cover the touched call sites.

Fresh-eye result: No P0/P1 findings. Reviewed with: "本次的所有改动已经是最优解了吗？是否是最简洁、最优雅、最安心、最彻底的方案？用奥卡姆剃刀大胆思考。" The one possible concern, a private ACP helper around `AppRuntime`, is intentionally file-local async boundary glue rather than a new exported facade.

## How To Verify

```text
RED: bun test test/effect/legacy-boundaries.test.ts -t "Agent and Settings services do not expose Promise facades" failed on the existing Agent facade import/export.
Focused tests: bun test test/agent/agent.test.ts test/agent/no-plan-agent.test.ts test/config/agent-color.test.ts test/permission/pawwork-defaults.test.ts test/tool/registry.test.ts test/lsp/lifecycle.test.ts test/lsp/index.test.ts test/effect/legacy-boundaries.test.ts -> 101 pass, 0 fail.
Typecheck: GOMAXPROCS=2 bun run typecheck -> pass.
Diff check: git diff --check -> pass.
Facade grep: no remaining Agent.get/list/defaultAgent/generate or Settings.*Enabled Promise facade callers in packages/opencode/src or packages/opencode/test.
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
