### PR TITLE
refactor(opencode): retire snapshot facades

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -5,7 +5,6 @@ import path from "path"
 import z from "zod"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Hash } from "@/util/hash"
 import { Config } from "../config/config"
@@ -847,34 +846,4 @@ export namespace Snapshot {
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(Config.defaultLayer),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function init() {
-    return runPromise((svc) => svc.init())
-  }
-
-  export async function track() {
-    return runPromise((svc) => svc.track())
-  }
-
-  export async function patch(hash: string) {
-    return runPromise((svc) => svc.patch(hash))
-  }
-
-  export async function restore(snapshot: string) {
-    return runPromise((svc) => svc.restore(snapshot))
-  }
-
-  export async function revert(patches: Patch[]) {
-    return runPromise((svc) => svc.revert(patches))
-  }
-
-  export async function diff(hash: string) {
-    return runPromise((svc) => svc.diff(hash))
-  }
-
-  export async function diffFull(from: string, to: string) {
-    return runPromise((svc) => svc.diffFull(from, to))
-  }
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -92,6 +92,25 @@ test("ModelState recent writes stay on the Effect service boundary", async () =>
   expect(providerTest).not.toContain("ModelState.recordRecent(")
 })
 
+test("Snapshot service does not expose Promise facades", async () => {
+  const service = await readFile(path.join(srcRoot, "snapshot/index.ts"), "utf8")
+  const snapshotTest = await readFile(path.join(testRoot, "snapshot/snapshot.test.ts"), "utf8")
+  const facades = [
+    "export async function init",
+    "export async function track",
+    "export async function patch",
+    "export async function restore",
+    "export async function revert",
+    "export async function diff",
+    "export async function diffFull",
+  ]
+
+  expect(service).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+  expect(service).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+  for (const facade of facades) expect(service).not.toContain(facade)
+  expect(snapshotTest).not.toMatch(/\bSnapshot\.(init|track|patch|restore|revert|diff|diffFull)\s*\(/)
+})
+
 test("session summary/revert/compaction services do not expose Promise facades", async () => {
   const files = {
     "session/summary.ts": ["export async function diff", "export async function artifacts"],

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -2,6 +2,8 @@ import { afterEach, test, expect } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
+import { Effect } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Snapshot } from "../../src/snapshot"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
@@ -9,7 +11,7 @@ import { Filesystem } from "../../src/util/filesystem"
 import { Hash } from "../../src/util/hash"
 import { tmpdir } from "../fixture/fixture"
 
-// Git always outputs /-separated paths internally. Snapshot.patch() joins them
+// Git always outputs /-separated paths internally. snapshot.patch() joins them
 // with path.join (which produces \ on Windows) then normalizes back to /.
 // This helper does the same for expected values so assertions match cross-platform.
 const fwd = (...parts: string[]) => path.join(...parts).replaceAll("\\", "/")
@@ -18,6 +20,28 @@ const OVER_BATCH_COUNT = SNAPSHOT_BATCH_BOUNDARY + 1
 const MIXED_BATCH_GROUP_COUNT = Math.ceil(OVER_BATCH_COUNT / 4)
 const gitPath = (item: string) => item.replaceAll("\\", "/")
 const resolveGitPath = (cwd: string, item: string) => (path.isAbsolute(item) ? item : path.resolve(cwd, item))
+const useSnapshot = <A>(fn: (snapshot: Snapshot.Interface) => Effect.Effect<A, never, never>): Promise<A> =>
+  AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      return yield* fn(snapshot)
+    }),
+  )
+const snapshot: {
+  track: () => Promise<string | undefined>
+  patch: (hash: string) => Promise<Snapshot.Patch>
+  restore: (hash: string) => Promise<void>
+  revert: (patches: Snapshot.Patch[]) => Promise<void>
+  diff: (hash: string) => Promise<string>
+  diffFull: (from: string, to: string) => Promise<Snapshot.FileDiff[]>
+} = {
+  track: () => useSnapshot((svc) => svc.track()),
+  patch: (hash: string) => useSnapshot((svc) => svc.patch(hash)),
+  restore: (hash: string) => useSnapshot((svc) => svc.restore(hash)),
+  revert: (patches: Snapshot.Patch[]) => useSnapshot((svc) => svc.revert(patches)),
+  diff: (hash: string) => useSnapshot((svc) => svc.diff(hash)),
+  diffFull: (from: string, to: string) => useSnapshot((svc) => svc.diffFull(from, to)),
+}
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -61,7 +85,7 @@ test("initial snapshot reuses source git object database", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      expect(await Snapshot.track()).toBeTruthy()
+      expect(await snapshot.track()).toBeTruthy()
 
       await expectSnapshotAlternatesInclude(tmp.path)
     },
