### PR TITLE
refactor(opencode): retire File and SessionShare promise facades

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/file.ts
+++ b/packages/opencode/src/cli/cmd/debug/file.ts
@@ -16,7 +16,7 @@ const FileSearchCommand = cmd({
     }),
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
-      const results = await File.search({ query: args.query })
+      const results = await AppRuntime.runPromise(File.Service.use((file) => file.search({ query: args.query })))
       process.stdout.write(results.join(EOL) + EOL)
     })
   },
@@ -33,7 +33,7 @@ const FileReadCommand = cmd({
     }),
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
-      const content = await File.read(args.path)
+      const content = await AppRuntime.runPromise(File.Service.use((file) => file.read(args.path)))
       process.stdout.write(JSON.stringify(content, null, 2) + EOL)
     })
   },
@@ -45,7 +45,7 @@ const FileStatusCommand = cmd({
   builder: (yargs) => yargs,
   async handler() {
     await bootstrap(process.cwd(), async () => {
-      const status = await File.status()
+      const status = await AppRuntime.runPromise(File.Service.use((file) => file.status()))
       process.stdout.write(JSON.stringify(status, null, 2) + EOL)
     })
   },
@@ -62,7 +62,7 @@ const FileListCommand = cmd({
     }),
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
-      const files = await File.list(args.path)
+      const files = await AppRuntime.runPromise(File.Service.use((file) => file.list(args.path)))
       process.stdout.write(JSON.stringify(files, null, 2) + EOL)
     })
   },

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -577,7 +577,7 @@ export const GithubRunCommand = cmd({
         shareId = await (async () => {
           if (share === false) return
           if (!share && repoData.data.private) return
-          await SessionShare.share(session.id)
+          await AppRuntime.runPromise(SessionShare.Service.use((svc) => svc.share(session.id)))
           return session.id.slice(-8)
         })()
         console.log("opencode session", session.id)

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -1,6 +1,5 @@
 import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Git } from "@/git"
 import { Effect, Layer, Context } from "effect"
@@ -658,26 +657,4 @@ export namespace File {
     Layer.provide(Git.defaultLayer),
     Layer.provide(Ripgrep.defaultLayer),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export function init() {
-    return runPromise((svc) => svc.init())
-  }
-
-  export async function status() {
-    return runPromise((svc) => svc.status())
-  }
-
-  export async function read(file: string): Promise<Content> {
-    return runPromise((svc) => svc.read(file))
-  }
-
-  export async function list(dir?: string) {
-    return runPromise((svc) => svc.list(dir))
-  }
-
-  export async function search(input: { query: string; limit?: number; dirs?: boolean; type?: "file" | "directory" }) {
-    return runPromise((svc) => svc.search(input))
-  }
 }

--- a/packages/opencode/src/share/session.ts
+++ b/packages/opencode/src/share/session.ts
@@ -1,10 +1,7 @@
-import { makeRuntime } from "@/effect/run-service"
 import { Session } from "@/session"
 import { SessionID } from "@/session/schema"
 import { SyncEvent } from "@/sync"
-import { fn } from "@/util/fn"
 import { Effect, Layer, Scope, Context } from "effect"
-import z from "zod"
 import { Config } from "../config/config"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { ShareNext } from "./share-next"
@@ -74,10 +71,4 @@ export namespace SessionShare {
       Layer.provide(ShareRuntime.cloudShareGateDefaultLayer),
     ),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export const create = fn(z.lazy(() => Session.CreateInput), (input) => runPromise((svc) => svc.create(input)))
-  export const share = fn(SessionID.zod, (sessionID) => runPromise((svc) => svc.share(sessionID)))
-  export const unshare = fn(SessionID.zod, (sessionID) => runPromise((svc) => svc.unshare(sessionID)))
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -259,6 +259,26 @@ test("Config service does not expose Promise facades", async () => {
   for (const facade of facades) expect(text).not.toContain(facade)
 })
 
+test("File and SessionShare services do not expose Promise facades", async () => {
+  const services = {
+    "file/index.ts": [
+      "export function init",
+      "export async function status",
+      "export async function read",
+      "export async function list",
+      "export async function search",
+    ],
+    "share/session.ts": ["export const create =", "export const share =", "export const unshare ="],
+  }
+
+  for (const [file, facades] of Object.entries(services)) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+    for (const facade of facades) expect(text).not.toContain(facade)
+  }
+})
+
 test("MCP services do not expose Promise facades", async () => {
   const services = {
     "mcp/index.ts": [

--- a/packages/opencode/test/file/fsmonitor.test.ts
+++ b/packages/opencode/test/file/fsmonitor.test.ts
@@ -2,11 +2,16 @@ import { $ } from "bun"
 import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { File } from "../../src/file"
+import { File as FileCore } from "../../src/file"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
 const wintest = process.platform === "win32" ? test : test.skip
+const File = {
+  status: () => AppRuntime.runPromise(FileCore.Service.use((svc) => svc.status())),
+  read: (file: string) => AppRuntime.runPromise(FileCore.Service.use((svc) => svc.read(file))),
+}
 
 describe("file fsmonitor", () => {
   wintest("status does not start fsmonitor for readonly git checks", async () => {

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -3,7 +3,8 @@ import { $ } from "bun"
 import path from "path"
 import fs from "fs/promises"
 import { Effect } from "effect"
-import { File } from "../../src/file"
+import { File as FileCore } from "../../src/file"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { Instance } from "../../src/project/instance"
 import { Project } from "../../src/project/project"
@@ -16,6 +17,16 @@ afterEach(async () => {
 
 const projectFromDirectory = (directory: string) =>
   Effect.runPromise(Project.Service.use((project) => project.fromDirectory(directory)).pipe(Effect.provide(Project.defaultLayer)))
+
+const File = {
+  ...FileCore,
+  init: () => AppRuntime.runPromise(FileCore.Service.use((svc) => svc.init())),
+  status: () => AppRuntime.runPromise(FileCore.Service.use((svc) => svc.status())),
+  read: (file: string) => AppRuntime.runPromise(FileCore.Service.use((svc) => svc.read(file))),
+  list: (dir?: string) => AppRuntime.runPromise(FileCore.Service.use((svc) => svc.list(dir))),
+  search: (input: Parameters<FileCore.Interface["search"]>[0]) =>
+    AppRuntime.runPromise(FileCore.Service.use((svc) => svc.search(input))),
+}
 
 test("File service init works with InstanceRef and no legacy ALS", async () => {
   await using tmp = await tmpdir({

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -2,9 +2,15 @@ import { test, expect, describe } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
 import { Filesystem } from "../../src/util/filesystem"
-import { File } from "../../src/file"
+import { File as FileCore } from "../../src/file"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
+
+const File = {
+  read: (file: string) => AppRuntime.runPromise(FileCore.Service.use((svc) => svc.read(file))),
+  list: (dir?: string) => AppRuntime.runPromise(FileCore.Service.use((svc) => svc.list(dir))),
+}
 
 describe("Filesystem.contains", () => {
   test("allows paths within project", () => {


### PR DESCRIPTION
## Summary

Retire the remaining File and SessionShare Promise facades so direct callers use the Effect service boundary instead.

## Why

Related to #936. The File and SessionShare services still exposed per-service `makeRuntime(Service, defaultLayer)` Promise helpers after their real service implementations had moved into the shared runtime graph.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the remaining direct callers now cross the shared runtime boundary without reintroducing a production compatibility facade, and whether the local test runners stay limited to test files.

## Risk Notes

No visible UI or copy changed, so the UI check is not applicable. No docs, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes were introduced. Platform impact is limited to existing File behavior and debug/GitHub CLI paths; focused File tests passed on macOS, while the Windows-only fsmonitor cases remained skipped by their existing platform guard.

Fresh-eye result: P0/P1 none. P2/P3 none worth changing; keeping tiny test-local runners is simpler and safer than adding another shared helper or production compatibility layer.

## How To Verify

`bun test test/effect/legacy-boundaries.test.ts`: passed; new File/SessionShare facade guard stays green.
`bun test test/file/index.test.ts test/file/path-traversal.test.ts test/file/fsmonitor.test.ts test/share/session-pawwork-fail-closed.test.ts`: 86 passed, 2 Windows-only fsmonitor tests skipped by existing guard.
`bun test test/server/file-routes.test.ts`: 2 passed; file HttpApi handlers still find/list/read/status through services.
`GOMAXPROCS=2 bun run typecheck`: passed.
`git diff --check`: passed.
`rg "@/effect/run-service|makeRuntime\(Service, defaultLayer\)|export async function (status|read|list|search)|export function init\(\)|export const (create|share|unshare) =" ...`: no File/SessionShare facade hits outside the guardrail literals.

## Screenshots or Recordings

N/A, no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.