### PR TITLE
refactor(opencode): retire Config promise facades

### DIFF
--- a/packages/opencode/script/seed-e2e.ts
+++ b/packages/opencode/script/seed-e2e.ts
@@ -57,6 +57,7 @@ const seed = async () => {
 
   const { Instance } = await import("../src/project/instance")
   const { Config } = await import("../src/config/config")
+  const { AppRuntime } = await import("../src/effect/app-runtime")
   const { Session } = await import("../src/session")
   const { MessageID, PartID } = await import("../src/session/schema")
   const { Project } = await import("../src/project/project")
@@ -66,7 +67,7 @@ const seed = async () => {
     await Instance.provide({
       directory: dir,
       fn: async () => {
-        await Config.waitForDependencies()
+        await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.waitForDependencies()))
 
         const session = await Session.create({ title })
         const messageID = MessageID.ascending()

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -434,7 +434,7 @@ async function addMcpToConfig(name: string, mcpConfig: Config.Mcp, configPath: s
 async function seedGlobalConfigIfNeeded(configPath: string, globalConfigPath: string) {
   if (!Runtime.isPawWork() || Config.configFileLockKey(configPath) !== Config.configFileLockKey(globalConfigPath)) return true
   try {
-    await Config.seedGlobalConfig()
+    await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.updateGlobal({})))
     return true
   } catch (err) {
     prompts.log.error(errorMessage(err))

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -14,6 +14,7 @@ import { UI } from "../ui"
 import { cmd } from "./cmd"
 import { PawWorkHome } from "@opencode-ai/core/pawwork-home"
 import { Runtime } from "@opencode-ai/core/runtime"
+import { AppRuntime } from "@/effect/app-runtime"
 
 type Spin = {
   start: (msg: string) => void
@@ -71,7 +72,9 @@ const defaultPlugDeps: PlugDeps = {
   exists: (file) => Filesystem.exists(file),
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
   global: defaultPluginGlobalConfigDir,
-  seedGlobalConfig: () => Config.seedGlobalConfig(),
+  seedGlobalConfig: async () => {
+    await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.updateGlobal({})))
+  },
 }
 
 function cause(err: unknown) {

--- a/packages/opencode/src/cli/upgrade.ts
+++ b/packages/opencode/src/cli/upgrade.ts
@@ -3,11 +3,19 @@ import { Config } from "@/config/config"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Installation } from "@/installation"
+import { Effect } from "effect"
 
 export async function upgrade() {
-  const config = await Config.getGlobal()
-  const method = await AppRuntime.runPromise(Installation.Service.use((svc) => svc.method()))
-  const latest = await AppRuntime.runPromise(Installation.Service.use((svc) => svc.latest(method))).catch(() => {})
+  const { config, method, latest } = await AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const cfg = yield* Config.Service
+      const installation = yield* Installation.Service
+      const config = yield* cfg.getGlobal()
+      const method = yield* installation.method()
+      const latest = yield* installation.latest(method).pipe(Effect.catch(() => Effect.succeed(undefined)))
+      return { config, method, latest }
+    }),
+  )
   if (!latest) return
 
   if (Flag.OPENCODE_ALWAYS_NOTIFY_UPDATE) {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1399,70 +1399,18 @@ export const defaultLayer = layer.pipe(
   Layer.provide(Account.defaultLayer),
 )
 
-const { runPromise } = makeRuntime(Service, defaultLayer)
-
-export async function get() {
-  return runPromise((svc) => svc.get())
-}
-
-export async function getGlobal() {
-  return runPromise((svc) => svc.getGlobal())
-}
-
-export async function getConsoleState() {
-  return runPromise((svc) => svc.getConsoleState())
-}
-
-export async function update(config: Info) {
-  return runPromise((svc) => svc.update(config))
-}
-
-export async function updateGlobal(config: Info) {
-  return runPromise((svc) => svc.updateGlobal(config))
-}
-
-export async function seedGlobalConfig() {
-  await updateGlobal({})
-}
-
-export async function invalidate(wait = false) {
-  return runPromise((svc) => svc.invalidate(wait))
-}
-
-export async function directories() {
-  return runPromise((svc) => svc.directories())
-}
-
-export async function waitForDependencies() {
-  return runPromise((svc) => svc.waitForDependencies())
-}
-
-export async function installDependencies(dir: string) {
-  return runPromise((svc) => svc.installDependencies(dir))
-}
-
 const ConfigInfo = Info
 const ConfigServerZod = Server
 const ConfigLayoutZod = Layout
 const ConfigService = Service
 const ConfigLayer = layer
 const ConfigDefaultLayer = defaultLayer
-const ConfigGet = get
-const ConfigGetGlobal = getGlobal
-const ConfigGetConsoleState = getConsoleState
-const ConfigUpdate = update
-const ConfigUpdateGlobal = updateGlobal
-const ConfigSeedGlobalConfig = seedGlobalConfig
 const ConfigGlobalConfigFileForRead = globalConfigFileForRead
 const ConfigGlobalConfigFileForWrite = globalConfigFileForWrite
 const ConfigConfigFileLockKey = configFileLockKey
 const ConfigWithConfigFileLock = withConfigFileLock
 const ConfigWriteConfigTextAtomic = writeConfigTextAtomic
 const ConfigProjectConfigFileForWrite = projectConfigFileForWrite
-const ConfigInvalidate = invalidate
-const ConfigDirectories = directories
-const ConfigWaitForDependencies = waitForDependencies
-const ConfigInstallDependencies = installDependencies
 
 export namespace Config {
   export const Info = ConfigInfo
@@ -1496,20 +1444,10 @@ export namespace Config {
   export const managedConfigDir = ConfigManaged.managedConfigDir
   export const parseManagedPlist = ConfigManaged.parseManagedPlist
 
-  export const get = ConfigGet
-  export const getGlobal = ConfigGetGlobal
-  export const getConsoleState = ConfigGetConsoleState
-  export const update = ConfigUpdate
-  export const updateGlobal = ConfigUpdateGlobal
-  export const seedGlobalConfig = ConfigSeedGlobalConfig
   export const globalConfigFileForRead = ConfigGlobalConfigFileForRead
   export const globalConfigFileForWrite = ConfigGlobalConfigFileForWrite
   export const configFileLockKey = ConfigConfigFileLockKey
   export const withConfigFileLock = ConfigWithConfigFileLock
   export const writeConfigTextAtomic = ConfigWriteConfigTextAtomic
   export const projectConfigFileForWrite = ConfigProjectConfigFileForWrite
-  export const invalidate = ConfigInvalidate
-  export const directories = ConfigDirectories
-  export const waitForDependencies = ConfigWaitForDependencies
-  export const installDependencies = ConfigInstallDependencies
 }

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -181,15 +181,16 @@ export namespace Plugin {
             if (!(yield* Effect.promise(() => needsConfigDependencies(fileURLToPath(spec), dependencyDir(origin.source, ctx.directory))))) {
               continue
             }
-            yield* Effect.promise(() => Config.waitForDependencies().catch(() => undefined))
+            yield* config.waitForDependencies().pipe(Effect.catch(() => Effect.void))
             break
           }
 
+          const waitForDependencies = () => Effect.runPromise(config.waitForDependencies())
           const loaded = yield* Effect.promise(() =>
             PluginLoader.loadExternal({
               items: plugins,
               kind: "server",
-              wait: () => Config.waitForDependencies(),
+              wait: waitForDependencies,
               shouldRetry: (origin) => {
                 const spec = Config.pluginSpecifier(origin.spec)
                 if (!spec.startsWith("file://")) return Promise.resolve(false)

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -9,6 +9,7 @@ import {
 import { Effect } from "effect"
 
 import { Config } from "@/config"
+import { AppRuntime } from "@/effect/app-runtime"
 import { makeRuntime } from "@/effect/run-service"
 import { ConfigPaths } from "@/config/paths"
 import { Global } from "@/global"
@@ -440,7 +441,9 @@ async function patchOne(dir: string, files: string[], target: Target, spec: stri
 }
 
 export async function patchPluginConfig(input: PatchInput, dep: PatchDeps = defaultPatchDeps): Promise<PatchResult> {
-  if (input.global && Runtime.isPawWork() && !input.config) await Config.seedGlobalConfig()
+  if (input.global && Runtime.isPawWork() && !input.config) {
+    await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.updateGlobal({})))
+  }
   const dir = patchDir(input)
   const files = patchFiles(input, dir, dep)
   const items: PatchItem[] = []

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1514,7 +1514,7 @@ test("installDependencies bootstraps the config plugin package metadata", async 
   const install = spyOn(Npm, "install").mockResolvedValue(undefined)
 
   try {
-    await Config.installDependencies(tmp.path)
+    await installDeps(tmp.path)
 
     const pkg = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(path.join(tmp.path, "package.json"))
     const target = Installation.isLocal() ? "*" : Installation.VERSION
@@ -1610,7 +1610,7 @@ test("installDependencies does not pin config plugin metadata to a packaged app 
     ;(Installation as { VERSION: string }).VERSION = "0.0.0-prod-202605230200"
     ;(Installation as { CHANNEL: string }).CHANNEL = "prod"
 
-    await Config.installDependencies(tmp.path)
+    await installDeps(tmp.path)
 
     const pkg = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(path.join(tmp.path, "package.json"))
 

--- a/packages/opencode/test/config/pawwork-global-config.test.ts
+++ b/packages/opencode/test/config/pawwork-global-config.test.ts
@@ -600,7 +600,7 @@ describe("PawWork global config isolation", () => {
       await Instance.provide({
         directory: project.path,
         fn: async () => {
-          await Config.seedGlobalConfig()
+          await saveGlobal({})
           const saved = JSON.parse(await Bun.file(path.join(home.path, ".pawwork", "pawwork.json")).text())
           expect(saved.username).toBe("legacy-user")
           expect("default_agent" in saved).toBeFalse()
@@ -640,7 +640,7 @@ describe("PawWork global config isolation", () => {
       await Instance.provide({
         directory: project.path,
         fn: async () => {
-          await Config.seedGlobalConfig()
+          await saveGlobal({})
           const saved = JSON.parse(await Bun.file(path.join(home.path, ".pawwork", "pawwork.json")).text())
           expect(saved.model).toBe("legacy/model")
           expect(saved.theme).toBeUndefined()

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -175,3 +175,22 @@ test("Auth and WebSearchAuth services do not expose Promise facades", async () =
     for (const facade of facades) expect(text).not.toContain(facade)
   }
 })
+
+test("Config service does not expose Promise facades", async () => {
+  const text = await readFile(path.join(srcRoot, "config/config.ts"), "utf8")
+  const facades = [
+    "export async function get",
+    "export async function getGlobal",
+    "export async function getConsoleState",
+    "export async function update",
+    "export async function updateGlobal",
+    "export async function seedGlobalConfig",
+    "export async function invalidate",
+    "export async function directories",
+    "export async function waitForDependencies",
+    "export async function installDependencies",
+  ]
+
+  expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+  for (const facade of facades) expect(text).not.toContain(facade)
+})

--- a/packages/opencode/test/permission-agent.test.ts
+++ b/packages/opencode/test/permission-agent.test.ts
@@ -3,10 +3,14 @@ import { Permission } from "../src/permission"
 import { Config } from "../src/config/config"
 import { Instance } from "../src/project/instance"
 import { tmpdir } from "./fixture/fixture"
+import { Effect } from "effect"
 
 afterEach(async () => {
   await Instance.disposeAll()
 })
+
+const loadConfig = () =>
+  Effect.runPromise(Config.Service.use((svc) => svc.get()).pipe(Effect.scoped, Effect.provide(Config.defaultLayer)))
 
 describe("Permission.evaluate for permission.agent", () => {
   const createRuleset = (rules: Record<string, "allow" | "deny" | "ask">): Permission.Ruleset =>
@@ -158,7 +162,7 @@ describe("permission.agent with real config files", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const config = await Config.get()
+        const config = await loadConfig()
         const ruleset = Permission.fromConfig(config.permission ?? {})
         // general and orchestrator-fast should be allowed, code-reviewer denied
         expect(Permission.evaluate("agent", "general", ruleset).action).toBe("allow")
@@ -183,7 +187,7 @@ describe("permission.agent with real config files", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const config = await Config.get()
+        const config = await loadConfig()
         const ruleset = Permission.fromConfig(config.permission ?? {})
         // general and code-reviewer should be ask, orchestrator-* denied
         expect(Permission.evaluate("agent", "general", ruleset).action).toBe("ask")
@@ -208,7 +212,7 @@ describe("permission.agent with real config files", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const config = await Config.get()
+        const config = await loadConfig()
         const ruleset = Permission.fromConfig(config.permission ?? {})
         expect(Permission.evaluate("agent", "general", ruleset).action).toBe("allow")
         expect(Permission.evaluate("agent", "code-reviewer", ruleset).action).toBe("deny")
@@ -235,7 +239,7 @@ describe("permission.agent with real config files", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const config = await Config.get()
+        const config = await loadConfig()
         const ruleset = Permission.fromConfig(config.permission ?? {})
 
         // Verify agent permissions
@@ -273,7 +277,7 @@ describe("permission.agent with real config files", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const config = await Config.get()
+        const config = await loadConfig()
         const ruleset = Permission.fromConfig(config.permission ?? {})
 
         // Last matching rule wins - "*" deny is last, so all agents are denied
@@ -304,7 +308,7 @@ describe("permission.agent with real config files", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const config = await Config.get()
+        const config = await loadConfig()
         const ruleset = Permission.fromConfig(config.permission ?? {})
 
         // Evaluate uses findLast - "general" allow comes after "*" deny

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -12,7 +12,6 @@ const { Plugin } = await import("../../src/plugin/index")
 const { PluginLoader } = await import("../../src/plugin/loader")
 const { Instance } = await import("../../src/project/instance")
 const { Npm } = await import("@opencode-ai/core/npm")
-const { Config } = await import("../../src/config/config")
 const { writeMockConfigInstall } = await import("../shared/mock-npm-install")
 const { withConfigDepsLock } = await import("../shared/config-deps-lock")
 
@@ -738,14 +737,24 @@ describe("plugin.loader.shared", () => {
       },
     })
 
-    const wait = spyOn(Config, "waitForDependencies").mockResolvedValue()
+    const originalLoadExternal = PluginLoader.loadExternal
+    let waits = 0
+    const loadExternal = spyOn(PluginLoader, "loadExternal").mockImplementation((input) =>
+      originalLoadExternal({
+        ...input,
+        wait: async () => {
+          waits++
+          await input.wait?.()
+        },
+      }),
+    )
 
     try {
       await load(tmp.path)
-      expect(wait).not.toHaveBeenCalled()
+      expect(waits).toBe(0)
       expect(await Bun.file(tmp.extra.mark).text()).toBe("ok")
     } finally {
-      wait.mockRestore()
+      loadExternal.mockRestore()
     }
   })
 

--- a/packages/opencode/test/session/export.test.ts
+++ b/packages/opencode/test/session/export.test.ts
@@ -20,6 +20,8 @@ import { RunLifecycle } from "../../src/session/run-lifecycle"
 const projectRoot = path.join(__dirname, "../..")
 void Log.init({ print: false })
 
+const invalidateConfig = (wait = false) => AppRuntime.runPromise(Config.Service.use((svc) => svc.invalidate(wait)))
+
 type RemoveDirectory = (dir: string, options: Parameters<typeof fs.rm>[1]) => Promise<void>
 
 function isRetryableDirectoryRemovalError(error: unknown) {
@@ -370,7 +372,7 @@ describe("Export.session", () => {
         },
       })
 
-      await Config.invalidate(true)
+      await invalidateConfig(true)
       await removeLoadedSessionProjectDirectory(sessionProject.path)
       await Instance.provide({
         directory: currentProject.path,
@@ -393,7 +395,7 @@ describe("Export.session", () => {
       else process.env.GLOBAL_EXPORT_RULE = previousEnv
       if (previousRuntime === undefined) delete process.env.PAWWORK_RUNTIME_NAMESPACE
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
-      await Config.invalidate(true)
+      await invalidateConfig(true)
       if (sessionID) await SessionNs.remove(sessionID)
     }
   })
@@ -549,7 +551,7 @@ describe("Export.session", () => {
     process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
       instructions: [localFile, url],
     })
-    await Config.invalidate(true)
+    await invalidateConfig(true)
 
     try {
       await Instance.provide({
@@ -579,7 +581,7 @@ describe("Export.session", () => {
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
       if (previousConfig === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
       else process.env.OPENCODE_CONFIG_CONTENT = previousConfig
-      await Config.invalidate(true)
+      await invalidateConfig(true)
     }
   })
 
@@ -603,7 +605,7 @@ describe("Export.session", () => {
     process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
       instructions: [url],
     })
-    await Config.invalidate(true)
+    await invalidateConfig(true)
 
     try {
       await Instance.provide({
@@ -629,7 +631,7 @@ describe("Export.session", () => {
       else process.env.PAWWORK_RUNTIME_NAMESPACE = previousRuntime
       if (previousConfig === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
       else process.env.OPENCODE_CONFIG_CONTENT = previousConfig
-      await Config.invalidate(true)
+      await invalidateConfig(true)
     }
   })
 

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -15,13 +15,17 @@ import { tmpdir } from "../fixture/fixture"
 
 const run = <A>(effect: Effect.Effect<A, any, Instruction.Service>) =>
   Effect.runPromise(effect.pipe(Effect.provide(Instruction.defaultLayer)))
+const invalidateConfig = (wait = false) =>
+  Effect.runPromise(
+    Config.Service.use((svc) => svc.invalidate(wait)).pipe(Effect.scoped, Effect.provide(Config.defaultLayer)),
+  )
 
 beforeEach(async () => {
-  await Config.invalidate(true)
+  await invalidateConfig(true)
 })
 
 afterEach(async () => {
-  await Config.invalidate(true)
+  await invalidateConfig(true)
 })
 
 function loaded(filepath: string): MessageV2.WithParts[] {
@@ -1283,7 +1287,7 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     delete process.env.PAWWORK_HOME
     process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
     delete process.env.OPENCODE_CONFIG_CONTENT
-    await Config.invalidate(true)
+    await invalidateConfig(true)
     const originalGlobalConfig = Global.Path.config
     ;(Global.Path as { config: string }).config = globalTmp.path
 
@@ -1322,7 +1326,7 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     process.env.PAWWORK_HOME = pawworkHome.path
     delete process.env.PAWWORK_CONFIG_DIR
     delete process.env.OPENCODE_CONFIG_CONTENT
-    await Config.invalidate(true)
+    await invalidateConfig(true)
 
     await Instance.provide({
       directory: projectTmp.path,
@@ -1360,7 +1364,7 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     process.env.PAWWORK_HOME = pawworkHome.path
     process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
     delete process.env.OPENCODE_CONFIG_CONTENT
-    await Config.invalidate(true)
+    await invalidateConfig(true)
 
     await Instance.provide({
       directory: projectTmp.path,
@@ -1390,7 +1394,7 @@ describe("Instruction.systemPaths PawWork runtime config dir", () => {
     process.env.PAWWORK_HOME = pawworkHome.path
     process.env.PAWWORK_CONFIG_DIR = pawworkConfig.path
     delete process.env.OPENCODE_CONFIG_CONTENT
-    await Config.invalidate(true)
+    await invalidateConfig(true)
 
     await Instance.provide({
       directory: projectTmp.path,

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -24,6 +24,9 @@ import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.mergeAll(CrossSpawnSpawner.defaultLayer, SessionRunState.defaultLayer))
 
+const provideConfig = <A, E>(effect: Effect.Effect<A, E, Config.Service>) =>
+  effect.pipe(Effect.scoped, Effect.provide(Config.defaultLayer))
+
 describe("SessionRunState", () => {
   const expectDirectoryIdle = (directory: string) =>
     Effect.gen(function* () {
@@ -935,7 +938,7 @@ describe("SessionRunState", () => {
             .pipe(Effect.forkChild)
 
           yield* Effect.sleep("10 millis")
-          yield* Effect.promise(() => Config.update({ username: "config-update-origin" }))
+          yield* provideConfig(Config.Service.use((cfg) => cfg.update({ username: "config-update-origin" })))
 
           yield* Effect.sleep("20 millis")
           expect(captured).toBeUndefined()
@@ -973,7 +976,9 @@ describe("SessionRunState", () => {
           yield* Effect.sync(() => GlobalBus.on("event", onEvent))
           yield* Effect.addFinalizer(() => Effect.sync(() => GlobalBus.off("event", onEvent)))
           yield* Effect.sleep("10 millis")
-          const invalidateFiber = yield* Effect.promise(() => Config.invalidate(true)).pipe(Effect.forkChild)
+          const invalidateFiber = yield* provideConfig(Config.Service.use((cfg) => cfg.invalidate(true))).pipe(
+            Effect.forkChild,
+          )
 
           yield* Effect.sleep("20 millis")
           expect(captured).toBeUndefined()
@@ -1009,12 +1014,17 @@ describe("SessionRunState", () => {
             .pipe(Effect.forkChild)
 
           yield* Effect.sleep("10 millis")
-          yield* Effect.promise(async () => {
-            await using globalTmp = await tmpdir()
+          const globalTmp = yield* Effect.acquireRelease(
+            Effect.promise(() => tmpdir()),
+            (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+          )
+          yield* Effect.gen(function* () {
             const previous = Global.Path.config
             ;(Global.Path as { config: string }).config = globalTmp.path
             try {
-              await Config.updateGlobal({ username: "config-update-global-origin" })
+              yield* provideConfig(
+                Config.Service.use((cfg) => cfg.updateGlobal({ username: "config-update-global-origin" })),
+              )
             } finally {
               ;(Global.Path as { config: string }).config = previous
             }


### PR DESCRIPTION
## Summary

Retires the remaining Config service Promise facade exports and moves direct callers onto `Config.Service` through `AppRuntime` or focused test runtimes.

## Why

Related to #936. Config already has an Effect service and participates in `AppRuntime`; keeping a separate per-service runtime plus async facade methods lets new callers bypass the shared service graph.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the Config service call sites that still need Promise-shaped integration boundaries: plugin dependency loading, CLI config seeding, upgrade checks, and tests that previously called `Config.*` directly.

## Risk Notes

No visible UI or copy changed, so the UI/manual screenshot checklist item is not applicable. No platform, packaging, updater, signing, shell, dependency, credential, generated-content, or permission surface changed. The remaining `withConfigFileLock` Promise helper is intentionally retained as the config file lock compatibility boundary.

Fresh-eye result: No P0/P1 findings. One P2 self-review finding was fixed before PR open: the Config guardrail edit had briefly removed an existing TurnChange run-service guard, and that assertion is now restored.

## How To Verify

```text
Config facade guard RED: added legacy-boundaries coverage and confirmed it failed on the existing Config makeRuntime/facade block.
Focused tests: bun test test/effect/legacy-boundaries.test.ts test/config/config.test.ts test/config/pawwork-global-config.test.ts test/permission-agent.test.ts test/session/export.test.ts test/session/instruction.test.ts test/session/run-state.test.ts test/plugin/loader-shared.test.ts -> 338 pass, 1 existing todo, 0 fail.
Typecheck: GOMAXPROCS=2 bun run typecheck -> passed.
Diff check: git diff --check -> passed.
Fresh-eye: no P0/P1 findings; P2 guardrail regression fixed and rechecked.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal configuration management patterns to use service-based architecture, improving code maintainability and consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->