### PR TITLE
refactor(opencode): retire env session prompt facades

### DIFF
--- a/packages/opencode/src/automation/runner.ts
+++ b/packages/opencode/src/automation/runner.ts
@@ -111,7 +111,9 @@ export const sessionPromptExecutor: Automation.RunExecutor = async ({ definition
     )
   }
   const cancelPrompt = () => {
-    void SessionPrompt.cancel(sessionID, { source: "automation.cancel" }).catch(() => undefined)
+    void AppRuntime.runPromise(
+      SessionPrompt.Service.use((prompt) => prompt.cancel(sessionID, { source: "automation.cancel" })),
+    ).catch(() => undefined)
   }
   if (signal.aborted) cancelPrompt()
   else signal.addEventListener("abort", cancelPrompt, { once: true })
@@ -136,16 +138,21 @@ export const sessionPromptExecutor: Automation.RunExecutor = async ({ definition
     }
     const scoped =
       attendance === "attended" ? AutomationRunContext.attended(handlers) : AutomationRunContext.unattended(handlers)
-    const message = await SessionPrompt.promptWithAutomationContext(
-      {
-        sessionID,
-        automationID: definition.id,
-        model: definition.model,
-        ...(definition.variant ? { variant: definition.variant } : {}),
-        parts: [{ type: "text", text: definition.prompt }],
-      },
-      scoped,
-      { abortSignal: signal },
+    const message = await AppRuntime.runPromise(
+      SessionPrompt.Service.use((prompt) =>
+        prompt
+          .prompt(
+            SessionPrompt.PromptInput.parse({
+              sessionID,
+              automationID: definition.id,
+              model: definition.model,
+              ...(definition.variant ? { variant: definition.variant } : {}),
+              parts: [{ type: "text", text: definition.prompt }],
+            }),
+            { abortSignal: signal },
+          )
+          .pipe(Effect.provideService(AutomationRunContext.service, scoped)),
+      ),
     )
     signal.throwIfAborted()
     return {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -960,41 +960,47 @@ export const GithubRunCommand = cmd({
       async function chat(message: string, files: PromptFiles = []) {
         console.log("Sending message to opencode...")
 
-        const result = await SessionPrompt.prompt({
-          sessionID: session.id,
-          messageID: MessageID.ascending(),
-          variant,
-          model: {
-            providerID,
-            modelID,
-          },
-          // agent is omitted - server will choose the default primary agent
-          parts: [
-            {
-              id: PartID.ascending(),
-              type: "text",
-              text: message,
-            },
-            ...files.flatMap((f) => [
-              {
-                id: PartID.ascending(),
-                type: "file" as const,
-                mime: f.mime,
-                url: `data:${f.mime};base64,${f.content}`,
-                filename: f.filename,
-                source: {
-                  type: "file" as const,
-                  text: {
-                    value: f.replacement,
-                    start: f.start,
-                    end: f.end,
-                  },
-                  path: f.filename,
+        const result = await AppRuntime.runPromise(
+          SessionPrompt.Service.use((prompt) =>
+            prompt.prompt(
+              SessionPrompt.PromptInput.parse({
+                sessionID: session.id,
+                messageID: MessageID.ascending(),
+                variant,
+                model: {
+                  providerID,
+                  modelID,
                 },
-              },
-            ]),
-          ],
-        })
+                // agent is omitted - server will choose the default primary agent
+                parts: [
+                  {
+                    id: PartID.ascending(),
+                    type: "text",
+                    text: message,
+                  },
+                  ...files.flatMap((f) => [
+                    {
+                      id: PartID.ascending(),
+                      type: "file" as const,
+                      mime: f.mime,
+                      url: `data:${f.mime};base64,${f.content}`,
+                      filename: f.filename,
+                      source: {
+                        type: "file" as const,
+                        text: {
+                          value: f.replacement,
+                          start: f.start,
+                          end: f.end,
+                        },
+                        path: f.filename,
+                      },
+                    },
+                  ]),
+                ],
+              }),
+            ),
+          ),
+        )
 
         if (result.info.role === "assistant" && result.info.error) {
           const err = result.info.error
@@ -1007,23 +1013,29 @@ export const GithubRunCommand = cmd({
         if (text) return text
 
         console.log("Requesting summary from agent...")
-        const summary = await SessionPrompt.prompt({
-          sessionID: session.id,
-          messageID: MessageID.ascending(),
-          variant,
-          model: {
-            providerID,
-            modelID,
-          },
-          tools: { "*": false },
-          parts: [
-            {
-              id: PartID.ascending(),
-              type: "text",
-              text: "Summarize the actions (tool calls & reasoning) you did for the user in 1-2 sentences.",
-            },
-          ],
-        })
+        const summary = await AppRuntime.runPromise(
+          SessionPrompt.Service.use((prompt) =>
+            prompt.prompt(
+              SessionPrompt.PromptInput.parse({
+                sessionID: session.id,
+                messageID: MessageID.ascending(),
+                variant,
+                model: {
+                  providerID,
+                  modelID,
+                },
+                tools: { "*": false },
+                parts: [
+                  {
+                    id: PartID.ascending(),
+                    type: "text",
+                    text: "Summarize the actions (tool calls & reasoning) you did for the user in 1-2 sentences.",
+                  },
+                ],
+              }),
+            ),
+          ),
+        )
 
         if (summary.info.role === "assistant" && summary.info.error) {
           const err = summary.info.error

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -6,6 +6,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Bus } from "@/bus"
 import { Auth } from "@/auth"
 import { Account } from "@/account"
+import { Env } from "@/env"
 import { Config } from "@/config"
 import { Git } from "@/git"
 import { Ripgrep } from "@/file/ripgrep"
@@ -62,7 +63,7 @@ export const AppLayer = Layer.suspend(() =>
     Bus.defaultLayer,
     Auth.defaultLayer,
     Account.defaultLayer,
-    Config.defaultLayer,
+    Layer.mergeAll(Env.defaultLayer, Config.defaultLayer),
     Settings.defaultLayer,
     Git.defaultLayer,
     Ripgrep.defaultLayer,

--- a/packages/opencode/src/env/index.ts
+++ b/packages/opencode/src/env/index.ts
@@ -1,6 +1,5 @@
 import { Context, Effect, Layer } from "effect"
 import { InstanceState } from "@/effect"
-import { makeRuntime } from "../effect/run-service"
 
 type State = Record<string, string | undefined>
 
@@ -35,39 +34,13 @@ const layer = Layer.effect(
 
 const defaultLayer = layer
 
-const { runSync } = makeRuntime(Service, defaultLayer)
-
-export function get(key: string) {
-  return runSync((svc) => svc.get(key))
-}
-
-export function all() {
-  return runSync((svc) => svc.all())
-}
-
-export function set(key: string, value: string) {
-  return runSync((svc) => svc.set(key, value))
-}
-
-export function remove(key: string) {
-  return runSync((svc) => svc.remove(key))
-}
-
 const EnvServiceValue = Service
 const EnvLayerValue = layer
 const EnvDefaultLayerValue = defaultLayer
-const EnvGetValue = get
-const EnvAllValue = all
-const EnvSetValue = set
-const EnvRemoveValue = remove
 
 export namespace Env {
   export type Service = import("./index").Service
   export const Service = EnvServiceValue
   export const layer = EnvLayerValue
   export const defaultLayer = EnvDefaultLayerValue
-  export const get = EnvGetValue
-  export const all = EnvAllValue
-  export const set = EnvSetValue
-  export const remove = EnvRemoveValue
 }

--- a/packages/opencode/src/server/instance/permission-actions.ts
+++ b/packages/opencode/src/server/instance/permission-actions.ts
@@ -1,11 +1,13 @@
 import { Env } from "@/env"
+import { AppRuntime } from "@/effect/app-runtime"
 import { Permission } from "@/permission"
 import { SessionID } from "@/session/schema"
 import { Effect } from "effect"
 import z from "zod"
 
+const readEnv = (key: string) => AppRuntime.runSync(Env.Service.use((env) => env.get(key)))
 export const e2ePermissionRoutesEnabled = () =>
-  Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
+  readEnv("OPENCODE_E2E_ENABLED") === "true" && !!readEnv("OPENCODE_E2E_LLM_URL")
 
 export const E2EPermissionAskBody = z.object({
   sessionID: SessionID.zod,

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -27,7 +27,8 @@ import { File } from "@/file"
 import { LSP } from "@/lsp"
 import { Env } from "@/env"
 
-const e2eSessionRoutesEnabled = () => Env.get("OPENCODE_E2E_ENABLED") === "true" && !!Env.get("OPENCODE_E2E_LLM_URL")
+const readEnv = (key: string) => AppRuntime.runSync(Env.Service.use((env) => env.get(key)))
+const e2eSessionRoutesEnabled = () => readEnv("OPENCODE_E2E_ENABLED") === "true" && !!readEnv("OPENCODE_E2E_LLM_URL")
 const runSessionRoute: typeof AppRuntime.runPromise = (effect, options) => AppRuntime.runPromise(effect, options)
 
 type SessionListQuery = {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -44,6 +44,7 @@ import { LoopRenderer } from "./loop-renderer"
 import * as Tool from "@/tool/tool"
 import { ExternalResult } from "@/tool/external-result"
 import { Permission } from "@/permission"
+import { Env } from "@/env"
 import { SessionStatus } from "./status"
 import { LLM } from "./llm"
 import { Shell } from "@/shell/shell"
@@ -59,7 +60,7 @@ import { AgentTool, type AgentPromptOps } from "@/tool/agent"
 import { SessionRunState } from "./run-state"
 import { RunLifecycle } from "./run-lifecycle"
 import { EffectBridge } from "@/effect"
-import { attachWith, makeRuntime } from "@/effect/run-service"
+import { attachWith } from "@/effect/run-service"
 import { Instance } from "@/project/instance"
 import { MemoryFile } from "@/memory/memory"
 import { MemoryService } from "@/memory/service"
@@ -2849,6 +2850,7 @@ export const defaultLayer: Layer.Layer<Service, never, never> = Layer.suspend(()
     Layer.provide(Session.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(SessionSummary.defaultLayer),
+    Layer.provide(Env.defaultLayer),
     Layer.provide(
       Layer.mergeAll(
         Agent.defaultLayer,
@@ -2860,7 +2862,6 @@ export const defaultLayer: Layer.Layer<Service, never, never> = Layer.suspend(()
     ),
   ),
 )
-const { runPromise } = makeRuntime(Service, defaultLayer)
 
 export const PromptInput = z.object({
   sessionID: SessionID.zod,
@@ -2941,35 +2942,6 @@ export const PromptInput = z.object({
 })
 export type PromptInput = z.infer<typeof PromptInput>
 
-export async function prompt(input: PromptInput) {
-  // automationID is automation-run provenance, set only by the runner through
-  // promptWithAutomationContext (which also provides the trusted
-  // AutomationRunContext). Strip any client-supplied value here so HTTP callers
-  // (POST /:sessionID/message, /prompt_async both route through this) cannot
-  // forge the "sent via automation" attribution.
-  return runPromise((svc) => svc.prompt(PromptInput.parse({ ...input, automationID: undefined })))
-}
-
-export async function promptWithAutomationContext(
-  input: PromptInput,
-  context: import("@/automation/run-context").AutomationRunContext,
-  options?: PromptRuntimeOptions,
-) {
-  return runPromise((svc) =>
-    svc
-      .prompt(PromptInput.parse(input), options)
-      .pipe(Effect.provideService(AutomationRunContext.service, context)),
-  )
-}
-
-export async function resolvePromptParts(template: string) {
-  return runPromise((svc) => svc.resolvePromptParts(z.string().parse(template)))
-}
-
-export async function cancel(sessionID: SessionID, options?: { source?: string }) {
-  return runPromise((svc) => svc.cancel(SessionID.zod.parse(sessionID), options))
-}
-
 export const LoopInput = z.object({
   sessionID: SessionID.zod,
   traceMessageID: MessageID.zod.optional(),
@@ -2989,10 +2961,6 @@ export const LoopInput = z.object({
     .optional(),
 })
 
-export async function loop(input: z.infer<typeof LoopInput>) {
-  return runPromise((svc) => svc.loop(LoopInput.parse(input)))
-}
-
 export const ShellInput = z.object({
   sessionID: SessionID.zod,
   messageID: MessageID.zod.optional(),
@@ -3006,10 +2974,6 @@ export const ShellInput = z.object({
   command: z.string(),
 })
 export type ShellInput = z.infer<typeof ShellInput>
-
-export async function shell(input: ShellInput) {
-  return runPromise((svc) => svc.shell(ShellInput.parse(input)))
-}
 
 export const CommandInput = z.object({
   messageID: MessageID.zod.optional(),
@@ -3034,10 +2998,6 @@ export const CommandInput = z.object({
     .optional(),
 })
 export type CommandInput = z.infer<typeof CommandInput>
-
-export async function command(input: CommandInput) {
-  return runPromise((svc) => svc.command(CommandInput.parse(input)))
-}
 
 type McpContentItem =
   | { type: "text"; text: string }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -135,6 +135,7 @@ export namespace ToolRegistry {
     | Truncate.Service
     | Automation.Service
     | Worktree.Service
+    | Env.Service
   > = Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -143,6 +144,7 @@ export namespace ToolRegistry {
       const agents = yield* Agent.Service
       const truncate = yield* Truncate.Service
       const settings = yield* Settings.Service
+      const env = yield* Env.Service
 
       const invalid = yield* InvalidTool
       const agent = yield* AgentTool
@@ -448,12 +450,13 @@ export namespace ToolRegistry {
 
       const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
         const webSearchEnabled = yield* settings.webSearchEnabled()
+        const e2eLLMUrl = yield* env.get("OPENCODE_E2E_LLM_URL")
         const { allTools, availableDeferred, isDeferredAvailable } = yield* deferredAvailability(input)
         const filtered = allTools.filter((tool) => {
           if (tool.id === WebSearchTool.id) return webSearchEnabled
 
           const usePatch =
-            !!Env.get("OPENCODE_E2E_LLM_URL") ||
+            !!e2eLLMUrl ||
             (input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4"))
           if (tool.id === ApplyPatchTool.id) return usePatch
           if (tool.id === EditTool.id || tool.id === WriteTool.id) return !usePatch
@@ -521,7 +524,7 @@ export namespace ToolRegistry {
 
   export const defaultLayer = Layer.suspend(() =>
     layer.pipe(
-      Layer.provide(Config.defaultLayer),
+      Layer.provide(Layer.mergeAll(Config.defaultLayer, Env.defaultLayer)),
       Layer.provide(Plugin.defaultLayer),
       Layer.provide(Layer.mergeAll(Todo.defaultLayer, TurnChange.defaultLayer)),
       Layer.provide(Skill.defaultLayer),

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -373,6 +373,36 @@ test("File and SessionShare services do not expose Promise facades", async () =>
   }
 })
 
+test("Env service does not expose sync facades", async () => {
+  const text = await readFile(path.join(srcRoot, "env/index.ts"), "utf8")
+  const facades = [
+    "export function get",
+    "export function all",
+    "export function set",
+    "export function remove",
+  ]
+
+  expect(text).not.toMatch(/\bfrom\s+["'](?:@\/effect\/run-service|(?:\.\.\/)+effect\/run-service)["']/)
+  expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+  for (const facade of facades) expect(text).not.toContain(facade)
+})
+
+test("SessionPrompt service does not expose Promise facades", async () => {
+  const text = await readFile(path.join(srcRoot, "session/prompt.ts"), "utf8")
+  const facades = [
+    "export async function prompt",
+    "export async function promptWithAutomationContext",
+    "export async function resolvePromptParts",
+    "export async function cancel",
+    "export async function loop",
+    "export async function shell",
+    "export async function command",
+  ]
+
+  expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Service\s*,\s*defaultLayer\s*\)/)
+  for (const facade of facades) expect(text).not.toContain(facade)
+})
+
 test("MCP services do not expose Promise facades", async () => {
   const services = {
     "mcp/index.ts": [

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -11,10 +11,8 @@ import { Global } from "../../src/global"
 import { Filesystem } from "../../src/util/filesystem"
 import { Effect } from "effect"
 import { AppRuntime } from "../../src/effect/app-runtime"
-import { makeRuntime } from "../../src/effect/run-service"
 
-const env = makeRuntime(Env.Service, Env.defaultLayer)
-const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
+const set = (k: string, v: string) => AppRuntime.runSync(Env.Service.use((env) => env.set(k, v)))
 
 async function list() {
   return AppRuntime.runPromise(

--- a/packages/opencode/test/provider/models-refresh.test.ts
+++ b/packages/opencode/test/provider/models-refresh.test.ts
@@ -6,7 +6,6 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { Effect, Fiber, Layer } from "effect"
 import { tmpdir } from "../fixture/fixture"
-import { makeRuntime } from "../../src/effect/run-service"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Env } from "../../src/env"
 import { Global } from "../../src/global"
@@ -17,8 +16,7 @@ import { ModelID, ProviderID } from "../../src/provider/schema"
 
 const originalFetch = globalThis.fetch
 const originalModelsPath = process.env.OPENCODE_MODELS_PATH
-const env = makeRuntime(Env.Service, Env.defaultLayer)
-const setEnv = (key: string, value: string) => env.runSync((svc) => svc.set(key, value))
+const setEnv = (key: string, value: string) => AppRuntime.runSync(Env.Service.use((env) => env.set(key, value)))
 
 const runModels = <A, E>(fn: (svc: ModelsDev.Interface) => Effect.Effect<A, E, never>) =>
   AppRuntime.runPromise(ModelsDev.Service.use(fn))

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -17,7 +17,6 @@ import { Filesystem } from "../../src/util/filesystem"
 import { Env } from "../../src/env"
 import { Effect } from "effect"
 import { AppRuntime } from "../../src/effect/app-runtime"
-import { makeRuntime } from "../../src/effect/run-service"
 import {
   VOLCENGINE_PLAN_DEFAULT_MODEL_ID,
   VOLCENGINE_PLAN_HIDDEN_MODEL_IDS,
@@ -25,9 +24,8 @@ import {
   VOLCENGINE_PLAN_VISIBLE_MODEL_IDS,
 } from "@opencode-ai/util/volcengine-plan"
 
-const env = makeRuntime(Env.Service, Env.defaultLayer)
-const set = (k: string, v: string) => env.runSync((svc) => svc.set(k, v))
-const unset = (k: string) => env.runSync((svc) => svc.remove(k))
+const set = (k: string, v: string) => AppRuntime.runSync(Env.Service.use((env) => env.set(k, v)))
+const unset = (k: string) => AppRuntime.runSync(Env.Service.use((env) => env.remove(k)))
 
 function clearVertexEnv() {
   unset("GOOGLE_VERTEX_PROJECT")

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -3,7 +3,7 @@ import path from "path"
 import { describe, expect, test } from "bun:test"
 import { NamedError } from "@opencode-ai/util/error"
 import { fileURLToPath, pathToFileURL } from "url"
-import { Effect, Layer } from "effect"
+import { Effect, Fiber, Layer } from "effect"
 import { Instance } from "../../src/project/instance"
 import { Permission } from "../../src/permission"
 import { ModelID, ProviderID } from "../../src/provider/schema"
@@ -12,13 +12,17 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID } from "../../src/session/schema"
 import { Log } from "../../src/util"
+import { Env } from "../../src/env"
 import { tmpdir } from "../fixture/fixture"
 
 void Log.init({ print: false })
 
 function run<A, E>(fx: Effect.Effect<A, E, SessionPrompt.Service | Session.Service>) {
   return Effect.runPromise(
-    fx.pipe(Effect.scoped, Effect.provide(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer))),
+    fx.pipe(
+      Effect.scoped,
+      Effect.provide(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer, Env.defaultLayer)),
+    ),
   )
 }
 
@@ -445,24 +449,23 @@ describe("session.prompt regression", () => {
               const prompt = yield* SessionPrompt.Service
               const sessions = yield* Session.Service
               const session = yield* sessions.create({ title: "Prompt cancel regression" })
-              const task = Effect.runPromise(
-                prompt.prompt({
+              const task = yield* prompt
+                .prompt({
                   sessionID: session.id,
                   agent: "build",
                   parts: [{ type: "text", text: "Cancel me" }],
-                }),
-              )
+                })
+                .pipe(Effect.forkChild)
 
               yield* Effect.promise(() => ready.promise)
               yield* prompt.cancel(session.id)
 
-              const result = yield* Effect.promise(() =>
-                Promise.race([
-                  task,
-                  new Promise<never>((_, reject) =>
-                    setTimeout(() => reject(new Error("timed out waiting for cancel")), 1000),
+              const result = yield* Fiber.join(task).pipe(
+                Effect.race(
+                  Effect.sleep("1 second").pipe(
+                    Effect.flatMap(() => Effect.fail(new Error("timed out waiting for cancel"))),
                   ),
-                ]),
+                ),
               )
 
               expect(result.info.role).toBe("assistant")
@@ -973,11 +976,18 @@ describe("session.agent-resolution", () => {
         directory: tmp.path,
         fn: async () => {
           const session = await run(Session.Service.use((svc) => svc.create({})))
-          await SessionPrompt.command({
-            sessionID: session.id,
-            command: "literal",
-            arguments: "$$PID $& $1",
-          })
+          await run(
+            Effect.gen(function* () {
+              const prompt = yield* SessionPrompt.Service
+              yield* prompt.command(
+                SessionPrompt.CommandInput.parse({
+                  sessionID: session.id,
+                  command: "literal",
+                  arguments: "$$PID $& $1",
+                }),
+              )
+            }),
+          )
         },
       })
 
@@ -1058,24 +1068,29 @@ describe("session.agent-resolution", () => {
         fn: async () => {
           const session = await run(Session.Service.use((svc) => svc.create({})))
 
-          await SessionPrompt.prompt({
-            sessionID: session.id,
-            agent: "build",
-            parts: [{ type: "text", text: "hello" }],
-            locale: "zh-Hans",
-            noReply: true,
-          })
-
-          await SessionPrompt.loop({
-            sessionID: session.id,
-          })
-
-          await SessionPrompt.command({
-            sessionID: session.id,
-            command: "summarize",
-            arguments: "",
-            locale: "pt-BR",
-          })
+          await run(
+            Effect.gen(function* () {
+              const prompt = yield* SessionPrompt.Service
+              yield* prompt.prompt(
+                SessionPrompt.PromptInput.parse({
+                  sessionID: session.id,
+                  agent: "build",
+                  parts: [{ type: "text", text: "hello" }],
+                  locale: "zh-Hans",
+                  noReply: true,
+                }),
+              )
+              yield* prompt.loop(SessionPrompt.LoopInput.parse({ sessionID: session.id }))
+              yield* prompt.command(
+                SessionPrompt.CommandInput.parse({
+                  sessionID: session.id,
+                  command: "summarize",
+                  arguments: "",
+                  locale: "pt-BR",
+                }),
+              )
+            }),
+          )
 
           expect(systems.some((text) => text.includes("User locale: zh-Hans"))).toBe(true)
           expect(systems.some((text) => text.includes("User locale: pt-BR"))).toBe(true)

--- a/packages/opencode/test/tool/agent.test.ts
+++ b/packages/opencode/test/tool/agent.test.ts
@@ -14,6 +14,7 @@ import { AgentTool, sanitizeErrorMessage, type AgentPromptOps } from "../../src/
 import { SubagentRun } from "../../src/session/subagent-run"
 import { Truncate } from "../../src/tool/truncate"
 import { ToolRegistry } from "../../src/tool/registry"
+import { Env } from "../../src/env"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -35,6 +36,7 @@ const it = testEffect(
     SubagentRun.defaultLayer,
     Truncate.defaultLayer,
     ToolRegistry.defaultLayer,
+    Env.defaultLayer,
   ),
 )
 
@@ -94,7 +96,7 @@ function stubOps(opts?: {
   }
 }
 
-function reply(input: Parameters<typeof SessionPrompt.prompt>[0], text: string): MessageV2.WithParts {
+function reply(input: SessionPrompt.PromptInput, text: string): MessageV2.WithParts {
   const id = MessageID.ascending()
   return {
     info: {


### PR DESCRIPTION
## Summary

Retires the Env sync facade and SessionPrompt Promise facade runtime, moving direct callers onto `Env.Service` / `SessionPrompt.Service` through `AppRuntime` or existing Effect layers.

## Why

Related to #936.

Env and SessionPrompt still had per-service `makeRuntime(Service, defaultLayer)` blocks. Those independent service runtimes are no longer needed now that `AppRuntime` owns the composed Effect graph.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the service boundary changes:
- Env sync reads now go through `AppRuntime` or Effect service injection.
- SessionPrompt direct callers now use `SessionPrompt.Service` instead of the removed Promise facades.
- Test harnesses that previously used per-service runtimes now provide Env through `AppRuntime` or their local Effect layers.

## Risk Notes

No visible UI or copy changes. No dependencies, generated files, permissions, credentials, or deletion behavior changed. Runtime risk is limited to Env/SessionPrompt service-layer wiring; covered by focused provider/env, session prompt, tool agent, route, automation, typecheck, and legacy-boundary tests.

Fresh-eye result: P0/P1 none. P2 none. One P3 diff-noise issue in AppRuntime layer grouping was fixed before opening this PR.

Skipped conditional checklist items: visible UI/copy, platform/packaging, docs/release notes, dependencies/permissions, generated files, local file migration, and data/deletion surfaces are not applicable to this change.

## How To Verify

```text
Dependency install: bun install --frozen-lockfile passed.

Guardrail RED: bun test test/effect/legacy-boundaries.test.ts failed before migration on Env and SessionPrompt per-service facade runtime/exports.

Focused tests: bun test test/effect/legacy-boundaries.test.ts test/session/prompt.test.ts test/session/prompt-effect.test.ts test/tool/agent.test.ts test/provider/provider.test.ts test/provider/amazon-bedrock.test.ts test/provider/models-refresh.test.ts test/server/session-core-routes.test.ts test/server/automation-routes.test.ts passed with 349 pass, 1 skip, 0 fail, 1366 expect() calls.

Typecheck: GOMAXPROCS=2 bun run typecheck passed.

Diff check: git diff --check passed with no output.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

- [x] **Type label**: This PR has exactly one of `bug`, `enhancement`, `task`, or `documentation`.
- [x] **Routing label**: This PR has at least one area label (`harness`, `desktop`, `ui`, `api`, `ci`, `docs`, `dependencies`, `release`, `upstream`, `infra`, `workflow`, `security`).
- [x] **Priority label**: This PR has exactly one priority label (`P0`, `P1`, `P2`, or `P3`).
- [x] **Human review status** is included above and says `Pending`, `Addressed`, or `Not Needed`.
- [x] **Related issue** is linked above, or this PR explains why no issue is needed.
- [x] **Review focus and risk notes** are filled in above.
- [x] **Verification** lists the exact local checks run and their results.
- [x] **Screenshots or recordings** are attached above for visible UI changes, or this PR states why they are not needed.
- [x] **Unrelated changes** are intentionally excluded.
- [ ] **Visible UI or copy changes** were checked against `docs/DESIGN.md`, or this PR explains why that file does not apply.
- [ ] **Platform or packaging changes** were checked on every affected platform, or this PR lists the unverified platform risk.
- [ ] **Docs/release-note impact** was updated, or this PR explains why no user-facing docs/release notes are needed.
- [ ] **Dependencies or permissions** were reviewed for install size, license, security, and user trust impact.
- [ ] **Generated files** were produced by the documented generator, and the generator command is listed above.
- [ ] **Local file migrations** are reversible or backed up, with the rollback path documented above.
- [ ] **Data, credential, or deletion surfaces** have explicit regression coverage, or this PR explains why they are not touched.
- [x] **Final diff** was reviewed locally before requesting review.
- [x] **Target branch and title** are correct: base is `dev`, and the title follows Conventional Commits.
