### PR TITLE
refactor(opencode): retire provider model facades

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -72,7 +72,8 @@ export const AgentCommand = cmd({
 })
 
 async function getAvailableTools(agent: Agent.Info) {
-  const model = agent.model ?? (await Provider.defaultModel())
+  const model =
+    agent.model ?? (await AppRuntime.runPromise(Provider.Service.use((provider) => provider.defaultModel())))
   return ToolRegistry.tools({
     ...model,
     agent,
@@ -122,7 +123,8 @@ async function createToolContext(agent: Agent.Info) {
     Session.Service.use((svc) => svc.create({ title: `Debug tool run (${agent.name})` })),
   )
   const messageID = MessageID.ascending()
-  const model = agent.model ?? (await Provider.defaultModel())
+  const model =
+    agent.model ?? (await AppRuntime.runPromise(Provider.Service.use((provider) => provider.defaultModel())))
   const now = Date.now()
   const message: MessageV2.Assistant = {
     id: messageID,

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { exec } from "child_process"
+import { Effect } from "effect"
 import { Filesystem } from "../../util/filesystem"
 import * as prompts from "@clack/prompts"
 import { map, pipe, sortBy, values } from "remeda"
@@ -18,6 +19,7 @@ import type {
 import { UI } from "../ui"
 import { cmd } from "./cmd"
 import { ModelsDev } from "../../provider/models"
+import { withPawWorkProviders } from "../../provider/pawwork-providers"
 import { Instance } from "@/project/instance"
 import { bootstrap } from "../bootstrap"
 import { SessionShare } from "@/share/session"
@@ -222,11 +224,19 @@ export const GithubInstallCommand = cmd({
           const app = await getAppInfo()
           await installGitHubApp()
 
-          const providers = await ModelsDev.get().then((p) => {
-            // TODO: add guide for copilot, for now just hide it
-            delete p["github-copilot"]
-            return p
-          })
+          const providers = await AppRuntime.runPromise(
+            ModelsDev.Service.use((svc) =>
+              svc.data().pipe(
+                Effect.map((catalog) => {
+                  const providers = withPawWorkProviders(catalog as Record<string, ModelsDev.Provider>)
+                  // TODO: add guide for copilot, for now just hide it
+                  delete providers["github-copilot"]
+                  return providers
+                }),
+                Effect.orDie,
+              ),
+            ),
+          )
 
           const provider = await promptProvider()
           const model = await promptModel()

--- a/packages/opencode/src/cli/cmd/models.ts
+++ b/packages/opencode/src/cli/cmd/models.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect"
 import { Provider } from "../../provider/provider"
 import { ProviderID } from "../../provider/schema"
 import { ModelsDev } from "../../provider/models"
-import { CliError, effectCmd, fail } from "../effect-cmd"
+import { effectCmd, fail } from "../effect-cmd"
 import { UI } from "../ui"
 import { EOL } from "os"
 
@@ -28,13 +28,8 @@ export const ModelsCommand = effectCmd({
   },
   handler: Effect.fn("Cli.models")(function* (args) {
     if (args.refresh) {
-      yield* Effect.tryPromise({
-        try: () => ModelsDev.refresh(true),
-        catch: (cause) =>
-          new CliError({
-            message: `Failed to refresh models cache: ${cause instanceof Error ? cause.message : String(cause)}`,
-          }),
-      })
+      const modelsDev = yield* ModelsDev.Service
+      yield* modelsDev.refresh(true)
       UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Models cache refreshed" + UI.Style.TEXT_NORMAL)
     }
 

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -4,6 +4,7 @@ import { cmd } from "./cmd"
 import * as prompts from "@clack/prompts"
 import { UI } from "../ui"
 import { ModelsDev } from "../../provider/models"
+import { withPawWorkProviders } from "../../provider/pawwork-providers"
 import { map, pipe, sortBy, values } from "remeda"
 import path from "path"
 import os from "os"
@@ -283,7 +284,14 @@ export const ProvidersListCommand = cmd({
         return Object.entries(yield* auth.all())
       }),
     )
-    const database = await ModelsDev.get()
+    const database = await AppRuntime.runPromise(
+      ModelsDev.Service.use((svc) =>
+        svc.data().pipe(
+          Effect.map((catalog) => withPawWorkProviders(catalog as Record<string, ModelsDev.Provider>)),
+          Effect.orDie,
+        ),
+      ),
+    )
 
     for (const [providerID, result] of results) {
       const name = database[providerID]?.name || providerID
@@ -379,22 +387,30 @@ export const ProvidersLoginCommand = cmd({
       async fn() {
         UI.empty()
         prompts.intro("Add credential")
-        await ModelsDev.refresh(true).catch(() => {})
+        await AppRuntime.runPromise(ModelsDev.Service.use((svc) => svc.refresh(true).pipe(Effect.ignore)))
 
         const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get()))
 
         const disabled = new Set(config.disabled_providers ?? [])
         const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
 
-        const providers = await ModelsDev.get().then((x) => {
-          const filtered: Record<string, (typeof x)[string]> = {}
-          for (const [key, value] of Object.entries(x)) {
-            if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
-              filtered[key] = value
-            }
-          }
-          return filtered
-        })
+        const providers = await AppRuntime.runPromise(
+          ModelsDev.Service.use((svc) =>
+            svc.data().pipe(
+              Effect.map((catalog) => {
+                const all = withPawWorkProviders(catalog as Record<string, ModelsDev.Provider>)
+                const filtered: Record<string, (typeof all)[string]> = {}
+                for (const [key, value] of Object.entries(all)) {
+                  if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
+                    filtered[key] = value
+                  }
+                }
+                return filtered
+              }),
+              Effect.orDie,
+            ),
+          ),
+        )
         const hooks = await AppRuntime.runPromise(
           Effect.gen(function* () {
             const plugin = yield* Plugin.Service
@@ -550,7 +566,14 @@ export const ProvidersLogoutCommand = cmd({
       prompts.log.error("No credentials found")
       return
     }
-    const database = await ModelsDev.get()
+    const database = await AppRuntime.runPromise(
+      ModelsDev.Service.use((svc) =>
+        svc.data().pipe(
+          Effect.map((catalog) => withPawWorkProviders(catalog as Record<string, ModelsDev.Provider>)),
+          Effect.orDie,
+        ),
+      ),
+    )
     const selected = await prompts.select({
       message: "Select provider",
       options: credentials.map(([key, value]) => ({

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -430,7 +430,7 @@ function refreshInBackground() {
   return backgroundRuntime.runPromise(Service.use((svc) => svc.refresh()))
 }
 
-if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
+if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !modelsPathOverride() && !process.argv.includes("--get-yargs-completions")) {
   void refreshInBackground()
   setInterval(
     async () => {

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -430,7 +430,7 @@ function refreshInBackground() {
   return backgroundRuntime.runPromise(Service.use((svc) => svc.refresh()))
 }
 
-if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !modelsPathOverride() && !process.argv.includes("--get-yargs-completions")) {
+if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
   void refreshInBackground()
   setInterval(
     async () => {

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -8,7 +8,7 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { Hash } from "../util/hash"
 import { withPawWorkProviders } from "./pawwork-providers"
-import { Context, Effect, Layer, ManagedRuntime, Option } from "effect"
+import { Cause, Context, Effect, Exit, Layer, ManagedRuntime, Option } from "effect"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 
 // Try to import bundled snapshot (generated at build time)
@@ -346,7 +346,13 @@ export const layer = Layer.effect(
     })
 
     const data = Effect.fn("ModelsDev.data")(function* () {
-      return yield* cachedData
+      const exit = yield* Effect.exit(cachedData)
+      if (Exit.isSuccess(exit)) return exit.value
+      if (Cause.hasInterruptsOnly(exit.cause)) {
+        cachedData = yield* Effect.cached(loadData())
+        return yield* cachedData
+      }
+      return yield* Effect.failCause(exit.cause)
     })
 
     const publishCandidate = Effect.fn("ModelsDev.publishCandidate")(function* (text: string) {

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -8,8 +8,8 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { Hash } from "../util/hash"
 import { withPawWorkProviders } from "./pawwork-providers"
-import { Context, Effect, Layer, Option } from "effect"
-import { makeRuntime } from "../effect/run-service"
+import { Context, Effect, Layer, ManagedRuntime, Option } from "effect"
+import { memoMap } from "@opencode-ai/core/effect/memo-map"
 
 // Try to import bundled snapshot (generated at build time)
 // Falls back to undefined in dev mode when snapshot doesn't exist
@@ -397,39 +397,6 @@ export const layer = Layer.effect(
 
 export const defaultLayer = layer.pipe(Layer.provide(EffectFlock.defaultLayer), Layer.provide(AppFileSystem.defaultLayer))
 
-const { runPromise, runSync } = makeRuntime(Service, defaultLayer)
-
-export const Data = Object.assign(
-  () => runPromise((svc) => svc.data()),
-  {
-    reset: () => runSync((svc) => svc.reset()),
-  },
-)
-
-export async function get() {
-  const result = await Data()
-  return withPawWorkProviders(result as Record<string, Provider>)
-}
-
-export async function getWithVersion() {
-  while (true) {
-    const before = version()
-    const result = await Data()
-    const after = version()
-    if (before === after) {
-      return {
-        providers: withPawWorkProviders(result as Record<string, Provider>),
-        version: after,
-      }
-    }
-    Data.reset()
-  }
-}
-
-export async function refresh(force = false) {
-  return runPromise((svc) => svc.refresh(force))
-}
-
 function parseCatalog(text: string): Catalog {
   const parsed = JSON.parse(text)
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -443,10 +410,6 @@ const ModelsDevProviderValue = Provider
 const ModelsDevServiceValue = Service
 const ModelsDevLayerValue = layer
 const ModelsDevDefaultLayerValue = defaultLayer
-const ModelsDevDataValue = Data
-const ModelsDevGetValue = get
-const ModelsDevGetWithVersionValue = getWithVersion
-const ModelsDevRefreshValue = refresh
 const ModelsDevVersionValue = version
 
 export namespace ModelsDev {
@@ -459,18 +422,19 @@ export namespace ModelsDev {
   export const Service = ModelsDevServiceValue
   export const layer = ModelsDevLayerValue
   export const defaultLayer = ModelsDevDefaultLayerValue
-  export const Data = ModelsDevDataValue
-  export const get = ModelsDevGetValue
-  export const getWithVersion = ModelsDevGetWithVersionValue
-  export const refresh = ModelsDevRefreshValue
   export const version = ModelsDevVersionValue
 }
 
+const backgroundRuntime = ManagedRuntime.make(defaultLayer, { memoMap })
+function refreshInBackground() {
+  return backgroundRuntime.runPromise(Service.use((svc) => svc.refresh()))
+}
+
 if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
-  void refresh()
+  void refreshInBackground()
   setInterval(
     async () => {
-      await refresh()
+      await refreshInBackground()
     },
     60 * 1000 * 60,
   ).unref()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -28,7 +28,7 @@ import { InstanceState } from "@/effect"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { isRecord } from "@/util/record"
 import { withStatics } from "@/util/schema"
-import { makeRuntime } from "../effect/run-service"
+import { withPawWorkProviders } from "./pawwork-providers"
 
 import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
@@ -1136,7 +1136,7 @@ export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
 const layer: Layer.Layer<
   Service,
   never,
-  Config.Service | Auth.Service | Plugin.Service | AppFileSystem.Service | Env.Service
+  Config.Service | Auth.Service | Plugin.Service | AppFileSystem.Service | Env.Service | ModelsDev.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -1145,13 +1145,27 @@ const layer: Layer.Layer<
     const auth = yield* Auth.Service
     const env = yield* Env.Service
     const plugin = yield* Plugin.Service
+    const modelsService = yield* ModelsDev.Service
 
     const state = yield* InstanceState.make<State>(() =>
       Effect.gen(function* () {
         using _ = log.time("state")
         const bridge = yield* EffectBridge.make()
         const cfg = yield* config.get()
-        const modelsDev = yield* Effect.promise(() => ModelsDev.getWithVersion())
+        const modelsDev = yield* Effect.gen(function* () {
+          while (true) {
+            const before = ModelsDev.version()
+            const result = yield* modelsService.data().pipe(Effect.orDie)
+            const after = ModelsDev.version()
+            if (before === after) {
+              return {
+                providers: withPawWorkProviders(result as Record<string, ModelsDev.Provider>),
+                version: after,
+              }
+            }
+            yield* modelsService.reset()
+          }
+        })
         const database = mapValues(modelsDev.providers, fromModelsDevProvider)
 
         const providers: Record<ProviderID, Info> = {} as Record<ProviderID, Info>
@@ -1855,38 +1869,9 @@ export const defaultLayer = Layer.suspend(() =>
     Layer.provide(Config.defaultLayer),
     Layer.provide(Auth.defaultLayer),
     Layer.provide(Plugin.defaultLayer),
+    Layer.provide(ModelsDev.defaultLayer),
   ),
 )
-
-const { runPromise } = makeRuntime(Service, defaultLayer)
-
-export async function list() {
-  return runPromise((svc) => svc.list())
-}
-
-export async function getProvider(providerID: ProviderID) {
-  return runPromise((svc) => svc.getProvider(providerID))
-}
-
-export async function getModel(providerID: ProviderID, modelID: ModelID) {
-  return runPromise((svc) => svc.getModel(providerID, modelID))
-}
-
-export async function getLanguage(model: Model) {
-  return runPromise((svc) => svc.getLanguage(model))
-}
-
-export async function closest(providerID: ProviderID, query: string[]) {
-  return runPromise((svc) => svc.closest(providerID, query))
-}
-
-export async function getSmallModel(providerID: ProviderID) {
-  return runPromise((svc) => svc.getSmallModel(providerID))
-}
-
-export async function defaultModel() {
-  return runPromise((svc) => svc.defaultModel())
-}
 
 const priority = ["gpt-5", "claude-sonnet-4", "big-pickle", "gemini-3-pro"]
 export function sort<T extends { id: string }>(models: T[]) {
@@ -1942,13 +1927,6 @@ const ProviderConfigProvidersResultValue = ConfigProvidersResult
 const ProviderDefaultModelIDValue = defaultModelID
 const ProviderDefaultModelIDsValue = defaultModelIDs
 const ProviderFromModelsDevProviderValue = fromModelsDevProvider
-const ProviderListValue = list
-const ProviderGetProviderValue = getProvider
-const ProviderGetModelValue = getModel
-const ProviderGetLanguageValue = getLanguage
-const ProviderClosestValue = closest
-const ProviderGetSmallModelValue = getSmallModel
-const ProviderDefaultModelValue = defaultModel
 const ProviderSortValue = sort
 const ProviderParseModelValue = parseModel
 const ProviderModelNotFoundErrorValue = ModelNotFoundError
@@ -1972,13 +1950,6 @@ export namespace Provider {
   export const defaultModelID = ProviderDefaultModelIDValue
   export const defaultModelIDs = ProviderDefaultModelIDsValue
   export const fromModelsDevProvider = ProviderFromModelsDevProviderValue
-  export const list = ProviderListValue
-  export const getProvider = ProviderGetProviderValue
-  export const getModel = ProviderGetModelValue
-  export const getLanguage = ProviderGetLanguageValue
-  export const closest = ProviderClosestValue
-  export const getSmallModel = ProviderGetSmallModelValue
-  export const defaultModel = ProviderDefaultModelValue
   export const sort = ProviderSortValue
   export const parseModel = ProviderParseModelValue
   export const ModelNotFoundError = ProviderModelNotFoundErrorValue

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -111,6 +111,37 @@ test("Snapshot service does not expose Promise facades", async () => {
   expect(snapshotTest).not.toMatch(/\bSnapshot\.(init|track|patch|restore|revert|diff|diffFull)\s*\(/)
 })
 
+test("ModelsDev service does not expose Promise facades", async () => {
+  const text = await readFile(path.join(srcRoot, "provider/models.ts"), "utf8")
+  const facades = [
+    "export const Data",
+    "export async function get",
+    "export async function getWithVersion",
+    "export async function refresh",
+  ]
+
+  expect(text).not.toMatch(/\bfrom\s+["']\.\.\/effect\/run-service["']/)
+  expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+  for (const facade of facades) expect(text).not.toContain(facade)
+})
+
+test("Provider service does not expose Promise facades", async () => {
+  const text = await readFile(path.join(srcRoot, "provider/provider.ts"), "utf8")
+  const facades = [
+    "export async function list",
+    "export async function getProvider",
+    "export async function getModel",
+    "export async function getLanguage",
+    "export async function closest",
+    "export async function getSmallModel",
+    "export async function defaultModel",
+  ]
+
+  expect(text).not.toMatch(/\bfrom\s+["']\.\.\/effect\/run-service["']/)
+  expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+  for (const facade of facades) expect(text).not.toContain(facade)
+})
+
 test("session summary/revert/compaction services do not expose Promise facades", async () => {
   const files = {
     "session/summary.ts": ["export async function diff", "export async function artifacts"],

--- a/packages/opencode/test/provider/models-refresh.test.ts
+++ b/packages/opencode/test/provider/models-refresh.test.ts
@@ -4,7 +4,7 @@ import path from "path"
 
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
-import { Effect, Layer } from "effect"
+import { Effect, Fiber, Layer } from "effect"
 import { tmpdir } from "../fixture/fixture"
 import { makeRuntime } from "../../src/effect/run-service"
 import { AppRuntime } from "../../src/effect/app-runtime"
@@ -232,6 +232,43 @@ test("refresh does not publish to normal cache when models path override is set"
 
   await expect(readFile(cachePath(), "utf8")).rejects.toThrow()
   expect(ModelsDev.version()).toBe(beforeVersion + 1)
+})
+
+test("data retries when the cached catalog load was interrupted", async () => {
+  let reads = 0
+  const interruptingFsLayer = Layer.effect(
+    AppFileSystem.Service,
+    AppFileSystem.Service.use((fs) =>
+      Effect.succeed(
+        AppFileSystem.Service.of({
+          ...fs,
+          readFileString: (target) => {
+            reads++
+            if (reads === 1) return Effect.never
+            return Effect.succeed(JSON.stringify(catalogWithModels(["kimi-k2.6"])))
+          },
+        }),
+      ),
+    ),
+  ).pipe(Layer.provide(AppFileSystem.defaultLayer))
+  const interruptingLayer = ModelsDev.layer.pipe(
+    Layer.provide(interruptingFsLayer),
+    Layer.provide(EffectFlock.defaultLayer),
+  )
+
+  const catalog = await Effect.runPromise(
+    ModelsDev.Service.use((svc) =>
+      Effect.gen(function* () {
+        const first = yield* svc.data().pipe(Effect.forkChild)
+        yield* Effect.sleep("10 millis")
+        yield* Fiber.interrupt(first)
+        return yield* svc.data()
+      }),
+    ).pipe(Effect.provide(interruptingLayer)),
+  )
+
+  expect(catalog["moonshotai-cn"]?.models["kimi-k2.6"]).toBeDefined()
+  expect(reads).toBe(2)
 })
 
 test("provider state rebuilds after models path override refresh", async () => {

--- a/packages/opencode/test/provider/models-refresh.test.ts
+++ b/packages/opencode/test/provider/models-refresh.test.ts
@@ -7,10 +7,12 @@ import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { Effect, Layer } from "effect"
 import { tmpdir } from "../fixture/fixture"
 import { makeRuntime } from "../../src/effect/run-service"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Env } from "../../src/env"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { ModelsDev, Provider } from "../../src/provider"
+import { withPawWorkProviders } from "../../src/provider/pawwork-providers"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 
 const originalFetch = globalThis.fetch
@@ -18,11 +20,28 @@ const originalModelsPath = process.env.OPENCODE_MODELS_PATH
 const env = makeRuntime(Env.Service, Env.defaultLayer)
 const setEnv = (key: string, value: string) => env.runSync((svc) => svc.set(key, value))
 
+const runModels = <A, E>(fn: (svc: ModelsDev.Interface) => Effect.Effect<A, E, never>) =>
+  AppRuntime.runPromise(ModelsDev.Service.use(fn))
+
+const runProvider = <A, E>(fn: (svc: Provider.Interface) => Effect.Effect<A, E, never>) =>
+  AppRuntime.runPromise(Provider.Service.use(fn))
+
+const resetModels = () => runModels((svc) => svc.reset())
+const refreshModels = (force: boolean) => runModels((svc) => svc.refresh(force))
+const listProviders = () => runProvider((svc) => svc.list())
+const getProviderModel = (providerID: ProviderID, modelID: ModelID) =>
+  runProvider((svc) => svc.getModel(providerID, modelID))
+const getProviderLanguage = (model: Provider.Model) => runProvider((svc) => svc.getLanguage(model))
+const getModelsDatabase = () =>
+  runModels((svc) =>
+    svc.data().pipe(Effect.map((catalog) => withPawWorkProviders(catalog as Record<string, ModelsDev.Provider>))),
+  )
+
 afterEach(async () => {
   globalThis.fetch = originalFetch
   if (originalModelsPath === undefined) delete process.env.OPENCODE_MODELS_PATH
   else process.env.OPENCODE_MODELS_PATH = originalModelsPath
-  ModelsDev.Data.reset()
+  await resetModels()
   await rm(cachePath(), { force: true })
 })
 
@@ -94,7 +113,7 @@ test("refresh publishes a valid candidate catalog", async () => {
   mockFetchWithCatalog(catalogWithModels(["kimi-k2.5", "kimi-k2.6"]))
 
   const before = ModelsDev.version()
-  await ModelsDev.refresh(true)
+  await refreshModels(true)
 
   expect(await readCacheText()).toContain("kimi-k2.6")
   expect(ModelsDev.version()).toBe(before + 1)
@@ -107,7 +126,7 @@ test("refresh keeps existing cache when candidate JSON is invalid", async () => 
   const beforeVersion = ModelsDev.version()
   globalThis.fetch = asFetch(async () => new Response("not json", { status: 200 }))
 
-  await ModelsDev.refresh(true)
+  await refreshModels(true)
 
   expect(await readCacheText()).toBe(beforeCache)
   expect(ModelsDev.version()).toBe(beforeVersion)
@@ -122,7 +141,7 @@ test("refresh keeps existing cache when candidate catalog cannot become runtime 
   delete invalidCatalog["moonshotai-cn"].models["kimi-k2.6"].limit
   mockFetchWithCatalog(invalidCatalog)
 
-  await ModelsDev.refresh(true)
+  await refreshModels(true)
 
   expect(await readCacheText()).toBe(beforeCache)
   expect(ModelsDev.version()).toBe(beforeVersion)
@@ -137,7 +156,7 @@ test("refresh keeps existing cache when candidate catalog has invalid field type
   invalidCatalog["moonshotai-cn"].models["kimi-k2.6"].temperature = "true"
   mockFetchWithCatalog(invalidCatalog)
 
-  await ModelsDev.refresh(true)
+  await refreshModels(true)
 
   expect(await readCacheText()).toBe(beforeCache)
   expect(ModelsDev.version()).toBe(beforeVersion)
@@ -152,7 +171,7 @@ test("refresh keeps existing cache when network fetch fails", async () => {
     throw new Error("network down")
   })
 
-  await expect(ModelsDev.refresh(true)).resolves.toBeUndefined()
+  await expect(refreshModels(true)).resolves.toBeUndefined()
 
   expect(await readCacheText()).toBe(beforeCache)
   expect(ModelsDev.version()).toBe(beforeVersion)
@@ -165,7 +184,7 @@ test("refresh keeps existing cache when HTTP response is not successful", async 
   const beforeVersion = ModelsDev.version()
   globalThis.fetch = asFetch(async () => new Response("server down", { status: 500 }))
 
-  await ModelsDev.refresh(true)
+  await refreshModels(true)
 
   expect(await readCacheText()).toBe(beforeCache)
   expect(ModelsDev.version()).toBe(beforeVersion)
@@ -209,7 +228,7 @@ test("refresh does not publish to normal cache when models path override is set"
   mockFetchWithCatalog(catalogWithModels(["kimi-k2.5", "kimi-k2.6"]))
   const beforeVersion = ModelsDev.version()
 
-  await ModelsDev.refresh(true)
+  await refreshModels(true)
 
   await expect(readFile(cachePath(), "utf8")).rejects.toThrow()
   expect(ModelsDev.version()).toBe(beforeVersion + 1)
@@ -220,16 +239,16 @@ test("provider state rebuilds after models path override refresh", async () => {
   const overridePath = path.join(tmp.path, "models.json")
   await writeFile(overridePath, JSON.stringify(catalogWithModels(["kimi-k2.5"])))
   process.env.OPENCODE_MODELS_PATH = overridePath
-  ModelsDev.Data.reset()
+  await resetModels()
 
   await withTestInstance(async () => {
-    const before = await Provider.list()
+    const before = await listProviders()
     expect(before[moonshotProviderID]?.models[kimi26ModelID]).toBeUndefined()
 
     await writeFile(overridePath, JSON.stringify(catalogWithModels(["kimi-k2.5", "kimi-k2.6"])))
-    await ModelsDev.refresh(true)
+    await refreshModels(true)
 
-    const model = await Provider.getModel(moonshotProviderID, kimi26ModelID)
+    const model = await getProviderModel(moonshotProviderID, kimi26ModelID)
     expect(model.id).toBe(kimi26ModelID)
   })
 })
@@ -237,19 +256,19 @@ test("provider state rebuilds after models path override refresh", async () => {
 test("provider state rebuilds after a successful catalog refresh", async () => {
   delete process.env.OPENCODE_MODELS_PATH
   await writeCache(catalogWithModels(["kimi-k2.5"]))
-  ModelsDev.Data.reset()
+  await resetModels()
 
   await withTestInstance(async () => {
-    const before = await Provider.list()
+    const before = await listProviders()
     expect(before[moonshotProviderID]?.models[kimi26ModelID]).toBeUndefined()
 
     mockFetchWithCatalog(catalogWithModels(["kimi-k2.5", "kimi-k2.6"]))
-    await ModelsDev.refresh(true)
+    await refreshModels(true)
 
-    const model = await Provider.getModel(moonshotProviderID, kimi26ModelID)
+    const model = await getProviderModel(moonshotProviderID, kimi26ModelID)
     expect(model.id).toBe(kimi26ModelID)
 
-    const after = await Provider.list()
+    const after = await listProviders()
     expect(after[moonshotProviderID]?.models[kimi26ModelID]).toBeDefined()
   })
 })
@@ -257,16 +276,16 @@ test("provider state rebuilds after a successful catalog refresh", async () => {
 test("provider state rebuilds when refresh observes an already fresh cache from another process", async () => {
   delete process.env.OPENCODE_MODELS_PATH
   await writeCache(catalogWithModels(["kimi-k2.5"]))
-  ModelsDev.Data.reset()
+  await resetModels()
 
   await withTestInstance(async () => {
-    const before = await Provider.list()
+    const before = await listProviders()
     expect(before[moonshotProviderID]?.models[kimi26ModelID]).toBeUndefined()
 
     await writeCache(catalogWithModels(["kimi-k2.5", "kimi-k2.6"]))
-    await ModelsDev.refresh(false)
+    await refreshModels(false)
 
-    const model = await Provider.getModel(moonshotProviderID, kimi26ModelID)
+    const model = await getProviderModel(moonshotProviderID, kimi26ModelID)
     expect(model.id).toBe(kimi26ModelID)
   })
 })
@@ -274,25 +293,25 @@ test("provider state rebuilds when refresh observes an already fresh cache from 
 test("getLanguage reports ModelNotFoundError when refreshed catalog removes the provider", async () => {
   delete process.env.OPENCODE_MODELS_PATH
   await writeCache(catalogWithModels(["kimi-k2.5"]))
-  ModelsDev.Data.reset()
+  await resetModels()
 
   await withTestInstance(async () => {
-    const oldModel = await Provider.getModel(moonshotProviderID, ModelID.make("kimi-k2.5"))
+    const oldModel = await getProviderModel(moonshotProviderID, ModelID.make("kimi-k2.5"))
 
     mockFetchWithCatalog({})
-    await ModelsDev.refresh(true)
+    await refreshModels(true)
 
-    await expect(Provider.getLanguage(oldModel)).rejects.toThrow("ProviderModelNotFoundError")
+    await expect(getProviderLanguage(oldModel)).rejects.toThrow("ProviderModelNotFoundError")
   })
 })
 
 test("getLanguage reports provider suggestions after refreshed catalog replaces the provider", async () => {
   delete process.env.OPENCODE_MODELS_PATH
   await writeCache(catalogWithModels(["kimi-k2.5"]))
-  ModelsDev.Data.reset()
+  await resetModels()
 
   await withTestInstance(async () => {
-    const oldModel = await Provider.getModel(moonshotProviderID, ModelID.make("kimi-k2.5"))
+    const oldModel = await getProviderModel(moonshotProviderID, ModelID.make("kimi-k2.5"))
     mockFetchWithCatalog({
       "moonshotai-cn-next": {
         id: "moonshotai-cn-next",
@@ -305,9 +324,9 @@ test("getLanguage reports provider suggestions after refreshed catalog replaces 
         },
       },
     })
-    await ModelsDev.refresh(true)
+    await refreshModels(true)
 
-    const error = await Provider.getLanguage(oldModel).catch((error) => error)
+    const error = await getProviderLanguage(oldModel).catch((error) => error)
     expect(error.name).toBe("ProviderModelNotFoundError")
     expect(error.data).toMatchObject({
       providerID: moonshotProviderID,
@@ -320,16 +339,16 @@ test("getLanguage reports provider suggestions after refreshed catalog replaces 
 test("connected provider overlay uses refreshed provider state", async () => {
   delete process.env.OPENCODE_MODELS_PATH
   await writeCache(catalogWithModels(["kimi-k2.5"]))
-  ModelsDev.Data.reset()
+  await resetModels()
 
   await withTestInstance(async () => {
-    await Provider.list()
+    await listProviders()
 
     mockFetchWithCatalog(catalogWithModels(["kimi-k2.5", "kimi-k2.6"]))
-    await ModelsDev.refresh(true)
+    await refreshModels(true)
 
-    const allProviders = await ModelsDev.get()
-    const connected = await Provider.list()
+    const allProviders = await getModelsDatabase()
+    const connected = await listProviders()
     const merged = Object.assign(
       Object.fromEntries(
         Object.entries(allProviders).map(([id, provider]) => [id, Provider.fromModelsDevProvider(provider)]),

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -60,6 +60,14 @@ async function getModel(providerID: ProviderID, modelID: ModelID) {
   return run((provider) => provider.getModel(providerID, modelID))
 }
 
+async function modelsDatabase() {
+  return AppRuntime.runPromise(
+    ModelsDev.Service.use((svc) =>
+      svc.data().pipe(Effect.map((catalog) => withPawWorkProviders(catalog as Record<string, ModelsDev.Provider>))),
+    ),
+  )
+}
+
 async function getLanguage(model: Provider.Model) {
   return run((provider) => provider.getLanguage(model))
 }
@@ -1413,7 +1421,7 @@ test("provider.sort prioritizes preferred models", () => {
 })
 
 test("includes Volcano Engine Coding Plan as a PawWork provider overlay", async () => {
-  const models = await ModelsDev.get()
+  const models = await modelsDatabase()
   const provider = models[VOLCENGINE_PLAN_PROVIDER_ID]
 
   expect(provider).toBeDefined()
@@ -1443,7 +1451,7 @@ test("includes Volcano Engine Coding Plan as a PawWork provider overlay", async 
 
 
 test("Volcano Engine Coding Plan models have correct key parameters", async () => {
-  const models = await ModelsDev.get()
+  const models = await modelsDatabase()
   const provider = models[VOLCENGINE_PLAN_PROVIDER_ID]
 
   const expected: Record<string, {
@@ -1519,7 +1527,7 @@ test("does not add OpenAI-compatible replay metadata to Kimi Coding Plan Anthrop
 })
 
 test("uses doubao-seed-2.0-code as the Volcano Coding Plan default model", async () => {
-  const models = await ModelsDev.get()
+  const models = await modelsDatabase()
   const provider = models[VOLCENGINE_PLAN_PROVIDER_ID]
 
   expect(Provider.defaultModelIDs({ [provider.id]: provider })).toEqual({


### PR DESCRIPTION
## Summary

Retire the remaining per-service Promise facades from `ModelsDev` and `Provider`, and move direct callers onto `ModelsDev.Service` / `Provider.Service` through the existing Effect runtime boundaries.

## Why

The #936 cleanup lane is deleting service-local `makeRuntime(Service, defaultLayer)` facades now that `AppRuntime` owns the shared Effect graph. This slice removes the Provider and ModelsDev facade tail without changing catalog refresh behavior, PawWork provider overlays, provider model lookup, recent model state, or CLI/provider route behavior.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the ModelsDev refresh/version consistency path, PawWork provider overlay preservation, and the CLI/test call sites moved from facade calls to service/runtime style.

## Risk Notes

No UI, docs, dependency, generated file, credential, permission, packaging, or platform-specific behavior changed. The main risk is stale provider catalog state after refresh; this is covered by the refreshed provider-state tests and by keeping the existing version consistency loop inside `Provider.Service`.

Skipped checklist items:
- Visible UI/copy check: not applicable, no visible UI or copy changed.
- macOS/Windows platform check: not applicable, no platform/packaging surface changed.
- Docs/release/dependency/generated/permission/local-file check: not applicable, none of those surfaces changed.

Fresh-eye result: I reviewed the final diff with: `本次的所有改动已经是最优解了吗？是否是最简洁、最优雅、最安心、最彻底的方案？用奥卡姆剃刀大胆思考。` No P0/P1 findings. The only P2/P3 candidate was small duplication in CLI catalog reads, intentionally left in place to avoid introducing a new production compatibility helper.

## How To Verify

```text
RED: bun test test/effect/legacy-boundaries.test.ts failed on the existing ModelsDev/Provider makeRuntime facades before implementation.
Focused tests: bun test test/effect/legacy-boundaries.test.ts test/provider/models-refresh.test.ts test/provider/provider.test.ts test/provider/model-status-active.test.ts test/server/provider-recent-route.test.ts test/cli/plugin-auth-picker.test.ts test/cli/providers-login.test.ts -> 167 passed, 0 failed.
Typecheck: GOMAXPROCS=2 bun run typecheck -> passed.
Diff check: git diff --check -> passed.
Facade inventory: rg for ModelsDev/Provider facade calls and provider service makeRuntime blocks -> no production/test callers remain; only comments and service method names matched.
```

## Screenshots or Recordings

Not applicable, no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
