### PR TITLE
refactor(opencode): retire tool registry facades

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -73,10 +73,14 @@ export const AgentCommand = cmd({
 
 async function getAvailableTools(agent: Agent.Info) {
   const model = agent.model ?? (await Provider.defaultModel())
-  return ToolRegistry.tools({
-    ...model,
-    agent,
-  })
+  return AppRuntime.runPromise(
+    ToolRegistry.Service.use((registry) =>
+      registry.tools({
+        ...model,
+        agent,
+      }),
+    ),
+  )
 }
 
 async function resolveTools(agent: Agent.Info, availableTools: Awaited<ReturnType<typeof getAvailableTools>>) {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -57,7 +57,6 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Ripgrep } from "../file/ripgrep"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectBridge } from "@/effect"
-import { makeRuntime } from "@/effect/run-service"
 import { Env } from "../env"
 import { Todo } from "../session/todo"
 import { TurnChange } from "../session/turn-change"
@@ -544,31 +543,4 @@ export namespace ToolRegistry {
       Layer.provide(Worktree.defaultLayer),
     ),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function ids() {
-    return runPromise((svc) => svc.ids())
-  }
-
-  export async function tools(input: {
-    providerID: ProviderID
-    modelID: ModelID
-    agent: Agent.Info
-    activatedTools?: ReadonlySet<string>
-    deferredAvailable?: (id: string) => boolean
-  }): Promise<(Tool.Def & { id: string })[]> {
-    return runPromise((svc) => svc.tools(input))
-  }
-
-  export async function availableDeferred(input: {
-    activatedTools?: ReadonlySet<string>
-    deferredAvailable?: (id: string) => boolean
-  }): Promise<ReadonlySet<string>> {
-    return runPromise((svc) => svc.availableDeferred(input))
-  }
-
-  export async function invalidate() {
-    return runPromise((svc) => svc.invalidate())
-  }
 }

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -297,6 +297,20 @@ test("Plugin and Skill services do not expose Promise facades", async () => {
   }
 })
 
