### PR TITLE
refactor(opencode): retire plugin skill facades

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -74,6 +74,7 @@ export namespace Agent {
       const config = yield* Config.Service
       const auth = yield* Auth.Service
       const provider = yield* Provider.Service
+      const plugin = yield* Plugin.Service
 
       const state = yield* InstanceState.make<State>(
         Effect.fn("Agent.state")(function* (ctx) {
@@ -326,9 +327,7 @@ export namespace Agent {
           const language = yield* provider.getLanguage(resolved)
 
           const system = [PROMPT_GENERATE]
-          yield* Effect.promise(() =>
-            Plugin.trigger("experimental.chat.system.transform", { model: resolved }, { system }),
-          )
+          yield* plugin.trigger("experimental.chat.system.transform", { model: resolved }, { system })
           const existing = yield* InstanceState.useEffect(state, (s) => s.list())
 
           // TODO: clean this up so provider specific logic doesnt bleed over
@@ -394,6 +393,7 @@ export namespace Agent {
   )
 
   export const defaultLayer = layer.pipe(
+    Layer.provide(Plugin.defaultLayer),
     Layer.provide(Provider.defaultLayer),
     Layer.provide(Auth.defaultLayer),
     Layer.provide(Config.defaultLayer),

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -196,7 +196,7 @@ export namespace Workspace {
         const match = await Instance.provide({
           directory,
           fn: async () => {
-            await Plugin.init()
+            await AppRuntime.runPromise(Plugin.Service.use((plugin) => plugin.init()))
             const owner = ownerKey(Instance.directory, Instance.worktree)
             return {
               owner,

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -21,7 +21,6 @@ import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cl
 import { Effect, Layer, Context, Stream } from "effect"
 import * as EffectLogger from "@opencode-ai/core/effect/logger"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { errorMessage } from "@/util/error"
 import { needsConfigDependencies } from "@/config/dependency"
 import { PluginLoader } from "./loader"
@@ -321,21 +320,4 @@ export namespace Plugin {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer), Layer.provide(Config.defaultLayer))
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function trigger<
-    Name extends TriggerName,
-    Input = Parameters<Required<Hooks>[Name]>[0],
-    Output = Parameters<Required<Hooks>[Name]>[1],
-  >(name: Name, input: Input, output: Output): Promise<Output> {
-    return runPromise((svc) => svc.trigger(name, input, output))
-  }
-
-  export async function list(): Promise<Hooks[]> {
-    return runPromise((svc) => svc.list())
-  }
-
-  export async function init() {
-    return runPromise((svc) => svc.init())
-  }
 }

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -7,7 +7,6 @@ import { NamedError } from "@opencode-ai/util/error"
 import type { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Global } from "@/global"
 import { Permission } from "@/permission"
@@ -314,23 +313,5 @@ export namespace Skill {
         .toSorted((a, b) => a.name.localeCompare(b.name))
         .map((skill) => `- **${skill.name}**: ${skill.description}`),
     ].join("\n")
-  }
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function get(name: string) {
-    return runPromise((skill) => skill.get(name))
-  }
-
-  export async function all() {
-    return runPromise((skill) => skill.all())
-  }
-
-  export async function dirs() {
-    return runPromise((skill) => skill.dirs())
-  }
-
-  export async function available(agent?: Agent.Info) {
-    return runPromise((skill) => skill.available(agent))
   }
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -259,6 +259,25 @@ test("Config service does not expose Promise facades", async () => {
   for (const facade of facades) expect(text).not.toContain(facade)
 })
 
+test("Plugin and Skill services do not expose Promise facades", async () => {
+  const services = {
+    "plugin/index.ts": ["export async function trigger", "export async function list", "export async function init"],
+    "skill/index.ts": [
+      "export async function get",
+      "export async function all",
+      "export async function dirs",
+      "export async function available",
+    ],
+  }
+
+  for (const [file, facades] of Object.entries(services)) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+    for (const facade of facades) expect(text).not.toContain(facade)
+  }
+})
+
 test("File and SessionShare services do not expose Promise facades", async () => {
   const services = {
     "file/index.ts": [

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test"
+import type { Effect } from "effect"
+import type { Plugin as PluginNamespace } from "../../src/plugin/index"
 import fs from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -14,6 +16,7 @@ const { Instance } = await import("../../src/project/instance")
 const { Npm } = await import("@opencode-ai/core/npm")
 const { writeMockConfigInstall } = await import("../shared/mock-npm-install")
 const { withConfigDepsLock } = await import("../shared/config-deps-lock")
+const { AppRuntime } = await import("../../src/effect/app-runtime")
 
 afterAll(() => {
   if (disableDefault === undefined) {
@@ -27,11 +30,15 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
+function runPlugin<A>(fn: (plugin: PluginNamespace.Interface) => Effect.Effect<A>) {
+  return AppRuntime.runPromise(Plugin.Service.use(fn))
+}
+
 async function load(dir: string) {
   return Instance.provide({
     directory: dir,
     fn: async () => {
-      await Plugin.list()
+      await runPlugin((plugin) => plugin.list())
     },
   })
 }

--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import type { Effect } from "effect"
+import type { Plugin as PluginNamespace } from "../../src/plugin/index"
 import path from "path"
 import { pathToFileURL } from "url"
 import { tmpdir } from "../fixture/fixture"
@@ -8,6 +10,7 @@ process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
 
 const { Plugin } = await import("../../src/plugin/index")
 const { Instance } = await import("../../src/project/instance")
+const { AppRuntime } = await import("../../src/effect/app-runtime")
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -41,6 +44,25 @@ async function project(source: string) {
   })
 }
 
+function runPlugin<A>(fn: (plugin: PluginNamespace.Interface) => Effect.Effect<A>) {
+  return AppRuntime.runPromise(Plugin.Service.use(fn))
+}
+
+function triggerSystemTransform(output: { system: string[] }) {
+  return runPlugin((plugin) =>
+    plugin.trigger(
+      "experimental.chat.system.transform",
+      {
+        model: {
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4-6",
+        } as any,
+      },
+      output,
+    ),
+  )
+}
+
 describe("plugin.trigger", () => {
   test("runs synchronous hooks without crashing", async () => {
     await using tmp = await project(
@@ -58,16 +80,7 @@ describe("plugin.trigger", () => {
       directory: tmp.path,
       fn: async () => {
         const out = { system: [] as string[] }
-        await Plugin.trigger(
-          "experimental.chat.system.transform",
-          {
-            model: {
-              providerID: "anthropic",
-              modelID: "claude-sonnet-4-6",
-            } as any,
-          },
-          out,
-        )
+        await triggerSystemTransform(out)
         return out
       },
     })
@@ -92,16 +105,7 @@ describe("plugin.trigger", () => {
       directory: tmp.path,
       fn: async () => {
         const out = { system: [] as string[] }
-        await Plugin.trigger(
-          "experimental.chat.system.transform",
-          {
-            model: {
-              providerID: "anthropic",
-              modelID: "claude-sonnet-4-6",
-            } as any,
-          },
-          out,
-        )
+        await triggerSystemTransform(out)
         return out
       },
     })

--- a/packages/opencode/test/plugin/workspace-adaptor.test.ts
+++ b/packages/opencode/test/plugin/workspace-adaptor.test.ts
@@ -2,6 +2,7 @@ import { $ } from "bun"
 import { afterAll, afterEach, describe, expect, test } from "bun:test"
 import { unlink } from "node:fs/promises"
 import { Effect } from "effect"
+import type { Plugin as PluginNamespace } from "../../src/plugin/index"
 import { mkdir } from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -20,6 +21,7 @@ const { Plugin } = await import("../../src/plugin/index")
 const { Workspace } = await import("../../src/control-plane/workspace")
 const { Instance } = await import("../../src/project/instance")
 const { getAdaptor, ownerKey } = await import("../../src/control-plane/adaptors")
+const { AppRuntime } = await import("../../src/effect/app-runtime")
 
 const experimental = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
 // @ts-expect-error test-only flag override
@@ -74,6 +76,10 @@ async function waitForCounter(file: string, min: number, timeout = 5_000) {
 }
 
 const workspaceSyncRetryTimeout = process.platform === "win32" ? 20_000 : 5_000
+
+function runPlugin<A>(fn: (plugin: PluginNamespace.Interface) => Effect.Effect<A>) {
+  return AppRuntime.runPromise(Plugin.Service.use(fn))
+}
 
 async function pluginProject() {
   return tmpdir({
@@ -410,7 +416,7 @@ describe("plugin.workspace", () => {
       const fromRoot = await Instance.provide({
         directory: root.path,
         fn: async () => {
-          await Plugin.init()
+          await runPlugin((plugin) => plugin.init())
           return Workspace.create({
             type,
             branch: null,
@@ -424,7 +430,7 @@ describe("plugin.workspace", () => {
       const fromWorktree = await Instance.provide({
         directory: worktreePath,
         fn: async () => {
-          await Plugin.init()
+          await runPlugin((plugin) => plugin.init())
           return Workspace.create({
             type,
             branch: null,
@@ -509,7 +515,7 @@ describe("plugin.workspace", () => {
     const workspace = await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
         return Workspace.create({
           type: tmp.extra.type,
           branch: null,
@@ -580,7 +586,7 @@ describe("plugin.workspace", () => {
     const info = await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
         return Workspace.create({
           type: "worktree",
           branch: null,
@@ -605,7 +611,7 @@ describe("plugin.workspace", () => {
     const workspace = await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
         return Workspace.create({
           type: tmp.extra.type,
           branch: null,

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -70,6 +70,10 @@ async function readEffectContext() {
   )
 }
 
+function runPlugin<A>(fn: (plugin: Plugin.Interface) => Effect.Effect<A>) {
+  return AppRuntime.runPromise(Plugin.Service.use(fn))
+}
+
 async function writeOpencodeConfig(dir: string, pluginFile: string) {
   await Bun.write(
     path.join(dir, "opencode.json"),
@@ -153,7 +157,7 @@ async function persistRemoteWorkspace(input: { directory: string; type: string; 
   return Instance.provide({
     directory: input.directory,
     fn: async () => {
-      await Plugin.init()
+      await runPlugin((plugin) => plugin.init())
       const id = WorkspaceID.ascending()
       Database.use((db) =>
         db.insert(WorkspaceTable)
@@ -178,7 +182,7 @@ async function createLocalWorkspace(input: { directory: string; type: string }) 
   return Instance.provide({
     directory: input.directory,
     fn: async () => {
-      await Plugin.init()
+      await runPlugin((plugin) => plugin.init())
       return Workspace.create({
         type: input.type,
         branch: null,
@@ -816,7 +820,7 @@ describe("workspace router", () => {
       const workspace = await Instance.provide({
         directory: root.path,
         fn: async () => {
-          await Plugin.init()
+          await runPlugin((plugin) => plugin.init())
           return Workspace.create({
             type,
             branch: null,
@@ -828,7 +832,7 @@ describe("workspace router", () => {
 
       await Instance.provide({
         directory: worktreePath,
-        fn: async () => Plugin.init(),
+        fn: async () => runPlugin((plugin) => plugin.init()),
       })
 
       await Instance.provide({
@@ -869,7 +873,7 @@ describe("workspace router", () => {
 
     await Instance.provide({
       directory: second.path,
-      fn: async () => Plugin.init(),
+      fn: async () => runPlugin((plugin) => plugin.init()),
     })
 
     await Instance.provide({
@@ -1017,7 +1021,7 @@ describe("workspace router", () => {
       const workspace = await Instance.provide({
         directory: root.path,
         fn: async () => {
-          await Plugin.init()
+          await runPlugin((plugin) => plugin.init())
           return Workspace.create({
             type,
             branch: null,
@@ -1033,7 +1037,7 @@ describe("workspace router", () => {
 
       await Instance.provide({
         directory: worktreePath,
-        fn: async () => Plugin.init(),
+        fn: async () => runPlugin((plugin) => plugin.init()),
       })
 
       const app = Server.Default().app
@@ -1090,7 +1094,7 @@ describe("workspace router", () => {
     const workspace = await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
         return Workspace.create({
           type,
           branch: null,
@@ -1191,7 +1195,7 @@ describe("workspace router", () => {
     const workspace = await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
         const id = WorkspaceID.ascending()
         Database.use((db) =>
           db.insert(WorkspaceTable)

--- a/packages/opencode/test/server/workspace-routes.test.ts
+++ b/packages/opencode/test/server/workspace-routes.test.ts
@@ -55,6 +55,10 @@ function requestWorkspaceHttpApi(path: string, init?: RequestInit) {
   )
 }
 
+function runPlugin<A>(fn: (plugin: Plugin.Interface) => Effect.Effect<A>) {
+  return AppRuntime.runPromise(Plugin.Service.use(fn))
+}
+
 async function workspaceProject(label: string) {
   return tmpdir({
     git: true,
@@ -152,7 +156,7 @@ describe("workspace routes", () => {
     await Instance.provide({
       directory: other.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
         const response = await createWorkspace(other.extra.type)
         expect(response.status).toBe(200)
         otherWorkspace = await response.json()
@@ -163,7 +167,7 @@ describe("workspace routes", () => {
     await Instance.provide({
       directory: current.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
 
         const createdResponse = await createWorkspace(current.extra.type)
         expect(createdResponse.status).toBe(200)
@@ -200,7 +204,7 @@ describe("workspace routes", () => {
     await Instance.provide({
       directory: other.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
         const response = await app().request(`/workspace/${otherWorkspace!.id}`, { method: "DELETE" })
         expect(response.status).toBe(200)
       },
@@ -213,7 +217,7 @@ describe("workspace routes", () => {
     await Instance.provide({
       directory: current.path,
       fn: async () => {
-        await Plugin.init()
+        await runPlugin((plugin) => plugin.init())
 
         const createdResponse = await createWorkspaceHttpApi(current.extra.type)
         expect(createdResponse.status).toBe(200)

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, test, expect } from "bun:test"
+import type { Effect } from "effect"
 import { Skill } from "../../src/skill"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import path from "path"
@@ -11,6 +13,10 @@ const processWithResourcesPath = process as NodeJS.Process & { resourcesPath?: s
 afterEach(async () => {
   await Instance.disposeAll()
 })
+
+function runSkill<A>(fn: (skill: Skill.Interface) => Effect.Effect<A>) {
+  return AppRuntime.runPromise(Skill.Service.use(fn))
+}
 
 async function createBundledSkill(resourcesDir: string, name: string, description = "A bundled skill for testing.") {
   const skillDir = path.join(resourcesDir, "skills", name)
@@ -50,7 +56,7 @@ Instructions here.
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const skills = await Skill.all()
+      const skills = await runSkill((skill) => skill.all())
       const testSkill = skills.find((s) => s.name === "test-skill")
       expect(testSkill).toBeDefined()
       expect(testSkill!.description).toBe("A test skill for verification.")
@@ -84,7 +90,7 @@ description: Skill for dirs test.
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const dirs = await Skill.dirs()
+        const dirs = await runSkill((skill) => skill.dirs())
         const skillDir = path.join(tmp.path, ".opencode", "skill", "dir-skill")
         expect(dirs).toContain(skillDir)
         expect(dirs.length).toBeGreaterThanOrEqual(1)
@@ -127,7 +133,7 @@ description: Second test skill.
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const skills = await Skill.all()
+      const skills = await runSkill((skill) => skill.all())
       expect(skills.find((s) => s.name === "skill-one")).toBeDefined()
       expect(skills.find((s) => s.name === "skill-two")).toBeDefined()
     },
@@ -152,7 +158,7 @@ Just some content without YAML frontmatter.
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const skills = await Skill.all()
+      const skills = await runSkill((skill) => skill.all())
       expect(skills.find((s) => s.name === "no-frontmatter")).toBeUndefined()
     },
   })
@@ -180,7 +186,7 @@ Instructions here.
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const skills = await Skill.all()
+      const skills = await runSkill((skill) => skill.all())
       const item = skills.find((s) => s.name === "manual-skill")
       expect(item).toBeDefined()
       expect(item!.description).toBeUndefined()
@@ -198,7 +204,7 @@ test("returns empty array when no skills exist", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const skills = await Skill.all()
+      const skills = await runSkill((skill) => skill.all())
       expect(
         skills.find(
           (s) =>
@@ -240,7 +246,7 @@ description: A skill in the .agents/skills directory.
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const skills = await Skill.all()
+      const skills = await runSkill((skill) => skill.all())
       const agentSkill = skills.find((s) => s.name === "agent-skill")
       expect(agentSkill).toBeDefined()
       expect(agentSkill!.location).toContain(path.join(".agents", "skills", "agent-skill", "SKILL.md"))
@@ -273,7 +279,7 @@ This skill is loaded from the global home directory.
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const skills = await Skill.all()
+        const skills = await runSkill((skill) => skill.all())
         const skill = skills.find((item) => item.name === "global-agent-skill")
         expect(skill).toBeDefined()
         expect(skill!.description).toBe("A global skill from ~/.agents/skills for testing.")
@@ -314,7 +320,7 @@ description: A global skill from ~/.agents/skills for testing.
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const skills = await Skill.all()
+        const skills = await runSkill((skill) => skill.all())
         expect(skills.filter((item) => item.name === "global-agent-skill")).toHaveLength(1)
       },
     })
@@ -362,7 +368,7 @@ description: Duplicate skill name from ${folder}.
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const skill = await Skill.get("shared-skill")
+        const skill = await runSkill((skill) => skill.get("shared-skill"))
         expect(skill).toBeDefined()
       },
     })
@@ -409,7 +415,7 @@ description: A skill in the .claude/skills directory.
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const skills = await Skill.all()
+      const skills = await runSkill((skill) => skill.all())
       expect(skills.find((s) => s.name === "agent-skill")).toBeDefined()
       expect(skills.find((s) => s.name === "claude-skill")).toBeUndefined()
     },
@@ -452,7 +458,7 @@ description: A skill in the .claude/skills directory.
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const skills = await Skill.all()
+        const skills = await runSkill((skill) => skill.all())
         expect(skills.find((s) => s.name === "agent-skill")).toBeDefined()
         expect(skills.find((s) => s.name === "claude-skill")).toBeUndefined()
       },
@@ -506,7 +512,7 @@ description: A skill in the .opencode/skills directory.
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const dirs = await Skill.dirs()
+      const dirs = await runSkill((skill) => skill.dirs())
       expect(dirs).toContain(path.join(tmp.path, ".opencode", "skill", "agent-skill"))
       expect(dirs).toContain(path.join(tmp.path, ".opencode", "skills", "agent-skill"))
       expect(dirs).toContain(path.join(tmp.path, ".agents", "skills", "agent-skill"))
@@ -526,7 +532,7 @@ test("discovers bundled skills from process.resourcesPath", async () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const skills = await Skill.all()
+        const skills = await runSkill((skill) => skill.all())
         const bundled = skills.find((item) => item.name === "packaged-only-skill")
         expect(bundled).toBeDefined()
         expect(bundled!.description).toBe("A bundled packaged skill.")
@@ -548,7 +554,7 @@ test("discovers bundled skills from the repo skills directory in dev", async () 
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const skills = await Skill.all()
+        const skills = await runSkill((skill) => skill.all())
         // Positive: every vendored officecli/morph skill must be present. Missing entries
         // signal upstream layout drift or a broken sync that ships an incomplete bundle.
         const vendoredNames = [


### PR DESCRIPTION
## Summary

Retires the remaining Plugin and Skill Promise facade exports from their service namespaces.

## Why

Related to #936. `Plugin` and `Skill` already expose Effect services through `Plugin.Service` and `Skill.Service`, so their per-service `makeRuntime(Service, defaultLayer)` compatibility facades were migration residue.

## Related Issue

Related to #936.

## Human Review Status

Pending

## Review Focus

Please focus on whether the migrated callers still run under the same instance context and whether plugin initialization, plugin trigger ordering, skill discovery, and workspace adaptor bootstrap semantics remain unchanged.

## Risk Notes

No visible UI, platform, packaging, dependency, permission, generated content, or docs surfaces changed. Remaining Plugin install/meta runtime boundaries are intentionally out of scope for this Plugin/Skill facade cleanup.

## How To Verify

```text
Guardrail RED: bun test test/effect/legacy-boundaries.test.ts failed before implementation because Plugin still imported @/effect/run-service and exposed Promise facades.
Guardrail GREEN: bun test test/effect/legacy-boundaries.test.ts -> 19 passed.
Skill focused tests: bun test test/skill/skill.test.ts -> 17 passed.
Plugin focused tests: bun test test/plugin/trigger.test.ts test/plugin/loader-shared.test.ts test/plugin/workspace-adaptor.test.ts -> 34 passed.
Workspace focused tests: bun test test/server/workspace-routes.test.ts test/server/workspace-router.test.ts -> 23 passed.
Trigger helper cleanup check: bun test test/plugin/trigger.test.ts -> 2 passed.
Typecheck: GOMAXPROCS=2 bun run typecheck -> passed.
Whitespace: git diff --check -> passed.
Fresh-eye result: no P0/P1/P2 findings; one P3 readability issue in trigger.test.ts was fixed and reverified.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored plugin and skill modules to use unified Effect-based service architecture throughout.
  * Removed async convenience wrapper functions from public module interfaces to enforce service-layer usage.
  * Updated agent layer, workspace bootstrapping, and initialization flows to use Effect service patterns consistently.

* **Tests**
  * Updated all plugin and skill test suites to interact with refactored service architecture.
  * Added validation test ensuring service modules maintain proper layering and do not expose Promise facades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->