### PR TITLE
refactor(opencode): remove auth facades

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -1,6 +1,5 @@
 import path from "path"
 import { Effect, Layer, Record, Result, Schema, Context } from "effect"
-import { makeRuntime } from "@/effect/run-service"
 import { zod } from "@/util/effect-zod"
 import { Global } from "../global"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -89,22 +88,4 @@ export namespace Auth {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(AppFileSystem.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function get(providerID: string) {
-    return runPromise((service) => service.get(providerID))
-  }
-
-  export async function all(): Promise<Record<string, Info>> {
-    return runPromise((service) => service.all())
-  }
-
-  export async function set(key: string, info: Info) {
-    return runPromise((service) => service.set(key, info))
-  }
-
-  export async function remove(key: string) {
-    return runPromise((service) => service.remove(key))
-  }
 }

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -142,24 +142,35 @@ export namespace Workspace {
       catch: workspaceFailure(reason, message),
     })
 
-  export const layer = Layer.succeed(
+  const preserveError = (cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause)))
+
+  export const layer: Layer.Layer<Service, never, Auth.Service> = Layer.effect(
     Service,
-    Service.of({
-      create: (input) => promise("create", "Failed to create workspace", () => Workspace.create(input)),
-      list: (project) => effect("list", "Failed to list workspaces", () => Workspace.list(project)),
-      record: (id) => promise("record", `Failed to read workspace: ${id}`, () => Workspace.record(id)),
-      get: (id) => promise("get", `Failed to get workspace: ${id}`, () => Workspace.get(id)),
-      ensureSync: (space, hint) =>
-        effect("sync", space ? `Failed to start workspace sync: ${space.id}` : "Failed to start workspace sync", () =>
-          Workspace.ensureSync(space, hint),
-        ),
-      remove: (id) => promise("remove", `Failed to remove workspace: ${id}`, () => Workspace.remove(id)),
-      resolveAdaptor: (input) =>
-        promise("adaptor", `Failed to resolve workspace adaptor: ${input.type}`, () => Workspace.resolveAdaptor(input)),
-      status: () => effect("status", "Failed to read workspace status", () => Workspace.status()),
+    Effect.gen(function* () {
+      const auth = yield* Auth.Service
+      return Service.of({
+        create: (input) =>
+          createWithAuth(input).pipe(
+            Effect.provideService(Auth.Service, auth),
+            Effect.mapError(workspaceFailure("create", "Failed to create workspace")),
+          ),
+        list: (project) => effect("list", "Failed to list workspaces", () => Workspace.list(project)),
+        record: (id) => promise("record", `Failed to read workspace: ${id}`, () => Workspace.record(id)),
+        get: (id) => promise("get", `Failed to get workspace: ${id}`, () => Workspace.get(id)),
+        ensureSync: (space, hint) =>
+          effect("sync", space ? `Failed to start workspace sync: ${space.id}` : "Failed to start workspace sync", () =>
+            Workspace.ensureSync(space, hint),
+          ),
+        remove: (id) => promise("remove", `Failed to remove workspace: ${id}`, () => Workspace.remove(id)),
+        resolveAdaptor: (input) =>
+          promise("adaptor", `Failed to resolve workspace adaptor: ${input.type}`, () =>
+            Workspace.resolveAdaptor(input),
+          ),
+        status: () => effect("status", "Failed to read workspace status", () => Workspace.status()),
+      })
     }),
   )
-  export const defaultLayer = layer
+  export const defaultLayer = layer.pipe(Layer.provide(Auth.defaultLayer))
 
   async function bootstrapAdaptor(
     input: Pick<StoredInfo, "projectID" | "type" | "owner"> & { hint?: string | null },
@@ -248,12 +259,16 @@ export namespace Workspace {
     return bootstrapAdaptor({ ...input, hint }, new Error(`Missing workspace owner for adaptor: ${input.type}`))
   }
 
-  export const create = fn(CreateInput, async (input) => {
+  const createWithAuth = Effect.fn("Workspace.create")(function* (input: CreateInput) {
+    const auth = yield* Auth.Service
     const id = WorkspaceID.ascending(input.id)
     const owner = ownerKey(Instance.directory, Instance.worktree)
     const adaptor = getAdaptor(input.projectID, input.type, owner)
 
-    const config = await adaptor.configure({ ...input, id, name: null, directory: null })
+    const config = yield* Effect.tryPromise({
+      try: () => Promise.resolve(adaptor.configure({ ...input, id, name: null, directory: null })),
+      catch: preserveError,
+    })
 
     const info: StoredInfo = {
       id,
@@ -282,15 +297,14 @@ export namespace Workspace {
     })
 
     const requestedProviders = [...new Set(adaptor.auth?.providers ?? [])]
+    const authData = requestedProviders.length === 0 ? undefined : yield* auth.all()
     const scopedAuth =
       requestedProviders.length === 0
         ? undefined
-        : await Auth.all().then((all) =>
-            Object.fromEntries(
-              requestedProviders
-                .map((provider) => [provider, all[provider]] as const)
-                .filter(([, value]) => value !== undefined),
-            ),
+        : Object.fromEntries(
+            requestedProviders
+              .map((provider) => [provider, authData?.[provider]] as const)
+              .filter(([, value]) => value !== undefined),
           )
 
     const env = Object.fromEntries(
@@ -304,12 +318,19 @@ export namespace Workspace {
         OTEL_RESOURCE_ATTRIBUTES: process.env.OTEL_RESOURCE_ATTRIBUTES,
       }).filter(([, value]) => value !== undefined),
     ) as Record<string, string>
-    await adaptor.create(config, env)
+    yield* Effect.tryPromise({
+      try: () => adaptor.create(config, env),
+      catch: preserveError,
+    })
 
     startSync({ space: info })
 
     return toInfo(info)
   })
+
+  export const create = fn(CreateInput, (input) =>
+    Effect.runPromise(createWithAuth(input).pipe(Effect.provide(Auth.defaultLayer))),
+  )
 
   export function list(project: Project.Info) {
     const rows = Database.use((db) =>

--- a/packages/opencode/src/tool/websearch-auth.ts
+++ b/packages/opencode/src/tool/websearch-auth.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto"
 import { Context, Effect, Layer, Schema } from "effect"
 import { Auth } from "../auth"
-import { makeRuntime } from "../effect/run-service"
 import * as McpExa from "./mcp-exa"
 
 export namespace WebSearchAuth {
@@ -151,18 +150,4 @@ export namespace WebSearchAuth {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Auth.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function status() {
-    return runPromise((svc) => svc.status())
-  }
-
-  export async function saveKey(key: string) {
-    return runPromise((svc) => svc.saveKey(key))
-  }
-
-  export async function removeKey() {
-    return runPromise((svc) => svc.removeKey())
-  }
 }

--- a/packages/opencode/test/auth/auth.test.ts
+++ b/packages/opencode/test/auth/auth.test.ts
@@ -1,31 +1,42 @@
 import { test, expect } from "bun:test"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Auth } from "../../src/auth"
 
+function runAuth<A, E>(fn: (auth: Auth.Interface) => import("effect").Effect.Effect<A, E, never>) {
+  return AppRuntime.runPromise(Auth.Service.use(fn))
+}
+
 test("set normalizes trailing slashes in keys", async () => {
-  await Auth.set("https://example.com/", {
-    type: "wellknown",
-    key: "TOKEN",
-    token: "abc",
-  })
-  const data = await Auth.all()
+  await runAuth((auth) =>
+    auth.set("https://example.com/", {
+      type: "wellknown",
+      key: "TOKEN",
+      token: "abc",
+    }),
+  )
+  const data = await runAuth((auth) => auth.all())
   expect(data["https://example.com"]).toBeDefined()
   expect(data["https://example.com/"]).toBeUndefined()
 })
 
 test("set cleans up pre-existing trailing-slash entry", async () => {
   // Simulate a pre-fix entry with trailing slash
-  await Auth.set("https://example.com/", {
-    type: "wellknown",
-    key: "TOKEN",
-    token: "old",
-  })
+  await runAuth((auth) =>
+    auth.set("https://example.com/", {
+      type: "wellknown",
+      key: "TOKEN",
+      token: "old",
+    }),
+  )
   // Re-login with normalized key (as the CLI does post-fix)
-  await Auth.set("https://example.com", {
-    type: "wellknown",
-    key: "TOKEN",
-    token: "new",
-  })
-  const data = await Auth.all()
+  await runAuth((auth) =>
+    auth.set("https://example.com", {
+      type: "wellknown",
+      key: "TOKEN",
+      token: "new",
+    }),
+  )
+  const data = await runAuth((auth) => auth.all())
   const keys = Object.keys(data).filter((k) => k.includes("example.com"))
   expect(keys).toEqual(["https://example.com"])
   const entry = data["https://example.com"]!
@@ -34,25 +45,29 @@ test("set cleans up pre-existing trailing-slash entry", async () => {
 })
 
 test("remove deletes both trailing-slash and normalized keys", async () => {
-  await Auth.set("https://example.com", {
-    type: "wellknown",
-    key: "TOKEN",
-    token: "abc",
-  })
-  await Auth.remove("https://example.com/")
-  const data = await Auth.all()
+  await runAuth((auth) =>
+    auth.set("https://example.com", {
+      type: "wellknown",
+      key: "TOKEN",
+      token: "abc",
+    }),
+  )
+  await runAuth((auth) => auth.remove("https://example.com/"))
+  const data = await runAuth((auth) => auth.all())
   expect(data["https://example.com"]).toBeUndefined()
   expect(data["https://example.com/"]).toBeUndefined()
 })
 
 test("set and remove are no-ops on keys without trailing slashes", async () => {
-  await Auth.set("anthropic", {
-    type: "api",
-    key: "sk-test",
-  })
-  const data = await Auth.all()
+  await runAuth((auth) =>
+    auth.set("anthropic", {
+      type: "api",
+      key: "sk-test",
+    }),
+  )
+  const data = await runAuth((auth) => auth.all())
   expect(data["anthropic"]).toBeDefined()
-  await Auth.remove("anthropic")
-  const after = await Auth.all()
+  await runAuth((auth) => auth.remove("anthropic"))
+  const after = await runAuth((auth) => auth.all())
   expect(after["anthropic"]).toBeUndefined()
 })

--- a/packages/opencode/test/cli/providers-login.test.ts
+++ b/packages/opencode/test/cli/providers-login.test.ts
@@ -2,16 +2,21 @@ import { afterEach, expect, mock, spyOn, test } from "bun:test"
 import { Readable } from "node:stream"
 import { Auth } from "../../src/auth"
 import { ProvidersLoginCommand } from "../../src/cli/cmd/providers"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { Process } from "../../src/util/process"
 
 const originalFetch = globalThis.fetch
 const loginUrl = "https://enterprise-auth.test"
 
+function runAuth<A, E>(fn: (auth: Auth.Interface) => import("effect").Effect.Effect<A, E, never>) {
+  return AppRuntime.runPromise(Auth.Service.use(fn))
+}
+
 afterEach(async () => {
   globalThis.fetch = originalFetch
   mock.restore()
-  await Auth.remove(loginUrl).catch(() => {})
+  await runAuth((auth) => auth.remove(loginUrl)).catch(() => {})
 })
 
 test("url login skips instance bootstrap so stale remote config cannot block re-auth", async () => {
@@ -66,7 +71,7 @@ test("url login stores the refreshed well-known credential outside instance boot
   await ProvidersLoginCommand.handler({ url: `${loginUrl}/` } as never)
 
   expect(provide).not.toHaveBeenCalled()
-  expect(await Auth.get(loginUrl)).toEqual({
+  expect(await runAuth((auth) => auth.get(loginUrl))).toEqual({
     type: "wellknown",
     key: "TEST_TOKEN",
     token: "fresh-token",

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -151,3 +151,27 @@ test("Agent and Settings services do not expose Promise facades", async () => {
     for (const facade of facades) expect(text).not.toContain(facade)
   }
 })
+
+test("Auth and WebSearchAuth services do not expose Promise facades", async () => {
+  const services = {
+    "auth/index.ts": [
+      "export async function get",
+      "export async function all",
+      "export async function set",
+      "export async function remove",
+    ],
+    "tool/websearch-auth.ts": [
+      "export async function status",
+      "export async function saveKey",
+      "export async function removeKey",
+    ],
+  }
+
+  for (const [file, facades] of Object.entries(services)) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bfrom\s+["']\.\.\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+    for (const facade of facades) expect(text).not.toContain(facade)
+  }
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -80,6 +80,10 @@ async function recordRecent(model: ModelState.ModelRef) {
   return AppRuntime.runPromise(ModelState.Service.use((modelState) => modelState.recordRecent(model)))
 }
 
+async function runAuth<A, E>(fn: (auth: Auth.Interface) => Effect.Effect<A, E, never>) {
+  return AppRuntime.runPromise(Auth.Service.use(fn))
+}
+
 async function readAuthSnapshot() {
   try {
     return await Filesystem.readText(path.join(Global.Path.data, "auth.json"))
@@ -3531,7 +3535,7 @@ test("multiple provider model hooks run for the same provider", async () => {
 
 test("Codex no-op hook does not block external OpenAI model hooks", async () => {
   const authSnapshot = await readAuthSnapshot()
-  await Auth.remove(ProviderID.openai)
+  await runAuth((auth) => auth.remove(ProviderID.openai))
   await using tmp = await tmpdir({
     init: async (dir) => {
       const root = path.join(dir, ".opencode", "plugin")
@@ -3582,7 +3586,7 @@ test("Codex no-op hook does not block external OpenAI model hooks", async () => 
 
 test("Codex OAuth provider hook filters OpenAI models added by config", async () => {
   const authSnapshot = await readAuthSnapshot()
-  await Auth.remove(ProviderID.openai)
+  await runAuth((auth) => auth.remove(ProviderID.openai))
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -3616,14 +3620,16 @@ test("Codex OAuth provider hook filters OpenAI models added by config", async ()
     await Instance.provide({
       directory: tmp.path,
       init: async () => {
-        await Auth.set(
-          ProviderID.openai,
-          {
-            type: "oauth",
-            access: "access",
-            refresh: "refresh",
-            expires: Date.now() + 60_000,
-          } as never,
+        await runAuth((auth) =>
+          auth.set(
+            ProviderID.openai,
+            {
+              type: "oauth",
+              access: "access",
+              refresh: "refresh",
+              expires: Date.now() + 60_000,
+            } as never,
+          ),
         )
       },
       fn: async () => {
@@ -3646,7 +3652,7 @@ test("Codex OAuth provider hook filters OpenAI models added by config", async ()
 
 test("Codex OAuth config model override survives external OpenAI model hook", async () => {
   const authSnapshot = await readAuthSnapshot()
-  await Auth.remove(ProviderID.openai)
+  await runAuth((auth) => auth.remove(ProviderID.openai))
   await using tmp = await tmpdir({
     init: async (dir) => {
       const root = path.join(dir, ".opencode", "plugin")
@@ -3699,14 +3705,16 @@ test("Codex OAuth config model override survives external OpenAI model hook", as
     await Instance.provide({
       directory: tmp.path,
       init: async () => {
-        await Auth.set(
-          ProviderID.openai,
-          {
-            type: "oauth",
-            access: "access",
-            refresh: "refresh",
-            expires: Date.now() + 60_000,
-          } as never,
+        await runAuth((auth) =>
+          auth.set(
+            ProviderID.openai,
+            {
+              type: "oauth",
+              access: "access",
+              refresh: "refresh",
+              expires: Date.now() + 60_000,
+            } as never,
+          ),
         )
       },
       fn: async () => {
@@ -3728,7 +3736,7 @@ test("Codex OAuth config model override survives external OpenAI model hook", as
 
 test("post-config OAuth rerun only reprocesses providers with config models", async () => {
   const authSnapshot = await readAuthSnapshot()
-  await Auth.remove(ProviderID.anthropic)
+  await runAuth((auth) => auth.remove(ProviderID.anthropic))
   await using tmp = await tmpdir({
     init: async (dir) => {
       const root = path.join(dir, ".opencode", "plugin")
@@ -3783,14 +3791,16 @@ test("post-config OAuth rerun only reprocesses providers with config models", as
       directory: tmp.path,
       init: async () => {
         set("ANTHROPIC_API_KEY", "test-anthropic-key")
-        await Auth.set(
-          ProviderID.anthropic,
-          {
-            type: "oauth",
-            access: "access",
-            refresh: "refresh",
-            expires: Date.now() + 60_000,
-          } as never,
+        await runAuth((auth) =>
+          auth.set(
+            ProviderID.anthropic,
+            {
+              type: "oauth",
+              access: "access",
+              refresh: "refresh",
+              expires: Date.now() + 60_000,
+            } as never,
+          ),
         )
       },
       fn: async () => {

--- a/packages/opencode/test/server/control-routes.test.ts
+++ b/packages/opencode/test/server/control-routes.test.ts
@@ -12,8 +12,12 @@ import { Server } from "../../src/server/server"
 
 const testProviderID = "httpapi-control-provider"
 
+function runAuth<A, E>(fn: (auth: Auth.Interface) => Effect.Effect<A, E, never>) {
+  return AppRuntime.runPromise(Auth.Service.use(fn))
+}
+
 afterEach(async () => {
-  await Auth.remove(testProviderID).catch(() => {})
+  await runAuth((auth) => auth.remove(testProviderID)).catch(() => {})
 })
 
 describe("control routes", () => {
@@ -99,13 +103,13 @@ describe("control routes", () => {
 
     expect(setResponse.status).toBe(200)
     expect(await setResponse.json()).toBe(true)
-    expect(await Auth.get(testProviderID)).toEqual({ type: "api", key: "sk-httpapi-control" })
+    expect(await runAuth((auth) => auth.get(testProviderID))).toEqual({ type: "api", key: "sk-httpapi-control" })
 
     const removeResponse = await requestControlHttpApi(`/auth/${testProviderID}`, { method: "DELETE" })
 
     expect(removeResponse.status).toBe(200)
     expect(await removeResponse.json()).toBe(true)
-    expect(await Auth.get(testProviderID)).toBeUndefined()
+    expect(await runAuth((auth) => auth.get(testProviderID))).toBeUndefined()
   })
 
   test("writes log entries through the HttpApi handlers", async () => {


### PR DESCRIPTION
## Summary

Remove the remaining Auth and WebSearchAuth Promise facades and move direct callers onto Effect service access.

## Why

Related to #936. Auth and WebSearchAuth still exposed per-service `makeRuntime(Service, defaultLayer)` Promise helpers even though `AppRuntime` now composes the service graph. This PR removes those legacy exits while preserving credential file behavior and the existing workspace/auth route semantics.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the `Workspace.create` Auth injection change and the test migrations away from `Auth.*` facade calls. The intended behavior is unchanged: workspace auth scoping, auth JSON normalization/removal, control auth set/remove, provider credential setup, and WebSearchAuth saved key status should all behave as before.

## Risk Notes

Credential persistence is touched, but the service implementation is unchanged and existing behavior tests cover trailing slash normalization, removal, control route set/remove, provider setup, and WebSearchAuth status. No visible UI changed, so screenshots are not applicable. No platform, packaging, dependency, generated file, or permission surface changed.

Fresh-eye result: no P0/P1 findings. One P2 was found and fixed before PR creation: keep the Workspace Effect helper private instead of exposing a new public API.

## How To Verify

```text
RED guard: legacy-boundaries.test.ts failed before implementation because Auth still imported makeRuntime.
Focused auth/websearch/control bundle: bun test test/effect/legacy-boundaries.test.ts test/auth/auth.test.ts test/cli/providers-login.test.ts test/server/control-routes.test.ts test/tool/websearch-auth.test.ts test/tool/websearch.test.ts -> 40 pass, 0 fail.
Provider focused tests: bun test test/provider/provider.test.ts -> 110 pass, 0 fail.
Workspace route regression tests: bun test test/server/workspace-router.test.ts test/server/workspace-routing-decision.test.ts test/server/workspace-routes.test.ts -> 32 pass, 0 fail.
Typecheck: GOMAXPROCS=2 bun run typecheck -> pass.
Diff check: git diff --check -> pass.
Facade grep: Auth/WebSearchAuth facade calls are gone; remaining matches are McpAuth, which is outside this PR scope.
```

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

