### PR TITLE
refactor(opencode): retire worktree adaptor runtime facade

### DIFF
--- a/packages/opencode/src/control-plane/adaptors/worktree.ts
+++ b/packages/opencode/src/control-plane/adaptors/worktree.ts
@@ -1,5 +1,5 @@
 import z from "zod"
-import { makeRuntime } from "@/effect/run-service"
+import type { Effect } from "effect"
 import { Worktree } from "@/worktree"
 import { type Adaptor, WorkspaceInfo } from "../types"
 
@@ -11,11 +11,14 @@ const Config = WorkspaceInfo.extend({
 
 type Config = z.infer<typeof Config>
 
-const worktreeRuntime = makeRuntime(Worktree.Service, Worktree.defaultLayer)
+async function runWorktree<A>(use: (worktrees: Worktree.Interface) => Effect.Effect<A>) {
+  const { AppRuntime } = await import("@/effect/app-runtime")
+  return AppRuntime.runPromise(Worktree.Service.use(use))
+}
 
 export const WorktreeAdaptor: Adaptor = {
   async configure(info) {
-    const worktree = await worktreeRuntime.runPromise((worktrees) => worktrees.makeWorktreeInfo(info.name ?? undefined))
+    const worktree = await runWorktree((worktrees) => worktrees.makeWorktreeInfo(info.name ?? undefined))
     return {
       ...info,
       name: worktree.name,
@@ -25,7 +28,7 @@ export const WorktreeAdaptor: Adaptor = {
   },
   async create(info) {
     const config = Config.parse(info)
-    await worktreeRuntime.runPromise((worktrees) =>
+    await runWorktree((worktrees) =>
       worktrees.createFromInfo({
         name: config.name,
         directory: config.directory,
@@ -36,7 +39,7 @@ export const WorktreeAdaptor: Adaptor = {
   },
   async remove(info) {
     const config = Config.parse(info)
-    await worktreeRuntime.runPromise((worktrees) => worktrees.remove({ directory: config.directory }))
+    await runWorktree((worktrees) => worktrees.remove({ directory: config.directory }))
   },
   target(info) {
     const config = Config.parse(info)

--- a/packages/opencode/test/effect/legacy-boundaries.test.ts
+++ b/packages/opencode/test/effect/legacy-boundaries.test.ts
@@ -70,6 +70,8 @@ test("worktree adaptor does not call Worktree Promise facades", async () => {
   expect(text).not.toContain("Worktree.makeWorktreeInfo")
   expect(text).not.toContain("Worktree.createFromInfo")
   expect(text).not.toContain("Worktree.remove")
+  expect(text).not.toMatch(/\bfrom\s+["']@\/effect\/run-service["']/)
+  expect(text).not.toMatch(/\bmakeRuntime\s*\(\s*Worktree\.Service\s*,\s*Worktree\.defaultLayer\s*\)/)
 })
 
 test("Worktree service uses the Effect-native gitignore guard boundary", async () => {


### PR DESCRIPTION
## Summary

Retire the Worktree adaptor's per-service runtime facade and route its Worktree service calls through the shared AppRuntime boundary.

## Why

Related to #936.

`control-plane/adaptors/worktree.ts` still created its own `makeRuntime(Worktree.Service, Worktree.defaultLayer)` even though Worktree is already composed into `AppRuntime`. This PR removes that local runtime while preserving WorktreeAdaptor configure/create/remove/target behavior.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on the Worktree adaptor bridge: it uses a dynamic AppRuntime import to avoid the static Workspace -> adaptors -> WorktreeAdaptor -> AppRuntime initialization cycle while still running Worktree service work through the shared runtime.

## Risk Notes

Risk is limited to Worktree-backed workspace configure/create/remove calls. I left the visible UI/copy checklist item unticked because this PR has no UI or copy changes. I left the docs/release/dependency checklist item unticked because this PR changes no docs, release notes, dependencies, permissions, credentials, generated content, or local-file behavior beyond the existing worktree creation/removal path.

Fresh-eye result: no P0/P1 findings. The only reviewed trade-off was the dynamic AppRuntime import; a broader Workspace/adaptor interface rewrite would be larger and less reviewable for this cleanup slice.

## How To Verify

```text
RED guardrail: bun test test/effect/legacy-boundaries.test.ts failed on the existing makeRuntime(Worktree.Service, Worktree.defaultLayer) usage before the implementation.
Focused tests: bun test test/effect/legacy-boundaries.test.ts test/plugin/workspace-adaptor.test.ts test/server/workspace-router.test.ts test/server/workspace-routes.test.ts -> 57 passed.
Typecheck: GOMAXPROCS=2 bun run typecheck -> tsgo --noEmit passed.
Diff check: git diff --check -> no whitespace errors.
Fresh-eye review: no P0/P1 findings; no follow-up changes required.
```

## Screenshots or Recordings

Not applicable. No visible UI changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
