### PR TITLE
refactor(opencode): retire Project Worktree VCS facades

### DIFF
--- a/packages/opencode/script/seed-e2e.ts
+++ b/packages/opencode/script/seed-e2e.ts
@@ -93,14 +93,14 @@ const seed = async () => {
           time: { start: now },
         }
         await AppRuntime.runPromise(
-          Session.Service.use((svc) =>
-            Effect.gen(function* () {
-              yield* svc.updateMessage(message)
-              yield* svc.updatePart(part)
-            }),
-          ),
+          Effect.gen(function* () {
+            const session = yield* Session.Service
+            const project = yield* Project.Service
+            yield* session.updateMessage(message)
+            yield* session.updatePart(part)
+            yield* project.update({ projectID: Instance.project.id, name: "E2E Project" })
+          }),
         )
-        await Project.update({ projectID: Instance.project.id, name: "E2E Project" })
       },
     })
   } finally {

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -1,6 +1,5 @@
 import z from "zod"
 import { Context as EffectContext, Effect, Layer } from "effect"
-import { AppRuntime } from "@/effect/app-runtime"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { BusEvent } from "@/bus/bus-event"
@@ -697,7 +696,7 @@ export namespace Automation {
     const targetProjectID = patch.where?.projectID
     const isMove = targetProjectID !== undefined && targetProjectID !== previous.where.projectID
     const targetProject = isMove
-      ? AppRuntime.runSync(Project.Service.use((project) => project.get(targetProjectID)))
+      ? Effect.runSync(Project.Service.use((project) => project.get(targetProjectID)).pipe(Effect.provide(Project.defaultLayer)))
       : undefined
     if (isMove) {
       if (previous.context === "continue") addDetail(updateDetails, "where.projectID", "unsupported_continue_move")

--- a/packages/opencode/src/automation/index.ts
+++ b/packages/opencode/src/automation/index.ts
@@ -1,5 +1,6 @@
 import z from "zod"
 import { Context as EffectContext, Effect, Layer } from "effect"
+import { AppRuntime } from "@/effect/app-runtime"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { BusEvent } from "@/bus/bus-event"
@@ -695,7 +696,9 @@ export namespace Automation {
     const updateDetails = validateUpdateInput(previous, patch, now)
     const targetProjectID = patch.where?.projectID
     const isMove = targetProjectID !== undefined && targetProjectID !== previous.where.projectID
-    const targetProject = isMove ? Project.get(targetProjectID) : undefined
+    const targetProject = isMove
+      ? AppRuntime.runSync(Project.Service.use((project) => project.get(targetProjectID)))
+      : undefined
     if (isMove) {
       if (previous.context === "continue") addDetail(updateDetails, "where.projectID", "unsupported_continue_move")
       if (hasActiveRun(previous.id)) addDetail(updateDetails, "where.projectID", "unsupported_move_with_active_run")

--- a/packages/opencode/src/automation/runner.ts
+++ b/packages/opencode/src/automation/runner.ts
@@ -8,7 +8,6 @@ import { Session } from "@/session"
 import { SessionPrompt } from "@/session/prompt"
 import { Database, NotFoundError, and, eq, sql } from "@/storage/db"
 import { AutomationRunContext, type AutomationRunBlocker } from "./run-context"
-import { Worktree } from "@/worktree"
 
 const log = Log.create({ service: "automation.runner" })
 
@@ -45,6 +44,7 @@ async function releaseAutomationWorktreeBindings(directory: string) {
 async function prepareWorktreePlacement(definition: Automation.Definition) {
   const placement = definition.where.worktree
   if (!placement) return undefined
+  const { Worktree } = await import("@/worktree")
   const existing = await AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.lookupBySlug(placement)))
   if (existing) {
     await releaseAutomationWorktreeBindings(existing.directory)

--- a/packages/opencode/src/automation/runner.ts
+++ b/packages/opencode/src/automation/runner.ts
@@ -45,13 +45,15 @@ async function releaseAutomationWorktreeBindings(directory: string) {
 async function prepareWorktreePlacement(definition: Automation.Definition) {
   const placement = definition.where.worktree
   if (!placement) return undefined
-  const existing = await Worktree.lookupBySlug(placement)
+  const existing = await AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.lookupBySlug(placement)))
   if (existing) {
     await releaseAutomationWorktreeBindings(existing.directory)
-    await Worktree.reset({ directory: existing.directory })
-    return (await Worktree.lookupBySlug(placement)) ?? existing
+    await AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.reset({ directory: existing.directory })))
+    return (
+      (await AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.lookupBySlug(placement)))) ?? existing
+    )
   }
-  return Worktree.createReady({ name: placement, exactName: true })
+  return AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.createReady({ name: placement, exactName: true })))
 }
 
 // Continue automations append to the conversation they were created in; fresh

--- a/packages/opencode/src/cli/cmd/debug/scrap.ts
+++ b/packages/opencode/src/cli/cmd/debug/scrap.ts
@@ -2,6 +2,7 @@ import { EOL } from "os"
 import { Project } from "../../../project/project"
 import { Log } from "@opencode-ai/core/util/log"
 import { cmd } from "../cmd"
