### PR TITLE
refactor(opencode): retire config plugin flock facades

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -22,7 +22,6 @@ import { isRecord } from "@/util/record"
 import type { ConsoleState } from "./console-state"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { InstanceState } from "@/effect"
-import { makeRuntime } from "@/effect/run-service"
 import { Context, Duration, Effect, Fiber, Layer, Option, Schema } from "effect"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { InstanceRef } from "@/effect/instance-ref"
@@ -422,17 +421,17 @@ export function configFileLockKey(file: string) {
   return `config-file:${Filesystem.resolve(file)}`
 }
 
-const { runPromise: runFlockPromise } = makeRuntime(EffectFlock.Service, EffectFlock.defaultLayer)
-
 export async function withConfigFileLock<T>(file: string, fn: () => Promise<T>) {
-  return runFlockPromise((flock) =>
-    flock.withLock(
-      Effect.tryPromise({
-        try: fn,
-        catch: (error) => error,
-      }),
-      configFileLockKey(file),
-    ),
+  return Effect.runPromise(
+    EffectFlock.Service.use((flock) =>
+      flock.withLock(
+        Effect.tryPromise({
+          try: fn,
+          catch: (error) => error,
+        }),
+        configFileLockKey(file),
+      ),
+    ).pipe(Effect.provide(EffectFlock.defaultLayer)),
   )
 }
 

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -10,7 +10,6 @@ import { Effect } from "effect"
 
 import { Config } from "@/config"
 import { AppRuntime } from "@/effect/app-runtime"
-import { makeRuntime } from "@/effect/run-service"
 import { ConfigPaths } from "@/config/paths"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
@@ -94,17 +93,17 @@ const defaultPatchDeps: PatchDeps = {
   files: (dir, name) => ConfigPaths.fileInDirectory(dir, name),
 }
 
-const { runPromise: runFlockPromise } = makeRuntime(EffectFlock.Service, EffectFlock.defaultLayer)
-
 function withLock<T>(key: string, fn: () => Promise<T>) {
-  return runFlockPromise((flock) =>
-    flock.withLock(
-      Effect.tryPromise({
-        try: fn,
-        catch: (error) => error,
-      }),
-      key,
-    ),
+  return Effect.runPromise(
+    EffectFlock.Service.use((flock) =>
+      flock.withLock(
+        Effect.tryPromise({
+          try: fn,
+          catch: (error) => error,
+        }),
+        key,
+      ),
+    ).pipe(Effect.provide(EffectFlock.defaultLayer)),
   )
 }
 

--- a/packages/opencode/src/plugin/meta.ts
+++ b/packages/opencode/src/plugin/meta.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from "url"
 import { Effect } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
-import { makeRuntime } from "@/effect/run-service"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 
@@ -48,17 +47,17 @@ export namespace PluginMeta {
     return `plugin-meta:${file}`
   }
 
-  const { runPromise: runFlockPromise } = makeRuntime(EffectFlock.Service, EffectFlock.defaultLayer)
-
   function withLock<T>(key: string, fn: () => Promise<T>) {
-    return runFlockPromise((flock) =>
-      flock.withLock(
-        Effect.tryPromise({
-          try: fn,
-          catch: (error) => error,
-        }),
-        key,
-      ),
+    return Effect.runPromise(
+      EffectFlock.Service.use((flock) =>
+        flock.withLock(
+          Effect.tryPromise({
+            try: fn,
+            catch: (error) => error,
+          }),
+          key,
+        ),
+      ).pipe(Effect.provide(EffectFlock.defaultLayer)),
     )
   }
 

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -55,6 +55,15 @@ test("production source does not use Promise flock compatibility", async () => {
   expect(hits.sort()).toEqual([])
 })
 
+test("config and plugin flock locks do not create EffectFlock facade runtimes", async () => {
+  const files = ["config/config.ts", "plugin/install.ts", "plugin/meta.ts"]
+
+  for (const file of files) {
+    const text = await readFile(path.join(srcRoot, file), "utf8")
+    expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*EffectFlock\.Service\s*,\s*EffectFlock\.defaultLayer\s*\)/)
+  }
+})
+
 test("worktree adaptor does not call Worktree Promise facades", async () => {
   const text = await readFile(path.join(srcRoot, "control-plane/adaptors/worktree.ts"), "utf8")
 


### PR DESCRIPTION
## Summary

Retires the remaining Config/plugin EffectFlock facade runtimes in this #936 slice.

- Remove `makeRuntime(EffectFlock.Service, EffectFlock.defaultLayer)` usage from Config file locks, plugin install config patching, and plugin metadata updates.
- Run the same lock bodies through the EffectFlock service graph directly, preserving the existing Promise-facing call sites where they are still the public CLI/helper boundary.
- Add a legacy-boundary guardrail so these three owners cannot silently reintroduce the EffectFlock facade runtime.

## Why

Related to #936.

Config/plugin lock helpers had already moved their critical sections onto `EffectFlock.Service`, but they still created local per-service facade runtimes. This removes that migration tail without expanding into Bus, Automation, Worktree, Hono/HttpApi, generated SDK/OpenAPI, UI, or other cleanup areas.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the local EffectFlock graph still preserves lock release and cross-process serialization for config patching and plugin metadata writes.

## Risk Notes

- No visible UI or copy changed, so the UI screenshot/checklist item is not applicable.
- No docs, release notes, dependency, permission, credential, deletion, generated content, or local-file-only changes were introduced, so that conditional checklist item is not applicable.
- Platform impact considered: this touches file-locking paths used on macOS and Windows; focused config install failure coverage and cross-process plugin install/meta tests passed.
- Fresh-eye result: P0 none, P1 none, P2 considered extracting the repeated local EffectFlock runner but rejected it because a shared production helper would create a new compatibility facade/helper; P3 none. The current local repetition is the smallest, clearest, and easiest to reverse.

## How To Verify

```text
RED guardrail: bun test test/effect/legacy-boundaries.test.ts failed before production changes because config/config.ts still used makeRuntime(EffectFlock.Service, EffectFlock.defaultLayer).
Guardrail: bun test test/effect/legacy-boundaries.test.ts -> 27 passed.
Config focused tests: bun test test/config/config.test.ts -> 115 passed.
Plugin install tests: bun test test/plugin/install.test.ts -> 34 passed.
Plugin lock concurrency and metadata tests: bun test test/plugin/install-concurrency.test.ts test/plugin/meta.test.ts -> 6 passed.
Typecheck: GOMAXPROCS=2 bun run typecheck -> passed.
Diff check: git diff --check -> passed.
Residual scan: rg for makeRuntime(EffectFlock.Service), runFlockPromise, and run-service imports in config/plugin target files -> no matches.
```

## Screenshots or Recordings

Not applicable: no visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
