### PR TITLE
fix(app): stop empty Enter from interrupting a running task

### DIFF
--- a/packages/app/e2e/prompt/prompt-interrupt.spec.ts
+++ b/packages/app/e2e/prompt/prompt-interrupt.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "../fixtures"
+import { promptSelector } from "../selectors"
+import { withSession } from "../actions"
+
+// The send/stop button mirrors `stopping = working && blank`: it carries
+// data-state="running" while a task is in flight with an empty composer, and
+// data-state="idle" once the task ends. We read that to assert interrupt intent.
+const runningButton = '[data-action="prompt-submit"][data-state="running"]'
+const idleButton = '[data-action="prompt-submit"][data-state="idle"]'
+
+// Regression: pressing Enter on an empty composer used to abort the running
+// task. Interrupting is ESC's job; Enter only ever sends.
+test("empty Enter does not interrupt a running task, but ESC does", async ({ page, sdk, gotoSession, llm }) => {
+  await withSession(sdk, `e2e prompt interrupt ${Date.now()}`, async (session) => {
+    // The next assistant turn never completes, so the session stays working
+    // until something explicitly aborts it.
+    await llm.hang()
+
+    await gotoSession(session.id)
+    const prompt = page.locator(promptSelector)
+    await prompt.click()
+    await page.keyboard.type("keep working")
+    await page.keyboard.press("Enter")
+
+    // Task is now in flight; the composer cleared, so the button shows "stop".
+    await expect(page.locator(runningButton)).toBeVisible({ timeout: 15_000 })
+
+    // Empty Enter must be inert — the task keeps running.
+    await prompt.click()
+    await page.keyboard.press("Enter")
+    await page.waitForTimeout(500)
+    await expect(page.locator(runningButton)).toBeVisible()
+
+    // ESC interrupts: the task ends and the button returns to the send state.
+    await page.keyboard.press("Escape")
+    await expect(page.locator(idleButton)).toBeVisible({ timeout: 15_000 })
+  })
+})

--- a/packages/app/e2e/prompt/prompt-interrupt.spec.ts
+++ b/packages/app/e2e/prompt/prompt-interrupt.spec.ts
@@ -4,7 +4,7 @@ import { withSession } from "../actions"
 
 // The send/stop button mirrors `stopping = working && blank`: it carries
 // data-state="running" while a task is in flight with an empty composer, and
-// data-state="idle" once the task ends. We read that to assert interrupt intent.
+// data-state="idle" once the task ends.
 const runningButton = '[data-action="prompt-submit"][data-state="running"]'
 const idleButton = '[data-action="prompt-submit"][data-state="idle"]'
 
@@ -16,23 +16,37 @@ test("empty Enter does not interrupt a running task, but ESC does", async ({ pag
     // until something explicitly aborts it.
     await llm.hang()
 
+    // Record every session-abort request with its source. The renderer tags ESC
+    // interrupts "renderer.escape"; an erroneous Enter abort would land here as a
+    // different (or extra) entry — a deterministic check, no fixed sleep needed.
+    const abortSources: string[] = []
+    page.on("request", (req) => {
+      const url = new URL(req.url())
+      if (req.method() === "POST" && url.pathname.endsWith("/abort")) {
+        abortSources.push(url.searchParams.get("source") ?? "")
+      }
+    })
+
     await gotoSession(session.id)
     const prompt = page.locator(promptSelector)
     await prompt.click()
     await page.keyboard.type("keep working")
     await page.keyboard.press("Enter")
 
-    // Task is now in flight; the composer cleared, so the button shows "stop".
+    // Wait until the server actually reaches the (hanging) assistant call, so the
+    // task is genuinely in flight — not merely optimistically busy — before we
+    // test interruption. This also consumes the queued hang.
+    await expect.poll(() => llm.calls(), { timeout: 15_000 }).toBeGreaterThanOrEqual(1)
     await expect(page.locator(runningButton)).toBeVisible({ timeout: 15_000 })
 
-    // Empty Enter must be inert — the task keeps running.
+    // Empty Enter must be inert; ESC must interrupt. Pressing Enter first then
+    // ESC, the only abort we should ever observe is ESC's. (If Enter wrongly
+    // aborted, it would fire first and this assertion would never match.)
     await prompt.click()
     await page.keyboard.press("Enter")
-    await page.waitForTimeout(500)
-    await expect(page.locator(runningButton)).toBeVisible()
-
-    // ESC interrupts: the task ends and the button returns to the send state.
     await page.keyboard.press("Escape")
+
+    await expect.poll(() => abortSources, { timeout: 15_000 }).toEqual(["renderer.escape"])
     await expect(page.locator(idleButton)).toBeVisible({ timeout: 15_000 })
   })
 })

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -335,7 +335,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     editorRef: () => editorRef,
     prompt,
     working,