+import { AppRuntime } from "../../../effect/app-runtime"
 
 export const ScrapCommand = cmd({
   command: "scrap",
@@ -9,7 +10,7 @@ export const ScrapCommand = cmd({
   builder: (yargs) => yargs,
   async handler() {
     const timer = Log.Default.time("scrap")
-    const list = await Project.list()
+    const list = await AppRuntime.runPromise(Project.Service.use((project) => project.list()))
     process.stdout.write(JSON.stringify(list, null, 2) + EOL)
     timer.stop()
   },

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -18,6 +18,7 @@ import { getAdaptor, getBuiltinAdaptor, ownerKey } from "./adaptors"
 import { type Adaptor, WorkspaceInfo } from "./types"
 import { WorkspaceID } from "./schema"
 import { parseSSE } from "./sse"
+import { AppRuntime } from "@/effect/app-runtime"
 
 export namespace Workspace {
   export const Info = WorkspaceInfo.meta({
@@ -176,7 +177,7 @@ export namespace Workspace {
     input: Pick<StoredInfo, "projectID" | "type" | "owner"> & { hint?: string | null },
     error: unknown,
   ) {
-    const project = Project.get(input.projectID)
+    const project = AppRuntime.runSync(Project.Service.use((project) => project.get(input.projectID)))
     if (!project) throw error
     const projectWorktree = project.worktree === "/" ? undefined : project.worktree
 
@@ -251,7 +252,7 @@ export namespace Workspace {
     const builtin = getBuiltinAdaptor(input.type)
     if (builtin) return builtin
 
-    const project = Project.get(input.projectID)
+    const project = AppRuntime.runSync(Project.Service.use((project) => project.get(input.projectID)))
     if (project?.worktree === "/" && !hint) {
       throw new Error(`Missing workspace owner for non-git adaptor: ${input.type}`)
     }

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -32,6 +32,7 @@ export const layer = Layer.effect(
     const fileWatcher = yield* FileWatcher.Service
     const vcs = yield* Vcs.Service
     const snapshot = yield* Snapshot.Service
+    const project = yield* Project.Service
 
     return {
       run: Effect.gen(function* () {
@@ -50,7 +51,7 @@ export const layer = Layer.effect(
         yield* plugin.init()
         const unsubscribe = yield* bus.subscribeCallback(Command.Event.Executed, (payload) => {
           if (payload.properties.name === Command.Default.INIT) {
-            Project.setInitialized(ctx.project.id)
+            Effect.runSync(project.setInitialized(ctx.project.id))
           }
         })
         yield* Effect.sync(() => {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -11,7 +11,6 @@ import { ProjectID } from "./schema"
 import { Effect, Layer, Path, Scope, Context, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
-import { makeRuntime } from "@/effect/run-service"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 
@@ -477,59 +476,4 @@ export namespace Project {
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),
   )
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  // ---------------------------------------------------------------------------
-  // Promise-based API (delegates to Effect service via runPromise)
-  // ---------------------------------------------------------------------------
-
-  export function fromDirectory(directory: string) {
-    return runPromise((svc) => svc.fromDirectory(directory))
-  }
-
-  export function discover(input: Info) {
-    return runPromise((svc) => svc.discover(input))
-  }
-
-  export function list() {
-    return Database.use((db) =>
-      db
-        .select()
-        .from(ProjectTable)
-        .all()
-        .map((row) => fromRow(row)),
-    )
-  }
-
-  export function get(id: ProjectID): Info | undefined {
-    const row = Database.use((db) => db.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
-    if (!row) return undefined
-    return fromRow(row)
-  }
-
-  export function setInitialized(id: ProjectID) {
-    Database.use((db) =>
-      db.update(ProjectTable).set({ time_initialized: Date.now() }).where(eq(ProjectTable.id, id)).run(),
-    )
-  }
-
-  export function initGit(input: { directory: string; project: Info }) {
-    return runPromise((svc) => svc.initGit(input))
-  }
-
-  export function update(input: UpdateInput) {
-    return runPromise((svc) => svc.update(input))
-  }
-
-  export function sandboxes(id: ProjectID) {
-    return runPromise((svc) => svc.sandboxes(id))
-  }
-
-  export function addSandbox(id: ProjectID, directory: string) {
-    return runPromise((svc) => svc.addSandbox(id, directory))
-  }
-
-  export function removeSandbox(id: ProjectID, directory: string) {
-    return runPromise((svc) => svc.removeSandbox(id, directory))
-  }
 }

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -3,7 +3,6 @@ import { formatPatch, structuredPatch } from "diff"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { FileWatcher } from "@/file/watcher"
 import { Git } from "@/git"
 import { Log } from "@opencode-ai/core/util/log"
@@ -386,34 +385,4 @@ export namespace Vcs {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Git.defaultLayer), Layer.provide(Bus.layer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function init() {
-    return runPromise((svc) => svc.init())
-  }
-
-  export async function branch() {
-    return runPromise((svc) => svc.branch())
-  }
-
-  export async function defaultBranch() {
-    return runPromise((svc) => svc.defaultBranch())
-  }
-
-  export async function status() {
-    return runPromise((svc) => svc.status())
-  }
-
-  export async function diff(mode: Mode) {
-    return runPromise((svc) => svc.diff(mode))
-  }
-
-  export async function diffRaw() {
-    return runPromise((svc) => svc.diffRaw())
-  }
-
-  export async function apply(input: ApplyInput) {
-    return runPromise((svc) => svc.apply(input))
-  }
 }

--- a/packages/opencode/src/tool/enter-worktree.ts
+++ b/packages/opencode/src/tool/enter-worktree.ts
@@ -34,6 +34,7 @@ export const EnterWorktreeTool = Tool.define(
   Effect.gen(function* () {
     const sessions = yield* Session.Service
     const subagents = yield* SubagentRun.Service
+    const worktrees = yield* Worktree.Service
     const spawner = yield* ChildProcessSpawner
 
     const guard = (sessionID: SessionID, messageID: Tool.Context["messageID"], callID: string | undefined) =>
@@ -129,7 +130,7 @@ export const EnterWorktreeTool = Tool.define(
             )
           }
           const branch = yield* currentBranch(spawner, canonical)
-          const info = yield* Effect.promise(() => Worktree.registerExistingByPath(canonical))
+          const info = yield* worktrees.registerExistingByPath(canonical)
           yield* applyEnter(ctx.sessionID, { ...info, branch: info.branch || branch }, info.source)
           return successResult({
             activeDirectory: canonical,
@@ -141,8 +142,8 @@ export const EnterWorktreeTool = Tool.define(
         }
 
         // name= or no-arg branch
-        const existing = params.name ? yield* Effect.promise(() => Worktree.lookupBySlug(params.name!)) : undefined
-        const planned = existing ?? (yield* Effect.promise(() => Worktree.makeWorktreeInfo(params.name)))
+        const existing = params.name ? yield* worktrees.lookupBySlug(params.name!) : undefined
+        const planned = existing ?? (yield* worktrees.makeWorktreeInfo(params.name))
         if (sameDirectory(exec.activeDirectory, planned.directory)) {
           return successResult({
             activeDirectory: planned.directory,
@@ -164,7 +165,7 @@ export const EnterWorktreeTool = Tool.define(
             .catch(() => false),
         )
         if (!exists) {
-          yield* Effect.promise(() => Worktree.createFromInfo(planned))
+          yield* worktrees.createFromInfo(planned)
         } else {
           const ownerCommon = yield* gitCommonDir(spawner, exec.ownerDirectory)
           const targetCommon = yield* gitCommonDir(spawner, planned.directory)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -69,6 +69,7 @@ import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
 import { SubagentRun } from "../session/subagent-run"
 import { needsConfigDependencies, usesConfigDependencies } from "../config/dependency"
+import { Worktree } from "@/worktree"
 
 export function localToolImportSpec(input: string) {
   return input.startsWith("file://") ? input : pathToFileURL(input).href
@@ -134,6 +135,7 @@ export namespace ToolRegistry {
     | Ripgrep.Service
     | Truncate.Service
     | Automation.Service
+    | Worktree.Service
   > = Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -539,6 +541,7 @@ export namespace ToolRegistry {
       Layer.provide(Ripgrep.defaultLayer),
       Layer.provide(Truncate.defaultLayer),
       Layer.provide(Automation.defaultLayer),
+      Layer.provide(Worktree.defaultLayer),
     ),
   )
 

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -17,7 +17,6 @@ import { ensureWorktreesIgnoredEffect, restoreWorktreesIgnoredEffect } from "./g
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
-import { makeRuntime } from "@/effect/run-service"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { InstanceState } from "@/effect/instance-state"
 import { Session } from "../session"
@@ -163,7 +162,7 @@ export namespace Worktree {
     readonly makeWorktreeInfo: (name?: string) => Effect.Effect<Info>
     readonly createFromInfo: (info: Info, startCommand?: string) => Effect.Effect<void>
     readonly create: (input?: CreateInput) => Effect.Effect<Info>
-    readonly createReady: (input?: CreateInput) => Effect.Effect<Info>
+    readonly createReady: (input?: CreateInput & { exactName?: boolean }) => Effect.Effect<Info>
     readonly list: () => Effect.Effect<Info[]>
     readonly lookupByDirectory: (directory: string) => Effect.Effect<Info | undefined>
     readonly lookupBySlug: (slug: string) => Effect.Effect<Info | undefined>
@@ -842,45 +841,4 @@ export namespace Worktree {
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),
   )
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function makeWorktreeInfo(name?: string) {
-    return runPromise((svc) => svc.makeWorktreeInfo(name))
-  }
-
-  export async function createFromInfo(info: Info, startCommand?: string) {
-    return runPromise((svc) => svc.createFromInfo(info, startCommand))
-  }
-
-  export async function create(input?: CreateInput) {
-    return runPromise((svc) => svc.create(input))
-  }
-
-  export async function createReady(input?: CreateInput & { exactName?: boolean }) {
-    return runPromise((svc) => svc.createReady(input))
-  }
-
-  export async function list() {
-    return runPromise((svc) => svc.list())
-  }
-
-  export async function lookupByDirectory(directory: string) {
-    return runPromise((svc) => svc.lookupByDirectory(directory))
-  }
-
-  export async function lookupBySlug(slug: string) {
-    return runPromise((svc) => svc.lookupBySlug(slug))
-  }
-
-  export async function registerExistingByPath(directory: string) {
-    return runPromise((svc) => svc.registerExistingByPath(directory))
-  }
-
-  export async function remove(input: RemoveInput) {
-    return runPromise((svc) => svc.remove(input))
-  }
-
-  export async function reset(input: ResetInput) {
-    return runPromise((svc) => svc.reset(input))
-  }
 }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -71,6 +71,8 @@ const installDepsWithLayer = (dir: string, targetLayer = layer) =>
     Config.Service.use((svc) => svc.installDependencies(dir)).pipe(Effect.scoped, Effect.provide(targetLayer)),
   )
 const installDeps = (dir: string) => installDepsWithLayer(dir)
+const projectFromDirectory = (directory: string) =>
+  Effect.runPromise(Project.Service.use((project) => project.fromDirectory(directory)).pipe(Effect.provide(Project.defaultLayer)))
 
 const lockFailureLayer = Config.layer.pipe(
   Layer.provide(
@@ -130,7 +132,7 @@ async function writeConfig(dir: string, config: object, name = "opencode.json") 
 
 async function withRawInstance<R>(directory: string, fn: () => R): Promise<Awaited<R>> {
   const resolved = Filesystem.resolve(directory)
-  const { project, sandbox } = await Project.fromDirectory(resolved)
+  const { project, sandbox } = await projectFromDirectory(resolved)
   return await Instance.restore({ directory: resolved, worktree: sandbox, project }, fn)
 }
 

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -219,3 +219,48 @@ test("Config service does not expose Promise facades", async () => {
   expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
   for (const facade of facades) expect(text).not.toContain(facade)
 })
+
+test("Project, Vcs, and Worktree services do not expose Promise facades", async () => {
+  const services = {
+    "project/project.ts": [
+      "export function fromDirectory",
+      "export function discover",
+      "export function list",
+      "export function get",
+      "export function setInitialized",
+      "export function initGit",
+      "export function update",
+      "export function sandboxes",
+      "export function addSandbox",
+      "export function removeSandbox",
+    ],
+    "project/vcs.ts": [
+      "export async function init",
+      "export async function branch",
+      "export async function defaultBranch",
+      "export async function status",
+      "export async function diff",
+      "export async function diffRaw",
+      "export async function apply",
+    ],
+    "worktree/index.ts": [
+      "export async function makeWorktreeInfo",
+      "export async function createFromInfo",
+      "export async function create",
+      "export async function createReady",
+      "export async function list",
+      "export async function lookupByDirectory",
+      "export async function lookupBySlug",
+      "export async function registerExistingByPath",
+      "export async function remove",
+      "export async function reset",
+    ],
+  }
+
+  for (const [file, facades] of Object.entries(services)) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+    for (const facade of facades) expect(text).not.toContain(facade)
+  }
+})

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -14,13 +14,16 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
+const projectFromDirectory = (directory: string) =>
+  Effect.runPromise(Project.Service.use((project) => project.fromDirectory(directory)).pipe(Effect.provide(Project.defaultLayer)))
+
 test("File service init works with InstanceRef and no legacy ALS", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await fs.writeFile(path.join(dir, "visible.txt"), "hello", "utf-8")
     },
   })
-  const { project, sandbox } = await Project.fromDirectory(tmp.path)
+  const { project, sandbox } = await projectFromDirectory(tmp.path)
 
   await Effect.runPromise(
     Effect.scoped(

--- a/packages/opencode/test/project/instance-bootstrap-regression.test.ts
+++ b/packages/opencode/test/project/instance-bootstrap-regression.test.ts
@@ -21,6 +21,9 @@ afterEach(async () => {
   await disposeAllInstances()
 })
 
+const projectGet = (id: Project.Info["id"]) =>
+  Effect.runSync(Project.Service.use((project) => project.get(id)).pipe(Effect.provide(Project.defaultLayer)))
+
 async function bootstrapFixture() {
   return tmpdir({
     init: async (dir) => {
@@ -52,7 +55,7 @@ async function bootstrapFixture() {
 
 async function waitForInitialized(projectID: Project.Info["id"]) {
   for (let i = 0; i < 20; i++) {
-    const project = Project.get(projectID)
+    const project = projectGet(projectID)
     if (project?.time.initialized) return
     await Bun.sleep(10)
   }
@@ -100,7 +103,7 @@ test("/init command event marks the bootstrapped project initialized", async () 
   await using tmp = await tmpdir({ git: true })
   const ctx = await InstanceRuntime.reloadInstance({ directory: tmp.path })
 
-  expect(Project.get(ctx.project.id)?.time.initialized).toBeUndefined()
+  expect(projectGet(ctx.project.id)?.time.initialized).toBeUndefined()
 
   await AppRuntime.runPromise(
     Bus.Service.use((bus) =>

--- a/packages/opencode/test/project/instance-store.test.ts
+++ b/packages/opencode/test/project/instance-store.test.ts
@@ -24,6 +24,8 @@ const noopBootstrap = Layer.succeed(
 const it = testEffect(
   Layer.mergeAll(InstanceStore.defaultLayer.pipe(Layer.provide(noopBootstrap)), CrossSpawnSpawner.defaultLayer),
 )
+const projectGet = (id: Project.Info["id"]) =>
+  Effect.runSync(Project.Service.use((project) => project.get(id)).pipe(Effect.provide(Project.defaultLayer)))
 
 afterEach(async () => {
   bootstrapRun = Effect.void
@@ -346,7 +348,7 @@ describe("InstanceStore", () => {
       directory: dir.path,
       fn: () => {
         projectID = Instance.project.id
-        expect(Project.get(projectID!)).toBeDefined()
+        expect(projectGet(projectID!)).toBeDefined()
       },
     })
 
@@ -356,7 +358,7 @@ describe("InstanceStore", () => {
       directory: dir.path,
       fn: () => {
         expect(Instance.project.id).toBe(projectID!)
-        expect(Project.get(projectID!)).toBeDefined()
+        expect(projectGet(projectID!)).toBeDefined()
       },
     })
   })

--- a/packages/opencode/test/project/migrate-global.test.ts
+++ b/packages/opencode/test/project/migrate-global.test.ts
@@ -8,8 +8,12 @@ import { SessionID } from "../../src/session/schema"
 import { Log } from "@opencode-ai/core/util/log"
 import { $ } from "bun"
 import { tmpdir } from "../fixture/fixture"
+import { Effect } from "effect"
 
 Log.init({ print: false })
+
+const projectFromDirectory = (directory: string) =>
+  Effect.runPromise(Project.Service.use((project) => project.fromDirectory(directory)).pipe(Effect.provide(Project.defaultLayer)))
 
 function uid() {
   return SessionID.make(crypto.randomUUID())
@@ -58,7 +62,7 @@ describe("migrateFromGlobal", () => {
     await $`git config user.name "Test"`.cwd(tmp.path).quiet()
     await $`git config user.email "test@opencode.test"`.cwd(tmp.path).quiet()
     await $`git config commit.gpgsign false`.cwd(tmp.path).quiet()
-    const { project: pre } = await Project.fromDirectory(tmp.path)
+    const { project: pre } = await projectFromDirectory(tmp.path)
     expect(pre.id).toBe(ProjectID.global)
 
     // 2. Seed a session under "global" with matching directory
@@ -68,7 +72,7 @@ describe("migrateFromGlobal", () => {
     // 3. Make a commit so the project gets a real ID
     await $`git commit --allow-empty -m "root"`.cwd(tmp.path).quiet()
 
-    const { project: real } = await Project.fromDirectory(tmp.path)
+    const { project: real } = await projectFromDirectory(tmp.path)
     expect(real.id).not.toBe(ProjectID.global)
 
     // 4. The session should have been migrated to the real project ID
@@ -84,7 +88,7 @@ describe("migrateFromGlobal", () => {
     await $`git config user.name "Test"`.cwd(tmp.path).quiet()
     await $`git config user.email "test@opencode.test"`.cwd(tmp.path).quiet()
     await $`git config commit.gpgsign false`.cwd(tmp.path).quiet()
-    const { project: pre } = await Project.fromDirectory(tmp.path)
+    const { project: pre } = await projectFromDirectory(tmp.path)
     expect(pre.id).toBe(ProjectID.global)
 
     // 2. Seed a session under "global" with an OLD update time
@@ -94,7 +98,7 @@ describe("migrateFromGlobal", () => {
 
     // 3. Commit so the project gets a real ID and the session migrates
     await $`git commit --allow-empty -m "root"`.cwd(tmp.path).quiet()
-    const { project: real } = await Project.fromDirectory(tmp.path)
+    const { project: real } = await projectFromDirectory(tmp.path)
     expect(real.id).not.toBe(ProjectID.global)
 
     // 4. The migration re-parents the session but must NOT bump time_updated,
@@ -108,7 +112,7 @@ describe("migrateFromGlobal", () => {
   test("migrates global sessions even when project row already exists", async () => {
     // 1. Create a repo with a commit — real project ID created immediately
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
     expect(project.id).not.toBe(ProjectID.global)
 
     // 2. Ensure "global" project row exists (as it would from a prior no-git session)
@@ -122,7 +126,7 @@ describe("migrateFromGlobal", () => {
 
     // 4. Call fromDirectory again — project row already exists,
     //    so the current code skips migration entirely. This is the bug.
-    await Project.fromDirectory(tmp.path)
+    await projectFromDirectory(tmp.path)
 
     const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
     expect(row).toBeDefined()
@@ -131,7 +135,7 @@ describe("migrateFromGlobal", () => {
 
   test("does not claim sessions with empty directory", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
     expect(project.id).not.toBe(ProjectID.global)
 
     ensureGlobal()
@@ -141,7 +145,7 @@ describe("migrateFromGlobal", () => {
     const id = uid()
     seed({ id, dir: "", project: ProjectID.global })
 
-    await Project.fromDirectory(tmp.path)
+    await projectFromDirectory(tmp.path)
 
     const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
     expect(row).toBeDefined()
@@ -150,7 +154,7 @@ describe("migrateFromGlobal", () => {
 
   test("does not steal sessions from unrelated directories", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
     expect(project.id).not.toBe(ProjectID.global)
 
     ensureGlobal()
@@ -159,7 +163,7 @@ describe("migrateFromGlobal", () => {
     const id = uid()
     seed({ id, dir: "/some/other/dir", project: ProjectID.global })
 
-    await Project.fromDirectory(tmp.path)
+    await projectFromDirectory(tmp.path)
 
     const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
     expect(row).toBeDefined()

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -16,6 +16,27 @@ Log.init({ print: false })
 
 const encoder = new TextEncoder()
 
+const projectFromDirectory = (directory: string) =>
+  Effect.runPromise(Project.Service.use((project) => project.fromDirectory(directory)).pipe(Effect.provide(Project.defaultLayer)))
+const projectDiscover = (input: Project.Info) =>
+  Effect.runPromise(Project.Service.use((project) => project.discover(input)).pipe(Effect.provide(Project.defaultLayer)))
+const projectUpdate = (input: Project.UpdateInput) =>
+  Effect.runPromise(Project.Service.use((project) => project.update(input)).pipe(Effect.provide(Project.defaultLayer)))
+const projectList = () =>
+  Effect.runSync(Project.Service.use((project) => project.list()).pipe(Effect.provide(Project.defaultLayer)))
+const projectGet = (id: Project.Info["id"]) =>
+  Effect.runSync(Project.Service.use((project) => project.get(id)).pipe(Effect.provide(Project.defaultLayer)))
+const projectSetInitialized = (id: Project.Info["id"]) =>
+  Effect.runSync(Project.Service.use((project) => project.setInitialized(id)).pipe(Effect.provide(Project.defaultLayer)))
+const projectAddSandbox = (id: Project.Info["id"], directory: string) =>
+  Effect.runPromise(
+    Project.Service.use((project) => project.addSandbox(id, directory)).pipe(Effect.provide(Project.defaultLayer)),
+  )
+const projectRemoveSandbox = (id: Project.Info["id"], directory: string) =>
+  Effect.runPromise(
+    Project.Service.use((project) => project.removeSandbox(id, directory)).pipe(Effect.provide(Project.defaultLayer)),
+  )
+
 /**
  * Creates a mock ChildProcessSpawner layer that intercepts git subcommands
  * matching `failArg` and returns exit code 128, while delegating everything
@@ -64,7 +85,7 @@ describe("Project.fromDirectory", () => {
     await using tmp = await tmpdir()
     await $`git init`.cwd(tmp.path).quiet()
 
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
     expect(project).toBeDefined()
     expect(project.id).toBe(ProjectID.global)
@@ -78,7 +99,7 @@ describe("Project.fromDirectory", () => {
   test("should handle git repository with commits", async () => {
     await using tmp = await tmpdir({ git: true })
 
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
     expect(project).toBeDefined()
     expect(project.id).not.toBe(ProjectID.global)
@@ -91,14 +112,14 @@ describe("Project.fromDirectory", () => {
 
   test("returns global for non-git directory", async () => {
     await using tmp = await tmpdir()
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
     expect(project.id).toBe(ProjectID.global)
   })
 
   test("derives stable project ID from root commit", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project: a } = await Project.fromDirectory(tmp.path)
-    const { project: b } = await Project.fromDirectory(tmp.path)
+    const { project: a } = await projectFromDirectory(tmp.path)
+    const { project: b } = await projectFromDirectory(tmp.path)
     expect(b.id).toBe(a.id)
   })
 })
@@ -109,7 +130,7 @@ describe("Project.fromDirectory git failure paths", () => {
     await $`git init`.cwd(tmp.path).quiet()
 
     // rev-list fails because HEAD doesn't exist yet — this is the natural scenario
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
     expect(project.vcs).toBe("git")
     expect(project.id).toBe(ProjectID.global)
     expect(project.worktree).toBe(tmp.path)
@@ -142,7 +163,7 @@ describe("Project.fromDirectory with worktrees", () => {
   test("should set worktree to root when called from root", async () => {
     await using tmp = await tmpdir({ git: true })
 
-    const { project, sandbox } = await Project.fromDirectory(tmp.path)
+    const { project, sandbox } = await projectFromDirectory(tmp.path)
 
     expect(project.worktree).toBe(tmp.path)
     expect(sandbox).toBe(tmp.path)
@@ -156,7 +177,7 @@ describe("Project.fromDirectory with worktrees", () => {
     try {
       await $`git worktree add ${worktreePath} -b test-branch-${Date.now()}`.cwd(tmp.path).quiet()
 
-      const { project, sandbox } = await Project.fromDirectory(worktreePath)
+      const { project, sandbox } = await projectFromDirectory(worktreePath)
 
       expect(project.worktree).toBe(tmp.path)
       expect(sandbox).toBe(worktreePath)
@@ -173,13 +194,13 @@ describe("Project.fromDirectory with worktrees", () => {
   test("worktree should share project ID with main repo", async () => {
     await using tmp = await tmpdir({ git: true })
 
-    const { project: main } = await Project.fromDirectory(tmp.path)
+    const { project: main } = await projectFromDirectory(tmp.path)
 
     const worktreePath = path.join(tmp.path, "..", path.basename(tmp.path) + "-wt-shared")
     try {
       await $`git worktree add ${worktreePath} -b shared-${Date.now()}`.cwd(tmp.path).quiet()
 
-      const { project: wt } = await Project.fromDirectory(worktreePath)
+      const { project: wt } = await projectFromDirectory(worktreePath)
 
       expect(wt.id).toBe(main.id)
 
@@ -205,8 +226,8 @@ describe("Project.fromDirectory with worktrees", () => {
       await $`git clone --bare ${tmp.path} ${bare}`.quiet()
       await $`git clone ${bare} ${clone}`.quiet()
 
-      const { project: a } = await Project.fromDirectory(tmp.path)
-      const { project: b } = await Project.fromDirectory(clone)
+      const { project: a } = await projectFromDirectory(tmp.path)
+      const { project: b } = await projectFromDirectory(clone)
 
       expect(b.id).toBe(a.id)
     } finally {
@@ -223,8 +244,8 @@ describe("Project.fromDirectory with worktrees", () => {
       await $`git worktree add ${worktree1} -b branch-${Date.now()}`.cwd(tmp.path).quiet()
       await $`git worktree add ${worktree2} -b branch-${Date.now() + 1}`.cwd(tmp.path).quiet()
 
-      await Project.fromDirectory(worktree1)
-      const { project } = await Project.fromDirectory(worktree2)
+      await projectFromDirectory(worktree1)
+      const { project } = await projectFromDirectory(worktree2)
 
       expect(project.worktree).toBe(tmp.path)
       expect(project.sandboxes).toContain(worktree1)
@@ -246,14 +267,14 @@ describe("Project.fromDirectory with worktrees", () => {
 describe("Project.discover", () => {
   test("should discover favicon.png in root", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
     const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
     await Bun.write(path.join(tmp.path, "favicon.png"), pngData)
 
-    await Project.discover(project)
+    await projectDiscover(project)
 
-    const updated = Project.get(project.id)
+    const updated = projectGet(project.id)
     expect(updated).toBeDefined()
     expect(updated!.icon).toBeDefined()
     expect(updated!.icon?.url).toStartWith("data:")
@@ -263,13 +284,13 @@ describe("Project.discover", () => {
 
   test("should not discover non-image files", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
     await Bun.write(path.join(tmp.path, "favicon.txt"), "not an image")
 
-    await Project.discover(project)
+    await projectDiscover(project)
 
-    const updated = Project.get(project.id)
+    const updated = projectGet(project.id)
     expect(updated).toBeDefined()
     expect(updated!.icon).toBeUndefined()
   })
@@ -278,67 +299,67 @@ describe("Project.discover", () => {
 describe("Project.update", () => {
   test("should update name", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
-    const updated = await Project.update({
+    const updated = await projectUpdate({
       projectID: project.id,
       name: "New Project Name",
     })
 
     expect(updated.name).toBe("New Project Name")
 
-    const fromDb = Project.get(project.id)
+    const fromDb = projectGet(project.id)
     expect(fromDb?.name).toBe("New Project Name")
   })
 
   test("should update icon url", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
-    const updated = await Project.update({
+    const updated = await projectUpdate({
       projectID: project.id,
       icon: { url: "https://example.com/icon.png" },
     })
 
     expect(updated.icon?.url).toBe("https://example.com/icon.png")
 
-    const fromDb = Project.get(project.id)
+    const fromDb = projectGet(project.id)
     expect(fromDb?.icon?.url).toBe("https://example.com/icon.png")
   })
 
   test("should update icon color", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
-    const updated = await Project.update({
+    const updated = await projectUpdate({
       projectID: project.id,
       icon: { color: "#ff0000" },
     })
 
     expect(updated.icon?.color).toBe("#ff0000")
 
-    const fromDb = Project.get(project.id)
+    const fromDb = projectGet(project.id)
     expect(fromDb?.icon?.color).toBe("#ff0000")
   })
 
   test("should update commands", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
-    const updated = await Project.update({
+    const updated = await projectUpdate({
       projectID: project.id,
       commands: { start: "npm run dev" },
     })
 
     expect(updated.commands?.start).toBe("npm run dev")
 
-    const fromDb = Project.get(project.id)
+    const fromDb = projectGet(project.id)
     expect(fromDb?.commands?.start).toBe("npm run dev")
   })
 
   test("should throw error when project not found", async () => {
     await expect(
-      Project.update({
+      projectUpdate({
         projectID: ProjectID.make("nonexistent-project-id"),
         name: "Should Fail",
       }),
@@ -350,7 +371,7 @@ describe("Project.update", () => {
 
   test("should emit GlobalBus event on update", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
     let eventPayload: any = null
     const on = (data: any) => {
@@ -359,7 +380,7 @@ describe("Project.update", () => {
     GlobalBus.on("event", on)
 
     try {
-      await Project.update({
+      await projectUpdate({
         projectID: project.id,
         name: "Updated Name",
       })
@@ -374,9 +395,9 @@ describe("Project.update", () => {
 
   test("should update multiple fields at once", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
-    const updated = await Project.update({
+    const updated = await projectUpdate({
       projectID: project.id,
       name: "Multi Update",
       icon: { url: "https://example.com/favicon.ico", color: "#00ff00" },
@@ -393,24 +414,24 @@ describe("Project.update", () => {
 describe("Project.list and Project.get", () => {
   test("list returns all projects", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
-    const all = Project.list()
+    const all = projectList()
     expect(all.length).toBeGreaterThan(0)
     expect(all.find((p) => p.id === project.id)).toBeDefined()
   })
 
   test("get returns project by id", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
-    const found = Project.get(project.id)
+    const found = projectGet(project.id)
     expect(found).toBeDefined()
     expect(found!.id).toBe(project.id)
   })
 
   test("get returns undefined for unknown id", () => {
-    const found = Project.get(ProjectID.make("nonexistent"))
+    const found = projectGet(ProjectID.make("nonexistent"))
     expect(found).toBeUndefined()
   })
 })
@@ -418,13 +439,13 @@ describe("Project.list and Project.get", () => {
 describe("Project.setInitialized", () => {
   test("sets time_initialized on project", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
 
     expect(project.time.initialized).toBeUndefined()
 
-    Project.setInitialized(project.id)
+    projectSetInitialized(project.id)
 
-    const updated = Project.get(project.id)
+    const updated = projectGet(project.id)
     expect(updated?.time.initialized).toBeDefined()
   })
 })
@@ -432,30 +453,30 @@ describe("Project.setInitialized", () => {
 describe("Project.addSandbox and Project.removeSandbox", () => {
   test("addSandbox adds directory and removeSandbox removes it", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
     const sandboxDir = path.join(tmp.path, "sandbox-test")
 
-    await Project.addSandbox(project.id, sandboxDir)
+    await projectAddSandbox(project.id, sandboxDir)
 
-    let found = Project.get(project.id)
+    let found = projectGet(project.id)
     expect(found?.sandboxes).toContain(sandboxDir)
 
-    await Project.removeSandbox(project.id, sandboxDir)
+    await projectRemoveSandbox(project.id, sandboxDir)
 
-    found = Project.get(project.id)
+    found = projectGet(project.id)
     expect(found?.sandboxes).not.toContain(sandboxDir)
   })
 
   test("addSandbox emits GlobalBus event", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await projectFromDirectory(tmp.path)
     const sandboxDir = path.join(tmp.path, "sandbox-event")
 
     const events: any[] = []
     const on = (evt: any) => events.push(evt)
     GlobalBus.on("event", on)
 
-    await Project.addSandbox(project.id, sandboxDir)
+    await projectAddSandbox(project.id, sandboxDir)
 
     GlobalBus.off("event", on)
     expect(events.some((e) => e.payload.type === Project.Event.Updated.type)).toBe(true)

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -28,7 +28,7 @@ async function withVcs(directory: string, body: () => Promise<void>) {
     directory,
     fn: async () => {
       void AppRuntime.runPromise(FileWatcher.Service.use((svc) => svc.init()))
-      Vcs.init()
+      vcsInit()
       await Bun.sleep(500)
       await body()
     },
@@ -48,6 +48,17 @@ function withVcsOnly(directory: string, body: () => Promise<void>) {
 type BranchEvent = { directory?: string; payload: { type: string; properties: { branch?: string } } }
 const weird = process.platform === "win32" ? "space file.txt" : "tab\tfile.txt"
 const vcsIt = testEffect(Vcs.defaultLayer)
+const vcsInit = () => Effect.runPromise(Vcs.Service.use((vcs) => vcs.init()).pipe(Effect.provide(Vcs.defaultLayer)))
+const vcsBranch = () => Effect.runPromise(Vcs.Service.use((vcs) => vcs.branch()).pipe(Effect.provide(Vcs.defaultLayer)))
+const vcsDefaultBranch = () =>
+  Effect.runPromise(Vcs.Service.use((vcs) => vcs.defaultBranch()).pipe(Effect.provide(Vcs.defaultLayer)))
+const vcsStatus = () => Effect.runPromise(Vcs.Service.use((vcs) => vcs.status()).pipe(Effect.provide(Vcs.defaultLayer)))
+const vcsDiff = (mode: Vcs.Mode) =>
+  Effect.runPromise(Vcs.Service.use((vcs) => vcs.diff(mode)).pipe(Effect.provide(Vcs.defaultLayer)))
+const vcsDiffRaw = () =>
+  Effect.runPromise(Vcs.Service.use((vcs) => vcs.diffRaw()).pipe(Effect.provide(Vcs.defaultLayer)))
+const vcsApply = (input: Vcs.ApplyInput) =>
+  Effect.runPromise(Vcs.Service.use((vcs) => vcs.apply(input)).pipe(Effect.provide(Vcs.defaultLayer)))
 
 type TmpdirOptions = Parameters<typeof tmpdir>[0]
 const scopedTmpdir = (options?: TmpdirOptions) =>
@@ -135,7 +146,7 @@ describeVcs("Vcs", () => {
     await using tmp = await tmpdir({ git: true })
 
     await withVcs(tmp.path, async () => {
-      const branch = await Vcs.branch()
+      const branch = await vcsBranch()
       expect(branch).toBeDefined()
       expect(typeof branch).toBe("string")
     })
@@ -145,7 +156,7 @@ describeVcs("Vcs", () => {
     await using tmp = await tmpdir()
 
     await withVcs(tmp.path, async () => {
-      const branch = await Vcs.branch()
+      const branch = await vcsBranch()
       expect(branch).toBeUndefined()
     })
   })
@@ -178,7 +189,7 @@ describeVcs("Vcs", () => {
       await fs.writeFile(head, `ref: refs/heads/${branch}\n`)
 
       await pending
-      const current = await Vcs.branch()
+      const current = await vcsBranch()
       expect(current).toBe(branch)
     })
   })
@@ -256,7 +267,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const status = await Vcs.status()
+        const status = await vcsStatus()
         expect(status).toEqual([
           { file: "staged.txt", additions: 1, deletions: 0, status: "added" },
           { file: "tracked.txt", additions: 1, deletions: 1, status: "modified" },
@@ -274,7 +285,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const branch = await Vcs.defaultBranch()
+        const branch = await vcsDefaultBranch()
         expect(branch).toBe("main")
       })
     }),
@@ -289,7 +300,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const branch = await Vcs.defaultBranch()
+        const branch = await vcsDefaultBranch()
         expect(branch).toBe("trunk")
       })
     }),
@@ -306,7 +317,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(dir, async () => {
-        const [branch, base] = await Promise.all([Vcs.branch(), Vcs.defaultBranch()])
+        const [branch, base] = await Promise.all([vcsBranch(), vcsDefaultBranch()])
         expect(branch).toBe("feature/test")
         expect(base).toBe("main")
       })
@@ -327,7 +338,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const diff = await Vcs.diff("git")
+        const diff = await vcsDiff("git")
         expect(diff).toEqual(
           expect.arrayContaining([
             expect.objectContaining({ file: "tracked.txt", status: "modified" }),
@@ -359,7 +370,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const diff = await Vcs.diff("git")
+        const diff = await vcsDiff("git")
         const entry = diff.find((item) => item.file === "tracked.txt")
         expect(entry).toBeDefined()
         expect(entry?.patch).toContain("+v2")
@@ -380,7 +391,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const patch = await Vcs.diffRaw()
+        const patch = await vcsDiffRaw()
         expect(patch).toContain("diff --git a/tracked.txt b/tracked.txt")
         expect(patch).toContain("-original")
         expect(patch).toContain("+changed")
@@ -402,7 +413,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const patch = await Vcs.diffRaw()
+        const patch = await vcsDiffRaw()
         expect(patch).toContain("+staged-content")
         expect(patch).toMatch(/deleted file|\+\+\+ \/dev\/null/)
       })
@@ -421,7 +432,7 @@ describe("Vcs diff", () => {
 
       let patch = ""
       yield* withVcsOnly(source.path, async () => {
-        patch = await Vcs.diffRaw()
+        patch = await vcsDiffRaw()
       })
 
       const target = yield* scopedTmpdir({ git: true })
@@ -432,7 +443,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(target.path, async () => {
-        await expect(Vcs.apply({ patch })).resolves.toEqual({ applied: true })
+        await expect(vcsApply({ patch })).resolves.toEqual({ applied: true })
         await expect(fs.readFile(path.join(target.path, "tracked.txt"), "utf-8")).resolves.toBe("changed\n")
       })
     }),
@@ -443,7 +454,7 @@ describe("Vcs diff", () => {
       const tmp = yield* scopedTmpdir()
 
       yield* withVcsOnly(tmp.path, async () => {
-        await expect(Vcs.apply({ patch: "diff --git a/file.txt b/file.txt\n" })).rejects.toMatchObject({
+        await expect(vcsApply({ patch: "diff --git a/file.txt b/file.txt\n" })).rejects.toMatchObject({
           reason: "non-git",
         })
       })
@@ -471,7 +482,7 @@ describe("Vcs diff", () => {
       ].join("\n")
 
       yield* withVcsOnly(tmp.path, async () => {
-        await expect(Vcs.apply({ patch })).rejects.toMatchObject({
+        await expect(vcsApply({ patch })).rejects.toMatchObject({
           reason: "not-clean",
         })
         await expect(fs.readFile(path.join(tmp.path, "tracked.txt"), "utf-8")).resolves.toBe("different\n")
@@ -485,7 +496,7 @@ describe("Vcs diff", () => {
       yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, weird), "hello\n", "utf-8"))
 
       yield* withVcsOnly(tmp.path, async () => {
-        const diff = await Vcs.diff("git")
+        const diff = await vcsDiff("git")
         expect(diff).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -508,7 +519,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const diff = await Vcs.diff("git")
+        const diff = await vcsDiff("git")
         expect(diff).toEqual(expect.arrayContaining([expect.objectContaining({ file: "first.txt", status: "added" })]))
       })
     }),
@@ -532,7 +543,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const diff = await Vcs.diff("branch")
+        const diff = await vcsDiff("branch")
         // Branch view must reflect the full delta the user sees against the default branch,
         // not just commits — this guards against the regression where `git diff <ref> HEAD`
         // silently dropped staged and working-tree changes.
@@ -560,7 +571,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const diff = await Vcs.diff("branch")
+        const diff = await vcsDiff("branch")
         expect(diff).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
@@ -591,7 +602,7 @@ describe("Vcs diff", () => {
       })
 
       yield* withVcsOnly(tmp.path, async () => {
-        const diff = await Vcs.diff("branch")
+        const diff = await vcsDiff("branch")
         const branch = diff.find((item) => item.file === "branch.txt")
         expect(branch?.patch).toContain("+dirty")
         expect(branch?.additions).toBeGreaterThan(0)

--- a/packages/opencode/test/project/worktree-remove.test.ts
+++ b/packages/opencode/test/project/worktree-remove.test.ts
@@ -13,6 +13,26 @@ import { tmpdir } from "../fixture/fixture"
 const wintest = process.platform === "win32" ? test : test.skip
 const unixtest = process.platform === "win32" ? test.skip : test
 const runSession = <A>(fn: (svc: Session.Interface) => Effect.Effect<A>) => AppRuntime.runPromise(Session.Service.use(fn))
+const worktreeMakeWorktreeInfo = (name?: string) =>
+  Effect.runPromise(Worktree.Service.use((worktree) => worktree.makeWorktreeInfo(name)).pipe(Effect.provide(Worktree.defaultLayer)))
+const worktreeCreateFromInfo = (info: Worktree.Info, startCommand?: string) =>
+  Effect.runPromise(
+    Worktree.Service.use((worktree) => worktree.createFromInfo(info, startCommand)).pipe(
+      Effect.provide(Worktree.defaultLayer),
+    ),
+  )
+const worktreeCreateReady = (input?: Worktree.CreateInput & { exactName?: boolean }) =>
+  Effect.runPromise(
+    Worktree.Service.use((worktree) => worktree.createReady(input)).pipe(Effect.provide(Worktree.defaultLayer)),
+  )
+const worktreeLookupByDirectory = (directory: string) =>
+  Effect.runPromise(
+    Worktree.Service.use((worktree) => worktree.lookupByDirectory(directory)).pipe(Effect.provide(Worktree.defaultLayer)),
+  )
+const worktreeRemove = (input: Worktree.RemoveInput) =>
+  Effect.runPromise(Worktree.Service.use((worktree) => worktree.remove(input)).pipe(Effect.provide(Worktree.defaultLayer)))
+const worktreeReset = (input: Worktree.ResetInput) =>
+  Effect.runPromise(Worktree.Service.use((worktree) => worktree.reset(input)).pipe(Effect.provide(Worktree.defaultLayer)))
 
 describe("Worktree.remove", () => {
   test("refuses to remove a worktree bound to an active session", async () => {
@@ -22,8 +42,8 @@ describe("Worktree.remove", () => {
     const { info, session } = await Instance.provide({
       directory: root,
       fn: async () => {
-        const info = await Worktree.makeWorktreeInfo("bound-session")
-        await Worktree.createFromInfo(info)
+        const info = await worktreeMakeWorktreeInfo("bound-session")
+        await worktreeCreateFromInfo(info)
         const session = await runSession((svc) => svc.create({ title: "Bound session" }))
         await runSession((svc) => svc.updateExecutionContext({
           sessionID: session.id,
@@ -36,13 +56,13 @@ describe("Worktree.remove", () => {
     await expect(
       Instance.provide({
         directory: root,
-        fn: () => Worktree.remove({ directory: info.directory }),
+        fn: () => worktreeRemove({ directory: info.directory }),
       }),
     ).rejects.toThrow("WorktreeRemoveFailedError")
     try {
       await Instance.provide({
         directory: root,
-        fn: () => Worktree.remove({ directory: info.directory }),
+        fn: () => worktreeRemove({ directory: info.directory }),
       })
     } catch (error) {
       expect((error as { data?: { message?: string } }).data?.message).toContain("Worktree is in use by session")
@@ -54,7 +74,7 @@ describe("Worktree.remove", () => {
       fn: async () => {
         await runSession((svc) => svc.updateExecutionContext({ sessionID: session.id, activeWorktree: null }))
         await runSession((svc) => svc.remove(session.id))
-        await Worktree.remove({ directory: info.directory })
+        await worktreeRemove({ directory: info.directory })
       },
     })
   })
@@ -97,7 +117,7 @@ describe("Worktree.remove", () => {
       try {
         return await Instance.provide({
           directory: root,
-          fn: () => Worktree.remove({ directory: dir }),
+          fn: () => worktreeRemove({ directory: dir }),
         })
       } finally {
         process.env.PATH = prev
@@ -120,8 +140,8 @@ describe("Worktree.remove", () => {
     const info = await Instance.provide({
       directory: root,
       fn: async () => {
-        const info = await Worktree.makeWorktreeInfo("branch-delete-fails")
-        await Worktree.createFromInfo(info)
+        const info = await worktreeMakeWorktreeInfo("branch-delete-fails")
+        await worktreeCreateFromInfo(info)
         return info
       },
     })
@@ -153,7 +173,7 @@ describe("Worktree.remove", () => {
       await expect(
         Instance.provide({
           directory: root,
-          fn: () => Worktree.remove({ directory: info.directory }),
+          fn: () => worktreeRemove({ directory: info.directory }),
         }),
       ).rejects.toThrow("WorktreeRemoveFailedError")
     } finally {
@@ -163,7 +183,7 @@ describe("Worktree.remove", () => {
     expect(await Filesystem.exists(info.directory)).toBe(false)
     const registryEntry = await Instance.provide({
       directory: root,
-      fn: () => Worktree.lookupByDirectory(info.directory),
+      fn: () => worktreeLookupByDirectory(info.directory),
     })
     expect(registryEntry).toBeUndefined()
 
@@ -189,7 +209,7 @@ describe("Worktree.remove", () => {
 
     const ok = await Instance.provide({
       directory: root,
-      fn: () => Worktree.remove({ directory: dir }),
+      fn: () => worktreeRemove({ directory: dir }),
     })
 
     expect(ok).toBe(true)
@@ -208,7 +228,7 @@ describe("Worktree.reset", () => {
     const { info, session } = await Instance.provide({
       directory: root,
       fn: async () => {
-        const info = await Worktree.createReady({ name: "reset-bound-session" })
+        const info = await worktreeCreateReady({ name: "reset-bound-session" })
         const session = await runSession((svc) => svc.create({ title: "Bound reset session" }))
         await runSession((svc) => svc.updateExecutionContext({
           sessionID: session.id,
@@ -223,7 +243,7 @@ describe("Worktree.reset", () => {
     await expect(
       Instance.provide({
         directory: root,
-        fn: () => Worktree.reset({ directory: info.directory }),
+        fn: () => worktreeReset({ directory: info.directory }),
       }),
     ).rejects.toThrow("WorktreeResetFailedError")
     expect(await Bun.file(path.join(info.directory, "unsaved.txt")).text()).toBe("do not delete\n")
@@ -233,7 +253,7 @@ describe("Worktree.reset", () => {
       fn: async () => {
         await runSession((svc) => svc.updateExecutionContext({ sessionID: session.id, activeWorktree: null }))
         await runSession((svc) => svc.remove(session.id))
-        await Worktree.remove({ directory: info.directory })
+        await worktreeRemove({ directory: info.directory })
       },
     })
   })

--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -17,6 +17,7 @@ import { Session } from "../../src/session"
 import { Database, eq } from "../../src/storage/db"
 import { Worktree } from "../../src/worktree"
 import { tmpdir } from "../fixture/fixture"
+import { AppRuntime } from "../../src/effect/app-runtime"
 
 const encoder = new TextEncoder()
 type StartCommandProbe = { spawned: boolean; released: boolean; release?: () => void }
@@ -24,6 +25,29 @@ type StartCommandProbe = { spawned: boolean; released: boolean; release?: () => 
 function withInstance(directory: string, fn: () => Promise<any>) {
   return Instance.provide({ directory, fn })
 }
+
+const worktreeMakeWorktreeInfo = (name?: string) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.makeWorktreeInfo(name)))
+const worktreeCreateFromInfo = (info: Worktree.Info, startCommand?: string) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.createFromInfo(info, startCommand)))
+const worktreeCreate = (input?: Worktree.CreateInput) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.create(input)))
+const worktreeCreateReady = (input?: Worktree.CreateInput & { exactName?: boolean }) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.createReady(input)))
+const worktreeList = () =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.list()))
+const worktreeLookupByDirectory = (directory: string) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.lookupByDirectory(directory)))
+const worktreeLookupBySlug = (slug: string) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.lookupBySlug(slug)))
+const worktreeRegisterExistingByPath = (directory: string) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.registerExistingByPath(directory)))
+const worktreeRemove = (input: Worktree.RemoveInput) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.remove(input)))
+const worktreeReset = (input: Worktree.ResetInput) =>
+  AppRuntime.runPromise(Worktree.Service.use((worktree) => worktree.reset(input)))
+const projectUpdate = (input: Project.UpdateInput) =>
+  Effect.runPromise(Project.Service.use((project) => project.update(input)).pipe(Effect.provide(Project.defaultLayer)))
 
 function startCommandSpawnProbe(probe: StartCommandProbe) {
   return Layer.effect(
@@ -112,7 +136,7 @@ describe("Worktree", () => {
     test("returns info with name, branch, and directory", async () => {
       await using tmp = await tmpdir({ git: true })
 
-      const info = await withInstance(tmp.path, () => Worktree.makeWorktreeInfo())
+      const info = await withInstance(tmp.path, () => worktreeMakeWorktreeInfo())
 
       expect(info.name).toBeDefined()
       expect(typeof info.name).toBe("string")
@@ -124,7 +148,7 @@ describe("Worktree", () => {
     test("uses provided name as base", async () => {
       await using tmp = await tmpdir({ git: true })
 
-      const info = await withInstance(tmp.path, () => Worktree.makeWorktreeInfo("my-feature"))
+      const info = await withInstance(tmp.path, () => worktreeMakeWorktreeInfo("my-feature"))
 
       expect(info.name).toBe("my-feature")
       expect(info.branch).toBe("pawwork/my-feature")
@@ -135,7 +159,7 @@ describe("Worktree", () => {
     test("slugifies the provided name", async () => {
       await using tmp = await tmpdir({ git: true })
 
-      const info = await withInstance(tmp.path, () => Worktree.makeWorktreeInfo("My Feature Branch!"))
+      const info = await withInstance(tmp.path, () => worktreeMakeWorktreeInfo("My Feature Branch!"))
 
       expect(info.name).toBe("my-feature-branch")
     })
@@ -143,7 +167,7 @@ describe("Worktree", () => {
     test("throws NotGitError for non-git directories", async () => {
       await using tmp = await tmpdir()
 
-      await expect(withInstance(tmp.path, () => Worktree.makeWorktreeInfo())).rejects.toThrow("WorktreeNotGitError")
+      await expect(withInstance(tmp.path, () => worktreeMakeWorktreeInfo())).rejects.toThrow("WorktreeNotGitError")
     })
   })
 
@@ -151,7 +175,7 @@ describe("Worktree", () => {
     test("create returns worktree info and remove cleans up", async () => {
       await using tmp = await tmpdir({ git: true })
 
-      const info = await withInstance(tmp.path, () => Worktree.create())
+      const info = await withInstance(tmp.path, () => worktreeCreate())
 
       expect(info.name).toBeDefined()
       expect(info.branch).toStartWith("pawwork/")
@@ -161,7 +185,7 @@ describe("Worktree", () => {
       // Wait for bootstrap to complete
       await Bun.sleep(1000)
 
-      const ok = await withInstance(tmp.path, () => Worktree.remove({ directory: info.directory }))
+      const ok = await withInstance(tmp.path, () => worktreeRemove({ directory: info.directory }))
       expect(ok).toBe(true)
     })
 
@@ -169,7 +193,7 @@ describe("Worktree", () => {
       await using tmp = await tmpdir({ git: true })
       const ready = waitReady(path.join(tmp.path, ".worktrees", "pawwork"))
 
-      const info = await withInstance(tmp.path, () => Worktree.create())
+      const info = await withInstance(tmp.path, () => worktreeCreate())
 
       // create returns before bootstrap completes, but the worktree already exists
       expect(info.name).toBeDefined()
@@ -189,14 +213,14 @@ describe("Worktree", () => {
       // Cleanup
       await withInstance(info.directory, () => Instance.dispose())
       await Bun.sleep(100)
-      await withInstance(tmp.path, () => Worktree.remove({ directory: info.directory }))
+      await withInstance(tmp.path, () => worktreeRemove({ directory: info.directory }))
     })
 
     test("create with custom name", async () => {
       await using tmp = await tmpdir({ git: true })
       const ready = waitReady(path.join(tmp.path, ".worktrees", "pawwork"))
 
-      const info = await withInstance(tmp.path, () => Worktree.create({ name: "test-workspace" }))
+      const info = await withInstance(tmp.path, () => worktreeCreate({ name: "test-workspace" }))
 
       expect(info.name).toBe("test-workspace")
       expect(info.branch).toBe("pawwork/test-workspace")
@@ -207,7 +231,7 @@ describe("Worktree", () => {
       await ready
       await withInstance(info.directory, () => Instance.dispose())
       await Bun.sleep(100)
-      await withInstance(tmp.path, () => Worktree.remove({ directory: info.directory }))
+      await withInstance(tmp.path, () => worktreeRemove({ directory: info.directory }))
     })
 
     test("createReady with exact name rejects occupied managed placement", async () => {
@@ -216,7 +240,7 @@ describe("Worktree", () => {
       await fs.mkdir(occupied, { recursive: true })
 
       await expect(
-        withInstance(tmp.path, () => Worktree.createReady({ name: "daily-brief", exactName: true })),
+        withInstance(tmp.path, () => worktreeCreateReady({ name: "daily-brief", exactName: true })),
       ).rejects.toThrow("WorktreeNameGenerationFailedError")
 
       const list = await $`git worktree list --porcelain`.cwd(tmp.path).quiet().text()
@@ -226,7 +250,7 @@ describe("Worktree", () => {
     test("createReady with exact name rejects names with an empty slug", async () => {
       await using tmp = await tmpdir({ git: true })
 
-      await expect(withInstance(tmp.path, () => Worktree.createReady({ name: "!!!", exactName: true }))).rejects.toThrow(
+      await expect(withInstance(tmp.path, () => worktreeCreateReady({ name: "!!!", exactName: true }))).rejects.toThrow(
         "WorktreeNameGenerationFailedError",
       )
 
@@ -242,7 +266,7 @@ describe("Worktree", () => {
         await $`git add opencode.json`.cwd(tmp.path).quiet()
         await $`git commit -m invalid-config`.cwd(tmp.path).quiet()
 
-        await expect(Worktree.createReady({ name: "bad-config" })).rejects.toThrow("WorktreeCreateFailedError")
+        await expect(worktreeCreateReady({ name: "bad-config" })).rejects.toThrow("WorktreeCreateFailedError")
       })
     })
 
@@ -252,7 +276,7 @@ describe("Worktree", () => {
       await $`git add .gitignore && git commit -m initial-gitignore`.cwd(tmp.path).quiet()
       await Bun.write(path.join(tmp.path, ".gitignore"), "node_modules\ndist\n")
 
-      await expect(withInstance(tmp.path, () => Worktree.create({ name: "blocked" }))).rejects.toThrow(
+      await expect(withInstance(tmp.path, () => worktreeCreate({ name: "blocked" }))).rejects.toThrow(
         "WorktreeGitignoreGuardError",
       )
 
@@ -262,11 +286,11 @@ describe("Worktree", () => {
 
     test("restores .gitignore when git worktree add fails", async () => {
       await using tmp = await tmpdir({ git: true })
-      const info = await withInstance(tmp.path, () => Worktree.makeWorktreeInfo("bad-branch"))
+      const info = await withInstance(tmp.path, () => worktreeMakeWorktreeInfo("bad-branch"))
       await fs.mkdir(info.directory, { recursive: true })
       await Bun.write(path.join(info.directory, "blocker"), "already here\n")
 
-      await expect(withInstance(tmp.path, () => Worktree.createFromInfo(info))).rejects.toThrow(
+      await expect(withInstance(tmp.path, () => worktreeCreateFromInfo(info))).rejects.toThrow(
         "WorktreeCreateFailedError",
       )
 
@@ -278,9 +302,9 @@ describe("Worktree", () => {
     wintest("creates git worktree and boots asynchronously", async () => {
       await using tmp = await tmpdir({ git: true })
 
-      const info = await withInstance(tmp.path, () => Worktree.makeWorktreeInfo("from-info-test"))
+      const info = await withInstance(tmp.path, () => worktreeMakeWorktreeInfo("from-info-test"))
       const ready = waitReady(path.join(tmp.path, ".worktrees", "pawwork"))
-      await withInstance(tmp.path, () => Worktree.createFromInfo(info))
+      await withInstance(tmp.path, () => worktreeCreateFromInfo(info))
 
       // Worktree should exist in git (normalize slashes for Windows)
       const list = await $`git worktree list --porcelain`.cwd(tmp.path).quiet().text()
@@ -289,7 +313,7 @@ describe("Worktree", () => {
       expect(normalizedList).toContain(normalizedDir)
 
       await ready
-      await withInstance(tmp.path, () => Worktree.remove({ directory: info.directory }))
+      await withInstance(tmp.path, () => worktreeRemove({ directory: info.directory }))
     })
   })
 
@@ -299,8 +323,8 @@ describe("Worktree", () => {
       const probe: StartCommandProbe = { spawned: false, released: false }
 
       await withInstance(tmp.path, async () => {
-        const info = await Worktree.createReady({ name: "reset-start-spawn-probe" })
-        await Project.update({
+        const info = await worktreeCreateReady({ name: "reset-start-spawn-probe" })
+        await projectUpdate({
           projectID: Instance.project.id,
           commands: {
             start: "start-spawn-probe",
@@ -324,7 +348,7 @@ describe("Worktree", () => {
         expect(probe.spawned).toBe(true)
         expect(probe.released).toBe(false)
         probe.release?.()
-        await Worktree.remove({ directory: info.directory })
+        await worktreeRemove({ directory: info.directory })
       })
     })
 
@@ -332,14 +356,14 @@ describe("Worktree", () => {
       await using tmp = await tmpdir({ git: true })
 
       await withInstance(tmp.path, async () => {
-        const info = await Worktree.createReady({ name: "reset-branch-metadata" })
+        const info = await worktreeCreateReady({ name: "reset-branch-metadata" })
         await $`git checkout -b manual-reset-branch`.cwd(info.directory).quiet()
 
-        await Worktree.reset({ directory: info.directory })
+        await worktreeReset({ directory: info.directory })
 
-        const refreshed = await Worktree.lookupBySlug("reset-branch-metadata")
+        const refreshed = await worktreeLookupBySlug("reset-branch-metadata")
         expect(refreshed?.branch).toBe("manual-reset-branch")
-        await Worktree.remove({ directory: info.directory })
+        await worktreeRemove({ directory: info.directory })
       })
     })
   })
@@ -348,31 +372,31 @@ describe("Worktree", () => {
     test("created worktrees are slug-addressable, existing worktrees are path-addressable only", async () => {
       await using tmp = await tmpdir({ git: true })
       const ready = waitReady(path.join(tmp.path, ".worktrees", "pawwork"))
-      const created = await withInstance(tmp.path, () => Worktree.create({ name: "feature-a" }))
+      const created = await withInstance(tmp.path, () => worktreeCreate({ name: "feature-a" }))
       await ready
 
-      const bySlug = await withInstance(tmp.path, () => Worktree.lookupBySlug("feature-a"))
+      const bySlug = await withInstance(tmp.path, () => worktreeLookupBySlug("feature-a"))
       expect(bySlug?.directory).toBe(created.directory)
       expect(bySlug?.source).toBe("created")
 
-      const byRawName = await withInstance(tmp.path, () => Worktree.lookupBySlug("Feature A"))
+      const byRawName = await withInstance(tmp.path, () => worktreeLookupBySlug("Feature A"))
       expect(byRawName?.directory).toBe(created.directory)
 
       const external = path.join(tmp.path, "..", path.basename(tmp.path) + "-external")
       await $`git worktree add ${external} -b external-${Date.now()}`.cwd(tmp.path).quiet()
 
-      const registered = await withInstance(tmp.path, () => Worktree.registerExistingByPath(external))
+      const registered = await withInstance(tmp.path, () => worktreeRegisterExistingByPath(external))
       expect(registered.source).toBe("existing")
       expect(registered.name).toBe(path.basename(external))
 
-      const byDirectory = await withInstance(tmp.path, () => Worktree.lookupByDirectory(external))
+      const byDirectory = await withInstance(tmp.path, () => worktreeLookupByDirectory(external))
       expect(byDirectory?.source).toBe("existing")
 
-      const notBySlug = await withInstance(tmp.path, () => Worktree.lookupBySlug(path.basename(external)))
+      const notBySlug = await withInstance(tmp.path, () => worktreeLookupBySlug(path.basename(external)))
       expect(notBySlug).toBeUndefined()
 
-      await withInstance(tmp.path, () => Worktree.remove({ directory: created.directory }))
-      await withInstance(tmp.path, () => Worktree.remove({ directory: external }))
+      await withInstance(tmp.path, () => worktreeRemove({ directory: created.directory }))
+      await withInstance(tmp.path, () => worktreeRemove({ directory: external }))
     })
 
     test("legacy string registry entries remain slug-addressable", async () => {
@@ -389,15 +413,15 @@ describe("Worktree", () => {
             .run(),
         )
 
-        const bySlug = await Worktree.lookupBySlug(path.basename(legacy))
+        const bySlug = await worktreeLookupBySlug(path.basename(legacy))
         expect(bySlug?.directory).toBe(legacy)
         expect(bySlug?.source).toBe("created")
 
-        const listed = await Worktree.list()
+        const listed = await worktreeList()
         expect(listed.some((entry) => entry.directory === legacy)).toBe(true)
 
-        await Worktree.remove({ directory: legacy })
-        const afterRemove = await Worktree.lookupBySlug(path.basename(legacy))
+        await worktreeRemove({ directory: legacy })
+        const afterRemove = await worktreeLookupBySlug(path.basename(legacy))
         expect(afterRemove).toBeUndefined()
       })
     })
@@ -407,11 +431,11 @@ describe("Worktree", () => {
       const unrelated = path.join(tmp.path, "not-a-worktree")
       await fs.mkdir(unrelated, { recursive: true })
 
-      await expect(withInstance(tmp.path, () => Worktree.registerExistingByPath(unrelated))).rejects.toThrow(
+      await expect(withInstance(tmp.path, () => worktreeRegisterExistingByPath(unrelated))).rejects.toThrow(
         "WorktreeCreateFailedError",
       )
 
-      const entry = await withInstance(tmp.path, () => Worktree.lookupByDirectory(unrelated))
+      const entry = await withInstance(tmp.path, () => worktreeLookupByDirectory(unrelated))
       expect(entry).toBeUndefined()
     })
   })
@@ -421,7 +445,7 @@ describe("Worktree", () => {
       await using tmp = await tmpdir({ git: true })
 
       const ok = await withInstance(tmp.path, () =>
-        Worktree.remove({ directory: path.join(tmp.path, "does-not-exist") }),
+        worktreeRemove({ directory: path.join(tmp.path, "does-not-exist") }),
       )
       expect(ok).toBe(true)
     })
@@ -429,7 +453,7 @@ describe("Worktree", () => {
     test("throws NotGitError for non-git directories", async () => {
       await using tmp = await tmpdir()
 
-      await expect(withInstance(tmp.path, () => Worktree.remove({ directory: "/tmp/fake" }))).rejects.toThrow(
+      await expect(withInstance(tmp.path, () => worktreeRemove({ directory: "/tmp/fake" }))).rejects.toThrow(
         "WorktreeNotGitError",
       )
     })

--- a/packages/opencode/test/server/automation-runner.test.ts
+++ b/packages/opencode/test/server/automation-runner.test.ts
@@ -28,6 +28,17 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
+const projectUpdate = (input: Project.UpdateInput) =>
+  Effect.runPromise(Project.Service.use((project) => project.update(input)).pipe(Effect.provide(Project.defaultLayer)))
+const worktreeCreateReady = (input?: Worktree.CreateInput & { exactName?: boolean }) =>
+  Effect.runPromise(
+    Worktree.Service.use((worktree) => worktree.createReady(input)).pipe(Effect.provide(Worktree.defaultLayer)),
+  )
+const worktreeLookupBySlug = (slug: string) =>
+  Effect.runPromise(
+    Worktree.Service.use((worktree) => worktree.lookupBySlug(slug)).pipe(Effect.provide(Worktree.defaultLayer)),
+  )
+
 async function withAutomation<T>(fn: (projectID: ProjectID) => Promise<T>) {
   await using tmp = await tmpdir({ git: true })
   return await Instance.provide({
@@ -791,7 +802,7 @@ describe("automation runNow execution", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          await Project.update({
+          await projectUpdate({
             projectID: Instance.project.id,
             commands: {
               start:
@@ -811,7 +822,7 @@ describe("automation runNow execution", () => {
             Bun.sleep(RUN_WAIT_TIMEOUT_MS).then(() => ({ state: "timeout" as const })),
           ])
           if (result.state === "timeout") {
-            const worktree = await Worktree.lookupBySlug("long-start")
+            const worktree = await worktreeLookupBySlug("long-start")
             if (worktree) await Bun.write(path.join(worktree.directory, ".automation-start-release"), "done")
             throw new Error("Automation waited for the worktree start command to exit before prompting")
           }
@@ -819,7 +830,7 @@ describe("automation runNow execution", () => {
           const succeeded = result.run
           if (!succeeded.sessionID) throw new Error("expected run session")
           expect(providerCalls).toBe(1)
-          const worktree = await Worktree.lookupBySlug("long-start")
+          const worktree = await worktreeLookupBySlug("long-start")
           if (!worktree) throw new Error("expected worktree placement")
           await Bun.write(path.join(worktree.directory, ".automation-start-release"), "done")
         },
@@ -883,7 +894,7 @@ describe("automation runNow execution", () => {
 
           await Automation.runNowExecuting(definition.id, { executor: sessionPromptExecutor })
           await waitForRun(definition.id, "succeeded")
-          const worktree = await Worktree.lookupBySlug("daily-brief")
+          const worktree = await worktreeLookupBySlug("daily-brief")
           if (!worktree) throw new Error("expected worktree placement")
           await $`git checkout -b manual-automation-branch`.cwd(worktree.directory).quiet()
           await Automation.runNowExecuting(definition.id, { executor: sessionPromptExecutor })
@@ -949,7 +960,7 @@ describe("automation runNow execution", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const worktree = await Worktree.createReady({ name: "daily-brief" })
+          const worktree = await worktreeCreateReady({ name: "daily-brief" })
           await Bun.write(path.join(worktree.directory, "user-draft.txt"), "keep me\n")
           const userSession = await runSession((svc) => svc.create({ title: "Automation: User renamed" }))
           await runSession((svc) =>

--- a/packages/opencode/test/server/experimental-routes.test.ts
+++ b/packages/opencode/test/server/experimental-routes.test.ts
@@ -23,6 +23,15 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
+const worktreeMakeWorktreeInfo = (name?: string) =>
+  Effect.runPromise(Worktree.Service.use((worktree) => worktree.makeWorktreeInfo(name)).pipe(Effect.provide(Worktree.defaultLayer)))
+const worktreeCreateFromInfo = (info: Worktree.Info, startCommand?: string) =>
+  Effect.runPromise(
+    Worktree.Service.use((worktree) => worktree.createFromInfo(info, startCommand)).pipe(
+      Effect.provide(Worktree.defaultLayer),
+    ),
+  )
+
 describe("experimental routes", () => {
   function app() {
     return new Hono().route("/experimental", ExperimentalRoutes()).onError(ErrorMiddleware)
@@ -153,8 +162,8 @@ describe("experimental routes", () => {
     const info = await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const info = await Worktree.makeWorktreeInfo("bound-session")
-        await Worktree.createFromInfo(info)
+        const info = await worktreeMakeWorktreeInfo("bound-session")
+        await worktreeCreateFromInfo(info)
         const session = await runSession((svc) => svc.create({ title: "Bound session" }))
         await runSession((svc) => svc.updateExecutionContext({ sessionID: session.id, activeWorktree: info }))
         return info
@@ -183,8 +192,8 @@ describe("experimental routes", () => {
     const info = await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const info = await Worktree.makeWorktreeInfo("bound-session-httpapi")
-        await Worktree.createFromInfo(info)
+        const info = await worktreeMakeWorktreeInfo("bound-session-httpapi")
+        await worktreeCreateFromInfo(info)
         const session = await runSession((svc) => svc.create({ title: "Bound session HttpApi" }))
         await runSession((svc) => svc.updateExecutionContext({ sessionID: session.id, activeWorktree: info }))
         return info

--- a/packages/opencode/test/server/global-session-list.test.ts
+++ b/packages/opencode/test/server/global-session-list.test.ts
@@ -11,6 +11,9 @@ import { testEffect } from "../lib/effect"
 
 void Log.init({ print: false })
 
+const projectGet = (id: Project.Info["id"]) =>
+  Effect.runSync(Project.Service.use((project) => project.get(id)).pipe(Effect.provide(Project.defaultLayer)))
+
 function run<A, E>(fx: Effect.Effect<A, E, SessionNs.Service>) {
   return Effect.runPromise(fx.pipe(Effect.provide(SessionNs.defaultLayer)))
 }
@@ -50,8 +53,8 @@ describe("session.listGlobal", () => {
     expect(ids).toContain(firstSession.id)
     expect(ids).toContain(secondSession.id)
 
-    const firstProject = Project.get(firstSession.projectID)
-    const secondProject = Project.get(secondSession.projectID)
+    const firstProject = projectGet(firstSession.projectID)
+    const secondProject = projectGet(secondSession.projectID)
 
     const firstItem = sessions.find((session) => session.id === firstSession.id)
     const secondItem = sessions.find((session) => session.id === secondSession.id)

--- a/packages/opencode/test/server/vcs-routes.test.ts
+++ b/packages/opencode/test/server/vcs-routes.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun"
-import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Instance } from "../../src/project/instance"
@@ -412,30 +412,24 @@ describe("VCS routes", () => {
 
   test("rejects oversized apply request bodies before JSON validation", async () => {
     await using tmp = await tmpdir()
-    const apply = spyOn(Vcs, "apply")
     const maxEncodedBodyBytes = Vcs.MAX_APPLY_PATCH_BYTES * 6 + Buffer.byteLength(JSON.stringify({ patch: "" }))
 
-    try {
-      const response = await Server.Default().app.request("/vcs/apply", {
-        method: "POST",
-        headers: {
-          "content-length": String(maxEncodedBodyBytes + 1),
-          "content-type": "application/json",
-          "x-opencode-directory": tmp.path,
-        },
-        body: JSON.stringify({ patch: "" }),
-      })
+    const response = await Server.Default().app.request("/vcs/apply", {
+      method: "POST",
+      headers: {
+        "content-length": String(maxEncodedBodyBytes + 1),
+        "content-type": "application/json",
+        "x-opencode-directory": tmp.path,
+      },
+      body: JSON.stringify({ patch: "" }),
+    })
 
-      expect(response.status).toBe(413)
-      expect(apply).not.toHaveBeenCalled()
-      expect(await response.json()).toEqual({
-        error: "vcs_apply_failed",
-        reason: "too-large",
-        message: "Patch exceeds the 10 MB input limit",
-      })
-    } finally {
-      apply.mockRestore()
-    }
+    expect(response.status).toBe(413)
+    expect(await response.json()).toEqual({
+      error: "vcs_apply_failed",
+      reason: "too-large",
+      message: "Patch exceeds the 10 MB input limit",
+    })
   })
 
   test("accepts escaped JSON bodies when decoded apply patches are within the byte limit", async () => {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -43,6 +43,7 @@ import { SystemPrompt } from "../../src/session/system"
 import { Shell } from "../../src/shell/shell"
 import { Snapshot } from "../../src/snapshot"
 import { ToolRegistry } from "../../src/tool/registry"
+import { Worktree } from "../../src/worktree"
 import { Automation } from "../../src/automation"
 import { AutomationScheduler } from "../../src/automation/scheduler"
 import { WebSearchAuth } from "../../src/tool/websearch-auth"
@@ -289,6 +290,7 @@ function makeHttp(httpLayer: Layer.Layer<HttpClient.HttpClient> = FetchHttpClien
     Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(SubagentRun.defaultLayer),
     Layer.provide(Automation.defaultLayer),
+    Layer.provide(Worktree.defaultLayer),
     Layer.provideMerge(todo),
     Layer.provideMerge(deps),
   )

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -52,6 +52,7 @@ import { SessionStatus } from "../../src/session/status"
 import { TurnChange } from "../../src/session/turn-change"
 import { Snapshot } from "../../src/snapshot"
 import { ToolRegistry } from "../../src/tool/registry"
+import { Worktree } from "../../src/worktree"
 import { Automation } from "../../src/automation"
 import { WebSearchAuth } from "../../src/tool/websearch-auth"
 import { Truncate } from "../../src/tool/truncate"
@@ -138,6 +139,7 @@ function makeHttp() {
     Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(SubagentRun.defaultLayer),
     Layer.provide(Automation.defaultLayer),
+    Layer.provide(Worktree.defaultLayer),
     Layer.provideMerge(todo),
     Layer.provideMerge(deps),
   )

--- a/packages/opencode/test/tool/enter-worktree.test.ts
+++ b/packages/opencode/test/tool/enter-worktree.test.ts
@@ -10,6 +10,7 @@ import { EnterWorktreeTool } from "../../src/tool/enter-worktree"
 import { ExitWorktreeTool } from "../../src/tool/exit-worktree"
 import type { Context } from "../../src/tool/tool"
 import { Truncate } from "../../src/tool/truncate"
+import { Worktree } from "../../src/worktree"
 import * as EffectZod from "../../src/util/effect-zod"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { provideTmpdirInstance } from "../fixture/fixture"
@@ -22,6 +23,7 @@ const it = testEffect(
     Session.defaultLayer,
     SubagentRun.defaultLayer,
     Truncate.defaultLayer,
+    Worktree.defaultLayer,
   ),
 )
 


### PR DESCRIPTION
## Summary

Retire the Project, Vcs, and Worktree service namespace facades by removing their per-service `makeRuntime(Service, defaultLayer)` blocks and exported Promise/sync helper functions. Production callers now enter these services through `Project.Service`, `Vcs.Service`, or `Worktree.Service` via `AppRuntime` or an existing Effect graph.

Related to #936.

## Why

These namespace facades kept a legacy Promise boundary alive after the services had Effect-native interfaces. Removing them makes the remaining call sites explicit about runtime ownership and prevents new callers from bypassing the service graph.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

Please focus on the migrated call sites that previously used `Project.*`, `Vcs.*`, or `Worktree.*`, and on the `ToolRegistry` layer update for `enter-worktree` now that the tool depends directly on `Worktree.Service`.

## Risk Notes

Behavior risk is low but present around worktree lifecycle tests because `Worktree.createReady` forks background bootstrap work; the focused worktree tests were rerun after preserving the shared `AppRuntime` path for those helpers. CI initially exposed an automation startup cycle caused by statically importing `AppRuntime` from `automation/index.ts`; the fix keeps the Project lookup on `Project.defaultLayer` and lazily loads Worktree only when an automation placement needs it. No UI, docs, dependency, generated file, permission, credential, release note, or packaging surfaces changed. The platform checklist is considered because worktree and git behavior are shell/path-sensitive; focused tests covered the touched worktree and VCS paths.

Fresh-eye result: P0/P1 none. P2 found and fixed: the new guardrail originally sampled only part of the removed facade names, so it now checks the full Project, Vcs, and Worktree facade export lists. P3 none.

## How To Verify

```text
bun test test/effect/legacy-boundaries.test.ts: 15 pass, 0 fail
bun test test/effect/legacy-boundaries.test.ts test/project/project.test.ts test/project/migrate-global.test.ts test/project/instance-store.test.ts test/project/instance-bootstrap-regression.test.ts test/project/worktree.test.ts test/project/worktree-remove.test.ts test/project/vcs.test.ts test/config/config.test.ts test/file/index.test.ts test/server/automation-runner.test.ts test/server/experimental-routes.test.ts test/server/global-session-list.test.ts test/server/vcs-routes.test.ts test/tool/enter-worktree.test.ts test/session/prompt-effect.test.ts test/session/snapshot-tool-race.test.ts: 431 pass, 1 skip, 0 fail
bun test test/effect/legacy-boundaries.test.ts test/server/automation-runner.test.ts test/project/worktree.test.ts test/project/worktree-remove.test.ts test/tool/enter-worktree.test.ts test/session/prompt-effect.test.ts test/session/snapshot-tool-race.test.ts: 142 pass, 1 skip, 0 fail after CI startup-cycle fix
GOMAXPROCS=2 bun run typecheck: passed
bun --cwd packages/app test:e2e:local:smoke: 38 passed, 1 skipped; reproduced and fixed the Automation.MAX_TITLE_CHARS startup cycle
root git diff --check: passed
Facade caller scan for Project/Vcs/Worktree namespace calls under packages/opencode: no matches
Target service makeRuntime/run-service scan for project/project.ts, project/vcs.ts, and worktree/index.ts: no matches
Fresh-eye review: P0/P1 none; fixed one P2 guardrail completeness issue
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

