### PR TITLE
refactor(opencode): retire MCP promise facades

### DIFF
--- a/packages/opencode/src/mcp/auth.ts
+++ b/packages/opencode/src/mcp/auth.ts
@@ -4,7 +4,6 @@ import { Global } from "@opencode-ai/core/global"
 import { Effect, Layer, Context } from "effect"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
-import { makeRuntime } from "@/effect/run-service"
 
 export namespace McpAuth {
   export const Tokens = z.object({
@@ -170,32 +169,4 @@ export namespace McpAuth {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(EffectFlock.defaultLayer), Layer.provide(AppFileSystem.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  // Async facades for backward compat (used by McpOAuthProvider, CLI)
-
-  export const get = async (mcpName: string) => runPromise((svc) => svc.get(mcpName))
-
-  export const getForUrl = async (mcpName: string, serverUrl: string) =>
-    runPromise((svc) => svc.getForUrl(mcpName, serverUrl))
-
-  export const all = async () => runPromise((svc) => svc.all())
-
-  export const set = async (mcpName: string, entry: Entry, serverUrl?: string) =>
-    runPromise((svc) => svc.set(mcpName, entry, serverUrl))
-
-  export const remove = async (mcpName: string) => runPromise((svc) => svc.remove(mcpName))
-
-  export const updateTokens = async (mcpName: string, tokens: Tokens, serverUrl?: string) =>
-    runPromise((svc) => svc.updateTokens(mcpName, tokens, serverUrl))
-
-  export const updateClientInfo = async (mcpName: string, clientInfo: ClientInfo, serverUrl?: string) =>
-    runPromise((svc) => svc.updateClientInfo(mcpName, clientInfo, serverUrl))
-
-  export const updateCodeVerifier = async (mcpName: string, codeVerifier: string) =>
-    runPromise((svc) => svc.updateCodeVerifier(mcpName, codeVerifier))
-
-  export const updateOAuthState = async (mcpName: string, oauthState: string) =>
-    runPromise((svc) => svc.updateOAuthState(mcpName, oauthState))
 }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -28,7 +28,6 @@ import open from "open"
 import { Cause, Effect, Exit, Layer, Option, Context, Stream } from "effect"
 import { EffectBridge, type Shape as EffectBridgeShape } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 
@@ -400,6 +399,7 @@ export namespace MCP {
                 log.info("oauth redirect requested", { key, url: url.toString() })
               },
             },
+            (fn) => Effect.runPromise(fn(auth)),
           )
         }
 
@@ -917,6 +917,7 @@ export namespace MCP {
               capturedUrl = url
             },
           },
+          (fn) => Effect.runPromise(fn(auth)),
         )
 
         const transport = new StreamableHTTPClientTransport(url, { authProvider })
@@ -1089,43 +1090,4 @@ export namespace MCP {
     Layer.provide(CrossSpawnSpawner.defaultLayer),
     Layer.provide(AppFileSystem.defaultLayer),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  // --- Async facade functions ---
-
-  export const status = async () => runPromise((svc) => svc.status())
-
-  export const tools = async () => runPromise((svc) => svc.tools())
-
-  export const prompts = async () => runPromise((svc) => svc.prompts())
-
-  export const resources = async () => runPromise((svc) => svc.resources())
-
-  export const add = async (name: string, mcp: Config.Mcp) => runPromise((svc) => svc.add(name, mcp))
-
-  export const connect = async (name: string) => runPromise((svc) => svc.connect(name))
-
-  export const disconnect = async (name: string) => runPromise((svc) => svc.disconnect(name))
-
-  export const startAuth = async (mcpName: string) => {
-    // The /:name/auth route serializes this with c.json, so the public result
-    // must stay plain data. authenticate() consumes the connected client via the
-    // internal startAuth; never expose the live (cyclic) Client here.
-    const { authorizationUrl, oauthState } = await runPromise((svc) => svc.startAuth(mcpName))
-    return { authorizationUrl, oauthState }
-  }
-
-  export const authenticate = async (mcpName: string) => runPromise((svc) => svc.authenticate(mcpName))
-
-  export const finishAuth = async (mcpName: string, authorizationCode: string) =>
-    runPromise((svc) => svc.finishAuth(mcpName, authorizationCode))
-
-  export const removeAuth = async (mcpName: string) => runPromise((svc) => svc.removeAuth(mcpName))
-
-  export const supportsOAuth = async (mcpName: string) => runPromise((svc) => svc.supportsOAuth(mcpName))
-
-  export const hasStoredTokens = async (mcpName: string) => runPromise((svc) => svc.hasStoredTokens(mcpName))
-
-  export const getAuthStatus = async (mcpName: string) => runPromise((svc) => svc.getAuthStatus(mcpName))
 }

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -7,11 +7,19 @@ import type {
 } from "@modelcontextprotocol/sdk/shared/auth.js"
 import { McpAuth } from "./auth"
 import { Log } from "@opencode-ai/core/util/log"
+import type { Effect } from "effect"
 
 const log = Log.create({ service: "mcp.oauth" })
 
 const OAUTH_CALLBACK_PORT = 19876
 const OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