-    stopping,
     actionReady,
     abortReady,
     selectPopoverActive,

--- a/packages/app/src/components/prompt-input/keydown.ts
+++ b/packages/app/src/components/prompt-input/keydown.ts
@@ -21,7 +21,6 @@ export interface PromptKeydownDeps {
   editorRef: () => HTMLDivElement
   prompt: ReturnType<typeof usePrompt>
   working: Accessor<boolean>
-  stopping: Accessor<boolean>
   actionReady: Accessor<boolean>
   abortReady: Accessor<boolean>
   // popover handlers
@@ -39,7 +38,7 @@ export interface PromptKeydownDeps {
   navigateHistory: (direction: "up" | "down") => boolean
   // submit / mode / file pick
   pick: () => void
-  abort: (source?: "stopButton" | "emptyEnter" | "ctrlG" | "escape") => void
+  abort: (source?: "stopButton" | "ctrlG" | "escape") => void
   handleSubmit: (event: KeyboardEvent) => void
 }
 
@@ -50,7 +49,6 @@ export function createPromptKeydownHandler(deps: PromptKeydownDeps): (event: Key
     editorRef,
     prompt,
     working,
-    stopping,
     actionReady,
     abortReady,
     selectPopoverActive,
@@ -72,7 +70,6 @@ export function createPromptKeydownHandler(deps: PromptKeydownDeps): (event: Key
       !promptKeyActionReady({
         key: event.key,
         working: working(),
-        stopping: stopping(),
         actionReady: actionReady(),
         abortReady: abortReady(),
       })

--- a/packages/app/src/components/prompt-input/keydown.ts
+++ b/packages/app/src/components/prompt-input/keydown.ts
@@ -39,7 +39,7 @@ export interface PromptKeydownDeps {
   // submit / mode / file pick
   pick: () => void
   abort: (source?: "stopButton" | "ctrlG" | "escape") => void
-  handleSubmit: (event: KeyboardEvent) => void
+  handleSubmit: (event: KeyboardEvent, trigger: "keyboard") => void
 }
 
 export function createPromptKeydownHandler(deps: PromptKeydownDeps): (event: KeyboardEvent) => void {
@@ -261,7 +261,7 @@ export function createPromptKeydownHandler(deps: PromptKeydownDeps): (event: Key
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault()
       if (event.repeat) return
-      handleSubmit(event)
+      handleSubmit(event, "keyboard")
     }
   }
 }

--- a/packages/app/src/components/prompt-input/readiness.test.ts
+++ b/packages/app/src/components/prompt-input/readiness.test.ts
@@ -7,12 +7,11 @@ import {
 } from "./readiness"
 
 describe("promptKeyActionReady", () => {
-  test("allows keyboard stop when submit is blocked but abort is ready", () => {
+  test("gates the ESC interrupt on abort readiness while working", () => {
     expect(
       promptKeyActionReady({
         key: "Escape",
         working: true,
-        stopping: false,
         actionReady: false,
         abortReady: true,
       }),
@@ -20,25 +19,34 @@ describe("promptKeyActionReady", () => {
 
     expect(
       promptKeyActionReady({
-        key: "Enter",
+        key: "Escape",
         working: true,
-        stopping: true,
-        actionReady: false,
-        abortReady: true,
-      }),
-    ).toBe(true)
-  })
-
-  test("keeps submit keys blocked when neither submit nor abort is ready", () => {
-    expect(
-      promptKeyActionReady({
-        key: "Enter",
-        working: true,
-        stopping: true,
-        actionReady: false,
+        actionReady: true,
         abortReady: false,
       }),
     ).toBe(false)
+  })
+
+  test("gates Enter on submit readiness, never on abort readiness", () => {
+    // Enter only submits — it must not ride on abort readiness even while a
+    // task is running, so it can never interrupt that task.
+    expect(
+      promptKeyActionReady({
+        key: "Enter",
+        working: true,
+        actionReady: false,
+        abortReady: true,
+      }),
+    ).toBe(false)
+
+    expect(
+      promptKeyActionReady({
+        key: "Enter",
+        working: true,
+        actionReady: true,
+        abortReady: false,
+      }),
+    ).toBe(true)
   })
 
   test("allows local navigation while submit is blocked", () => {
@@ -46,7 +54,6 @@ describe("promptKeyActionReady", () => {
       promptKeyActionReady({
         key: "ArrowUp",
         working: false,
-        stopping: false,
         actionReady: false,
         abortReady: true,
       }),
@@ -58,7 +65,6 @@ describe("promptKeyActionReady", () => {
       promptKeyActionReady({
         key: "a",
         working: false,
-        stopping: false,
         actionReady: false,
         abortReady: true,
       }),

--- a/packages/app/src/components/prompt-input/readiness.ts
+++ b/packages/app/src/components/prompt-input/readiness.ts
@@ -1,12 +1,12 @@
 export function promptKeyActionReady(input: {
   key: string
   working: boolean
-  stopping: boolean
   actionReady: boolean
   abortReady: boolean
 }) {
+  // ESC is the keyboard interrupt: gate it on abort readiness while working.
+  // Enter only ever submits, so it always follows submit readiness.
   if (input.key === "Escape" && input.working) return input.abortReady
-  if (input.key === "Enter" && input.stopping) return input.abortReady
   if (input.key === "Enter" || input.key === "Escape") return input.actionReady
   return true
 }

--- a/packages/app/src/components/prompt-input/submit-abort.ts
+++ b/packages/app/src/components/prompt-input/submit-abort.ts
@@ -2,7 +2,7 @@ import type { useSDK } from "@/context/sdk"
 import { emitRendererDiagnostic, sessionAbortDiagnosticEvent } from "@/context/renderer-diagnostics"
 import { rendererAbortDiagnosticSource, type RendererAbortSource } from "@/session/abort-source"
 
-export type AbortSource = Extract<RendererAbortSource, "ctrlG" | "emptyEnter" | "escape" | "stopButton">
+export type AbortSource = Extract<RendererAbortSource, "ctrlG" | "escape" | "stopButton">
 
 export type PendingPrompt = {
   abort: AbortController

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -486,7 +486,7 @@ describe("prompt submit worktree selection", () => {
       onSubmit: () => submits.push("submit"),
     })
 
-    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event, "submitButton")
 
     expect(aborts).toEqual(["called"])
     expect(abortedSessions).toEqual([{ sessionID: "session-visible", source: "renderer.stopButton" }])
@@ -520,7 +520,7 @@ describe("prompt submit worktree selection", () => {
       onAbort: () => aborts.push("called"),
     })
 
-    await submit.handleSubmit(new KeyboardEvent("keydown", { key: "Enter" }))
+    await submit.handleSubmit(new KeyboardEvent("keydown", { key: "Enter" }), "keyboard")
 
     // Interrupting a running task is ESC's job; Enter must never abort.
     expect(aborts).toEqual([])

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -494,9 +494,10 @@ describe("prompt submit worktree selection", () => {
     expect(promptAsyncCalls).toEqual([])
   })
 
-  test("marks keyboard empty-enter abort with caller source", async () => {
+  test("keyboard empty Enter does not interrupt a running task", async () => {
     params = { id: "session-visible" }
     promptValue = [{ type: "text", content: "", start: 0, end: 0 }]
+    const aborts: string[] = []
     const submit = createPromptSubmit({
       navigate: (path) => navigateImpl(path),
       routeParams: () => params,
@@ -516,11 +517,14 @@ describe("prompt submit worktree selection", () => {
       resetHistoryNavigation: () => undefined,
       setMode: () => undefined,
       setPopover: () => undefined,
+      onAbort: () => aborts.push("called"),
     })
 
     await submit.handleSubmit(new KeyboardEvent("keydown", { key: "Enter" }))
 
-    expect(abortedSessions).toEqual([{ sessionID: "session-visible", source: "renderer.emptyEnter" }])
+    // Interrupting a running task is ESC's job; Enter must never abort.
+    expect(aborts).toEqual([])
+    expect(abortedSessions).toEqual([])
   })
 
   test("reads the latest worktree accessor value per submit", async () => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -30,6 +30,11 @@ import { createPromptDraftLifecycle } from "./prompt-draft-lifecycle"
 import { createWaitForWorktree } from "./wait-for-worktree"
 import { buildAttachmentRequestParts } from "./build-request-parts"
 
+// How a submit was initiated. Only "submitButton" (the Stop button / form
+// submit) may interrupt a running task on an empty prompt; keyboard Enter never
+// does. Making the trigger explicit avoids guessing intent from the DOM event.
+export type SubmitTrigger = "keyboard" | "submitButton"
+
 type PromptSubmitInput = {
   sessionID?: Accessor<string | undefined>
   isNewSession?: Accessor<boolean>
@@ -106,7 +111,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     })
   }
 
-  const handleSubmit = async (event: Event) => {
+  const handleSubmit = async (event: Event, trigger: SubmitTrigger = "submitButton") => {
     event.preventDefault()
 
     const currentPrompt = prompt.current()
@@ -121,8 +126,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
       // Enter never interrupts a running task — ESC does. Only the explicit Stop
-      // button (a non-keyboard submit) aborts on an empty prompt.
-      if (input.working() && !(event instanceof KeyboardEvent)) abort("stopButton")
+      // button (a "submitButton" trigger) aborts on an empty prompt.
+      if (input.working() && trigger === "submitButton") abort("stopButton")
       return
     }
     if (

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -120,7 +120,9 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const hasSkillPart = currentPrompt.some((part) => part.type === "skill")
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
-      if (input.working()) abort(event instanceof KeyboardEvent ? "emptyEnter" : "stopButton")
+      // Enter never interrupts a running task — ESC does. Only the explicit Stop
+      // button (a non-keyboard submit) aborts on an empty prompt.
+      if (input.working() && !(event instanceof KeyboardEvent)) abort("stopButton")
       return
     }
     if (


### PR DESCRIPTION
## Summary

While a task is in flight, pressing **Enter** on an empty composer aborted the running task. This changes interruption to be ESC-only from the keyboard:

- `submit.ts`: the empty-prompt branch now aborts **only** for the explicit Stop button (a non-keyboard submit). Keyboard Enter on an empty prompt is inert.
- Removed the now-dead `emptyEnter` source from the composer `AbortSource` (`submit-abort.ts`) and the `keydown` abort type. The cross-process `RendererAbortSource` diagnostic enum keeps the value (desktop-electron / opencode tests use it as a fixture).
- `readiness.ts`: dropped the vestigial `Enter && stopping -> abortReady` gate and its `stopping` threading. Enter now follows submit readiness; ESC-while-working follows abort readiness.

Unchanged: typing a message and pressing Enter while a task runs still **queues** it. ESC (single press), the visible Stop button, and Ctrl+G still interrupt.

## Why

Enter is a typing-flow key and was being pressed accidentally, killing in-progress work. Interrupting a task should require a deliberate key (ESC), consistent with the visible "Stop / ESC" affordance.

## Related Issue

No issue — reported directly by the maintainer.

## Human Review Status

Pending

## Review Focus

- `submit.ts` condition: `input.working() && !(event instanceof KeyboardEvent)` — confirm the Stop button (non-keyboard) still aborts and Enter no longer does.
- In-scope cleanup vs scope creep: the `emptyEnter` removal and the `readiness` simplification are dead/misleading code created by this fix, not unrelated refactors. The global `RendererAbortSource` enum was intentionally left untouched to avoid churn in desktop-electron / opencode tests.

## Risk Notes

- No visible pixel or copy change; the send/stop button look and tooltip are unchanged. Interaction is covered by a new real-path E2E, so the visible-UI screenshot checklist item is left unticked.
- No platform/packaging/updater surface touched (pure renderer keyboard logic) — platform checklist item left unticked.
- No docs/deps/permissions/credentials/generated-content surfaces touched — that conditional item left unticked.

## How To Verify

\`\`\`text
bun test readiness.test.ts submit.test.ts (--preload happydom): 55 pass / 0 fail
bun run typecheck (tsgo -b): exit 0
eslint touched files: 0 errors
e2e/prompt/prompt-interrupt.spec.ts (real user path): 1 passed (7.4s)
  - empty Enter while working -> Stop button stays data-state="running" (task not interrupted)
  - ESC -> button returns to data-state="idle" (task interrupted)
\`\`\`

## Screenshots or Recordings

No visible UI change (button visuals/copy unchanged). Behavior verified by `e2e/prompt/prompt-interrupt.spec.ts`.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

https://claude.ai/code/session_01DkxRfb4jbNSziUAFBFX64x