@@ -77,7 +101,7 @@ test("initial snapshot in secondary worktree reuses common object database", asy
     await Instance.provide({
       directory: worktreePath,
       fn: async () => {
-        expect(await Snapshot.track()).toBeTruthy()
+        expect(await snapshot.track()).toBeTruthy()
 
         await expectSnapshotAlternatesInclude(worktreePath)
       },
@@ -104,7 +128,7 @@ test("initial snapshot preserves source relative alternates", async () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        expect(await Snapshot.track()).toBeTruthy()
+        expect(await snapshot.track()).toBeTruthy()
 
         const alternates = await fs.readFile(path.join(snapshotGitdir(), "objects", "info", "alternates"), "utf8")
         expect(alternates.split(/\r?\n/).filter(Boolean)).toContain(gitPath(sharedObjects))
@@ -123,13 +147,13 @@ test("initial snapshot falls back when source index uses split index", async () 
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       const file = fwd(tmp.path, "split-index-new.txt")
       await Filesystem.write(file, "split index fallback")
 
-      expect((await Snapshot.patch(before!)).files).toContain(file)
+      expect((await snapshot.patch(before!)).files).toContain(file)
     },
   })
 })
@@ -139,12 +163,12 @@ test("tracks deleted files correctly", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await $`rm ${tmp.path}/a.txt`.quiet()
 
-      expect((await Snapshot.patch(before!)).files).toContain(fwd(tmp.path, "a.txt"))
+      expect((await snapshot.patch(before!)).files).toContain(fwd(tmp.path, "a.txt"))
     },
   })
 })
@@ -154,12 +178,12 @@ test("revert should remove new files", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/new.txt`, "NEW")
 
-      await Snapshot.revert([await Snapshot.patch(before!)])
+      await snapshot.revert([await snapshot.patch(before!)])
 
       expect(
         await fs
@@ -176,13 +200,13 @@ test("revert in subdirectory", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await $`mkdir -p ${tmp.path}/sub`.quiet()
       await Filesystem.write(`${tmp.path}/sub/file.txt`, "SUB")
 
-      await Snapshot.revert([await Snapshot.patch(before!)])
+      await snapshot.revert([await snapshot.patch(before!)])
 
       expect(
         await fs
@@ -201,7 +225,7 @@ test("multiple file operations", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await $`rm ${tmp.path}/a.txt`.quiet()
@@ -210,7 +234,7 @@ test("multiple file operations", async () => {
       await Filesystem.write(`${tmp.path}/dir/d.txt`, "D")
       await Filesystem.write(`${tmp.path}/b.txt`, "MODIFIED")
 
-      await Snapshot.revert([await Snapshot.patch(before!)])
+      await snapshot.revert([await snapshot.patch(before!)])
 
       expect(await fs.readFile(`${tmp.path}/a.txt`, "utf-8")).toBe(tmp.extra.aContent)
       expect(
@@ -231,12 +255,12 @@ test("empty directory handling", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await $`mkdir ${tmp.path}/empty`.quiet()
 
-      expect((await Snapshot.patch(before!)).files.length).toBe(0)
+      expect((await snapshot.patch(before!)).files.length).toBe(0)
     },
   })
 })
@@ -246,15 +270,15 @@ test("binary file handling", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/image.png`, new Uint8Array([0x89, 0x50, 0x4e, 0x47]))
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files).toContain(fwd(tmp.path, "image.png"))
 
-      await Snapshot.revert([patch])
+      await snapshot.revert([patch])
       expect(
         await fs
           .access(`${tmp.path}/image.png`)
@@ -270,12 +294,12 @@ test("symlink handling", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await fs.symlink(`${tmp.path}/a.txt`, `${tmp.path}/link.txt`, "file")
 
-      expect((await Snapshot.patch(before!)).files).toContain(fwd(tmp.path, "link.txt"))
+      expect((await snapshot.patch(before!)).files).toContain(fwd(tmp.path, "link.txt"))
     },
   })
 })
@@ -285,12 +309,12 @@ test("file under size limit handling", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/large.txt`, "x".repeat(1024 * 1024))
 
-      expect((await Snapshot.patch(before!)).files).toContain(fwd(tmp.path, "large.txt"))
+      expect((await snapshot.patch(before!)).files).toContain(fwd(tmp.path, "large.txt"))
     },
   })
 })
@@ -300,14 +324,14 @@ test("large added files are skipped", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/huge.txt`, new Uint8Array(2 * 1024 * 1024 + 1))
 
-      expect((await Snapshot.patch(before!)).files).toEqual([])
-      expect(await Snapshot.diff(before!)).toBe("")
-      expect(await Snapshot.track()).toBe(before)
+      expect((await snapshot.patch(before!)).files).toEqual([])
+      expect(await snapshot.diff(before!)).toBe("")
+      expect(await snapshot.track()).toBe(before)
     },
   })
 })