+test("ToolRegistry service does not expose Promise facades", async () => {
+  const text = await readFile(path.join(srcRoot, "tool/registry.ts"), "utf8")
+  const facades = [
+    "export async function ids",
+    "export async function tools",
+    "export async function availableDeferred",
+    "export async function invalidate",
+  ]
+
+  expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+  expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+  for (const facade of facades) expect(text).not.toContain(facade)
+})
+
 test("File and SessionShare services do not expose Promise facades", async () => {
   const services = {
     "file/index.ts": [

--- a/packages/opencode/test/server/built-node-opencli-adapters.test.ts
+++ b/packages/opencode/test/server/built-node-opencli-adapters.test.ts
@@ -51,19 +51,22 @@ describe("built node opencli adapters", () => {
       expectModelsSnapshotUnchanged(modelsFixture)
 
       const script = `
-        import { Effect } from "effect"
+        import { Effect, ManagedRuntime } from "effect"
         import { Instance, Log, ToolRegistry } from ${JSON.stringify(pathToFileURL(distEntry).href)}
 
         const directory = process.env.TEST_DIRECTORY
         if (!directory) throw new Error("missing TEST_DIRECTORY")
 
         await Log.init({ level: "DEBUG", print: false })
+        const registryRuntime = ManagedRuntime.make(ToolRegistry.defaultLayer)
+        const registryTools = (input) =>
+          registryRuntime.runPromise(ToolRegistry.Service.use((registry) => registry.tools(input)))
         let exitCode = 0
         try {
           const result = await Instance.provide({
             directory,
             fn: async () => {
-              const tools = await ToolRegistry.tools({
+              const tools = await registryTools({
                 providerID: "openai",
                 modelID: "gpt-5",
                 agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -98,6 +101,7 @@ describe("built node opencli adapters", () => {
           exitCode = 1
         } finally {
           await Instance.disposeAll()
+          await registryRuntime.dispose()
         }
 
         await new Promise((resolve) => setTimeout(resolve, 50))

--- a/packages/opencode/test/server/built-node-webfetch.test.ts
+++ b/packages/opencode/test/server/built-node-webfetch.test.ts
@@ -52,7 +52,7 @@ describe("built node webfetch", () => {
       const script = `
         import http from "node:http"
         import https from "node:https"
-        import { Effect } from "effect"
+        import { Effect, ManagedRuntime } from "effect"
         import { FetchHttpClient } from "effect/unstable/http"
         import { Instance, Log, ToolRegistry } from ${JSON.stringify(pathToFileURL(distEntry).href)}
 
@@ -64,6 +64,9 @@ describe("built node webfetch", () => {
         if (!directory) throw new Error("missing TEST_DIRECTORY")
 
         await Log.init({ level: "DEBUG", print: false })
+        const registryRuntime = ManagedRuntime.make(ToolRegistry.defaultLayer)
+        const registryTools = (input) =>
+          registryRuntime.runPromise(ToolRegistry.Service.use((registry) => registry.tools(input)))
 
         const happyHTML = [
           "<!doctype html>",
@@ -162,7 +165,7 @@ describe("built node webfetch", () => {
           const output = await Instance.provide({
             directory,
             fn: async () => {
-              const tools = await ToolRegistry.tools({
+              const tools = await registryTools({
                 providerID: "openai",
                 modelID: "gpt-5",
                 agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -207,6 +210,7 @@ describe("built node webfetch", () => {
           console.log(JSON.stringify(output))
         } finally {
           await Instance.disposeAll()
+          await registryRuntime.dispose()
           await new Promise((resolve, reject) => {
             server.close((error) => (error ? reject(error) : resolve()))
             server.closeAllConnections?.()

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -28,6 +28,26 @@ function settings<A, E>(fn: (svc: Settings.Interface) => Effect.Effect<A, E>) {
   return AppRuntime.runPromise(Settings.Service.use(fn))
 }
 
+function toolRegistry<A, E>(fn: (svc: ToolRegistry.Interface) => Effect.Effect<A, E>) {
+  return AppRuntime.runPromise(ToolRegistry.Service.use(fn))
+}
+
+function registryIds() {
+  return toolRegistry((svc) => svc.ids())
+}
+
+function registryTools(input: Parameters<ToolRegistry.Interface["tools"]>[0]) {
+  return toolRegistry((svc) => svc.tools(input))
+}
+
+function registryAvailableDeferred(input: Parameters<ToolRegistry.Interface["availableDeferred"]>[0]) {
+  return toolRegistry((svc) => svc.availableDeferred(input))
+}
+
+function registryInvalidate() {
+  return toolRegistry((svc) => svc.invalidate())
+}
+
 async function withMockedConfigInstall<T>(fn: () => Promise<T>): Promise<T> {
   return await withConfigDepsLock(async () => {
     const install = spyOn(Npm, "install").mockImplementation((dir: string) => writeMockConfigInstall(dir))
@@ -47,7 +67,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const ids = await ToolRegistry.ids()
+          const ids = await registryIds()
           expect(ids).not.toContain("trash")
         },
       })
@@ -61,10 +81,10 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const ids = await ToolRegistry.ids()
+          const ids = await registryIds()
           expect(ids).toContain("automate")
 
-          const tools = await ToolRegistry.tools({
+          const tools = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -93,19 +113,19 @@ describe("tool.registry", () => {
             agent: { name: "build", mode: "primary" as const, permission: [], options: {} },
           }
 
-          const def = await ToolRegistry.tools(base)
+          const def = await registryTools(base)
           const defIds = def.map((tool) => tool.id)
           expect(defIds).toContain("automate")
           expect(defIds).not.toContain("automate_manage")
           expect(def.find((tool) => tool.id === "tool_info")!.description).toContain("**automate_manage**")
 
-          const act = await ToolRegistry.tools({ ...base, activatedTools: new Set(["automate_manage"]) })
+          const act = await registryTools({ ...base, activatedTools: new Set(["automate_manage"]) })
           const actIds = act.map((tool) => tool.id)
           expect(actIds).toContain("automate")
           expect(actIds).toContain("automate_manage")
           expect(act.find((tool) => tool.id === "tool_info")!.description).not.toContain("**automate_manage**")
 
-          const denied = await ToolRegistry.tools({
+          const denied = await registryTools({
             ...base,
             activatedTools: new Set(["automate_manage"]),
             deferredAvailable: () => false,
@@ -125,7 +145,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const tools = await ToolRegistry.tools({
+          const tools = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary" as const, permission: [], options: {} },
@@ -279,7 +299,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const ids = await ToolRegistry.ids()
+          const ids = await registryIds()
           expect(ids).toContain("hello")
         },
       })
@@ -315,7 +335,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const ids = await ToolRegistry.ids()
+          const ids = await registryIds()
           expect(ids).toContain("hello")
         },
       })
@@ -347,7 +367,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const ids = await ToolRegistry.ids()
+          const ids = await registryIds()
           // The valid default export still loads.
           expect(ids).toContain("mixed")
           // The non-tool string export must not be wrapped into a phantom tool —
@@ -398,7 +418,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const ids = await ToolRegistry.ids()
+          const ids = await registryIds()
           expect(ids).not.toContain("mixed")
           expect(ids).not.toContain("mixed_helper")
         },
@@ -433,7 +453,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const tools = await ToolRegistry.tools({
+          const tools = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -542,7 +562,7 @@ describe("tool.registry", () => {
         await Instance.provide({
           directory: tmp.path,
           fn: async () => {
-            const tools = await ToolRegistry.tools({
+            const tools = await registryTools({
               providerID: ProviderID.make("openai"),
               modelID: ModelID.make("gpt-5"),
               agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -628,7 +648,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const ids = await ToolRegistry.ids()
+          const ids = await registryIds()
           expect(ids).toContain("cowsay")
         },
       })
@@ -676,7 +696,7 @@ describe("tool.registry", () => {
         await Instance.provide({
           directory: tmp.path,
           fn: async () => {
-            const ids = await ToolRegistry.ids()
+            const ids = await registryIds()
             expect(ids).toContain("late")
           },
         })
@@ -731,7 +751,7 @@ describe("tool.registry", () => {
         await Instance.provide({
           directory: tmp.path,
           fn: async () => {
-            const ids = await ToolRegistry.ids()
+            const ids = await registryIds()
             expect(ids).not.toContain("late")
             expect(ids).toContain("local")
           },
@@ -782,7 +802,7 @@ describe("tool.registry", () => {
         await Instance.provide({
           directory: tmp.path,
           fn: async () => {
-            const ids = await ToolRegistry.ids()
+            const ids = await registryIds()
             expect(ids).toContain("late")
           },
         })
@@ -828,7 +848,7 @@ describe("tool.registry", () => {
         await Instance.provide({
           directory: tmp.path,
           fn: async () => {
-            const ids = await ToolRegistry.ids()
+            const ids = await registryIds()
             expect(ids).toContain("late")
           },
         })
@@ -870,7 +890,7 @@ describe("tool.registry", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const ids = await ToolRegistry.ids()
+        const ids = await registryIds()
         expect(ids).not.toContain("boom")
       },
     })
@@ -911,7 +931,7 @@ describe("tool.registry", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const ids = await ToolRegistry.ids()
+        const ids = await registryIds()
         expect(ids).not.toContain("math_add")
         expect(ids).not.toContain("math_multiply")
       },
@@ -947,7 +967,7 @@ describe("tool.registry", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const ids = await ToolRegistry.ids()
+        const ids = await registryIds()
         expect(ids).not.toContain("boom")
       },
     })
@@ -959,7 +979,7 @@ describe("tool.registry", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const ids = await ToolRegistry.ids()
+        const ids = await registryIds()
         expect(ids).not.toContain("lsp")
       },
     })
@@ -970,7 +990,7 @@ describe("tool.registry", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const ids = await ToolRegistry.ids()
+        const ids = await registryIds()
         expect(ids).not.toContain("codesearch")
       },
     })
@@ -983,10 +1003,10 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const ids = await ToolRegistry.ids()
+          const ids = await registryIds()
           expect(ids).toContain("lsp")
 
-          const tools = await ToolRegistry.tools({
+          const tools = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1009,17 +1029,17 @@ describe("tool.registry", () => {
         directory: tmp.path,
         fn: async () => {
           await settings((svc) => svc.setLspEnabled(true))
-          const before = await ToolRegistry.ids()
+          const before = await registryIds()
           expect(before).toContain("lsp")
 
           await settings((svc) => svc.setLspEnabled(false))
-          await ToolRegistry.invalidate()
-          const off = await ToolRegistry.ids()
+          await registryInvalidate()
+          const off = await registryIds()
           expect(off).not.toContain("lsp")
 
           await settings((svc) => svc.setLspEnabled(true))
-          await ToolRegistry.invalidate()
-          const on = await ToolRegistry.ids()
+          await registryInvalidate()
+          const on = await registryIds()
           expect(on).toContain("lsp")
         },
       })
@@ -1037,7 +1057,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const tools = await ToolRegistry.tools({
+          const tools = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1061,12 +1081,12 @@ describe("tool.registry", () => {
         directory: tmp.path,
         fn: async () => {
           await settings((svc) => svc.setWebSearchEnabled(true))
-          await ToolRegistry.invalidate()
+          await registryInvalidate()
 
-          const visibleIds = await ToolRegistry.ids()
+          const visibleIds = await registryIds()
           expect(visibleIds).toContain("websearch")
 
-          const visible = await ToolRegistry.tools({
+          const visible = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1074,12 +1094,12 @@ describe("tool.registry", () => {
           expect(visible.map((tool) => tool.id)).toContain("websearch")
 
           await settings((svc) => svc.setWebSearchEnabled(false))
-          await ToolRegistry.invalidate()
+          await registryInvalidate()
 
-          const hiddenRegistryIds = await ToolRegistry.ids()
+          const hiddenRegistryIds = await registryIds()
           expect(hiddenRegistryIds).not.toContain("websearch")
 
-          const hidden = await ToolRegistry.tools({
+          const hidden = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1100,7 +1120,7 @@ describe("tool.registry", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tools = await ToolRegistry.tools({
+        const tools = await registryTools({
           providerID: ProviderID.make("openai"),
           modelID: ModelID.make("gpt-5"),
           agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1118,7 +1138,7 @@ describe("tool.registry", () => {
       fn: async () => {
         // Default: deferred worktree tools are not in the surface; tool_info is,
         // and advertises both as cards.
-        const def = await ToolRegistry.tools({
+        const def = await registryTools({
           providerID: ProviderID.make("openai"),
           modelID: ModelID.make("gpt-5"),
           agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1135,7 +1155,7 @@ describe("tool.registry", () => {
         expect(card).not.toContain("browser")
 
         // Activated: enter-worktree becomes callable; tool_info stops listing it.
-        const act = await ToolRegistry.tools({
+        const act = await registryTools({
           providerID: ProviderID.make("openai"),
           modelID: ModelID.make("gpt-5"),
           agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1149,7 +1169,7 @@ describe("tool.registry", () => {
         expect(actCard).toContain("exit-worktree")
 
         // Permission-disabled: even activated, it stays hidden and uncarded.
-        const denied = await ToolRegistry.tools({
+        const denied = await registryTools({
           providerID: ProviderID.make("openai"),
           modelID: ModelID.make("gpt-5"),
           agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1168,7 +1188,7 @@ describe("tool.registry", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const tools = await ToolRegistry.tools({
+        const tools = await registryTools({
           providerID: ProviderID.make("openai"),
           modelID: ModelID.make("gpt-5"),
           agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1198,7 +1218,7 @@ describe("tool.registry", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const availableDeferredTools = await ToolRegistry.availableDeferred({
+        const availableDeferredTools = await registryAvailableDeferred({
           deferredAvailable: () => true,
         })
         const repair = JSON.parse(
@@ -1227,7 +1247,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const availableDeferredTools = await ToolRegistry.availableDeferred({
+          const availableDeferredTools = await registryAvailableDeferred({
             activatedTools: new Set(["lsp"]),
             deferredAvailable: () => true,
           })
@@ -1262,7 +1282,7 @@ describe("tool.registry", () => {
         fn: async () => {
           // Default: deferred tools are not in the surface; tool_info is,
           // and advertises each available tool as a card.
-          const def = await ToolRegistry.tools({
+          const def = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1282,7 +1302,7 @@ describe("tool.registry", () => {
           expect(card).toContain("lsp")
 
           // Activated: selected tools become callable; tool_info stops listing them.
-          const act = await ToolRegistry.tools({
+          const act = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1302,7 +1322,7 @@ describe("tool.registry", () => {
           expect(actCard).not.toContain("lsp")
 
           // Permission-disabled: even activated, it stays hidden and uncarded.
-          const denied = await ToolRegistry.tools({
+          const denied = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1334,7 +1354,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const tools = await ToolRegistry.tools({
+          const tools = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1361,7 +1381,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const tools = await ToolRegistry.tools({
+          const tools = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1377,7 +1397,7 @@ describe("tool.registry", () => {
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const deferred = await ToolRegistry.tools({
+          const deferred = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1386,7 +1406,7 @@ describe("tool.registry", () => {
           expect(deferredIds).not.toContain("opencli_search")
           expect(deferred.find((tool) => tool.id === "tool_info")!.description).toContain("**opencli**")
 
-          const activated = await ToolRegistry.tools({
+          const activated = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1401,7 +1421,7 @@ describe("tool.registry", () => {
             { permission: "opencli_write", pattern: "*", action: "deny" as const },
           ]
           const opencliDeniedDeferredAvailable = (id: string) => !Permission.disabled([id], opencliDenied).has(id)
-          const deniedDeferred = await ToolRegistry.tools({
+          const deniedDeferred = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1409,7 +1429,7 @@ describe("tool.registry", () => {
           })
           expect(deniedDeferred.find((tool) => tool.id === "tool_info")!.description).not.toContain("**opencli**")
 
-          const deniedActivated = await ToolRegistry.tools({
+          const deniedActivated = await registryTools({
             providerID: ProviderID.make("openai"),
             modelID: ModelID.make("gpt-5"),
             agent: { name: "build", mode: "primary", permission: [], options: {} },
@@ -1438,7 +1458,7 @@ describe("tool.registry", () => {
         }
 
         // Step 1: enter-worktree carries no full schema in the surface; only tool_info does.
-        const deferred = await ToolRegistry.tools(base)
+        const deferred = await registryTools(base)
         expect(deferred.map((tool) => tool.id)).not.toContain("enter-worktree")
         const toolInfo = deferred.find((tool) => tool.id === "tool_info")!
 
@@ -1452,7 +1472,7 @@ describe("tool.registry", () => {
         } as unknown as Parameters<typeof ProviderTransform.schema>[0]
 
         // The schema the model will see once enter-worktree is activated, transformed.
-        const activated = await ToolRegistry.tools({ ...base, activatedTools: new Set(["enter-worktree"]) })
+        const activated = await registryTools({ ...base, activatedTools: new Set(["enter-worktree"]) })
         const enterWorktree = activated.find((tool) => tool.id === "enter-worktree")!
         const expectedSchema = ProviderTransform.schema(model, EffectZod.toJsonSchema(enterWorktree.parameters))
 

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -13,6 +13,7 @@ import { SkillTool } from "../../src/tool/skill"
 import { ToolRegistry } from "../../src/tool/registry"
 import { tmpdir } from "../fixture/fixture"
 import { SessionID, MessageID } from "../../src/session/schema"
+import { AppRuntime } from "../../src/effect/app-runtime"
 
 const baseCtx: Omit<Tool.Context, "ask"> = {
   sessionID: SessionID.make("ses_test"),
@@ -29,6 +30,10 @@ const testLayer = Layer.mergeAll(Skill.defaultLayer, Ripgrep.defaultLayer, Trunc
 afterEach(async () => {
   await Instance.disposeAll()
 })
+
+function registryTools(input: Parameters<ToolRegistry.Interface["tools"]>[0]) {
+  return AppRuntime.runPromise(ToolRegistry.Service.use((svc) => svc.tools(input)))
+}
 
 describe("tool.skill", () => {
   test("description does not duplicate the available skill catalog", async () => {
@@ -56,7 +61,7 @@ description: Skill for tool tests.
       await Instance.provide({
         directory: tmp.path,
         fn: async () => {
-          const desc = await ToolRegistry.tools({
+          const desc = await registryTools({
             providerID: "opencode" as any,
             modelID: "gpt-5" as any,
             agent: { name: "build", mode: "primary" as const, permission: [], options: {} },
@@ -104,7 +109,7 @@ description: ${description}
         fn: async () => {
           const agent = { name: "build", mode: "primary" as const, permission: [], options: {} }
           const load = () =>
-            ToolRegistry.tools({
+            registryTools({
               providerID: "opencode" as any,
               modelID: "gpt-5" as any,
               agent,
@@ -156,7 +161,7 @@ name: manual-skill
             ],
             options: {},
           }
-          const desc = await ToolRegistry.tools({
+          const desc = await registryTools({
             providerID: "opencode" as any,
             modelID: "gpt-5" as any,
             agent,


### PR DESCRIPTION
## Summary

Retire the ToolRegistry Promise facade runtime and move its remaining direct callers onto the Effect service boundary.

## Why

Related to #936. ToolRegistry still had its own `makeRuntime(Service, defaultLayer)` and exported async facade functions (`ids`, `tools`, `availableDeferred`, `invalidate`) after the shared `AppRuntime` service graph became the intended runtime boundary.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the migrated callers preserve the existing ToolRegistry behavior while avoiding a replacement production compatibility facade.

## Risk Notes

Runtime risk is limited to ToolRegistry call sites: debug agent now uses `AppRuntime.runPromise(ToolRegistry.Service.use(...))`, and tests use local helpers around the service boundary. Deferred tool behavior, plugin/skill behavior, tool_info cards, browser/opencli/worktree activation, and registry invalidation are covered by the focused tests.

Skipped conditional checklist items:
- Visible UI/copy check: not applicable; no visible UI or copy changed.
- macOS/Windows platform check: not applicable; no platform, packaging, updater, signing, shell, or permission surface changed.
- Docs/release/dependency/generated-content check: not applicable; no docs, release notes, dependencies, credentials, deletion behavior, or generated files changed.

Fresh-eye result: P0/P1 none. P2 found and fixed: an intermediate version exported `AppRuntime` from the built Node entry only for tests; the final diff keeps that out of production exports and uses test-local `ManagedRuntime` helpers instead. P3 none worth changing.

## How To Verify

```text
RED guardrail: `bun test test/effect/legacy-boundaries.test.ts --test-name-pattern "ToolRegistry service does not expose Promise facades"` failed before implementation on the existing ToolRegistry run-service import/facade runtime.
Focused tests: `bun test test/effect/legacy-boundaries.test.ts test/tool/registry.test.ts test/tool/skill.test.ts test/server/built-node-opencli-adapters.test.ts test/server/built-node-webfetch.test.ts` passed, 64 tests / 429 expects.
Typecheck: `GOMAXPROCS=2 bun run typecheck` passed from packages/opencode.
Diff check: `git diff --check` passed from the repository root.
Inventory: `rg "ToolRegistry\.(ids|tools|availableDeferred|invalidate)\s*\(|makeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)|@/effect/run-service"` found no remaining ToolRegistry facade callers or runtime import in the touched boundary.
```

## Screenshots or Recordings

Not applicable; no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of tool registry service architecture to improve code maintainability and consistency across the codebase.

No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->