+
+type AuthRunner = <A>(fn: (auth: McpAuth.Interface) => Effect.Effect<A>) => Promise<A>
+
+const appAuthRunner: AuthRunner = async (fn) => {
+  const { AppRuntime } = await import("@/effect/app-runtime")
+  return AppRuntime.runPromise(McpAuth.Service.use(fn))
+}
 
 export interface McpOAuthConfig {
   clientId?: string
@@ -30,6 +38,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     private serverUrl: string,
     private config: McpOAuthConfig,
     private callbacks: McpOAuthCallbacks,
+    private runAuth: AuthRunner = appAuthRunner,
   ) {}
 
   get redirectUrl(): string {
@@ -62,7 +71,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
     // Check stored client info (from dynamic registration)
     // Use getForUrl to validate credentials are for the current server URL
-    const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
+    const entry = await this.runAuth((auth) => auth.getForUrl(this.mcpName, this.serverUrl))
     if (entry?.clientInfo) {
       // Check if client secret has expired
       if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
@@ -80,15 +89,17 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
-    await McpAuth.updateClientInfo(
-      this.mcpName,
-      {
-        clientId: info.client_id,
-        clientSecret: info.client_secret,
-        clientIdIssuedAt: info.client_id_issued_at,
-        clientSecretExpiresAt: info.client_secret_expires_at,
-      },
-      this.serverUrl,
+    await this.runAuth((auth) =>
+      auth.updateClientInfo(
+        this.mcpName,
+        {
+          clientId: info.client_id,
+          clientSecret: info.client_secret,
+          clientIdIssuedAt: info.client_id_issued_at,
+          clientSecretExpiresAt: info.client_secret_expires_at,
+        },
+        this.serverUrl,
+      ),
     )
     log.info("saved dynamically registered client", {
       mcpName: this.mcpName,
@@ -98,7 +109,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   async tokens(): Promise<OAuthTokens | undefined> {
     // Use getForUrl to validate tokens are for the current server URL
-    const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
+    const entry = await this.runAuth((auth) => auth.getForUrl(this.mcpName, this.serverUrl))
     if (!entry?.tokens) return undefined
 
     return {
@@ -113,15 +124,17 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    await McpAuth.updateTokens(
-      this.mcpName,
-      {
-        accessToken: tokens.access_token,
-        refreshToken: tokens.refresh_token,
-        expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
-        scope: tokens.scope,
-      },
-      this.serverUrl,
+    await this.runAuth((auth) =>
+      auth.updateTokens(
+        this.mcpName,
+        {
+          accessToken: tokens.access_token,
+          refreshToken: tokens.refresh_token,
+          expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
+          scope: tokens.scope,
+        },
+        this.serverUrl,
+      ),
     )
     log.info("saved oauth tokens", { mcpName: this.mcpName })
   }
@@ -132,11 +145,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    await McpAuth.updateCodeVerifier(this.mcpName, codeVerifier)
+    await this.runAuth((auth) => auth.updateCodeVerifier(this.mcpName, codeVerifier))
   }
 
   async codeVerifier(): Promise<string> {
-    const entry = await McpAuth.get(this.mcpName)
+    const entry = await this.runAuth((auth) => auth.get(this.mcpName))
     if (!entry?.codeVerifier) {
       throw new Error(`No code verifier saved for MCP server: ${this.mcpName}`)
     }
@@ -144,11 +157,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveState(state: string): Promise<void> {
-    await McpAuth.updateOAuthState(this.mcpName, state)
+    await this.runAuth((auth) => auth.updateOAuthState(this.mcpName, state))
   }
 
   async state(): Promise<string> {
-    const entry = await McpAuth.get(this.mcpName)
+    const entry = await this.runAuth((auth) => auth.get(this.mcpName))
     if (entry?.oauthState) {
       return entry.oauthState
     }
@@ -160,28 +173,28 @@ export class McpOAuthProvider implements OAuthClientProvider {
     const newState = Array.from(crypto.getRandomValues(new Uint8Array(32)))
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("")
-    await McpAuth.updateOAuthState(this.mcpName, newState)
+    await this.runAuth((auth) => auth.updateOAuthState(this.mcpName, newState))
     return newState
   }
 
   async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
     log.info("invalidating credentials", { mcpName: this.mcpName, type })
-    const entry = await McpAuth.get(this.mcpName)
+    const entry = await this.runAuth((auth) => auth.get(this.mcpName))
     if (!entry) {
       return
     }
 
     switch (type) {
       case "all":
-        await McpAuth.remove(this.mcpName)
+        await this.runAuth((auth) => auth.remove(this.mcpName))
         break
       case "client":
         delete entry.clientInfo
-        await McpAuth.set(this.mcpName, entry)
+        await this.runAuth((auth) => auth.set(this.mcpName, entry))
         break
       case "tokens":
         delete entry.tokens
-        await McpAuth.set(this.mcpName, entry)
+        await this.runAuth((auth) => auth.set(this.mcpName, entry))
         break
     }
   }

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -130,7 +130,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
         {
           accessToken: tokens.access_token,
           refreshToken: tokens.refresh_token,
-          expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
+          expiresAt: tokens.expires_in != null ? Date.now() / 1000 + tokens.expires_in : undefined,
           scope: tokens.scope,
         },
         this.serverUrl,

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -219,3 +219,42 @@ test("Config service does not expose Promise facades", async () => {
   expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
   for (const facade of facades) expect(text).not.toContain(facade)
 })
+
+test("MCP services do not expose Promise facades", async () => {
+  const services = {
+    "mcp/index.ts": [
+      "export const status = async",
+      "export const tools = async",
+      "export const prompts = async",
+      "export const resources = async",
+      "export const add = async",
+      "export const connect = async",
+      "export const disconnect = async",
+      "export const startAuth = async",
+      "export const authenticate = async",
+      "export const finishAuth = async",
+      "export const removeAuth = async",
+      "export const supportsOAuth = async",
+      "export const hasStoredTokens = async",
+      "export const getAuthStatus = async",
+    ],
+    "mcp/auth.ts": [
+      "export const get = async",
+      "export const getForUrl = async",
+      "export const all = async",
+      "export const set = async",
+      "export const remove = async",
+      "export const updateTokens = async",
+      "export const updateClientInfo = async",
+      "export const updateCodeVerifier = async",
+      "export const updateOAuthState = async",
+    ],
+  }
+
+  for (const [file, facades] of Object.entries(services)) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+    for (const facade of facades) expect(text).not.toContain(facade)
+  }
+})

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -223,31 +223,31 @@ test("Config service does not expose Promise facades", async () => {
 test("MCP services do not expose Promise facades", async () => {
   const services = {
     "mcp/index.ts": [
-      "export const status = async",
-      "export const tools = async",
-      "export const prompts = async",
-      "export const resources = async",
-      "export const add = async",
-      "export const connect = async",
-      "export const disconnect = async",
-      "export const startAuth = async",
-      "export const authenticate = async",
-      "export const finishAuth = async",
-      "export const removeAuth = async",
-      "export const supportsOAuth = async",
-      "export const hasStoredTokens = async",
-      "export const getAuthStatus = async",
+      "status",
+      "tools",
+      "prompts",
+      "resources",
+      "add",
+      "connect",
+      "disconnect",
+      "startAuth",
+      "authenticate",
+      "finishAuth",
+      "removeAuth",
+      "supportsOAuth",
+      "hasStoredTokens",
+      "getAuthStatus",
     ],
     "mcp/auth.ts": [
-      "export const get = async",
-      "export const getForUrl = async",
-      "export const all = async",
-      "export const set = async",
-      "export const remove = async",
-      "export const updateTokens = async",
-      "export const updateClientInfo = async",
-      "export const updateCodeVerifier = async",
-      "export const updateOAuthState = async",
+      "get",
+      "getForUrl",
+      "all",
+      "set",
+      "remove",
+      "updateTokens",
+      "updateClientInfo",
+      "updateCodeVerifier",
+      "updateOAuthState",
     ],
   }
 
@@ -255,6 +255,8 @@ test("MCP services do not expose Promise facades", async () => {
     const text = await readFile(path.join(srcRoot, file), "utf8")
     expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
     expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
-    for (const facade of facades) expect(text).not.toContain(facade)
+    for (const facade of facades) {
+      expect(text).not.toMatch(new RegExp(`\\bexport\\s+const\\s+${facade}\\b`))
+    }
   }
 })

--- a/packages/opencode/test/mcp/headers.test.ts
+++ b/packages/opencode/test/mcp/headers.test.ts
@@ -46,6 +46,11 @@ beforeEach(() => {
 const { MCP } = await import("../../src/mcp/index")
 const { Instance } = await import("../../src/project/instance")
 const { tmpdir } = await import("../fixture/fixture")
+const { makeRuntime } = await import("../../src/effect/run-service")
+const mcpRuntime = makeRuntime(MCP.Service, MCP.defaultLayer)
+const MCPFacade = {
+  add: (name: string, mcpConfig: any) => mcpRuntime.runPromise((mcp) => mcp.add(name, mcpConfig)),
+}
 
 test("headers are passed to transports when oauth is enabled (default)", async () => {
   await using tmp = await tmpdir({
@@ -73,7 +78,7 @@ test("headers are passed to transports when oauth is enabled (default)", async (
     directory: tmp.path,
     fn: async () => {
       // Trigger MCP initialization - it will fail to connect but we can check the transport options
-      await MCP.add("test-server", {
+      await MCPFacade.add("test-server", {
         type: "remote",
         url: "https://example.com/mcp",
         headers: {
@@ -106,7 +111,7 @@ test("headers are passed to transports when oauth is explicitly disabled", async
     fn: async () => {
       transportCalls.length = 0
 
-      await MCP.add("test-server-no-oauth", {
+      await MCPFacade.add("test-server-no-oauth", {
         type: "remote",
         url: "https://example.com/mcp",
         oauth: false,
@@ -137,7 +142,7 @@ test("no requestInit when headers are not provided", async () => {
     fn: async () => {
       transportCalls.length = 0
 
-      await MCP.add("test-server-no-headers", {
+      await MCPFacade.add("test-server-no-headers", {
         type: "remote",
         url: "https://example.com/mcp",
       }).catch(() => {})
@@ -160,7 +165,7 @@ test("invalid remote url returns failed status without constructing transports",
     fn: async () => {
       transportCalls.length = 0
 
-      const result = await MCP.add("bad-url", {
+      const result = await MCPFacade.add("bad-url", {
         type: "remote",
         url: "not a valid url",
       })

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -254,6 +254,15 @@ const { NotFoundError } = await import("../../src/storage/db")
 const { tmpdir } = await import("../fixture/fixture")
 const { makeRuntime } = await import("../../src/effect/run-service")
 const mcpRuntime = makeRuntime(MCP.Service, MCP.defaultLayer)
+const MCPFacade = {
+  status: () => mcpRuntime.runPromise((mcp) => mcp.status()),
+  tools: () => mcpRuntime.runPromise((mcp) => mcp.tools()),
+  prompts: () => mcpRuntime.runPromise((mcp) => mcp.prompts()),
+  resources: () => mcpRuntime.runPromise((mcp) => mcp.resources()),
+  add: (name: string, mcpConfig: any) => mcpRuntime.runPromise((mcp) => mcp.add(name, mcpConfig)),
+  connect: (name: string) => mcpRuntime.runPromise((mcp) => mcp.connect(name)),
+  disconnect: (name: string) => mcpRuntime.runPromise((mcp) => mcp.disconnect(name)),
+}
 
 // --- Helper ---
 
@@ -297,7 +306,7 @@ test(
     ]
 
     // First: add the server successfully
-    const addResult = await MCP.add("my-server", {
+    const addResult = await MCPFacade.add("my-server", {
       type: "local",
       command: ["echo", "test"],
     })
@@ -305,8 +314,8 @@ test(
 
     expect(serverState.listToolsCalls).toBe(1)
 
-    const toolsA = await MCP.tools()
-    const toolsB = await MCP.tools()
+    const toolsA = await MCPFacade.tools()
+    const toolsB = await MCPFacade.tools()
     expect(Object.keys(toolsA).length).toBeGreaterThan(0)
     expect(Object.keys(toolsB).length).toBeGreaterThan(0)
     expect(serverState.listToolsCalls).toBe(1)
@@ -323,12 +332,12 @@ test(
     lastCreatedClientName = "status-server"
     const serverState = getOrCreateClientState("status-server")
 
-    await MCP.add("status-server", {
+    await MCPFacade.add("status-server", {
       type: "local",
       command: ["echo", "test"],
     })
 
-    const before = await MCP.tools()
+    const before = await MCPFacade.tools()
     expect(Object.keys(before).some((key) => key.includes("test_tool"))).toBe(true)
     expect(serverState.listToolsCalls).toBe(1)
 
@@ -338,7 +347,7 @@ test(
     expect(handler).toBeDefined()
     await handler?.()
 
-    const after = await MCP.tools()
+    const after = await MCPFacade.tools()
     expect(Object.keys(after).some((key) => key.includes("next_tool"))).toBe(true)
     expect(Object.keys(after).some((key) => key.includes("test_tool"))).toBe(false)
     expect(serverState.listToolsCalls).toBe(2)
@@ -353,7 +362,7 @@ test(
     serverState.capabilities = { resources: {} }
     serverState.resources = [{ name: "docs", uri: "docs://readme" }]
 
-    const addResult = await MCP.add("resource-only-server", {
+    const addResult = await MCPFacade.add("resource-only-server", {
       type: "local",
       command: ["echo", "test"],
     })
@@ -363,8 +372,8 @@ test(
     )
     expect(serverState.listToolsCalls).toBe(0)
     expect(serverState.notificationHandlers.size).toBe(0)
-    expect(await MCP.tools()).toEqual({})
-    expect(Object.keys(await MCP.resources())).toEqual(["resource-only-server:docs"])
+    expect(await MCPFacade.tools()).toEqual({})
+    expect(Object.keys(await MCPFacade.resources())).toEqual(["resource-only-server:docs"])
     expect(serverState.listResourcesCalls).toBe(1)
     expect(serverState.listPromptsCalls).toBe(0)
 
@@ -372,13 +381,13 @@ test(
     const toolsOnlyState = getOrCreateClientState("tools-only-server")
     toolsOnlyState.capabilities = { tools: {} }
 
-    await MCP.add("tools-only-server", {
+    await MCPFacade.add("tools-only-server", {
       type: "local",
       command: ["echo", "test"],
     })
 
-    expect(Object.keys(await MCP.tools())).toEqual(["tools-only-server_test_tool"])
-    expect(await MCP.prompts()).toEqual({})
+    expect(Object.keys(await MCPFacade.tools())).toEqual(["tools-only-server_test_tool"])
+    expect(await MCPFacade.prompts()).toEqual({})
     expect(toolsOnlyState.listPromptsCalls).toBe(0)
     expect(toolsOnlyState.listResourcesCalls).toBe(0)
 
@@ -387,13 +396,13 @@ test(
     nullToolsState.capabilities = { tools: null, resources: {} }
     nullToolsState.resources = [{ name: "null-docs", uri: "docs://null" }]
 
-    await MCP.add("null-tools-server", {
+    await MCPFacade.add("null-tools-server", {
       type: "local",
       command: ["echo", "test"],
     })
 
     expect(nullToolsState.listToolsCalls).toBe(0)
-    expect(Object.keys(await MCP.resources())).toContain("null-tools-server:null-docs")
+    expect(Object.keys(await MCPFacade.resources())).toContain("null-tools-server:null-docs")
   }),
 )
 
@@ -415,14 +424,14 @@ test(
       "": { resources: [{ name: "resource-two", uri: "test://two" }], nextCursor: null },
     }
 
-    await MCP.add("paged-server", {
+    await MCPFacade.add("paged-server", {
       type: "local",
       command: ["echo", "test"],
     })
 
-    expect(Object.keys(await MCP.tools())).toEqual(["paged-server_tool-one", "paged-server_tool-two"])
-    expect(Object.keys(await MCP.prompts())).toEqual(["paged-server:prompt-one", "paged-server:prompt-two"])
-    expect(Object.keys(await MCP.resources())).toEqual(["paged-server:resource-one", "paged-server:resource-two"])
+    expect(Object.keys(await MCPFacade.tools())).toEqual(["paged-server_tool-one", "paged-server_tool-two"])
+    expect(Object.keys(await MCPFacade.prompts())).toEqual(["paged-server:prompt-one", "paged-server:prompt-two"])
+    expect(Object.keys(await MCPFacade.resources())).toEqual(["paged-server:resource-one", "paged-server:resource-two"])
     expect(pagedState.listToolsCalls).toBe(2)
     expect(pagedState.listPromptsCalls).toBe(2)
     expect(pagedState.listResourcesCalls).toBe(2)
@@ -434,7 +443,7 @@ test(
       repeat: { tools: [], nextCursor: "repeat" },
     }
 
-    const addResult = await MCP.add("looping-server", {
+    const addResult = await MCPFacade.add("looping-server", {
       type: "local",
       command: ["echo", "test"],
     })
@@ -451,14 +460,14 @@ test(
     const serverState = getOrCreateClientState("defective-server")
     serverState.capabilitiesShouldThrow = true
 
-    const addResult = await MCP.add("defective-server", {
+    const addResult = await MCPFacade.add("defective-server", {
       type: "local",
       command: ["echo", "test"],
     })
 
     const serverStatus = (addResult.status as any)["defective-server"] ?? addResult.status
     expect(serverStatus).toEqual({ status: "failed", error: "capability discovery failed" })
-    expect((await MCP.status())["defective-server"]).toEqual({
+    expect((await MCPFacade.status())["defective-server"]).toEqual({
       status: "failed",
       error: "capability discovery failed",
     })
@@ -472,12 +481,12 @@ test(
     lastCreatedClientName = "abort-server"
     const serverState = getOrCreateClientState("abort-server")
 
-    await MCP.add("abort-server", {
+    await MCPFacade.add("abort-server", {
       type: "local",
       command: ["echo", "test"],
     })
 
-    const tools = await MCP.tools()
+    const tools = await MCPFacade.tools()
     const tool = tools["abort-server_test_tool"] as unknown as {
       execute: (args: unknown, options: { abortSignal: AbortSignal }) => any
     }
@@ -497,7 +506,7 @@ test(
       lastCreatedClientName = "timeout-server"
       const timeoutState = getOrCreateClientState("timeout-server")
 
-      await MCP.add("timeout-server", {
+      await MCPFacade.add("timeout-server", {
         type: "local",
         command: ["echo", "test"],
         timeout: 2500,
@@ -511,7 +520,7 @@ test(
       lastCreatedClientName = "fallback-server"
       const fallbackState = getOrCreateClientState("fallback-server")
 
-      await MCP.add("fallback-server", {
+      await MCPFacade.add("fallback-server", {
         type: "local",
         command: ["echo", "test"],
       })
@@ -535,13 +544,13 @@ test(
       timeoutState.prompts = [{ name: "prompt" }]
       timeoutState.resources = [{ name: "resource", uri: "test://resource" }]
 
-      await MCP.add("catalog-timeout-server", {
+      await MCPFacade.add("catalog-timeout-server", {
         type: "local",
         command: ["echo", "test"],
         timeout: 2500,
       })
-      await MCP.prompts()
-      await MCP.resources()
+      await MCPFacade.prompts()
+      await MCPFacade.resources()
 
       expect(timeoutState.listPromptsTimeouts).toEqual([2500])
       expect(timeoutState.listResourcesTimeouts).toEqual([2500])
@@ -560,12 +569,12 @@ test(
       timeoutState.prompts = [{ name: "prompt" }]
       timeoutState.resources = [{ name: "resource", uri: "test://resource" }]
 
-      await MCP.add("catalog-fallback-server", {
+      await MCPFacade.add("catalog-fallback-server", {
         type: "local",
         command: ["echo", "test"],
       })
-      await MCP.prompts()
-      await MCP.resources()
+      await MCPFacade.prompts()
+      await MCPFacade.resources()
 
       expect(timeoutState.listPromptsTimeouts).toEqual([5000])
       expect(timeoutState.listResourcesTimeouts).toEqual([5000])
@@ -606,7 +615,7 @@ test("tool change notification reaches the instance bus from a detached callback
       lastCreatedClientName = "notify-server"
       const serverState = getOrCreateClientState("notify-server")
 
-      await MCP.add("notify-server", { type: "local", command: ["echo", "test"] })
+      await MCPFacade.add("notify-server", { type: "local", command: ["echo", "test"] })
 
       unsubscribe = Bus.subscribe(MCP.ToolsChanged, (event) => {
         received.push(event.properties.server)
@@ -651,21 +660,21 @@ test(
       lastCreatedClientName = "disc-server"
       getOrCreateClientState("disc-server")
 
-      await MCP.add("disc-server", {
+      await MCPFacade.add("disc-server", {
         type: "local",
         command: ["echo", "test"],
       })
 
-      const statusBefore = await MCP.status()
+      const statusBefore = await MCPFacade.status()
       expect(statusBefore["disc-server"]?.status).toBe("connected")
 
-      await MCP.disconnect("disc-server")
+      await MCPFacade.disconnect("disc-server")
 
-      const statusAfter = await MCP.status()
+      const statusAfter = await MCPFacade.status()
       expect(statusAfter["disc-server"]?.status).toBe("disabled")
 
       // Tools should be empty after disconnect
-      const tools = await MCP.tools()
+      const tools = await MCPFacade.tools()
       const serverTools = Object.keys(tools).filter((k) => k.startsWith("disc-server"))
       expect(serverTools.length).toBe(0)
     },
@@ -686,19 +695,19 @@ test(
       const serverState = getOrCreateClientState("reconn-server")
       serverState.tools = [{ name: "my_tool", description: "a tool", inputSchema: { type: "object", properties: {} } }]
 
-      await MCP.add("reconn-server", {
+      await MCPFacade.add("reconn-server", {
         type: "local",
         command: ["echo", "test"],
       })
 
-      await MCP.disconnect("reconn-server")
-      expect((await MCP.status())["reconn-server"]?.status).toBe("disabled")
+      await MCPFacade.disconnect("reconn-server")
+      expect((await MCPFacade.status())["reconn-server"]?.status).toBe("disabled")
 
       // Reconnect
-      await MCP.connect("reconn-server")
-      expect((await MCP.status())["reconn-server"]?.status).toBe("connected")
+      await MCPFacade.connect("reconn-server")
+      expect((await MCPFacade.status())["reconn-server"]?.status).toBe("connected")
 
-      const tools = await MCP.tools()
+      const tools = await MCPFacade.tools()
       expect(Object.keys(tools).some((k) => k.includes("my_tool"))).toBe(true)
     },
   ),
@@ -716,7 +725,7 @@ test(
     lastCreatedClientName = "replace-server"
     const firstState = getOrCreateClientState("replace-server")
 
-    await MCP.add("replace-server", {
+    await MCPFacade.add("replace-server", {
       type: "local",
       command: ["echo", "test"],
     })
@@ -728,7 +737,7 @@ test(
     const secondState = getOrCreateClientState("replace-server")
 
     // Re-add should close the first client
-    await MCP.add("replace-server", {
+    await MCPFacade.add("replace-server", {
       type: "local",
       command: ["echo", "test"],
     })
@@ -744,32 +753,32 @@ test(
     lastCreatedClientName = "dynamic-server"
     const serverState = getOrCreateClientState("dynamic-server")
 
-    await MCP.add("dynamic-server", {
+    await MCPFacade.add("dynamic-server", {
       type: "local",
       command: ["echo", "test"],
       timeout: 1234,
     })
 
-    expect((await MCP.status())["dynamic-server"]?.status).toBe("connected")
+    expect((await MCPFacade.status())["dynamic-server"]?.status).toBe("connected")
 
-    const tools = await MCP.tools()
+    const tools = await MCPFacade.tools()
     const tool = tools["dynamic-server_test_tool"] as unknown as {
       execute: (args: unknown, options?: { abortSignal?: AbortSignal }) => any
     }
     await tool.execute({})
     expect(serverState.callToolTimeouts).toEqual([1234])
 
-    await MCP.disconnect("dynamic-server")
-    expect((await MCP.status())["dynamic-server"]?.status).toBe("disabled")
+    await MCPFacade.disconnect("dynamic-server")
+    expect((await MCPFacade.status())["dynamic-server"]?.status).toBe("disabled")
 
     clientStates.delete("dynamic-server")
     lastCreatedClientName = "dynamic-server"
     const reconnectedState = getOrCreateClientState("dynamic-server")
 
-    await MCP.connect("dynamic-server")
-    expect((await MCP.status())["dynamic-server"]?.status).toBe("connected")
+    await MCPFacade.connect("dynamic-server")
+    expect((await MCPFacade.status())["dynamic-server"]?.status).toBe("connected")
 
-    const reconnectedTools = await MCP.tools()
+    const reconnectedTools = await MCPFacade.tools()
     const reconnectedTool = reconnectedTools["dynamic-server_test_tool"] as unknown as {
       execute: (args: unknown, options?: { abortSignal?: AbortSignal }) => any
     }
@@ -806,24 +815,24 @@ test(
 
       // Add good server first
       lastCreatedClientName = "good-server"
-      await MCP.add("good-server", {
+      await MCPFacade.add("good-server", {
         type: "local",
         command: ["echo", "good"],
       })
 
       // Add bad server - should fail but not affect good server
       lastCreatedClientName = "bad-server"
-      await MCP.add("bad-server", {
+      await MCPFacade.add("bad-server", {
         type: "local",
         command: ["echo", "bad"],
       })
 
-      const status = await MCP.status()
+      const status = await MCPFacade.status()
       expect(status["good-server"]?.status).toBe("connected")
       expect(status["bad-server"]?.status).toBe("failed")
 
       // Good server's tools should still be available
-      const tools = await MCP.tools()
+      const tools = await MCPFacade.tools()
       expect(Object.keys(tools).some((k) => k.includes("good_tool"))).toBe(true)
     },
   ),
@@ -849,7 +858,7 @@ test(
       },
     ]
 
-    const addResult = await MCP.add("stitch-like-server", {
+    const addResult = await MCPFacade.add("stitch-like-server", {
       type: "local",
       command: ["echo", "test"],
     })
@@ -857,7 +866,7 @@ test(
     const serverStatus = (addResult.status as any)["stitch-like-server"] ?? addResult.status
     expect(serverStatus.status).toBe("connected")
 
-    const tools = await MCP.tools()
+    const tools = await MCPFacade.tools()
     expect(Object.keys(tools).some((key) => key.includes("render_screen"))).toBe(true)
     expect(serverState.listToolsCalls).toBe(1)
     expect(serverState.requestCalls).toBe(1)
@@ -872,7 +881,7 @@ test(
     serverState.listToolsShouldFail = true
     serverState.listToolsError = "transport closed"
 
-    const addResult = await MCP.add("broken-server", {
+    const addResult = await MCPFacade.add("broken-server", {
       type: "local",
       command: ["echo", "test"],
     })
@@ -901,7 +910,7 @@ test(
     async () => {
       const countBefore = clientCreateCount
 
-      await MCP.add("disabled-server", {
+      await MCPFacade.add("disabled-server", {
         type: "local",
         command: ["echo", "test"],
         enabled: false,
@@ -910,7 +919,7 @@ test(
       // No client should have been created
       expect(clientCreateCount).toBe(countBefore)
 
-      const status = await MCP.status()
+      const status = await MCPFacade.status()
       expect(status["disabled-server"]?.status).toBe("disabled")
     },
   ),
@@ -934,12 +943,12 @@ test(
       const serverState = getOrCreateClientState("prompt-server")
       serverState.prompts = [{ name: "my-prompt", description: "A test prompt" }]
 
-      await MCP.add("prompt-server", {
+      await MCPFacade.add("prompt-server", {
         type: "local",
         command: ["echo", "test"],
       })
 
-      const prompts = await MCP.prompts()
+      const prompts = await MCPFacade.prompts()
       expect(Object.keys(prompts).length).toBe(1)
       const key = Object.keys(prompts)[0]
       expect(key).toContain("prompt-server")
@@ -962,12 +971,12 @@ test(
       const serverState = getOrCreateClientState("resource-server")
       serverState.resources = [{ name: "my-resource", uri: "file:///test.txt", description: "A test resource" }]
 
-      await MCP.add("resource-server", {
+      await MCPFacade.add("resource-server", {
         type: "local",
         command: ["echo", "test"],
       })
 
-      const resources = await MCP.resources()
+      const resources = await MCPFacade.resources()
       expect(Object.keys(resources).length).toBe(1)
       const key = Object.keys(resources)[0]
       expect(key).toContain("resource-server")
@@ -990,14 +999,14 @@ test(
       const serverState = getOrCreateClientState("prompt-disc-server")
       serverState.prompts = [{ name: "hidden-prompt", description: "Should not appear" }]
 
-      await MCP.add("prompt-disc-server", {
+      await MCPFacade.add("prompt-disc-server", {
         type: "local",
         command: ["echo", "test"],
       })
 
-      await MCP.disconnect("prompt-disc-server")
+      await MCPFacade.disconnect("prompt-disc-server")
 
-      const prompts = await MCP.prompts()
+      const prompts = await MCPFacade.prompts()
       expect(Object.keys(prompts).length).toBe(0)
     },
   ),
@@ -1015,13 +1024,13 @@ test(
   "connect() on an unknown server name rejects with NotFoundError",
   withInstance({}, async () => {
     let caught: unknown
-    await MCP.connect("nonexistent").catch((err) => {
+    await MCPFacade.connect("nonexistent").catch((err) => {
       caught = err
     })
     expect(caught).toBeInstanceOf(NotFoundError)
 
     // The unknown server is never registered.
-    const status = await MCP.status()
+    const status = await MCPFacade.status()
     expect(status["nonexistent"]).toBeUndefined()
   }),
 )
@@ -1033,7 +1042,7 @@ test(
 test(
   "disconnect() on nonexistent server does not throw",
   withInstance({}, async () => {
-    await MCP.disconnect("nonexistent")
+    await MCPFacade.disconnect("nonexistent")
     // Should complete without error
   }),
 )
@@ -1045,7 +1054,7 @@ test(
 test(
   "tools() returns empty when no MCP servers are configured",
   withInstance({}, async () => {
-    const tools = await MCP.tools()
+    const tools = await MCPFacade.tools()
     expect(Object.keys(tools).length).toBe(0)
   }),
 )
@@ -1069,19 +1078,19 @@ test(
       connectShouldFail = true
       connectError = "Connection refused"
 
-      await MCP.add("fail-connect", {
+      await MCPFacade.add("fail-connect", {
         type: "local",
         command: ["echo", "test"],
       })
 
-      const status = await MCP.status()
+      const status = await MCPFacade.status()
       expect(status["fail-connect"]?.status).toBe("failed")
       if (status["fail-connect"]?.status === "failed") {
         expect(status["fail-connect"].error).toContain("Connection refused")
       }
 
       // No tools should be available
-      const tools = await MCP.tools()
+      const tools = await MCPFacade.tools()
       expect(Object.keys(tools).length).toBe(0)
     },
   ),
@@ -1137,12 +1146,12 @@ test(
         { name: "tool.b", description: "Tool B", inputSchema: { type: "object", properties: {} } },
       ]
 
-      await MCP.add("my.special-server", {
+      await MCPFacade.add("my.special-server", {
         type: "local",
         command: ["echo", "test"],
       })
 
-      const tools = await MCP.tools()
+      const tools = await MCPFacade.tools()
       const keys = Object.keys(tools)
 
       // Server name dots should be replaced with underscores
@@ -1165,7 +1174,7 @@ test(
     getOrCreateClientState("hanging-server")
     connectShouldHang = true
 
-    const addResult = await MCP.add("hanging-server", {
+    const addResult = await MCPFacade.add("hanging-server", {
       type: "local",
       command: ["node", "fake.js"],
       timeout: 100,
@@ -1190,7 +1199,7 @@ test(
     getOrCreateClientState("hanging-remote")
     connectShouldHang = true
 
-    const addResult = await MCP.add("hanging-remote", {
+    const addResult = await MCPFacade.add("hanging-remote", {
       type: "remote",
       url: "http://localhost:9999/mcp",
       timeout: 100,
@@ -1216,7 +1225,7 @@ test(
     connectShouldFail = true
     connectError = "Connection refused"
 
-    const addResult = await MCP.add("fail-remote", {
+    const addResult = await MCPFacade.add("fail-remote", {
       type: "remote",
       url: "http://localhost:9999/mcp",
       timeout: 5000,

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -118,8 +118,27 @@ beforeEach(() => {
 
 // Import modules after mocking
 const { MCP } = await import("../../src/mcp/index")
+const { McpAuth } = await import("../../src/mcp/auth")
 const { Instance } = await import("../../src/project/instance")
 const { tmpdir } = await import("../fixture/fixture")
+const { makeRuntime } = await import("../../src/effect/run-service")
+const mcpRuntime = makeRuntime(MCP.Service, MCP.defaultLayer)
+const authRuntime = makeRuntime(McpAuth.Service, McpAuth.defaultLayer)
+const MCPFacade = {
+  status: () => mcpRuntime.runPromise((mcp) => mcp.status()),
+  tools: () => mcpRuntime.runPromise((mcp) => mcp.tools()),
+  add: (name: string, mcpConfig: any) => mcpRuntime.runPromise((mcp) => mcp.add(name, mcpConfig)),
+  authenticate: (name: string) => mcpRuntime.runPromise((mcp) => mcp.authenticate(name)),
+  startAuth: async (name: string) => {
+    const { authorizationUrl, oauthState } = await mcpRuntime.runPromise((mcp) => mcp.startAuth(name))
+    return { authorizationUrl, oauthState }
+  },
+}
+const McpAuthFacade = {
+  get: (name: string) => authRuntime.runPromise((auth) => auth.get(name)),
+  updateOAuthState: (name: string, state: string) =>
+    authRuntime.runPromise((auth) => auth.updateOAuthState(name, state)),
+}
 
 test("first connect to OAuth server shows needs_auth instead of failed", async () => {
   await using tmp = await tmpdir({
@@ -142,7 +161,7 @@ test("first connect to OAuth server shows needs_auth instead of failed", async (
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const result = await MCP.add("test-oauth", {
+      const result = await MCPFacade.add("test-oauth", {
         type: "remote",
         url: "https://example.com/mcp",
       })
@@ -176,7 +195,7 @@ test("state() generates a new state when none is saved", async () => {
       )
 
       // Ensure no state exists
-      const entryBefore = await McpAuth.get("test-state-gen")
+      const entryBefore = await McpAuthFacade.get("test-state-gen")
       expect(entryBefore?.oauthState).toBeUndefined()
 
       // state() should generate and return a new state, not throw
@@ -185,7 +204,7 @@ test("state() generates a new state when none is saved", async () => {
       expect(state.length).toBe(64) // 32 bytes as hex
 
       // The generated state should be persisted
-      const entryAfter = await McpAuth.get("test-state-gen")
+      const entryAfter = await McpAuthFacade.get("test-state-gen")
       expect(entryAfter?.oauthState).toBe(state)
     },
   })
@@ -209,7 +228,7 @@ test("state() returns existing state when one is saved", async () => {
 
       // Pre-save a state
       const existingState = "pre-saved-state-value"
-      await McpAuth.updateOAuthState("test-state-existing", existingState)
+      await McpAuthFacade.updateOAuthState("test-state-existing", existingState)
 
       // state() should return the existing state
       const state = await provider.state()
@@ -243,7 +262,7 @@ test("authenticate() persists the client when OAuth completes without a redirect
     fn: async () => {
       try {
         // First connect: no stored tokens → needs_auth.
-        const added = await MCP.add("test-oauth-connect", {
+        const added = await MCPFacade.add("test-oauth-connect", {
           type: "remote",
           url: "https://example.com/mcp",
         })
@@ -254,15 +273,15 @@ test("authenticate() persists the client when OAuth completes without a redirect
         simulateAuthFlow = false
         connectSucceedsImmediately = true
 
-        const result = await MCP.authenticate("test-oauth-connect")
+        const result = await MCPFacade.authenticate("test-oauth-connect")
         expect(result.status).toBe("connected")
 
         // The immediately-connected client must be stored, not dropped, so the
         // server reports connected and its tools are registered (no leak).
-        const after = await MCP.status()
+        const after = await MCPFacade.status()
         expect(after["test-oauth-connect"]?.status).toBe("connected")
 
-        const tools = await MCP.tools()
+        const tools = await MCPFacade.tools()
         expect(Object.keys(tools).some((key) => key.includes("test-oauth-connect"))).toBe(true)
       } finally {
         await McpOAuthCallback.stop()
@@ -301,7 +320,7 @@ test("startAuth() keeps the public result plain data on immediate connect (#2237
         simulateAuthFlow = false
         connectSucceedsImmediately = true
 
-        const result = await MCP.startAuth("test-oauth-startauth")
+        const result = await MCPFacade.startAuth("test-oauth-startauth")
         expect(Object.keys(result).sort()).toEqual(["authorizationUrl", "oauthState"])
         expect("client" in result).toBe(false)
         expect(() => JSON.stringify(result)).not.toThrow()

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -237,6 +237,36 @@ test("state() returns existing state when one is saved", async () => {
   })
 })
 
+test("saveTokens() preserves an immediately expiring token", async () => {
+  const { McpOAuthProvider } = await import("../../src/mcp/oauth-provider")
+
+  await using tmp = await tmpdir()
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const provider = new McpOAuthProvider(
+        "test-token-expiry-zero",
+        "https://example.com/mcp",
+        {},
+        { onRedirect: async () => {} },
+      )
+
+      const before = Date.now() / 1000
+      await provider.saveTokens({
+        access_token: "access-token",
+        token_type: "Bearer",
+        expires_in: 0,
+      })
+      const after = Date.now() / 1000
+
+      const entry = await McpAuthFacade.get("test-token-expiry-zero")
+      expect(entry?.tokens?.expiresAt).toBeGreaterThanOrEqual(before)
+      expect(entry?.tokens?.expiresAt).toBeLessThanOrEqual(after)
+    },
+  })
+})
+
 test("authenticate() persists the client when OAuth completes without a redirect (#22376)", async () => {
   const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
 

--- a/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -104,6 +104,11 @@ const { Bus } = await import("../../src/bus")
 const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
 const { Instance } = await import("../../src/project/instance")
 const { tmpdir } = await import("../fixture/fixture")
+const { makeRuntime } = await import("../../src/effect/run-service")
+const mcpRuntime = makeRuntime(MCP.Service, MCP.defaultLayer)
+const MCPFacade = {
+  authenticate: (name: string) => mcpRuntime.runPromise((mcp) => mcp.authenticate(name)),
+}
 
 test("BrowserOpenFailed event is published when open() throws", async () => {
   await using tmp = await tmpdir({
@@ -136,7 +141,7 @@ test("BrowserOpenFailed event is published when open() throws", async () => {
       // Run authenticate with a timeout to avoid waiting forever for the callback
       // Attach a handler immediately so callback shutdown rejections
       // don't show up as unhandled between tests.
-      const authPromise = MCP.authenticate("test-oauth-server").catch(() => undefined)
+      const authPromise = MCPFacade.authenticate("test-oauth-server").catch(() => undefined)
 
       // Config.get() can be slow in tests, so give it plenty of time.
       await new Promise((resolve) => setTimeout(resolve, 2_000))
@@ -185,7 +190,7 @@ test("BrowserOpenFailed event is NOT published when open() succeeds", async () =
       })
 
       // Run authenticate with a timeout to avoid waiting forever for the callback
-      const authPromise = MCP.authenticate("test-oauth-server-2").catch(() => undefined)
+      const authPromise = MCPFacade.authenticate("test-oauth-server-2").catch(() => undefined)
 
       // Config.get() can be slow in tests; also covers the ~500ms open() error-detection window.
       await new Promise((resolve) => setTimeout(resolve, 2_000))
@@ -230,7 +235,7 @@ test("open() is called with the authorization URL", async () => {
       openCalledWith = undefined
 
       // Run authenticate with a timeout to avoid waiting forever for the callback
-      const authPromise = MCP.authenticate("test-oauth-server-3").catch(() => undefined)
+      const authPromise = MCPFacade.authenticate("test-oauth-server-3").catch(() => undefined)
 
       // Config.get() can be slow in tests; also covers the ~500ms open() error-detection window.
       await new Promise((resolve) => setTimeout(resolve, 2_000))


### PR DESCRIPTION
## Summary

Retires the MCP and McpAuth Promise facade exports and keeps callers on the Effect service boundary.

## Why

Related to #936.

The MCP services were still carrying per-service `makeRuntime(Service, defaultLayer)` bridges and exported async facade functions after the shared `AppRuntime` graph became the production runtime. This removes that compatibility surface without changing MCP catalog, OAuth, auth storage, or connection semantics.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the OAuth provider boundary and the MCP test helper conversions. The production MCP service now injects its existing `McpAuth.Service` into `McpOAuthProvider`; standalone provider usage falls back to `AppRuntime` without reintroducing exported service facades.

## Risk Notes

No visible UI or copy changed, so the UI/manual screenshot checklist item is not applicable. No platform, packaging, updater, signing, shell, or permissions surface changed. No docs, release notes, dependencies, credentials, deletion behavior, generated content, or local file output changed.

Fresh-eye result: no P0/P1 findings. One P2 simplification was found and fixed by using the already-injected MCP auth service inside the production provider path instead of bouncing every OAuth callback through the full AppRuntime.

## How To Verify

```text
Guardrail RED: bun test test/effect/legacy-boundaries.test.ts failed before implementation because MCP still imported @/effect/run-service and exposed async facades.
Guardrail GREEN: bun test test/effect/legacy-boundaries.test.ts -> 15 passed.
Focused MCP tests: bun test test/mcp/lifecycle.test.ts test/mcp/oauth-auto-connect.test.ts test/mcp/oauth-browser.test.ts test/mcp/headers.test.ts test/mcp/auth.test.ts -> 43 passed.
Typecheck: GOMAXPROCS=2 bun run typecheck -> passed.
Diff check: git diff --check -> passed.
Caller scan: rg for old MCP/McpAuth facade calls in packages/opencode/src and packages/opencode/test found no remaining callers; remaining matches are service trace names only.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the public Promise-based façade exports for MCP and auth operations, keeping only the effect-based service/layer surface.
  * Updated the OAuth provider to execute auth persistence via an injected effect runner.
* **Tests**
  * Added a test to ensure MCP/auth modules no longer expose Promise facades.
  * Updated MCP and OAuth tests to route interactions through an effect runtime wrapper.
  * Added coverage for token persistence with immediately expiring tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->