@@ -317,13 +341,13 @@ test("nested directory revert", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await $`mkdir -p ${tmp.path}/level1/level2/level3`.quiet()
       await Filesystem.write(`${tmp.path}/level1/level2/level3/deep.txt`, "DEEP")
 
-      await Snapshot.revert([await Snapshot.patch(before!)])
+      await snapshot.revert([await snapshot.patch(before!)])
 
       expect(
         await fs
@@ -340,14 +364,14 @@ test("special characters in filenames", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/file with spaces.txt`, "SPACES")
       await Filesystem.write(`${tmp.path}/file-with-dashes.txt`, "DASHES")
       await Filesystem.write(`${tmp.path}/file_with_underscores.txt`, "UNDERSCORES")
 
-      const files = (await Snapshot.patch(before!)).files
+      const files = (await snapshot.patch(before!)).files
       expect(files).toContain(fwd(tmp.path, "file with spaces.txt"))
       expect(files).toContain(fwd(tmp.path, "file-with-dashes.txt"))
       expect(files).toContain(fwd(tmp.path, "file_with_underscores.txt"))
@@ -361,10 +385,10 @@ test("revert with empty patches", async () => {
     directory: tmp.path,
     fn: async () => {
       // Should not crash with empty patches
-      expect(Snapshot.revert([])).resolves.toBeUndefined()
+      expect(snapshot.revert([])).resolves.toBeUndefined()
 
       // Should not crash with patches that have empty file lists
-      expect(Snapshot.revert([{ hash: "dummy", files: [] }])).resolves.toBeUndefined()
+      expect(snapshot.revert([{ hash: "dummy", files: [] }])).resolves.toBeUndefined()
     },
   })
 })
@@ -374,14 +398,14 @@ test("patch with invalid hash", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Create a change
       await Filesystem.write(`${tmp.path}/test.txt`, "TEST")
 
       // Try to patch with invalid hash - should handle gracefully
-      const patch = await Snapshot.patch("invalid-hash-12345")
+      const patch = await snapshot.patch("invalid-hash-12345")
       expect(patch.files).toEqual([])
       expect(patch.hash).toBe("invalid-hash-12345")
     },
@@ -393,13 +417,13 @@ test("revert non-existent file", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Try to revert a file that doesn't exist in the snapshot
       // This should not crash
       expect(
-        Snapshot.revert([
+        snapshot.revert([
           {
             hash: before!,
             files: [`${tmp.path}/nonexistent.txt`],
@@ -415,7 +439,7 @@ test("unicode filenames", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       const unicodeFiles = [
@@ -429,14 +453,14 @@ test("unicode filenames", async () => {
         await Filesystem.write(file.path, file.content)
       }
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files.length).toBe(4)
 
       for (const file of unicodeFiles) {
         expect(patch.files).toContain(file.path)
       }
 
-      await Snapshot.revert([patch])
+      await snapshot.revert([patch])
 
       for (const file of unicodeFiles) {
         expect(
@@ -461,17 +485,17 @@ test.skip("unicode filenames modification and restore", async () => {
       await Filesystem.write(chineseFile, "original chinese")
       await Filesystem.write(cyrillicFile, "original cyrillic")
 
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(chineseFile, "modified chinese")
       await Filesystem.write(cyrillicFile, "modified cyrillic")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files).toContain(chineseFile)
       expect(patch.files).toContain(cyrillicFile)
 
-      await Snapshot.revert([patch])
+      await snapshot.revert([patch])
 
       expect(await fs.readFile(chineseFile, "utf-8")).toBe("original chinese")
       expect(await fs.readFile(cyrillicFile, "utf-8")).toBe("original cyrillic")
@@ -484,17 +508,17 @@ test("unicode filenames in subdirectories", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await $`mkdir -p "${tmp.path}/目录/подкаталог"`.quiet()
       const deepFile = fwd(tmp.path, "目录", "подкаталог", "文件.txt")
       await Filesystem.write(deepFile, "deep unicode content")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files).toContain(deepFile)
 
-      await Snapshot.revert([patch])
+      await snapshot.revert([patch])
       expect(
         await fs
           .access(deepFile)
@@ -510,7 +534,7 @@ test("very long filenames", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       const longName = "a".repeat(200) + ".txt"
@@ -518,10 +542,10 @@ test("very long filenames", async () => {
 
       await Filesystem.write(longFile, "long filename content")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files).toContain(longFile)
 
-      await Snapshot.revert([patch])
+      await snapshot.revert([patch])
       expect(
         await fs
           .access(longFile)
@@ -537,14 +561,14 @@ test("hidden files", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/.hidden`, "hidden content")
       await Filesystem.write(`${tmp.path}/.gitignore`, "*.log")
       await Filesystem.write(`${tmp.path}/.config`, "config content")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files).toContain(fwd(tmp.path, ".hidden"))
       expect(patch.files).toContain(fwd(tmp.path, ".gitignore"))
       expect(patch.files).toContain(fwd(tmp.path, ".config"))
@@ -557,7 +581,7 @@ test("nested symlinks", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await $`mkdir -p ${tmp.path}/sub/dir`.quiet()
@@ -565,7 +589,7 @@ test("nested symlinks", async () => {
       await fs.symlink(`${tmp.path}/sub/dir/target.txt`, `${tmp.path}/sub/dir/link.txt`, "file")
       await fs.symlink(`${tmp.path}/sub`, `${tmp.path}/sub-link`, "dir")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files).toContain(fwd(tmp.path, "sub", "dir", "link.txt"))
       expect(patch.files).toContain(fwd(tmp.path, "sub-link"))
     },
@@ -577,7 +601,7 @@ test("file permissions and ownership changes", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Change permissions multiple times
@@ -585,7 +609,7 @@ test("file permissions and ownership changes", async () => {
       await $`chmod 755 ${tmp.path}/a.txt`.quiet()
       await $`chmod 644 ${tmp.path}/a.txt`.quiet()
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       // Note: git doesn't track permission changes on existing files by default
       // Only tracks executable bit when files are first added
       expect(patch.files.length).toBe(0)
@@ -598,13 +622,13 @@ test("circular symlinks", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Create circular symlink
       await fs.symlink(`${tmp.path}/circular`, `${tmp.path}/circular`, "dir").catch(() => {})
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files.length).toBeGreaterThanOrEqual(0) // Should not crash
     },
   })
@@ -629,7 +653,7 @@ test("source project gitignore is respected - ignored files are not snapshotted"
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Modify tracked files and create new ones - some ignored, some not
@@ -638,7 +662,7 @@ test("source project gitignore is respected - ignored files are not snapshotted"
       await Filesystem.write(`${tmp.path}/new-tracked.txt`, "new tracked")
       await Filesystem.write(`${tmp.path}/build/new-build.js`, "new build file")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
 
       // Modified and new tracked files should be in snapshot
       expect(patch.files).toContain(fwd(tmp.path, "new-tracked.txt"))
@@ -658,14 +682,14 @@ test("gitignore changes", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/.gitignore`, "*.ignored")
       await Filesystem.write(`${tmp.path}/test.ignored`, "ignored content")
       await Filesystem.write(`${tmp.path}/normal.txt`, "normal content")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
 
       // Should track gitignore itself
       expect(patch.files).toContain(fwd(tmp.path, ".gitignore"))
@@ -684,7 +708,7 @@ test("files tracked in snapshot but now gitignored are filtered out", async () =
     fn: async () => {
       // First, create a file and snapshot it
       await Filesystem.write(`${tmp.path}/later-ignored.txt`, "initial content")
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Modify the file (so it appears in diff-files)
@@ -696,7 +720,7 @@ test("files tracked in snapshot but now gitignored are filtered out", async () =
       // Also create another tracked file
       await Filesystem.write(`${tmp.path}/still-tracked.txt`, "new tracked file")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
 
       // The file that is now gitignored should NOT appear, even though it was
       // previously tracked and modified
@@ -717,7 +741,7 @@ test("gitignore updated between track calls filters from diff", async () => {
     directory: tmp.path,
     fn: async () => {
       // a.txt is already committed from bootstrap - track it in snapshot
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Modify a.txt (so it appears in diff-files)
@@ -730,11 +754,11 @@ test("gitignore updated between track calls filters from diff", async () => {
       await Filesystem.write(`${tmp.path}/b.txt`, "also modified")
 
       // Second track - should not include a.txt even though it changed
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
       // Verify a.txt is NOT in the diff between snapshots
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.some((x) => x.file === "a.txt")).toBe(false)
 
       // But .gitignore should be in the diff
@@ -751,7 +775,7 @@ test("git info exclude changes", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       const file = `${tmp.path}/.git/info/exclude`
@@ -760,12 +784,12 @@ test("git info exclude changes", async () => {
       await Bun.write(`${tmp.path}/ignored.txt`, "ignored content")
       await Bun.write(`${tmp.path}/normal.txt`, "normal content")
 
-      const patch = await Snapshot.patch(before!)
+      const patch = await snapshot.patch(before!)
       expect(patch.files).toContain(fwd(tmp.path, "normal.txt"))
       expect(patch.files).not.toContain(fwd(tmp.path, "ignored.txt"))
 
-      const after = await Snapshot.track()
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const after = await snapshot.track()
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.some((x) => x.file === "normal.txt")).toBe(true)
       expect(diffs.some((x) => x.file === "ignored.txt")).toBe(false)
     },
@@ -785,7 +809,7 @@ test("git info exclude keeps global excludes", async () => {
       const prev = process.env.GIT_CONFIG_GLOBAL
       process.env.GIT_CONFIG_GLOBAL = config
       try {
-        const before = await Snapshot.track()
+        const before = await snapshot.track()
         expect(before).toBeTruthy()
 
         const file = `${tmp.path}/.git/info/exclude`
@@ -796,7 +820,7 @@ test("git info exclude keeps global excludes", async () => {
         await Bun.write(`${tmp.path}/info.tmp`, "info content")
         await Bun.write(`${tmp.path}/normal.txt`, "normal content")
 
-        const patch = await Snapshot.patch(before!)
+        const patch = await snapshot.patch(before!)
         expect(patch.files).toContain(fwd(tmp.path, "normal.txt"))
         expect(patch.files).not.toContain(fwd(tmp.path, "global.tmp"))
         expect(patch.files).not.toContain(fwd(tmp.path, "info.tmp"))
@@ -813,7 +837,7 @@ test("concurrent file operations during patch", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Start creating files
@@ -826,7 +850,7 @@ test("concurrent file operations during patch", async () => {
       })()
 
       // Get patch while files are being created
-      const patchPromise = Snapshot.patch(before!)
+      const patchPromise = snapshot.patch(before!)
 
       await createPromise
       const patch = await patchPromise
@@ -845,9 +869,9 @@ test("snapshot state isolation between projects", async () => {
   await Instance.provide({
     directory: tmp1.path,
     fn: async () => {
-      const before1 = await Snapshot.track()
+      const before1 = await snapshot.track()
       await Filesystem.write(`${tmp1.path}/project1.txt`, "project1 content")
-      const patch1 = await Snapshot.patch(before1!)
+      const patch1 = await snapshot.patch(before1!)
       expect(patch1.files).toContain(fwd(tmp1.path, "project1.txt"))
     },
   })
@@ -855,9 +879,9 @@ test("snapshot state isolation between projects", async () => {
   await Instance.provide({
     directory: tmp2.path,
     fn: async () => {
-      const before2 = await Snapshot.track()
+      const before2 = await snapshot.track()
       await Filesystem.write(`${tmp2.path}/project2.txt`, "project2 content")
-      const patch2 = await Snapshot.patch(before2!)
+      const patch2 = await snapshot.patch(before2!)
       expect(patch2.files).toContain(fwd(tmp2.path, "project2.txt"))
 
       // Ensure project1 files don't appear in project2
@@ -875,20 +899,20 @@ test("patch detects changes in secondary worktree", async () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        expect(await Snapshot.track()).toBeTruthy()
+        expect(await snapshot.track()).toBeTruthy()
       },
     })
 
     await Instance.provide({
       directory: worktreePath,
       fn: async () => {
-        const before = await Snapshot.track()
+        const before = await snapshot.track()
         expect(before).toBeTruthy()
 
         const worktreeFile = fwd(worktreePath, "worktree.txt")
         await Filesystem.write(worktreeFile, "worktree content")
 
-        const patch = await Snapshot.patch(before!)
+        const patch = await snapshot.patch(before!)
         expect(patch.files).toContain(worktreeFile)
       },
     })
@@ -907,7 +931,7 @@ test("revert only removes files in invoking worktree", async () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        expect(await Snapshot.track()).toBeTruthy()
+        expect(await snapshot.track()).toBeTruthy()
       },
     })
     const primaryFile = `${tmp.path}/worktree.txt`
@@ -916,14 +940,14 @@ test("revert only removes files in invoking worktree", async () => {
     await Instance.provide({
       directory: worktreePath,
       fn: async () => {
-        const before = await Snapshot.track()
+        const before = await snapshot.track()
         expect(before).toBeTruthy()
 
         const worktreeFile = fwd(worktreePath, "worktree.txt")
         await Filesystem.write(worktreeFile, "worktree content")
 
-        const patch = await Snapshot.patch(before!)
-        await Snapshot.revert([patch])
+        const patch = await snapshot.patch(before!)
+        await snapshot.revert([patch])
 
         expect(
           await fs
@@ -951,14 +975,14 @@ test("diff reports worktree-only/shared edits and ignores primary-only", async (
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        expect(await Snapshot.track()).toBeTruthy()
+        expect(await snapshot.track()).toBeTruthy()
       },
     })
 
     await Instance.provide({
       directory: worktreePath,
       fn: async () => {
-        const before = await Snapshot.track()
+        const before = await snapshot.track()
         expect(before).toBeTruthy()
 
         await Filesystem.write(`${worktreePath}/worktree-only.txt`, "worktree diff content")
@@ -966,7 +990,7 @@ test("diff reports worktree-only/shared edits and ignores primary-only", async (
         await Filesystem.write(`${tmp.path}/shared.txt`, "primary edit")
         await Filesystem.write(`${tmp.path}/primary-only.txt`, "primary change")
 
-        const diff = await Snapshot.diff(before!)
+        const diff = await snapshot.diff(before!)
         expect(diff).toContain("worktree-only.txt")
         expect(diff).toContain("shared.txt")
         expect(diff).not.toContain("primary-only.txt")
@@ -985,15 +1009,15 @@ test("track with no changes returns same hash", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const hash1 = await Snapshot.track()
+      const hash1 = await snapshot.track()
       expect(hash1).toBeTruthy()
 
       // Track again with no changes
-      const hash2 = await Snapshot.track()
+      const hash2 = await snapshot.track()
       expect(hash2).toBe(hash1!)
 
       // Track again
-      const hash3 = await Snapshot.track()
+      const hash3 = await snapshot.track()
       expect(hash3).toBe(hash1!)
     },
   })
@@ -1004,7 +1028,7 @@ test("diff function with various changes", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Make various changes
@@ -1012,7 +1036,7 @@ test("diff function with various changes", async () => {
       await Filesystem.write(`${tmp.path}/new.txt`, "new content")
       await Filesystem.write(`${tmp.path}/b.txt`, "modified content")
 
-      const diff = await Snapshot.diff(before!)
+      const diff = await snapshot.diff(before!)
       expect(diff).toContain("a.txt")
       expect(diff).toContain("b.txt")
       expect(diff).toContain("new.txt")
@@ -1025,7 +1049,7 @@ test("restore function", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       // Make changes
@@ -1034,7 +1058,7 @@ test("restore function", async () => {
       await Filesystem.write(`${tmp.path}/b.txt`, "modified")
 
       // Restore to original state
-      await Snapshot.restore(before!)
+      await snapshot.restore(before!)
 
       expect(
         await fs
@@ -1059,20 +1083,20 @@ test("revert should not delete files that existed but were deleted in snapshot",
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const snapshot1 = await Snapshot.track()
+      const snapshot1 = await snapshot.track()
       expect(snapshot1).toBeTruthy()
 
       await $`rm ${tmp.path}/a.txt`.quiet()
 
-      const snapshot2 = await Snapshot.track()
+      const snapshot2 = await snapshot.track()
       expect(snapshot2).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/a.txt`, "recreated content")
 
-      const patch = await Snapshot.patch(snapshot2!)
+      const patch = await snapshot.patch(snapshot2!)
       expect(patch.files).toContain(fwd(tmp.path, "a.txt"))
 
-      await Snapshot.revert([patch])
+      await snapshot.revert([patch])
 
       expect(
         await fs
@@ -1091,18 +1115,18 @@ test("revert preserves file that existed in snapshot when deleted then recreated
     fn: async () => {
       await Filesystem.write(`${tmp.path}/existing.txt`, "original content")
 
-      const snapshot = await Snapshot.track()
-      expect(snapshot).toBeTruthy()
+      const snapshotHash = await snapshot.track()
+      expect(snapshotHash).toBeTruthy()
 
       await $`rm ${tmp.path}/existing.txt`.quiet()
       await Filesystem.write(`${tmp.path}/existing.txt`, "recreated")
       await Filesystem.write(`${tmp.path}/newfile.txt`, "new")
 
-      const patch = await Snapshot.patch(snapshot!)
+      const patch = await snapshot.patch(snapshotHash!)
       expect(patch.files).toContain(fwd(tmp.path, "existing.txt"))
       expect(patch.files).toContain(fwd(tmp.path, "newfile.txt"))
 
-      await Snapshot.revert([patch])
+      await snapshot.revert([patch])
 
       expect(
         await fs
@@ -1130,7 +1154,7 @@ test("diffFull sets status based on git change type", async () => {
       await Filesystem.write(`${tmp.path}/trim.txt`, "line1\nline2\n")
       await Filesystem.write(`${tmp.path}/delete.txt`, "gone")
 
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/grow.txt`, "one\ntwo\n")
@@ -1138,10 +1162,10 @@ test("diffFull sets status based on git change type", async () => {
       await $`rm ${tmp.path}/delete.txt`.quiet()
       await Filesystem.write(`${tmp.path}/added.txt`, "new")
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(4)
 
       const added = diffs.find((d) => d.file === "added.txt")
@@ -1172,15 +1196,15 @@ test("diffFull with new file additions", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/new.txt`, "new content")
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(1)
 
       const newFileDiff = diffs[0]
@@ -1210,7 +1234,7 @@ test("diffFull with a large interleaved mixed diff", async () => {
         ...bin.map((file, i) => Filesystem.write(file, new Uint8Array([0, i, 255, i % 251]))),
       ])
 
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Promise.all([
@@ -1220,10 +1244,10 @@ test("diffFull with a large interleaved mixed diff", async () => {
         ...del.map((file) => fs.rm(file)),
       ])
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs).toHaveLength(ids.length * 4)
 
       const map = new Map(diffs.map((item) => [item.file, item]))
@@ -1265,17 +1289,17 @@ test("diffFull preserves git diff order across batch boundaries", async () => {
       await $`mkdir -p ${tmp.path}/order`.quiet()
       await Promise.all(ids.map((id) => Filesystem.write(`${tmp.path}/order/${id}.txt`, `before-${id}`)))
 
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Promise.all(ids.map((id) => Filesystem.write(`${tmp.path}/order/${id}.txt`, `after-${id}`)))
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
       const expected = ids.map((id) => `order/${id}.txt`)
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.map((item) => item.file)).toEqual(expected)
     },
   })
@@ -1286,15 +1310,15 @@ test("diffFull with file modifications", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/b.txt`, "modified content")
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(1)
 
       const modifiedFileDiff = diffs[0]
@@ -1312,15 +1336,15 @@ test("diffFull with file deletions", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await $`rm ${tmp.path}/a.txt`.quiet()
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(1)
 
       const removedFileDiff = diffs[0]
@@ -1337,15 +1361,15 @@ test("diffFull with multiple line additions", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/multi.txt`, "line1\nline2\nline3")
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(1)
 
       const multiDiff = diffs[0]
@@ -1363,16 +1387,16 @@ test("diffFull with addition and deletion", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/added.txt`, "added content")
       await $`rm ${tmp.path}/a.txt`.quiet()
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(2)
 
       const addedFileDiff = diffs.find((d) => d.file === "added.txt")
@@ -1395,7 +1419,7 @@ test("diffFull with multiple additions and deletions", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/multi1.txt`, "line1\nline2\nline3")
@@ -1403,10 +1427,10 @@ test("diffFull with multiple additions and deletions", async () => {
       await $`rm ${tmp.path}/a.txt`.quiet()
       await $`rm ${tmp.path}/b.txt`.quiet()
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(4)
 
       const multi1Diff = diffs.find((d) => d.file === "multi1.txt")
@@ -1437,13 +1461,13 @@ test("diffFull with no changes", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(0)
     },
   })
@@ -1454,15 +1478,15 @@ test("diffFull with binary file changes", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/binary.bin`, new Uint8Array([0x00, 0x01, 0x02, 0x03]))
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(1)
 
       const binaryDiff = diffs[0]
@@ -1478,15 +1502,15 @@ test("diffFull with whitespace changes", async () => {
     directory: tmp.path,
     fn: async () => {
       await Filesystem.write(`${tmp.path}/whitespace.txt`, "line1\nline2")
-      const before = await Snapshot.track()
+      const before = await snapshot.track()
       expect(before).toBeTruthy()
 
       await Filesystem.write(`${tmp.path}/whitespace.txt`, "line1\n\nline2\n")
 
-      const after = await Snapshot.track()
+      const after = await snapshot.track()
       expect(after).toBeTruthy()
 
-      const diffs = await Snapshot.diffFull(before!, after!)
+      const diffs = await snapshot.diffFull(before!, after!)
       expect(diffs.length).toBe(1)
 
       const whitespaceDiff = diffs[0]
@@ -1503,26 +1527,26 @@ test("revert with overlapping files across patches uses first patch hash", async
     fn: async () => {
       // Write initial content and snapshot
       await Filesystem.write(`${tmp.path}/shared.txt`, "v1")
-      const snap1 = await Snapshot.track()
+      const snap1 = await snapshot.track()
       expect(snap1).toBeTruthy()
 
       // Modify and snapshot again
       await Filesystem.write(`${tmp.path}/shared.txt`, "v2")
-      const snap2 = await Snapshot.track()
+      const snap2 = await snapshot.track()
       expect(snap2).toBeTruthy()
 
       // Modify once more so both patches include shared.txt
       await Filesystem.write(`${tmp.path}/shared.txt`, "v3")
 
-      const patch1 = await Snapshot.patch(snap1!)
-      const patch2 = await Snapshot.patch(snap2!)
+      const patch1 = await snapshot.patch(snap1!)
+      const patch2 = await snapshot.patch(snap2!)
 
       // Both patches should include shared.txt
       expect(patch1.files).toContain(fwd(tmp.path, "shared.txt"))
       expect(patch2.files).toContain(fwd(tmp.path, "shared.txt"))
 
       // Revert with patch1 first — should use snap1's hash (restoring "v1")
-      await Snapshot.revert([patch1, patch2])
+      await snapshot.revert([patch1, patch2])
 
       const content = await fs.readFile(`${tmp.path}/shared.txt`, "utf-8")
       expect(content).toBe("v1")
@@ -1539,20 +1563,20 @@ test("revert preserves patch order when the same hash appears again", async () =
       await Filesystem.write(`${tmp.path}/foo/bar`, "v1")
       await Filesystem.write(`${tmp.path}/a.txt`, "v1")
 
-      const snap1 = await Snapshot.track()
+      const snap1 = await snapshot.track()
       expect(snap1).toBeTruthy()
 
       await $`rm -rf ${tmp.path}/foo`.quiet()
       await Filesystem.write(`${tmp.path}/foo`, "v2")
       await Filesystem.write(`${tmp.path}/a.txt`, "v2")
 
-      const snap2 = await Snapshot.track()
+      const snap2 = await snapshot.track()
       expect(snap2).toBeTruthy()
 
       await $`rm -rf ${tmp.path}/foo`.quiet()
       await Filesystem.write(`${tmp.path}/a.txt`, "v3")
 
-      await Snapshot.revert([
+      await snapshot.revert([
         { hash: snap1!, files: [fwd(tmp.path, "a.txt")] },
         { hash: snap2!, files: [fwd(tmp.path, "foo")] },
         { hash: snap1!, files: [fwd(tmp.path, "foo", "bar")] },
@@ -1576,16 +1600,16 @@ test("revert handles large mixed batches across chunk boundaries", async () => {
       await $`mkdir -p ${tmp.path}/batch ${tmp.path}/fresh`.quiet()
       await Promise.all(base.map((file, i) => Filesystem.write(file, `base-${i}`)))
 
-      const snap = await Snapshot.track()
+      const snap = await snapshot.track()
       expect(snap).toBeTruthy()
 
       await Promise.all(base.map((file, i) => Filesystem.write(file, `next-${i}`)))
       await Promise.all(fresh.map((file, i) => Filesystem.write(file, `fresh-${i}`)))
 
-      const patch = await Snapshot.patch(snap!)
+      const patch = await snapshot.patch(snap!)
       expect(patch.files.length).toBe(base.length + fresh.length)
 
-      await Snapshot.revert([patch])
+      await snapshot.revert([patch])
 
       await Promise.all(
         base.map(async (file, i) => {


### PR DESCRIPTION
## Summary

Retire the Snapshot service Promise facade now that production callers use `Snapshot.Service` through the shared runtime graph.

- Removed the Snapshot namespace `makeRuntime(Service, defaultLayer)` bridge and exported async facade functions.
- Moved snapshot tests onto a file-local Effect runner that resolves `Snapshot.Service` through `AppRuntime.runPromise(...)`.
- Added a legacy-boundary guard so Snapshot facades and direct test facade calls cannot quietly return.

## Why

Related to #936.

This closes the Snapshot-specific facade tail without touching Provider/ModelsDev, ToolRegistry, Permission, Bus, Automation, Env, SessionPrompt, route dispatchers, OpenAPI/SDK generation, UI, or special HTTP surfaces.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the test-local Snapshot runner is the smallest acceptable replacement for direct Promise facade calls, and whether the guardrail correctly prevents the retired facade from returning.

## Risk Notes

Fresh-eye result: No P0/P1 findings. No P2/P3 fixes were needed; the local helper is narrower than converting the whole large snapshot suite to a new test harness and does not add a production compatibility API.

Skipped conditional checklist items:

- Screenshots or recordings: no visible UI or copy changed.
- Docs/release/dependencies/credentials/generated content: none of those surfaces changed.

## How To Verify

```text
RED guard: bun test test/effect/legacy-boundaries.test.ts failed before implementation because Snapshot still imported @/effect/run-service and exposed Promise facades.
Guard + Snapshot behavior: bun test test/effect/legacy-boundaries.test.ts test/snapshot/snapshot.test.ts -> 76 passed, 1 skipped, 0 failed.
Focused caller coverage: bun test test/effect/legacy-boundaries.test.ts test/snapshot/snapshot.test.ts test/session/processor-effect.test.ts test/session/processor-rate-limit.test.ts test/session/snapshot-tool-race.test.ts test/session/revert-compact.test.ts test/session/compaction.test.ts test/session/prompt-effect.test.ts test/server/project-init-git.test.ts -> 260 passed, 1 skipped, 0 failed.
Typecheck: GOMAXPROCS=2 bun run typecheck -> passed.
Diff check: git diff --check -> passed.
Inventory: rg for Snapshot facade calls in src/test -> no Snapshot facade callers; remaining makeRuntime hits are outside this Snapshot slice.
```

## Screenshots or Recordings

Not applicable, no visible UI changes.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.