### PR TITLE
refactor(opencode): retire LSP and PTY promise facades

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -11,7 +11,6 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Process } from "../util/process"
 import { Effect, Layer, Context } from "effect"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { Settings } from "@/settings"
 import { Npm } from "@opencode-ai/core/npm"
 
@@ -543,41 +542,6 @@ export namespace LSP {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Settings.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export const init = async () => runPromise((svc) => svc.init())
-
-  export const status = async () => runPromise((svc) => svc.status())
-
-  export const hasClients = async (file: string) => runPromise((svc) => svc.hasClients(file))
-
-  export const touchFile = async (input: string, waitForDiagnostics?: boolean) =>
-    runPromise((svc) => svc.touchFile(input, waitForDiagnostics))
-
-  export const diagnostics = async () => runPromise((svc) => svc.diagnostics())
-
-  export const hover = async (input: LocInput) => runPromise((svc) => svc.hover(input))
-
-  export const definition = async (input: LocInput) => runPromise((svc) => svc.definition(input))
-
-  export const references = async (input: LocInput) => runPromise((svc) => svc.references(input))
-
-  export const implementation = async (input: LocInput) => runPromise((svc) => svc.implementation(input))
-
-  export const documentSymbol = async (uri: string) => runPromise((svc) => svc.documentSymbol(uri))
-
-  export const workspaceSymbol = async (query: string) => runPromise((svc) => svc.workspaceSymbol(query))
-
-  export const prepareCallHierarchy = async (input: LocInput) => runPromise((svc) => svc.prepareCallHierarchy(input))
-
-  export const incomingCalls = async (input: LocInput) => runPromise((svc) => svc.incomingCalls(input))
-
-  export const outgoingCalls = async (input: LocInput) => runPromise((svc) => svc.outgoingCalls(input))
-
-  export const shutdownAll = async () => runPromise((svc) => svc.shutdownAll())
-
-  export const invalidate = async () => runPromise((svc) => svc.invalidate())
 
   export namespace Diagnostic {
     const MAX_PER_FILE = 20

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -1,7 +1,6 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { Instance } from "@/project/instance"
 import type { Proc } from "#pty"
 import z from "zod"
@@ -458,34 +457,4 @@ export namespace Pty {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer), Layer.provide(Plugin.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function list() {
-    return runPromise((svc) => svc.list())
-  }
-
-  export async function get(id: PtyID) {
-    return runPromise((svc) => svc.get(id))
-  }
-
-  export async function write(id: PtyID, data: string) {
-    return runPromise((svc) => svc.write(id, data))
-  }
-
-  export async function connect(id: PtyID, ws: Socket, cursor?: number) {
-    return runPromise((svc) => svc.connect(id, ws, cursor))
-  }
-
-  export async function create(input: CreateInput) {
-    return runPromise((svc) => svc.create(input))
-  }
-
-  export async function update(id: PtyID, input: UpdateInput) {
-    return runPromise((svc) => svc.update(id, input))
-  }
-
-  export async function remove(id: PtyID) {
-    return runPromise((svc) => svc.remove(id))
-  }
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -177,6 +177,45 @@ test("Agent and Settings services do not expose Promise facades", async () => {
   }
 })
 
+test("LSP and Pty services do not expose Promise facades", async () => {
+  const services = {
+    "lsp/index.ts": [
+      "export const init = async",
+      "export const status = async",
+      "export const hasClients = async",
+      "export const touchFile = async",
+      "export const diagnostics = async",
+      "export const hover = async",
+      "export const definition = async",
+      "export const references = async",
+      "export const implementation = async",
+      "export const documentSymbol = async",
+      "export const workspaceSymbol = async",
+      "export const prepareCallHierarchy = async",
+      "export const incomingCalls = async",
+      "export const outgoingCalls = async",
+      "export const shutdownAll = async",
+      "export const invalidate = async",
+    ],
+    "pty/index.ts": [
+      "export async function list",
+      "export async function get",
+      "export async function write",
+      "export async function connect",
+      "export async function create",
+      "export async function update",
+      "export async function remove",
+    ],
+  }
+
+  for (const [file, facades] of Object.entries(services)) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+    for (const facade of facades) expect(text).not.toContain(facade)
+  }
+})
+
 test("Auth and WebSearchAuth services do not expose Promise facades", async () => {
   const services = {
     "auth/index.ts": [

--- a/packages/opencode/test/lsp/index.test.ts
+++ b/packages/opencode/test/lsp/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import { Effect } from "effect"
 import path from "path"
-import * as Lsp from "../../src/lsp/index"
+import { LSP } from "../../src/lsp"
 import { LSPServer } from "../../src/lsp/server"
 import { Settings } from "../../src/settings"
 import { AppRuntime } from "../../src/effect/app-runtime"
@@ -10,6 +10,10 @@ import { tmpdir } from "../fixture/fixture"
 
 function settings<A, E>(fn: (svc: Settings.Interface) => Effect.Effect<A, E>) {
   return AppRuntime.runPromise(Settings.Service.use(fn))
+}
+
+function lsp<A, E>(fn: (svc: LSP.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(LSP.Service.use(fn))
 }
 
 describe("lsp.spawn", () => {
@@ -28,12 +32,14 @@ describe("lsp.spawn", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          await Lsp.LSP.touchFile(path.join(tmp.path, "..", "outside.ts"))
-          await Lsp.LSP.hover({
-            file: path.join(tmp.path, "..", "hover.ts"),
-            line: 0,
-            character: 0,
-          })
+          await lsp((svc) => svc.touchFile(path.join(tmp.path, "..", "outside.ts")))
+          await lsp((svc) =>
+            svc.hover({
+              file: path.join(tmp.path, "..", "hover.ts"),
+              line: 0,
+              character: 0,
+            }),
+          )
         },
       })
 
@@ -52,11 +58,13 @@ describe("lsp.spawn", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          await Lsp.LSP.hover({
-            file: path.join(tmp.path, "src", "inside.ts"),
-            line: 0,
-            character: 0,
-          })
+          await lsp((svc) =>
+            svc.hover({
+              file: path.join(tmp.path, "src", "inside.ts"),
+              line: 0,
+              character: 0,
+            }),
+          )
         },
       })
 

--- a/packages/opencode/test/lsp/lifecycle.test.ts
+++ b/packages/opencode/test/lsp/lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test"
 import { Effect } from "effect"
 import path from "path"
-import * as Lsp from "../../src/lsp/index"
+import { LSP } from "../../src/lsp"
 import { LSPServer } from "../../src/lsp/server"
 import { Settings } from "../../src/settings"
 import { AppRuntime } from "../../src/effect/app-runtime"
@@ -10,6 +10,10 @@ import { tmpdir } from "../fixture/fixture"
 
 function settings<A, E>(fn: (svc: Settings.Interface) => Effect.Effect<A, E>) {
   return AppRuntime.runPromise(Settings.Service.use(fn))
+}
+
+function lsp<A, E>(fn: (svc: LSP.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(LSP.Service.use(fn))
 }
 
 function withInstance(fn: (dir: string) => Promise<void>) {
@@ -42,14 +46,14 @@ describe("LSP service lifecycle", () => {
   test(
     "init() completes without error",
     withInstance(async () => {
-      await Lsp.LSP.init()
+      await lsp((svc) => svc.init())
     }),
   )
 
   test(
     "status() returns empty array initially",
     withInstance(async () => {
-      const result = await Lsp.LSP.status()
+      const result = await lsp((svc) => svc.status())
       expect(Array.isArray(result)).toBe(true)
       expect(result.length).toBe(0)
     }),
@@ -58,7 +62,7 @@ describe("LSP service lifecycle", () => {
   test(
     "diagnostics() returns empty object initially",
     withInstance(async () => {
-      const result = await Lsp.LSP.diagnostics()
+      const result = await lsp((svc) => svc.diagnostics())
       expect(typeof result).toBe("object")
       expect(Object.keys(result).length).toBe(0)
     }),
@@ -67,7 +71,7 @@ describe("LSP service lifecycle", () => {
   test(
     "hasClients() returns true for .ts files in instance",
     withInstance(async (dir) => {
-      const result = await Lsp.LSP.hasClients(path.join(dir, "test.ts"))
+      const result = await lsp((svc) => svc.hasClients(path.join(dir, "test.ts")))
       expect(result).toBe(true)
     }),
   )
@@ -75,7 +79,7 @@ describe("LSP service lifecycle", () => {
   test(
     "hasClients() returns false for files outside instance",
     withInstance(async (dir) => {
-      const result = await Lsp.LSP.hasClients(path.join(dir, "..", "outside.ts"))
+      const result = await lsp((svc) => svc.hasClients(path.join(dir, "..", "outside.ts")))
       // hasClients checks servers but doesn't check containsPath — getClients does
       // So hasClients may return true even for outside files (it checks extension + root)
       // The guard is in getClients, not hasClients
@@ -86,7 +90,7 @@ describe("LSP service lifecycle", () => {
   test(
     "workspaceSymbol() returns empty array with no clients",
     withInstance(async () => {
-      const result = await Lsp.LSP.workspaceSymbol("test")
+      const result = await lsp((svc) => svc.workspaceSymbol("test"))
       expect(Array.isArray(result)).toBe(true)
       expect(result.length).toBe(0)
     }),
@@ -95,11 +99,13 @@ describe("LSP service lifecycle", () => {
   test(
     "definition() returns empty array for unknown file",
     withInstance(async (dir) => {
-      const result = await Lsp.LSP.definition({
-        file: path.join(dir, "nonexistent.ts"),
-        line: 0,
-        character: 0,
-      })
+      const result = await lsp((svc) =>
+        svc.definition({
+          file: path.join(dir, "nonexistent.ts"),
+          line: 0,
+          character: 0,
+        }),
+      )
       expect(Array.isArray(result)).toBe(true)
     }),
   )
@@ -107,11 +113,13 @@ describe("LSP service lifecycle", () => {
   test(
     "references() returns empty array for unknown file",
     withInstance(async (dir) => {
-      const result = await Lsp.LSP.references({
-        file: path.join(dir, "nonexistent.ts"),
-        line: 0,
-        character: 0,
-      })
+      const result = await lsp((svc) =>
+        svc.references({
+          file: path.join(dir, "nonexistent.ts"),
+          line: 0,
+          character: 0,
+        }),
+      )
       expect(Array.isArray(result)).toBe(true)
     }),
   )
@@ -119,9 +127,9 @@ describe("LSP service lifecycle", () => {
   test(
     "multiple init() calls are idempotent",
     withInstance(async () => {
-      await Lsp.LSP.init()
-      await Lsp.LSP.init()
-      await Lsp.LSP.init()
+      await lsp((svc) => svc.init())
+      await lsp((svc) => svc.init())
+      await lsp((svc) => svc.init())
       // Should not throw or create duplicate state
     }),
   )
@@ -129,7 +137,7 @@ describe("LSP service lifecycle", () => {
 
 describe("LSP.Diagnostic", () => {
   test("pretty() formats error diagnostic", () => {
-    const result = Lsp.LSP.Diagnostic.pretty({
+    const result = LSP.Diagnostic.pretty({
       range: { start: { line: 9, character: 4 }, end: { line: 9, character: 10 } },
       message: "Type 'string' is not assignable to type 'number'",
       severity: 1,
@@ -138,7 +146,7 @@ describe("LSP.Diagnostic", () => {
   })
 
   test("pretty() formats warning diagnostic", () => {
-    const result = Lsp.LSP.Diagnostic.pretty({
+    const result = LSP.Diagnostic.pretty({
       range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
       message: "Unused variable",
       severity: 2,
@@ -147,7 +155,7 @@ describe("LSP.Diagnostic", () => {
   })
 
   test("pretty() defaults to ERROR when no severity", () => {
-    const result = Lsp.LSP.Diagnostic.pretty({
+    const result = LSP.Diagnostic.pretty({
       range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
       message: "Something wrong",
     } as any)

--- a/packages/opencode/test/pty/pty-output-isolation.test.ts
+++ b/packages/opencode/test/pty/pty-output-isolation.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { Pty } from "../../src/pty"
 import { tmpdir } from "../fixture/fixture"
@@ -14,6 +16,10 @@ const wait = async (fn: () => boolean, ms = 5000) => {
   throw new Error(`timeout waiting ${ms}ms for pty output`)
 }
 
+function pty<A, E>(fn: (svc: Pty.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(Pty.Service.use(fn))
+}
+
 describe("pty", () => {
   test("does not leak output when websocket objects are reused", async () => {
     await using dir = await tmpdir({ git: true })
@@ -21,8 +27,8 @@ describe("pty", () => {
     await Instance.provide({
       directory: dir.path,
       fn: async () => {
-        const a = await Pty.create({ command: "cat", title: "a" })
-        const b = await Pty.create({ command: "cat", title: "b" })
+        const a = await pty((svc) => svc.create({ command: "cat", title: "a" }))
+        const b = await pty((svc) => svc.create({ command: "cat", title: "b" }))
         try {
           const outA: string[] = []
           const outB: string[] = []
@@ -39,27 +45,27 @@ describe("pty", () => {
           }
 
           // Connect "a" first with ws.
-          await Pty.connect(a.id, ws as any)
+          await pty((svc) => svc.connect(a.id, ws as any))
 
           // Now "reuse" the same ws object for another connection.
           ws.data = { events: { connection: "b" } }
           ws.send = (data: unknown) => {
             outB.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"))
           }
-          await Pty.connect(b.id, ws as any)
+          await pty((svc) => svc.connect(b.id, ws as any))
 
           // Clear connect metadata writes.
           outA.length = 0
           outB.length = 0
 
           // Output from a must never show up in b.
-          await Pty.write(a.id, "AAA\n")
+          await pty((svc) => svc.write(a.id, "AAA\n"))
           await sleep(100)
 
           expect(outB.join("")).not.toContain("AAA")
         } finally {
-          await Pty.remove(a.id)
-          await Pty.remove(b.id)
+          await pty((svc) => svc.remove(a.id))
+          await pty((svc) => svc.remove(b.id))
         }
       },
     })
@@ -71,7 +77,7 @@ describe("pty", () => {
     await Instance.provide({
       directory: dir.path,
       fn: async () => {
-        const a = await Pty.create({ command: "cat", title: "a" })
+        const a = await pty((svc) => svc.create({ command: "cat", title: "a" }))
         try {
           const outA: string[] = []
           const outB: string[] = []
@@ -88,7 +94,7 @@ describe("pty", () => {
           }
 
           // Connect "a" first.
-          await Pty.connect(a.id, ws as any)
+          await pty((svc) => svc.connect(a.id, ws as any))
           outA.length = 0
 
           // Simulate Bun reusing the same websocket object for another
@@ -98,12 +104,12 @@ describe("pty", () => {
             outB.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"))
           }
 
-          await Pty.write(a.id, "AAA\n")
+          await pty((svc) => svc.write(a.id, "AAA\n"))
           await sleep(100)
 
           expect(outB.join("")).not.toContain("AAA")
         } finally {
-          await Pty.remove(a.id)
+          await pty((svc) => svc.remove(a.id))
         }
       },
     })
@@ -115,7 +121,7 @@ describe("pty", () => {
     await Instance.provide({
       directory: dir.path,
       fn: async () => {
-        const a = await Pty.create({ command: "cat", title: "a" })
+        const a = await pty((svc) => svc.create({ command: "cat", title: "a" }))
         try {
           const out: string[] = []
 
@@ -131,19 +137,19 @@ describe("pty", () => {
             },
           }
 
-          await Pty.connect(a.id, ws as any)
+          await pty((svc) => svc.connect(a.id, ws as any))
           out.length = 0
 
           // Mutating fields on ws.data should not look like a new
           // connection lifecycle when the object identity stays stable.
           ctx.connId = 2
 
-          await Pty.write(a.id, "AAA\n")
+          await pty((svc) => svc.write(a.id, "AAA\n"))
           await wait(() => out.join("").includes("AAA"))
 
           expect(out.join("")).toContain("AAA")
         } finally {
-          await Pty.remove(a.id)
+          await pty((svc) => svc.remove(a.id))
         }
       },
     })

--- a/packages/opencode/test/pty/pty-session.test.ts
+++ b/packages/opencode/test/pty/pty-session.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
 import { Bus } from "../../src/bus"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { Pty } from "../../src/pty"
 import type { PtyID } from "../../src/pty/schema"
@@ -20,6 +22,10 @@ const pick = (log: Array<{ type: "created" | "exited" | "deleted"; id: PtyID }>,
   return log.filter((evt) => evt.id === id).map((evt) => evt.type)
 }
 
+function pty<A, E>(fn: (svc: Pty.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(Pty.Service.use(fn))
+}
+
 describe("pty", () => {
   test("publishes created, exited, deleted in order for a short-lived process", async () => {
     if (process.platform === "win32") return
@@ -38,19 +44,21 @@ describe("pty", () => {
 
         let id: PtyID | undefined
         try {
-          const info = await Pty.create({
-            command: "/usr/bin/env",
-            args: ["sh", "-c", "sleep 0.1"],
-            title: "sleep",
-          })
+          const info = await pty((svc) =>
+            svc.create({
+              command: "/usr/bin/env",
+              args: ["sh", "-c", "sleep 0.1"],
+              title: "sleep",
+            }),
+          )
           id = info.id
 
           await wait(() => pick(log, id!).length >= 3)
           expect(pick(log, id!)).toEqual(["created", "exited", "deleted"])
-          expect(await Pty.get(id)).toBeUndefined()
+          expect(await pty((svc) => svc.get(id!))).toBeUndefined()
         } finally {
           off.forEach((x) => x())
-          if (id) await Pty.remove(id)
+          if (id) await pty((svc) => svc.remove(id!))
         }
       },
     })
@@ -73,21 +81,23 @@ describe("pty", () => {
 
         let id: PtyID | undefined
         try {
-          const info = await Pty.create({
-            command: "/bin/sh",
-            args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
-            title: "sh",
-          })
+          const info = await pty((svc) =>
+            svc.create({
+              command: "/bin/sh",
+              args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+              title: "sh",
+            }),
+          )
           id = info.id
 
           await sleep(100)
 
-          await Pty.remove(id)
+          await pty((svc) => svc.remove(id!))
           await wait(() => pick(log, id!).length >= 3)
           expect(pick(log, id!)).toEqual(["created", "exited", "deleted"])
         } finally {
           off.forEach((x) => x())
-          if (id) await Pty.remove(id)
+          if (id) await pty((svc) => svc.remove(id!))
         }
       },
     })
@@ -105,18 +115,20 @@ describe("pty", () => {
         let id: PtyID | undefined
         try {
           const child = `trap '' HUP TERM; echo $$ > ${JSON.stringify(pidFile)}; while :; do sleep 1; done`
-          const info = await Pty.create({
-            command: "/bin/sh",
-            args: ["-c", `trap 'exit 0' TERM; /bin/sh -c ${JSON.stringify(child)} & wait`],
-            title: "child-tree",
-          })
+          const info = await pty((svc) =>
+            svc.create({
+              command: "/bin/sh",
+              args: ["-c", `trap 'exit 0' TERM; /bin/sh -c ${JSON.stringify(child)} & wait`],
+              title: "child-tree",
+            }),
+          )
           id = info.id
 
           await wait(() => existsSync(pidFile))
           const pid = Number((await Bun.file(pidFile).text()).trim())
           expect(pid).toBeGreaterThan(0)
 
-          await Pty.remove(id)
+          await pty((svc) => svc.remove(id!))
           await wait(() => {
             try {
               process.kill(pid, 0)
@@ -126,7 +138,7 @@ describe("pty", () => {
             }
           })
         } finally {
-          if (id) await Pty.remove(id)
+          if (id) await pty((svc) => svc.remove(id!))
         }
       },
     })
@@ -150,23 +162,28 @@ describe("pty", () => {
         fn: async () => {
           let id: PtyID | undefined
           try {
-            const info = await Pty.create({
-              command: "/usr/bin/env",
-              args: [
-                "sh",
-                "-c",
-                'printf "username=%s\\n" "${OPENCODE_SERVER_USERNAME}" && printf "password=%s\\n" "${OPENCODE_SERVER_PASSWORD}" && printf "custom=%s\\n" "${PAWWORK_E2E_CUSTOM_ENV-unset}"',
-              ],
-              title: "env",
-            })
+            const info = await pty((svc) =>
+              svc.create({
+                command: "/usr/bin/env",
+                args: [
+                  "sh",
+                  "-c",
+                  'printf "username=%s\\n" "${OPENCODE_SERVER_USERNAME}" && printf "password=%s\\n" "${OPENCODE_SERVER_PASSWORD}" && printf "custom=%s\\n" "${PAWWORK_E2E_CUSTOM_ENV-unset}"',
+                ],
+                title: "env",
+              }),
+            )
             id = info.id
 
             const output: string[] = []
-            await Pty.connect(info.id, {
-              readyState: 1,
-              send: (data: unknown) => output.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8")),
-              close: () => undefined,
-            } as any)
+            await pty((svc) =>
+              svc.connect(info.id, {
+                readyState: 1,
+                send: (data: unknown) =>
+                  output.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8")),
+                close: () => undefined,
+              } as any),
+            )
 
             await wait(() => output.join("").includes("custom="))
 
@@ -177,7 +194,7 @@ describe("pty", () => {
             expect(text).not.toContain("secret")
             expect(text).not.toContain("PawWork")
           } finally {
-            if (id) await Pty.remove(id)
+            if (id) await pty((svc) => svc.remove(id!))
           }
         },
       })
@@ -207,27 +224,32 @@ describe("pty", () => {
         fn: async () => {
           let id: PtyID | undefined
           try {
-            const info = await Pty.create({
-              command: "/usr/bin/env",
-              args: [
-                "sh",
-                "-c",
-                'printf "username=%s\\n" "${OPENCODE_SERVER_USERNAME}" && printf "password=%s\\n" "${OPENCODE_SERVER_PASSWORD}"',
-              ],
-              title: "explicit-env",
-              env: {
-                OPENCODE_SERVER_USERNAME: "explicit-user",
-                OPENCODE_SERVER_PASSWORD: "explicit-password",
-              },
-            })
+            const info = await pty((svc) =>
+              svc.create({
+                command: "/usr/bin/env",
+                args: [
+                  "sh",
+                  "-c",
+                  'printf "username=%s\\n" "${OPENCODE_SERVER_USERNAME}" && printf "password=%s\\n" "${OPENCODE_SERVER_PASSWORD}"',
+                ],
+                title: "explicit-env",
+                env: {
+                  OPENCODE_SERVER_USERNAME: "explicit-user",
+                  OPENCODE_SERVER_PASSWORD: "explicit-password",
+                },
+              }),
+            )
             id = info.id
 
             const output: string[] = []
-            await Pty.connect(info.id, {
-              readyState: 1,
-              send: (data: unknown) => output.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8")),
-              close: () => undefined,
-            } as any)
+            await pty((svc) =>
+              svc.connect(info.id, {
+                readyState: 1,
+                send: (data: unknown) =>
+                  output.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8")),
+                close: () => undefined,
+              } as any),
+            )
 
             await wait(() => output.join("").includes("password="))
 
@@ -237,7 +259,7 @@ describe("pty", () => {
             expect(text).not.toContain("secret")
             expect(text).not.toContain("PawWork")
           } finally {
-            if (id) await Pty.remove(id)
+            if (id) await pty((svc) => svc.remove(id!))
           }
         },
       })

--- a/packages/opencode/test/pty/pty-shell.test.ts
+++ b/packages/opencode/test/pty/pty-shell.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { Pty } from "../../src/pty"
 import { Shell } from "../../src/shell/shell"
 import { tmpdir } from "../fixture/fixture"
 
 Shell.preferred.reset()
+
+function pty<A, E>(fn: (svc: Pty.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(Pty.Service.use(fn))
+}
 
 describe("pty shell args", () => {
   if (process.platform !== "win32") return
@@ -18,11 +24,11 @@ describe("pty shell args", () => {
         await Instance.provide({
           directory: dir.path,
           fn: async () => {
-            const info = await Pty.create({ command: ps, title: "pwsh" })
+            const info = await pty((svc) => svc.create({ command: ps, title: "pwsh" }))
             try {
               expect(info.args).toEqual([])
             } finally {
-              await Pty.remove(info.id)
+              await pty((svc) => svc.remove(info.id))
             }
           },
         })
@@ -44,11 +50,11 @@ describe("pty shell args", () => {
         await Instance.provide({
           directory: dir.path,
           fn: async () => {
-            const info = await Pty.create({ command: bash, title: "bash" })
+            const info = await pty((svc) => svc.create({ command: bash, title: "bash" }))
             try {
               expect(info.args).toEqual(["-l"])
             } finally {
-              await Pty.remove(info.id)
+              await pty((svc) => svc.remove(info.id))
             }
           },
         })

--- a/packages/opencode/test/server/pty-routes.test.ts
+++ b/packages/opencode/test/server/pty-routes.test.ts
@@ -28,6 +28,10 @@ afterEach(async () => {
 
 const testUpgradeWebSocket: UpgradeWebSocket = () => new Response("upgraded")
 
+function pty<A, E>(fn: (svc: Pty.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(Pty.Service.use(fn))
+}
+
 async function requestPtyWebSocket(path: string) {
   const response = await handleWebSocketCompatibilityRequest(
     new Request(new URL(path, "http://localhost")),
@@ -126,7 +130,7 @@ describe("pty routes", () => {
           expect(removeResponse.status).toBe(200)
           expect(await removeResponse.json()).toBe(true)
         } finally {
-          await Pty.remove(created.id)
+          await pty((svc) => svc.remove(created.id))
         }
       },
     })
@@ -270,11 +274,13 @@ describe("pty routes", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const info = await Pty.create({
-          command: "/bin/sh",
-          args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
-          title: "ticket",
-        })
+        const info = await pty((svc) =>
+          svc.create({
+            command: "/bin/sh",
+            args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+            title: "ticket",
+          }),
+        )
         try {
           const app = new Hono().route("/pty", PtyRoutes())
           app.onError(ErrorMiddleware)
@@ -287,7 +293,7 @@ describe("pty routes", () => {
           expect(body.expires_in).toBe(60)
           expect(PtyTicket.consume({ ptyID: info.id, ticket: body.ticket })).toBe(true)
         } finally {
-          await Pty.remove(info.id)
+          await pty((svc) => svc.remove(info.id))
         }
       },
     })
@@ -311,11 +317,13 @@ describe("pty routes", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const info = await Pty.create({
-          command: "/bin/sh",
-          args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
-          title: "ticket-connect",
-        })
+        const info = await pty((svc) =>
+          svc.create({
+            command: "/bin/sh",
+            args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+            title: "ticket-connect",
+          }),
+        )
         try {
           const issued = PtyTicket.issue({ ptyID: info.id })
 
@@ -326,7 +334,7 @@ describe("pty routes", () => {
           expect(await first.text()).toBe("upgraded")
           expect(second.status).toBe(401)
         } finally {
-          await Pty.remove(info.id)
+          await pty((svc) => svc.remove(info.id))
         }
       },
     })
@@ -338,11 +346,13 @@ describe("pty routes", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const info = await Pty.create({
-          command: "/bin/sh",
-          args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
-          title: "ticket-wrong-pty",
-        })
+        const info = await pty((svc) =>
+          svc.create({
+            command: "/bin/sh",
+            args: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"],
+            title: "ticket-wrong-pty",
+          }),
+        )
         try {
           const issued = PtyTicket.issue({ ptyID: info.id })
 
@@ -354,7 +364,7 @@ describe("pty routes", () => {
           expect(wrong.status).toBe(401)
           expect(replay.status).toBe(401)
         } finally {
-          await Pty.remove(info.id)
+          await pty((svc) => svc.remove(info.id))
         }
       },
     })


### PR DESCRIPTION
## Summary

Retire the remaining LSP and PTY Promise facade exports now that their callers can use the Effect services directly through `AppRuntime`.

- Remove the per-service `makeRuntime(Service, defaultLayer)` bridges from `LSP` and `Pty`.
- Move direct LSP/PTy test callers onto `LSP.Service` / `Pty.Service` through local test helpers.
- Extend the legacy boundary guardrail so these facades cannot quietly return.

## Why

The #936 Effect migration is cleaning up per-service Promise facades after `AppRuntime` became the shared acyclic runtime. LSP and PTY were still exporting direct async helpers despite production paths already using the service boundary.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the migrated tests still exercise the same LSP and PTY behavior through the shared runtime, and whether the guardrail blocks the right legacy facade shapes without banning the remaining legitimate service API.

## Risk Notes

No production behavior change is intended. The main risk is a missed direct facade caller; this is covered by a repo-wide caller inventory, focused tests, and typecheck. PTY has platform-sensitive behavior; the macOS local run covered the non-Windows PTY paths, while the Windows-only `pty-shell` tests remain platform-gated for CI.

Skipped conditional checklist item: visible UI/copy check is not applicable because this PR has no visible UI or copy changes.

Fresh-eye result: no P0/P1 findings. P2/P3 review noted the repeated local test helpers, but keeping them file-local is the smaller and safer option because the task explicitly avoids introducing a new public compatibility helper.

## How To Verify

```text
RED guardrail: bun test test/effect/legacy-boundaries.test.ts failed before facade removal because LSP still imported @/effect/run-service.
Guardrail: bun test test/effect/legacy-boundaries.test.ts -> 16 pass, 0 fail.
Focused tests: bun test test/effect/legacy-boundaries.test.ts test/lsp/*.test.ts test/tool/lsp.test.ts test/tool/write.test.ts test/tool/edit.test.ts test/tool/apply_patch.test.ts test/pty/*.test.ts test/server/pty-routes.test.ts -> 161 pass, 0 fail.
Typecheck: GOMAXPROCS=2 bun run typecheck -> pass.
Residual scan: rg for LSP/Pty facade calls and makeRuntime/import residue in the touched services -> no matches.
Diff check: git diff --check -> pass.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
