### PR TITLE
refactor(remote-bridge): incremental channel add/remove (stop restarting every channel)

### DIFF
--- a/packages/desktop-electron/src/main/remote-bridge.test.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.test.ts
@@ -14,7 +14,11 @@ import {
   type RemotePlatform,
 } from "./remote-bridge"
 
-function memoryStore(initial: RemoteAccount[] = [], available = true): CredentialStore & { value: RemoteAccount[] } {
+function memoryStore(
+  initial: RemoteAccount[] = [],
+  available = true,
+  failSave = false,
+): CredentialStore & { value: RemoteAccount[] } {
   return {
     value: initial,
     isAvailable() {
@@ -24,6 +28,10 @@ function memoryStore(initial: RemoteAccount[] = [], available = true): Credentia
       return this.value
     },
     save(accounts) {
+      // The real store throws when secure storage is unavailable or the file write
+      // fails. `failSave` models a save that fails even though pairing's upfront
+      // availability check passed — the keyring locks or the disk errors mid-confirm.
+      if (failSave) throw new Error("secure storage is unavailable on this system, cannot save the connection")
       this.value = accounts
     },
     clear() {
@@ -85,7 +93,14 @@ function servingApp(names: string[]): BridgeApp {
       for (const name of names) onStatus?.({ name, phase: "serving" })
       return hangUntilAbort(signal)
     },
-    { addPlatform: async (config) => emitStatus?.({ name: config.name, phase: "serving" }) },
+    {
+      addPlatform: async (config, beforeCommit) => {
+        // Mirror the real gateway: run the commit hook (the runtime saves its
+        // credential here) after the build, before the channel starts serving.
+        await beforeCommit?.()
+        emitStatus?.({ name: config.name, phase: "serving" })
+      },
+    },
   )
 }
 
@@ -109,7 +124,10 @@ function bridgeHarness() {
         return hangUntilAbort(signal)
       },
       {
-        addPlatform: async (added) => {
+        addPlatform: async (added, beforeCommit) => {
+          // Mirror the real gateway: the commit hook (credential save) runs after the
+          // build and before the live swap, so a hook that throws records no add.
+          await beforeCommit?.()
           state.events.push(`add:${added.name}`)
           emitStatus?.({ name: added.name, phase: "serving" })
         },
@@ -576,6 +594,72 @@ test("a failed re-pair on a live bridge keeps the working channel connected and 
   expect(build).toBe(1) // ...but the shared bridge was never rebuilt
   expect(runtime.getStatus().channels[0].state).toBe("connected") // working channel preserved
   expect(store.value).toEqual([oldAccount]) // old credential not overwritten by the new one
+  await runtime.stop()
+})
+
+test("a re-pair whose credential save fails keeps the working channel and never half-commits", async () => {
+  // Prepare-first commit hook: addPlatform persists the credential BEFORE swapping out
+  // the old loop, so a save failure (the keyring locks, the disk errors) aborts the
+  // swap with the old channel still serving — never a live new channel backed by a
+  // stale stored credential, and never an in-memory account list out of sync with disk.
+  const oldAccount = sampleAccount("telegram")
+  const store = memoryStore([oldAccount], true, true) // available so pairing proceeds; save throws
+  const harness = bridgeHarness()
+  const newAccount: RemoteAccount = { platform: "telegram", token: "999:xyz", allowFrom: "99", userName: "new" }
+  const runtime = new RemoteBridgeRuntime(
+    deps({
+      credentials: store,
+      buildApp: harness.buildApp,
+      pairers: [
+        fakePairer("telegram", {
+          pair: async (_start, emit) => {
+            emit({ phase: "awaitingBind", platform: "telegram", hint: "message" })
+            return newAccount
+          },
+        }),
+      ],
+    }),
+  )
+  await runtime.startIfConfigured() // cold start with the old account → connected
+  const channel = () => runtime.getStatus().channels.find((c) => c.platform === "telegram")
+  expect(channel()?.state).toBe("connected")
+  expect(harness.state.build).toBe(1)
+
+  await runtime.startPairing("telegram", { token: "x" })
+  await expect(runtime.confirmPairing("telegram")).rejects.toThrow(/secure storage/)
+
+  // No incremental add was committed, no rebuild, exactly one channel still serving,
+  // and neither memory nor disk took the new account.
+  expect(harness.state.build).toBe(1)
+  expect(harness.state.events).toEqual([])
+  expect(runtime.getStatus().channels).toHaveLength(1)
+  expect(channel()?.state).toBe("connected")
+  expect(store.value).toEqual([oldAccount])
+  await runtime.stop()
+})
+
+test("a second channel whose credential save fails is not added and leaves the first connected", async () => {
+  // Same commit-before-swap guard on the incremental-add path: a save failure while
+  // connecting a SECOND channel adds no orphan live channel and rolls the in-memory
+  // swap back, so the first channel keeps serving and the store holds only its account.
+  const store = memoryStore([sampleAccount("telegram")], true, true)
+  const harness = bridgeHarness()
+  const runtime = new RemoteBridgeRuntime(
+    deps({ credentials: store, buildApp: harness.buildApp, pairers: [fakePairer("telegram"), fakePairer("wechat")] }),
+  )
+  const stateOf = (platform: RemotePlatform) => runtime.getStatus().channels.find((c) => c.platform === platform)?.state
+  await runtime.startIfConfigured() // telegram connected from the saved account
+  expect(stateOf("telegram")).toBe("connected")
+  expect(harness.state.build).toBe(1)
+
+  await runtime.startPairing("wechat")
+  await expect(runtime.confirmPairing("wechat")).rejects.toThrow(/secure storage/)
+
+  expect(harness.state.events).toEqual([]) // WeChat never joined the live set
+  expect(harness.state.build).toBe(1)
+  expect(stateOf("wechat")).toBeUndefined()
+  expect(stateOf("telegram")).toBe("connected")
+  expect(store.value).toEqual([sampleAccount("telegram")]) // store still holds only telegram
   await runtime.stop()
 })
 

--- a/packages/desktop-electron/src/main/remote-bridge.test.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.test.ts
@@ -18,9 +18,10 @@ function memoryStore(
   initial: RemoteAccount[] = [],
   available = true,
   failSave = false,
-): CredentialStore & { value: RemoteAccount[] } {
+): CredentialStore & { value: RemoteAccount[]; failSave: boolean } {
   return {
     value: initial,
+    failSave,
     isAvailable() {
       return available
     },
@@ -31,7 +32,8 @@ function memoryStore(
       // The real store throws when secure storage is unavailable or the file write
       // fails. `failSave` models a save that fails even though pairing's upfront
       // availability check passed — the keyring locks or the disk errors mid-confirm.
-      if (failSave) throw new Error("secure storage is unavailable on this system, cannot save the connection")
+      // Mutable, so a test can let setup persist and then fail a later save.
+      if (this.failSave) throw new Error("secure storage is unavailable on this system, cannot save the connection")
       this.value = accounts
     },
     clear() {
@@ -660,6 +662,40 @@ test("a second channel whose credential save fails is not added and leaves the f
   expect(stateOf("wechat")).toBeUndefined()
   expect(stateOf("telegram")).toBe("connected")
   expect(store.value).toEqual([sampleAccount("telegram")]) // store still holds only telegram
+  await runtime.stop()
+})
+
+test("a non-last disconnect whose credential save fails keeps the channel and is retryable", async () => {
+  // Prepare-first on disconnect too: the trimmed list is persisted BEFORE the channel
+  // leaves memory or the live App, so a save failure leaves the channel connected and
+  // the operation retryable — never half-removed in memory with the loop still running.
+  const store = memoryStore([sampleAccount("telegram"), sampleAccount("wechat")])
+  const harness = bridgeHarness()
+  const runtime = new RemoteBridgeRuntime(
+    deps({ credentials: store, buildApp: harness.buildApp, pairers: [fakePairer("telegram"), fakePairer("wechat")] }),
+  )
+  const stateOf = (platform: RemotePlatform) => runtime.getStatus().channels.find((c) => c.platform === platform)?.state
+  await runtime.startIfConfigured()
+  expect(stateOf("telegram")).toBe("connected")
+  expect(stateOf("wechat")).toBe("connected")
+  expect(harness.state.build).toBe(1)
+
+  // The save fails before anything moves: the channel stays connected and live, its
+  // sibling is untouched, and no remove reached the App.
+  store.failSave = true
+  await expect(runtime.disconnect("telegram")).rejects.toThrow(/secure storage/)
+  expect(harness.state.events).toEqual([])
+  expect(stateOf("telegram")).toBe("connected")
+  expect(stateOf("wechat")).toBe("connected")
+  expect(store.value).toEqual([sampleAccount("telegram"), sampleAccount("wechat")])
+
+  // Retry once storage recovers: now it actually disconnects, only telegram leaving.
+  store.failSave = false
+  await runtime.disconnect("telegram")
+  expect(harness.state.events).toEqual(["remove:telegram"])
+  expect(stateOf("telegram")).toBeUndefined()
+  expect(stateOf("wechat")).toBe("connected")
+  expect(store.value).toEqual([sampleAccount("wechat")])
   await runtime.stop()
 })
 

--- a/packages/desktop-electron/src/main/remote-bridge.test.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.test.ts
@@ -57,10 +57,21 @@ function fakePairer(platform: RemotePlatform, over: Partial<PlatformPairer> = {}
   }
 }
 
-/** Lift a custom run() into a full BridgeApp. add/remove default to no-ops for the
- * cold-start tests that never reach the incremental paths; override as needed. */
+/** Lift a custom run() into a full BridgeApp. add/remove default to throwing so a
+ * test that unexpectedly drives an incremental path fails loudly instead of silently
+ * passing through a no-op; incremental tests override them (see servingApp /
+ * bridgeHarness). */
 function appWith(run: BridgeApp["run"], over: Partial<BridgeApp> = {}): BridgeApp {
-  return { run, addPlatform: async () => {}, removePlatform: async () => {}, ...over }
+  return {
+    run,
+    addPlatform: async () => {
+      throw new Error("unexpected addPlatform — override appWith for incremental tests")
+    },
+    removePlatform: async () => {
+      throw new Error("unexpected removePlatform — override appWith for incremental tests")
+    },
+    ...over,
+  }
 }
 
 /** A bridge App whose run() emits "serving" for every configured platform (so the
@@ -510,6 +521,61 @@ test("after a fatal stream tears the bridge down, the next connect rebuilds it (
   expect(build).toBe(2)
   expect(stateOf("telegram")).toBe("connected") // recovered by the rebuild
   expect(stateOf("wechat")).toBe("connected")
+  await runtime.stop()
+})
+
+test("a failed re-pair on a live bridge keeps the working channel connected and its credential saved", async () => {
+  // Prepare-first: a re-pair whose incremental addPlatform rejects must not tear down
+  // the working channel or overwrite its saved credential — the user keeps the
+  // connection they had, and confirmPairing surfaces the failure by rejecting.
+  const oldAccount = sampleAccount("telegram")
+  const store = memoryStore([oldAccount])
+  let build = 0
+  let addCalls = 0
+  const buildApp: RemoteBridgeDeps["buildApp"] = async (config) => {
+    build++
+    return appWith(
+      (signal, _onReady, onStatus) => {
+        for (const platform of config.platforms) onStatus?.({ name: platform.name, phase: "serving" })
+        return hangUntilAbort(signal)
+      },
+      {
+        addPlatform: async () => {
+          addCalls++
+          throw new Error("rebuild boom")
+        },
+      },
+    )
+  }
+  // The re-pair captures a *different* telegram account, so we can tell whether the
+  // stored credential was overwritten.
+  const newAccount: RemoteAccount = { platform: "telegram", token: "999:xyz", allowFrom: "99", userName: "new" }
+  const runtime = new RemoteBridgeRuntime(
+    deps({
+      credentials: store,
+      buildApp,
+      pairers: [
+        fakePairer("telegram", {
+          pair: async (_start, emit) => {
+            emit({ phase: "awaitingBind", platform: "telegram", hint: "message" })
+            return newAccount
+          },
+        }),
+      ],
+    }),
+  )
+  await runtime.startIfConfigured() // cold start with the old account → connected
+  expect(runtime.getStatus().channels[0].state).toBe("connected")
+  expect(build).toBe(1)
+
+  // Re-pair telegram on the LIVE bridge; the incremental addPlatform rejects.
+  await runtime.startPairing("telegram", { token: "x" })
+  await expect(runtime.confirmPairing("telegram")).rejects.toThrow("rebuild boom")
+
+  expect(addCalls).toBe(1) // the incremental connect was attempted...
+  expect(build).toBe(1) // ...but the shared bridge was never rebuilt
+  expect(runtime.getStatus().channels[0].state).toBe("connected") // working channel preserved
+  expect(store.value).toEqual([oldAccount]) // old credential not overwritten by the new one
   await runtime.stop()
 })
 

--- a/packages/desktop-electron/src/main/remote-bridge.test.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.test.ts
@@ -784,6 +784,84 @@ test("a disconnect interrupted by a fatal stream rebuilds the surviving channels
   await runtime.stop()
 })
 
+test("a stop during an in-flight re-pair does not rebuild the bridge during shutdown", async () => {
+  // A user quit lands `stop()`'s synchronous abort on the live handle while a re-pair is parked
+  // in addPlatform. The abort makes addPlatform throw BridgeClosedError after the credential is
+  // committed. That error must NOT trigger a rebuild — the queued stop is tearing the bridge
+  // down, so rebuilding would only stand up a fresh stream just to tear it down again. The new
+  // account is persisted, so the next launch connects it.
+  const store = memoryStore([sampleAccount("telegram")])
+  let build = 0
+  let releaseAdd!: () => void
+  const addGate = new Promise<void>((resolve) => (releaseAdd = resolve))
+  const buildApp: RemoteBridgeDeps["buildApp"] = async (config) => {
+    ++build
+    return appWith(
+      (signal, _onReady, onStatus) => {
+        for (const platform of config.platforms) onStatus?.({ name: platform.name, phase: "serving" })
+        return hangUntilAbort(signal)
+      },
+      {
+        addPlatform: async (_config, beforeCommit) => {
+          await beforeCommit?.() // the credential is committed before the abort surfaces
+          await addGate // hold until the test has issued stop() (which aborts the handle)
+          throw new BridgeClosedError("telegram")
+        },
+      },
+    )
+  }
+  const runtime = new RemoteBridgeRuntime(deps({ credentials: store, buildApp }))
+  await runtime.startIfConfigured()
+  expect(build).toBe(1)
+
+  await runtime.startPairing("telegram", { token: "x" })
+  const confirming = runtime.confirmPairing("telegram") // parks in addPlatform at addGate
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  const stopping = runtime.stop() // synchronously aborts the live handle
+  releaseAdd() // addPlatform now throws BridgeClosedError on the aborted handle
+  await Promise.all([confirming, stopping])
+  expect(build).toBe(1) // shutdown did not rebuild the bridge
+  expect(store.value).toEqual([{ platform: "telegram", token: "123:abc", allowFrom: "42", userName: "yu" }])
+})
+
+test("a stop during an in-flight disconnect does not rebuild the bridge during shutdown", async () => {
+  // Same shutdown race on the disconnect path: stop()'s abort makes removePlatform throw
+  // BridgeClosedError. The trimmed accounts are persisted, but the queued stop is tearing the
+  // bridge down, so the survivor must not be rebuilt only to be torn down again.
+  const store = memoryStore([sampleAccount("telegram"), sampleAccount("wechat")])
+  let build = 0
+  let releaseRemove!: () => void
+  const removeGate = new Promise<void>((resolve) => (releaseRemove = resolve))
+  const buildApp: RemoteBridgeDeps["buildApp"] = async (config) => {
+    ++build
+    return appWith(
+      (signal, _onReady, onStatus) => {
+        for (const platform of config.platforms) onStatus?.({ name: platform.name, phase: "serving" })
+        return hangUntilAbort(signal)
+      },
+      {
+        removePlatform: async () => {
+          await removeGate // hold until the test has issued stop() (which aborts the handle)
+          throw new BridgeClosedError("telegram")
+        },
+      },
+    )
+  }
+  const runtime = new RemoteBridgeRuntime(
+    deps({ credentials: store, buildApp, pairers: [fakePairer("telegram"), fakePairer("wechat")] }),
+  )
+  await runtime.startIfConfigured()
+  expect(build).toBe(1)
+
+  const disconnecting = runtime.disconnect("telegram") // parks in removePlatform at removeGate
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  const stopping = runtime.stop() // synchronously aborts the live handle
+  releaseRemove() // removePlatform now throws BridgeClosedError on the aborted handle
+  await Promise.all([disconnecting, stopping])
+  expect(build).toBe(1) // shutdown did not rebuild the survivor
+  expect(store.value).toEqual([sampleAccount("wechat")]) // the trimmed accounts were persisted
+})
+
 test("startIfConfigured connects saved accounts; with none it stays empty", async () => {
   const runtime = new RemoteBridgeRuntime(deps({ credentials: memoryStore([sampleAccount("telegram")]) }))
   await runtime.startIfConfigured()

--- a/packages/desktop-electron/src/main/remote-bridge.test.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import type { PlatformStatus } from "@opencode-ai/remote-bridge/gateway"
 import {
+  type BridgeApp,
   type CredentialStore,
   type PlatformPairer,
   type RemoteAccount,
@@ -56,15 +57,58 @@ function fakePairer(platform: RemotePlatform, over: Partial<PlatformPairer> = {}
   }
 }
 
+/** Lift a custom run() into a full BridgeApp. add/remove default to no-ops for the
+ * cold-start tests that never reach the incremental paths; override as needed. */
+function appWith(run: BridgeApp["run"], over: Partial<BridgeApp> = {}): BridgeApp {
+  return { run, addPlatform: async () => {}, removePlatform: async () => {}, ...over }
+}
+
 /** A bridge App whose run() emits "serving" for every configured platform (so the
- * runtime reaches "connected") and then stays pending until aborted. */
-function servingApp(names: string[]) {
-  return {
-    run(signal?: AbortSignal, _onReady?: () => void, onStatus?: (status: PlatformStatus) => void) {
+ * runtime reaches "connected") and then stays pending until aborted; an
+ * incrementally-added channel is served too. */
+function servingApp(names: string[]): BridgeApp {
+  let emitStatus: ((status: PlatformStatus) => void) | undefined
+  return appWith(
+    (signal, _onReady, onStatus) => {
+      emitStatus = onStatus
       for (const name of names) onStatus?.({ name, phase: "serving" })
       return hangUntilAbort(signal)
     },
+    { addPlatform: async (config) => emitStatus?.({ name: config.name, phase: "serving" }) },
+  )
+}
+
+/**
+ * A bridge harness that records every lifecycle call across rebuilds, so a test can
+ * assert "added incrementally, stream not rebuilt" vs "rebuilt". `build` counts how
+ * many times buildApp ran (= how many shared streams were stood up); `events` logs
+ * add:/remove: in order. run() serves the channels it was built with; addPlatform
+ * serves the new one — all without a rebuild.
+ */
+function bridgeHarness() {
+  const state = { build: 0, events: [] as string[] }
+  let emitStatus: ((status: PlatformStatus) => void) | undefined
+  const buildApp: RemoteBridgeDeps["buildApp"] = async (config) => {
+    state.build++
+    const names = config.platforms.map((platform) => platform.name)
+    return appWith(
+      (signal, _onReady, onStatus) => {
+        emitStatus = onStatus
+        for (const name of names) onStatus?.({ name, phase: "serving" })
+        return hangUntilAbort(signal)
+      },
+      {
+        addPlatform: async (added) => {
+          state.events.push(`add:${added.name}`)
+          emitStatus?.({ name: added.name, phase: "serving" })
+        },
+        removePlatform: async (name) => {
+          state.events.push(`remove:${name}`)
+        },
+      },
+    )
   }
+  return { state, buildApp, emit: (status: PlatformStatus) => emitStatus?.(status) }
 }
 
 function hangUntilAbort(signal?: AbortSignal): Promise<void> {
@@ -228,8 +272,8 @@ test("a double confirm builds only one bridge (the second finds no pending)", as
   let maxRunning = 0
   const runtime = new RemoteBridgeRuntime(
     deps({
-      buildApp: async () => ({
-        run(signal?: AbortSignal) {
+      buildApp: async () =>
+        appWith((signal) => {
           running++
           maxRunning = Math.max(maxRunning, running)
           built++
@@ -241,8 +285,7 @@ test("a double confirm builds only one bridge (the second finds no pending)", as
             if (signal?.aborted) return done()
             signal?.addEventListener("abort", done, { once: true })
           })
-        },
-      }),
+        }),
     }),
   )
   await runtime.startPairing("telegram", { token: "x" })
@@ -256,7 +299,7 @@ test("a double confirm builds only one bridge (the second finds no pending)", as
 
 test("a fatal run() failure degrades every channel, not an unhandled rejection", async () => {
   const runtime = new RemoteBridgeRuntime(
-    deps({ buildApp: async () => ({ run: async () => { throw new Error("revoked token") } }) }),
+    deps({ buildApp: async () => appWith(async () => { throw new Error("revoked token") }) }),
   )
   await runtime.startPairing("telegram", { token: "x" })
   await runtime.confirmPairing("telegram")
@@ -279,12 +322,11 @@ test("status flips connecting → connected → degraded from the per-platform s
   let emit: ((status: PlatformStatus) => void) | undefined
   const runtime = new RemoteBridgeRuntime(
     deps({
-      buildApp: async () => ({
-        run(signal?: AbortSignal, _onReady?: () => void, onStatus?: (status: PlatformStatus) => void) {
+      buildApp: async () =>
+        appWith((signal, _onReady, onStatus) => {
           emit = onStatus
           return hangUntilAbort(signal)
-        },
-      }),
+        }),
     }),
   )
   await runtime.startPairing("telegram", { token: "x" })
@@ -349,8 +391,8 @@ test("disconnecting the last channel stops the bridge before deleting state, so 
   const runtime = new RemoteBridgeRuntime(
     deps({
       statePath,
-      buildApp: async () => ({
-        run(signal?: AbortSignal, _onReady?: () => void, onStatus?: (status: PlatformStatus) => void) {
+      buildApp: async () =>
+        appWith((signal, _onReady, onStatus) => {
           onStatus?.({ name: "telegram", phase: "serving" })
           return new Promise<void>((resolve) => {
             const finish = () => {
@@ -361,8 +403,7 @@ test("disconnecting the last channel stops the bridge before deleting state, so 
             if (signal?.aborted) return finish()
             signal?.addEventListener("abort", finish, { once: true })
           })
-        },
-      }),
+        }),
     }),
   )
   await runtime.startPairing("telegram", { token: "x" })
@@ -374,22 +415,13 @@ test("disconnecting the last channel stops the bridge before deleting state, so 
   await runtime.stop()
 })
 
-test("two channels run independently: one degrading or disconnecting leaves the other", async () => {
+test("two channels run independently: connect adds incrementally, disconnect removes only one", async () => {
   // Telegram + WeChat are both real platforms now, so the multi-channel paths
-  // (independent per-channel status, disconnect isolation) run against the actual
+  // (independent per-channel status, incremental add/remove) run against the actual
   // RemotePlatform union — no cast-past-union stand-in needed.
-  let emitStatus: ((status: PlatformStatus) => void) | undefined
+  const harness = bridgeHarness()
   const runtime = new RemoteBridgeRuntime(
-    deps({
-      pairers: [fakePairer("telegram"), fakePairer("wechat")],
-      buildApp: async (config) => ({
-        run(signal?: AbortSignal, _onReady?: () => void, onStatus?: (status: PlatformStatus) => void) {
-          emitStatus = onStatus
-          for (const platform of config.platforms) onStatus?.({ name: platform.name, phase: "serving" })
-          return hangUntilAbort(signal)
-        },
-      }),
-    }),
+    deps({ pairers: [fakePairer("telegram"), fakePairer("wechat")], buildApp: harness.buildApp }),
   )
   const stateOf = (platform: RemotePlatform) => runtime.getStatus().channels.find((c) => c.platform === platform)?.state
 
@@ -399,52 +431,85 @@ test("two channels run independently: one degrading or disconnecting leaves the 
   await runtime.confirmPairing("wechat")
   expect(stateOf("telegram")).toBe("connected")
   expect(stateOf("wechat")).toBe("connected")
+  // The second channel was added onto the running bridge, not a rebuild: one build
+  // (one shared event stream), and WeChat arrived via addPlatform.
+  expect(harness.state.build).toBe(1)
+  expect(harness.state.events).toEqual(["add:wechat"])
 
   // One channel degrades — the other is untouched.
-  emitStatus?.({ name: "wechat", phase: "degraded", error: "connection lost" })
+  harness.emit({ name: "wechat", phase: "degraded", error: "connection lost" })
   expect(stateOf("wechat")).toBe("degraded")
   expect(stateOf("telegram")).toBe("connected")
 
-  // Disconnecting one channel removes only it; the other survives as its own channel.
+  // Disconnecting one channel removes only it (still no rebuild); the other survives.
   await runtime.disconnect("telegram")
   expect(stateOf("telegram")).toBeUndefined()
   expect(runtime.getStatus().channels.map((c) => c.platform)).toEqual(["wechat"])
+  expect(harness.state.build).toBe(1)
+  expect(harness.state.events).toEqual(["add:wechat", "remove:telegram"])
   await runtime.stop()
 })
 
-test("rebuilding for a new channel keeps an already-connected channel from flapping to connecting", async () => {
-  let emit: ((status: PlatformStatus) => void) | undefined
+test("connecting a second channel leaves the first's shared stream and status untouched (no flap)", async () => {
+  // The root fix for #1404's flap-suppression: adding a channel never tears the
+  // shared stream down, so an already-connected channel can't blink "connecting".
+  // This asserts the real behavior (stream not rebuilt) rather than UI suppression.
+  const harness = bridgeHarness()
+  const runtime = new RemoteBridgeRuntime(
+    deps({ pairers: [fakePairer("telegram"), fakePairer("wechat")], buildApp: harness.buildApp }),
+  )
+  const stateOf = (platform: RemotePlatform) => runtime.getStatus().channels.find((c) => c.platform === platform)?.state
+
+  await runtime.startPairing("telegram", { token: "x" })
+  await runtime.confirmPairing("telegram")
+  expect(stateOf("telegram")).toBe("connected")
+
+  await runtime.startPairing("wechat")
+  await runtime.confirmPairing("wechat")
+  expect(harness.state.build).toBe(1) // one shared stream, never rebuilt
+  expect(harness.state.events).toEqual(["add:wechat"]) // WeChat added incrementally
+  expect(stateOf("telegram")).toBe("connected") // never flapped to "connecting"
+  expect(stateOf("wechat")).toBe("connected")
+  await runtime.stop()
+})
+
+test("after a fatal stream tears the bridge down, the next connect rebuilds it (not an add onto a dead app)", async () => {
+  let build = 0
+  let failFirstRun: (err: Error) => void = () => {}
   const runtime = new RemoteBridgeRuntime(
     deps({
       pairers: [fakePairer("telegram"), fakePairer("wechat")],
-      buildApp: async () => ({
-        run(signal?: AbortSignal, _onReady?: () => void, onStatus?: (status: PlatformStatus) => void) {
-          emit = onStatus
+      buildApp: async (config) => {
+        build++
+        const isFirst = build === 1
+        return appWith((signal, _onReady, onStatus) => {
+          for (const platform of config.platforms) onStatus?.({ name: platform.name, phase: "serving" })
+          // The first bridge's shared stream dies on demand; the rebuild serves.
+          if (isFirst) return new Promise<void>((_resolve, reject) => (failFirstRun = reject))
           return hangUntilAbort(signal)
-        },
-      }),
+        })
+      },
     }),
   )
   const stateOf = (platform: RemotePlatform) => runtime.getStatus().channels.find((c) => c.platform === platform)?.state
 
   await runtime.startPairing("telegram", { token: "x" })
   await runtime.confirmPairing("telegram")
-  emit?.({ name: "telegram", phase: "serving" })
   expect(stateOf("telegram")).toBe("connected")
 
-  // Adding WeChat rebuilds the shared bridge. Telegram is live and must stay
-  // "connected" through it — not blink "connecting" as if the whole page broke.
+  // The shared event stream dies: run() rejects, every channel degrades, and the
+  // live handle is dropped so it can't be added onto.
+  failFirstRun(new Error("event stream gone"))
+  await new Promise((resolve) => setTimeout(resolve, 5))
+  expect(stateOf("telegram")).toBe("degraded")
+
+  // Connecting another channel now rebuilds the whole bridge (build === 2),
+  // recovering the shared stream rather than adding onto the dead app.
   await runtime.startPairing("wechat")
   await runtime.confirmPairing("wechat")
-  expect(stateOf("telegram")).toBe("connected") // not flapped by the rebuild
-  expect(stateOf("wechat")).toBe("connecting") // the genuinely-new channel still shows connecting
-
-  // A supervisor re-drain (connecting) on the live channel is also suppressed...
-  emit?.({ name: "telegram", phase: "connecting" })
-  expect(stateOf("telegram")).toBe("connected")
-  // ...but a real failure still shows through.
-  emit?.({ name: "telegram", phase: "degraded", error: "ws closed" })
-  expect(stateOf("telegram")).toBe("degraded")
+  expect(build).toBe(2)
+  expect(stateOf("telegram")).toBe("connected") // recovered by the rebuild
+  expect(stateOf("wechat")).toBe("connected")
   await runtime.stop()
 })
 
@@ -465,15 +530,14 @@ test("stop() aborts the live bridge synchronously, before its returned promise s
   let abortedSync = false
   const runtime = new RemoteBridgeRuntime(
     deps({
-      buildApp: async () => ({
-        run(signal?: AbortSignal, _onReady?: () => void, onStatus?: (status: PlatformStatus) => void) {
+      buildApp: async () =>
+        appWith((signal, _onReady, onStatus) => {
           onStatus?.({ name: "telegram", phase: "serving" })
           return new Promise<void>((resolve) => {
             if (signal?.aborted) return resolve()
             signal?.addEventListener("abort", () => { abortedSync = true; resolve() }, { once: true })
           })
-        },
-      }),
+        }),
     }),
   )
   await runtime.startPairing("telegram", { token: "x" })

--- a/packages/desktop-electron/src/main/remote-bridge.test.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { existsSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
-import type { PlatformStatus } from "@opencode-ai/remote-bridge/gateway"
+import { BridgeClosedError, type PlatformStatus } from "@opencode-ai/remote-bridge/gateway"
 import {
   type BridgeApp,
   type CredentialStore,
@@ -693,6 +693,91 @@ test("a non-last disconnect whose credential save fails keeps the channel and is
   store.failSave = false
   await runtime.disconnect("telegram")
   expect(harness.state.events).toEqual(["remove:telegram"])
+  expect(stateOf("telegram")).toBeUndefined()
+  expect(stateOf("wechat")).toBe("connected")
+  expect(store.value).toEqual([sampleAccount("wechat")])
+  await runtime.stop()
+})
+
+test("a re-pair interrupted by a fatal stream rebuilds from the persisted account", async () => {
+  // If the shared stream goes fatal mid-add, addPlatform throws BridgeClosedError AFTER the
+  // credential is saved. The new account is durable, so the runtime rebuilds the whole bridge
+  // from it rather than reporting a success for a channel that never started.
+  const store = memoryStore([sampleAccount("telegram")])
+  const newAccount: RemoteAccount = { platform: "telegram", token: "999:xyz", allowFrom: "99", userName: "new" }
+  let build = 0
+  const buildApp: RemoteBridgeDeps["buildApp"] = async (config) => {
+    const isFirst = ++build === 1
+    return appWith(
+      (signal, _onReady, onStatus) => {
+        for (const platform of config.platforms) onStatus?.({ name: platform.name, phase: "serving" })
+        return hangUntilAbort(signal)
+      },
+      isFirst
+        ? {
+            // The live bridge: the stream dies mid-add — commit the credential, then report
+            // the bridge as closed so the runtime recovers by rebuilding.
+            addPlatform: async (_config, beforeCommit) => {
+              await beforeCommit?.()
+              throw new BridgeClosedError("telegram")
+            },
+          }
+        : {}, // the rebuilt bridge serves via run(); no incremental add
+    )
+  }
+  const runtime = new RemoteBridgeRuntime(
+    deps({
+      credentials: store,
+      buildApp,
+      pairers: [
+        fakePairer("telegram", {
+          pair: async (_start, emit) => {
+            emit({ phase: "awaitingBind", platform: "telegram", hint: "message" })
+            return newAccount
+          },
+        }),
+      ],
+    }),
+  )
+  await runtime.startIfConfigured()
+  expect(build).toBe(1)
+  expect(runtime.getStatus().channels[0].state).toBe("connected")
+
+  await runtime.startPairing("telegram", { token: "x" })
+  await runtime.confirmPairing("telegram") // the fatal add is recovered by a rebuild, not surfaced
+  expect(build).toBe(2) // rebuilt from the persisted account
+  expect(runtime.getStatus().channels[0].state).toBe("connected")
+  expect(store.value).toEqual([newAccount]) // the new credential was persisted before the rebuild
+  await runtime.stop()
+})
+
+test("a disconnect interrupted by a fatal stream rebuilds the surviving channels", async () => {
+  // The stream can die while removePlatform is winding the channel down. The trimmed accounts
+  // are already saved, so the runtime rebuilds the survivors rather than leaving them dead
+  // behind a reported-success disconnect.
+  const store = memoryStore([sampleAccount("telegram"), sampleAccount("wechat")])
+  let build = 0
+  const buildApp: RemoteBridgeDeps["buildApp"] = async (config) => {
+    const isFirst = ++build === 1
+    return appWith(
+      (signal, _onReady, onStatus) => {
+        for (const platform of config.platforms) onStatus?.({ name: platform.name, phase: "serving" })
+        return hangUntilAbort(signal)
+      },
+      isFirst ? { removePlatform: async () => { throw new BridgeClosedError("telegram") } } : {},
+    )
+  }
+  const runtime = new RemoteBridgeRuntime(
+    deps({ credentials: store, buildApp, pairers: [fakePairer("telegram"), fakePairer("wechat")] }),
+  )
+  const stateOf = (platform: RemotePlatform) => runtime.getStatus().channels.find((c) => c.platform === platform)?.state
+  await runtime.startIfConfigured()
+  expect(build).toBe(1)
+  expect(stateOf("telegram")).toBe("connected")
+  expect(stateOf("wechat")).toBe("connected")
+
+  await runtime.disconnect("telegram") // the fatal remove is recovered by rebuilding the survivor
+  expect(build).toBe(2)
   expect(stateOf("telegram")).toBeUndefined()
   expect(stateOf("wechat")).toBe("connected")
   expect(store.value).toEqual([sampleAccount("wechat")])

--- a/packages/desktop-electron/src/main/remote-bridge.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.ts
@@ -252,14 +252,9 @@ export class RemoteBridgeRuntime {
         await this.startBridge()
         return
       }
-      // Live bridge: prepare-first. addPlatform builds the new channel and runs the commit
-      // hook — which persists the credential — BEFORE it swaps out the old loop, so a save
-      // failure (locked keyring, unwritable file) aborts the swap with the old channel
-      // still serving, never a live new channel backed by a stale stored credential.
-      // `committed` flips inside the hook: once the credential is saved the desired set is
-      // durable, so a later failure must NOT roll it back. If the shared stream goes fatal
-      // mid-add, addPlatform throws BridgeClosedError after the commit (the change never
-      // took live) — rebuild the whole bridge from the now-persisted accounts.
+      // Live bridge: prepare-first. The commit hook persists the credential after the build and
+      // before the swap, so a save failure leaves the old channel serving; `committed` flips once
+      // it lands, marking the desired set durable so a later failure must not roll it back.
       const previousAccounts = this.accounts
       this.accounts = nextAccounts
       let committed = false
@@ -276,11 +271,9 @@ export class RemoteBridgeRuntime {
           throw err
         }
         if (!(err instanceof BridgeClosedError)) throw err
-        // The credential is already persisted. A user-initiated stop aborts the live handle
-        // before this BridgeClosedError surfaces, so if the handle is aborted, don't rebuild
-        // a bridge the queued stop is about to tear down — let it shut down cleanly; the next
-        // launch builds from the persisted accounts. A fatal stream (handle not aborted)
-        // still rebuilds to recover the connection.
+        // Committed, then the bridge closed: rebuild from the persisted accounts — unless a
+        // user-initiated stop aborted the handle, in which case let the queued stop tear it down
+        // (the next launch builds from the persisted accounts).
         if (handle.ac.signal.aborted) return
         await this.startBridge()
       }
@@ -323,10 +316,8 @@ export class RemoteBridgeRuntime {
         else await this.startBridge()
       } catch (err) {
         if (!(err instanceof BridgeClosedError)) throw err
-        // The shared stream went fatal mid-remove; the survivors went down with it. The
-        // trimmed accounts are already persisted, so rebuild them into a fresh bridge — unless
-        // a user-initiated stop aborted the handle, in which case the queued stop is tearing
-        // the bridge down and a rebuild during shutdown would only flap it; let stop take over.
+        // The stream closed mid-remove; the trimmed accounts are persisted, so rebuild the
+        // survivors — unless a user-initiated stop aborted the handle (then let stop take over).
         if (!handle?.ac.signal.aborted) await this.startBridge()
       }
       this.statusMap.delete(platform)

--- a/packages/desktop-electron/src/main/remote-bridge.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.ts
@@ -1,5 +1,6 @@
 import { rmSync } from "node:fs"
 import {
+  BridgeClosedError,
   normalizeLocale,
   type Config,
   type PlatformConfig,
@@ -242,8 +243,8 @@ export class RemoteBridgeRuntime {
     this.pending = null
     await this.enqueue(async () => {
       const nextAccounts = [...this.accounts.filter((account) => account.platform !== platform), pending]
-      const app = this.current?.app
-      if (!app) {
+      const handle = this.current
+      if (!handle) {
         // Cold start, or recovering after a fatal stream tore the bridge down: no live
         // channel to preserve, so commit the account and build from every saved one.
         this.accounts = nextAccounts
@@ -251,20 +252,31 @@ export class RemoteBridgeRuntime {
         await this.startBridge()
         return
       }
-      // Live bridge: prepare-first. addPlatform builds the new channel and runs the
-      // commit hook — which persists the credential — BEFORE it swaps out the old loop,
-      // so a save failure (locked keyring, unwritable file) aborts the swap with the old
-      // channel still serving, never a live new channel backed by a stale stored
-      // credential. Swap accounts in memory first so the hook persists the new list and
-      // the new channel's status renders the new identity; roll the swap back (leaving
-      // the old channel untouched) on any failure.
+      // Live bridge: prepare-first. addPlatform builds the new channel and runs the commit
+      // hook — which persists the credential — BEFORE it swaps out the old loop, so a save
+      // failure (locked keyring, unwritable file) aborts the swap with the old channel
+      // still serving, never a live new channel backed by a stale stored credential.
+      // `committed` flips inside the hook: once the credential is saved the desired set is
+      // durable, so a later failure must NOT roll it back. If the shared stream goes fatal
+      // mid-add, addPlatform throws BridgeClosedError after the commit (the change never
+      // took live) — rebuild the whole bridge from the now-persisted accounts.
       const previousAccounts = this.accounts
       this.accounts = nextAccounts
+      let committed = false
       try {
-        await app.addPlatform(this.platformConfig(pending), () => this.deps.credentials.save(this.accounts))
+        await handle.app.addPlatform(this.platformConfig(pending), () => {
+          this.deps.credentials.save(this.accounts)
+          committed = true
+        })
       } catch (err) {
-        this.accounts = previousAccounts
-        throw err
+        if (!committed) {
+          // Build or save failed before the credential was persisted: nothing is durable,
+          // so restore the in-memory accounts and surface the failure.
+          this.accounts = previousAccounts
+          throw err
+        }
+        if (!(err instanceof BridgeClosedError)) throw err
+        await this.startBridge()
       }
     })
   }
@@ -296,12 +308,19 @@ export class RemoteBridgeRuntime {
       // retryable — never half-removed in memory with its loop still live.
       this.deps.credentials.save(nextAccounts)
       this.accounts = nextAccounts
-      const app = this.current?.app
-      // Live bridge: removePlatform stops only this channel's loop and prunes its
-      // session pointers; the shared stream and the other channels keep serving.
-      // No live bridge (recovering from a fatal stream): rebuild from the rest.
-      if (app) await app.removePlatform(platform)
-      else await this.startBridge()
+      const handle = this.current
+      try {
+        // Live bridge: removePlatform stops only this channel's loop and prunes its
+        // session pointers; the shared stream and the other channels keep serving.
+        // No live bridge (recovering from a fatal stream): rebuild from the rest.
+        if (handle) await handle.app.removePlatform(platform)
+        else await this.startBridge()
+      } catch (err) {
+        if (!(err instanceof BridgeClosedError)) throw err
+        // The shared stream went fatal mid-remove; the survivors went down with it. The
+        // trimmed accounts are already persisted, so rebuild them into a fresh bridge.
+        await this.startBridge()
+      }
       this.statusMap.delete(platform)
       this.emitStatus()
     })

--- a/packages/desktop-electron/src/main/remote-bridge.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.ts
@@ -274,14 +274,15 @@ export class RemoteBridgeRuntime {
   async disconnect(platform: RemotePlatform): Promise<void> {
     if (this.pending?.platform === platform) this.cancelPairing()
     await this.enqueue(async () => {
-      this.accounts = this.accounts.filter((account) => account.platform !== platform)
-      if (this.accounts.length === 0) {
+      const nextAccounts = this.accounts.filter((account) => account.platform !== platform)
+      if (nextAccounts.length === 0) {
         // Last channel gone. Stop the live bridge FIRST, then delete the secret
         // AND the bridge state file (session pointers + event cursor): tearing
         // down before the delete keeps an in-flight inbound handler from writing
         // pointers back after the file is gone, which a reconnect would inherit.
         // Deleting needs no encryption, so revoking works even when the keyring is
         // locked — save([]) would throw and leave the token behind.
+        this.accounts = nextAccounts
         await this.stopBridge()
         this.statusMap.delete(platform)
         this.emitStatus()
@@ -289,8 +290,12 @@ export class RemoteBridgeRuntime {
         rmSync(this.deps.statePath, { force: true })
         return
       }
-      // A channel remains: persist the trimmed list, then drop just this one.
-      this.deps.credentials.save(this.accounts)
+      // A channel remains: prepare-first, mirroring add / re-pair. Persist the trimmed
+      // list BEFORE the channel leaves memory or the live App, so a save failure (locked
+      // keyring, unwritable file) leaves the channel connected and the disconnect
+      // retryable — never half-removed in memory with its loop still live.
+      this.deps.credentials.save(nextAccounts)
+      this.accounts = nextAccounts
       const app = this.current?.app
       // Live bridge: removePlatform stops only this channel's loop and prunes its
       // session pointers; the shared stream and the other channels keep serving.

--- a/packages/desktop-electron/src/main/remote-bridge.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.ts
@@ -226,32 +226,43 @@ export class RemoteBridgeRuntime {
   }
 
   /**
-   * Approve the pending account for `platform` and (re)start the bridge with it.
-   * The secret was captured main-side, so the renderer approves the captured
-   * identity without resending it. Replaces any existing account for the platform.
+   * Approve the pending account for `platform` and connect it. On a cold bridge this
+   * builds the whole bridge; on a live bridge it connects just this channel, leaving
+   * the shared event stream and the other channels running. A live re-pair is
+   * prepare-first: the new channel is built and connected before the saved credential
+   * is replaced, so a failed re-pair leaves the working channel and its stored
+   * credential exactly as they were (the in-memory account swap is rolled back and the
+   * error rethrown). The secret was captured main-side, so the renderer approves the
+   * captured identity without resending it.
    */
   async confirmPairing(platform: RemotePlatform): Promise<void> {
     const pending = this.pending
     if (!pending || pending.platform !== platform) throw new Error("no pairing is awaiting confirmation")
     this.pending = null
     await this.enqueue(async () => {
-      this.accounts = [...this.accounts.filter((account) => account.platform !== platform), pending]
-      this.deps.credentials.save(this.accounts)
+      const nextAccounts = [...this.accounts.filter((account) => account.platform !== platform), pending]
       const app = this.current?.app
       if (!app) {
-        // Cold start, or recovering after a fatal stream tore the bridge down:
-        // build the whole bridge from every saved account.
+        // Cold start, or recovering after a fatal stream tore the bridge down: no live
+        // channel to preserve, so commit the account and build from every saved one.
+        this.accounts = nextAccounts
+        this.deps.credentials.save(this.accounts)
         await this.startBridge()
         return
       }
-      // Live bridge: connect (or re-pair) just this channel, leaving the shared
-      // event stream and the other channels running. addPlatform replaces an
-      // existing same-name channel in place, keeping its conversation pointers.
-      this.putChannel({ platform, state: "connecting", identity: this.pairerFor(pending).identity(pending), error: null })
+      // Live bridge: prepare-first. Build + connect the new channel BEFORE persisting
+      // the new credential, so a failed re-pair keeps the working channel and its
+      // saved credential intact. Swap accounts in memory first so the new channel's
+      // status renders the new identity; persist only once addPlatform succeeds, and
+      // roll the swap back (leaving the old channel untouched) on failure.
+      const previousAccounts = this.accounts
+      this.accounts = nextAccounts
       try {
         await app.addPlatform(this.platformConfig(pending))
+        this.deps.credentials.save(this.accounts)
       } catch (err) {
-        this.putChannel({ platform, state: "degraded", identity: this.pairerFor(pending).identity(pending), error: message(err) })
+        this.accounts = previousAccounts
+        throw err
       }
     })
   }

--- a/packages/desktop-electron/src/main/remote-bridge.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.ts
@@ -1,5 +1,11 @@
 import { rmSync } from "node:fs"
-import { normalizeLocale, type Config, type PlatformFactory, type PlatformStatus } from "@opencode-ai/remote-bridge/gateway"
+import {
+  normalizeLocale,
+  type Config,
+  type PlatformConfig,
+  type PlatformFactory,
+  type PlatformStatus,
+} from "@opencode-ai/remote-bridge/gateway"
 import type { Platform } from "@opencode-ai/remote-bridge/types"
 import type {
   RemoteChannelStatus,
@@ -70,9 +76,15 @@ interface ServerInfo {
   password?: string | null
 }
 
-/** A runnable bridge, as the runtime needs it (`createApp`'s `App` satisfies it). */
-interface BridgeApp {
+/** A runnable bridge, as the runtime needs it (`createApp`'s `App` satisfies it).
+ * `run` owns the shared event stream for the bridge's life; addPlatform /
+ * removePlatform connect or disconnect a single channel on the running bridge
+ * without restarting the stream or the other channels. Exported so the runtime's
+ * tests can supply a fake bridge against the same contract. */
+export interface BridgeApp {
   run(signal?: AbortSignal, onReady?: () => void, onStatus?: (status: PlatformStatus) => void): Promise<void>
+  addPlatform(config: PlatformConfig): Promise<void>
+  removePlatform(name: string): Promise<void>
 }
 
 export interface RemoteBridgeDeps {
@@ -91,11 +103,15 @@ export interface RemoteBridgeDeps {
  * Owns the single in-process bridge for the desktop app. Several platforms can be
  * connected at once: they run under one `App` (the gateway supervises each in its
  * own restart loop) and report status independently — a dead channel shows
- * `degraded` while the others stay `connected`. Every lifecycle change (confirm /
- * disconnect / shutdown) runs through one serial queue so a double-click can never
- * start two bridges. Pairing runs off to the side on its own transport and is
- * always settled before the queue rebuilds the bridge. The bridge runs in the
- * background — its failures land in `status`, never as an unhandled rejection.
+ * `degraded` while the others stay `connected`. Once the bridge is up, connecting
+ * or disconnecting a channel adds/removes just that channel on the running `App`,
+ * leaving the shared event stream and the other channels untouched; a full rebuild
+ * is only for cold start, the last-channel teardown, and recovery after a fatal
+ * stream error. Every lifecycle change (confirm / disconnect / shutdown) runs
+ * through one serial queue so a double-click can never start two bridges. Pairing
+ * runs off to the side on its own transport and is always settled before the queue
+ * touches the bridge. The bridge runs in the background — its failures land in
+ * `status`, never as an unhandled rejection.
  */
 export class RemoteBridgeRuntime {
   private accounts: RemoteAccount[] = []
@@ -104,8 +120,10 @@ export class RemoteBridgeRuntime {
   private readonly pairingListeners = new Set<(event: RemotePairingEvent) => void>()
   private readonly pairers = new Map<RemotePlatform, PlatformPairer>()
   private queue: Promise<unknown> = Promise.resolve()
-  private ac: AbortController | null = null
-  private runPromise: Promise<void> | null = null
+  // The live bridge as one handle: "is a bridge running?" is a single null check,
+  // and a settled run (clean stop OR fatal stream) drops the whole handle at once,
+  // so a later confirm/disconnect can't add a channel onto a dead app.
+  private current: { app: BridgeApp; ac: AbortController; runPromise: Promise<void> } | null = null
   private pairingAc: AbortController | null = null
   // The captured-but-not-yet-approved account. Held main-side between the pairing
   // flow and confirmPairing so the renderer never has to resend the secret.
@@ -219,17 +237,31 @@ export class RemoteBridgeRuntime {
     await this.enqueue(async () => {
       this.accounts = [...this.accounts.filter((account) => account.platform !== platform), pending]
       this.deps.credentials.save(this.accounts)
-      await this.startBridge()
+      const app = this.current?.app
+      if (!app) {
+        // Cold start, or recovering after a fatal stream tore the bridge down:
+        // build the whole bridge from every saved account.
+        await this.startBridge()
+        return
+      }
+      // Live bridge: connect (or re-pair) just this channel, leaving the shared
+      // event stream and the other channels running. addPlatform replaces an
+      // existing same-name channel in place, keeping its conversation pointers.
+      this.putChannel({ platform, state: "connecting", identity: this.pairerFor(pending).identity(pending), error: null })
+      try {
+        await app.addPlatform(this.platformConfig(pending))
+      } catch (err) {
+        this.putChannel({ platform, state: "degraded", identity: this.pairerFor(pending).identity(pending), error: message(err) })
+      }
     })
   }
 
-  /** Remove one platform's account and rebuild the bridge from the rest. */
+  /** Disconnect one platform: stop just its channel when the bridge is live,
+   * leaving the others serving; tear the whole bridge down when it was the last. */
   async disconnect(platform: RemotePlatform): Promise<void> {
     if (this.pending?.platform === platform) this.cancelPairing()
     await this.enqueue(async () => {
       this.accounts = this.accounts.filter((account) => account.platform !== platform)
-      this.statusMap.delete(platform)
-      this.emitStatus()
       if (this.accounts.length === 0) {
         // Last channel gone. Stop the live bridge FIRST, then delete the secret
         // AND the bridge state file (session pointers + event cursor): tearing
@@ -238,15 +270,22 @@ export class RemoteBridgeRuntime {
         // Deleting needs no encryption, so revoking works even when the keyring is
         // locked — save([]) would throw and leave the token behind.
         await this.stopBridge()
+        this.statusMap.delete(platform)
+        this.emitStatus()
         this.deps.credentials.clear()
         rmSync(this.deps.statePath, { force: true })
         return
       }
-      // A channel remains: persist the trimmed list and rebuild from the rest.
-      // (Pruning just the disconnected platform's pointers from statePath lands
-      // with the 2nd platform.)
+      // A channel remains: persist the trimmed list, then drop just this one.
       this.deps.credentials.save(this.accounts)
-      await this.startBridge()
+      const app = this.current?.app
+      // Live bridge: removePlatform stops only this channel's loop and prunes its
+      // session pointers; the shared stream and the other channels keep serving.
+      // No live bridge (recovering from a fatal stream): rebuild from the rest.
+      if (app) await app.removePlatform(platform)
+      else await this.startBridge()
+      this.statusMap.delete(platform)
+      this.emitStatus()
     })
   }
 
@@ -258,19 +297,18 @@ export class RemoteBridgeRuntime {
     // sync prefix — otherwise the poll loop is still running against the sidecar
     // (the server it talks to) at the moment it is torn down. stopBridge re-aborts
     // (idempotent) and awaits the teardown.
-    this.ac?.abort()
+    this.current?.ac.abort()
     await this.enqueue(() => this.stopBridge())
   }
 
   private async startBridge(): Promise<void> {
     await this.stopBridge()
     if (this.accounts.length === 0) return
+    // A full (re)build starts every channel from "connecting". This path runs only
+    // at cold start, after the last channel is removed, or to recover from a fatal
+    // stream — never to add one channel onto a live bridge — so no channel is
+    // already connected here and there is nothing to flap.
     for (const account of this.accounts) {
-      // A rebuild restarts the shared stream for every channel (adding or removing
-      // one tears them all down and back up). Don't flap an already-connected channel
-      // back to "connecting" — to the user that reads as "everything just broke". Keep
-      // it as-is; only a channel that isn't connected yet shows "connecting".
-      if (this.statusMap.get(account.platform)?.state === "connected") continue
       this.putChannel({ platform: account.platform, state: "connecting", identity: this.pairerFor(account).identity(account), error: null })
     }
     let app: BridgeApp
@@ -284,18 +322,9 @@ export class RemoteBridgeRuntime {
         locale: normalizeLocale(this.deps.locale()),
         // Only the non-secret audience travels through config (which may be logged);
         // the secret is captured in the factory closure below, never placed here.
-        platforms: this.accounts.map((account) => ({
-          name: account.platform,
-          enabled: true,
-          options: this.pairerFor(account).audience(account),
-        })),
+        platforms: this.accounts.map((account) => this.platformConfig(account)),
       }
-      const factory: PlatformFactory = (name) => {
-        const account = this.accounts.find((candidate) => candidate.platform === name)
-        if (!account) throw new Error(`unsupported platform ${name}`)
-        return this.pairerFor(account).makePlatform(account)
-      }
-      app = await this.deps.buildApp(config, factory)
+      app = await this.deps.buildApp(config, this.buildFactory())
     } catch (err) {
       // serverInfo / buildApp failed before the bridge ran. Land every account on
       // degraded so confirmPairing/disconnect — which await this directly — can't
@@ -306,48 +335,76 @@ export class RemoteBridgeRuntime {
       throw err
     }
     const ac = new AbortController()
-    this.ac = ac
     // Per-platform status comes from the supervisor: each channel flips
     // connecting → connected as it drains its backlog and serves, or → degraded on
-    // a failure it is retrying. The `this.ac === ac` guard keeps a stale run from
-    // clobbering a newer build's status.
+    // a failure it is retrying. The `this.current?.ac === ac` guard keeps a stale
+    // run from clobbering a newer build's status.
     const onStatus = (status: PlatformStatus) => {
-      if (this.ac !== ac) return
-      const account = this.accounts.find((candidate) => candidate.platform === status.name)
-      if (!account) return
-      const state: RemoteState = status.phase === "serving" ? "connected" : status.phase === "degraded" ? "degraded" : "connecting"
-      // Same as the pre-mark above: don't drop a live channel to "connecting" while the
-      // rebuild re-drains it. It stays connected until it's serving again (confirmed) or
-      // degraded (a real failure), so adding one channel never makes the others blink.
-      if (state === "connecting" && this.statusMap.get(account.platform)?.state === "connected") return
-      this.putChannel({ platform: account.platform, state, identity: this.pairerFor(account).identity(account), error: status.error ?? null })
+      if (this.current?.ac !== ac) return
+      this.applyPlatformStatus(status)
     }
-    const run = app.run(ac.signal, undefined, onStatus)
-    this.runPromise = run
-    // run() resolves on a clean stop (an abort, handled by stopBridge / the next
-    // build) and rejects only on a fatal stream error — the shared event stream is
-    // dead, so every channel degrades. Observe it so that failure becomes status
-    // rather than an unhandled rejection.
-    run
+    // Publish the handle (with its ac) BEFORE run(), so a status the adapter emits
+    // synchronously inside run() passes the guard instead of being dropped.
+    // runPromise is filled on the same tick — no await before it — so stopBridge
+    // always sees the real promise.
+    const handle: { app: BridgeApp; ac: AbortController; runPromise: Promise<void> } = {
+      app,
+      ac,
+      runPromise: Promise.resolve(),
+    }
+    this.current = handle
+    const runPromise = app.run(ac.signal, undefined, onStatus)
+    handle.runPromise = runPromise
+    // run() resolves on a clean stop (an abort, from stopBridge / the next build)
+    // and rejects only on a fatal stream error — the shared event stream is dead,
+    // so every channel degrades. Observe it so failure becomes status, and clear
+    // the handle on any settle so a later confirm/disconnect rebuilds rather than
+    // adding a channel onto a dead app.
+    runPromise
       .then(() => {})
       .catch((err) => {
-        if (this.ac !== ac) return
+        if (this.current !== handle) return
         for (const account of this.accounts) {
           this.putChannel({ platform: account.platform, state: "degraded", identity: this.pairerFor(account).identity(account), error: message(err) })
         }
       })
+      .finally(() => {
+        if (this.current === handle) this.current = null
+      })
+  }
+
+  /** Map one supervisor status onto a channel's UI state. Skips a status whose
+   * platform is no longer a saved account (e.g. a removed channel's late event). */
+  private applyPlatformStatus(status: PlatformStatus): void {
+    const account = this.accounts.find((candidate) => candidate.platform === status.name)
+    if (!account) return
+    const state: RemoteState = status.phase === "serving" ? "connected" : status.phase === "degraded" ? "degraded" : "connecting"
+    this.putChannel({ platform: account.platform, state, identity: this.pairerFor(account).identity(account), error: status.error ?? null })
+  }
+
+  /** The non-secret config the gateway needs for one account: name + audience.
+   * The secret stays in the factory closure (buildFactory), never in config. */
+  private platformConfig(account: RemoteAccount): PlatformConfig {
+    return { name: account.platform, enabled: true, options: this.pairerFor(account).audience(account) }
+  }
+
+  /** Builds a live platform for a name by looking up its saved account, so the
+   * secret is read from `accounts` at build time (cold start or incremental add)
+   * rather than travelling through the loggable config. */
+  private buildFactory(): PlatformFactory {
+    return (name) => {
+      const account = this.accounts.find((candidate) => candidate.platform === name)
+      if (!account) throw new Error(`unsupported platform ${name}`)
+      return this.pairerFor(account).makePlatform(account)
+    }
   }
 
   private async stopBridge(): Promise<void> {
-    const ac = this.ac
-    const runPromise = this.runPromise
-    this.ac = null
-    this.runPromise = null
-    if (!ac) return
-    ac.abort()
-    if (runPromise) {
-      await Promise.race([runPromise.catch(() => {}), delay(STOP_TIMEOUT_MS)])
-    }
+    const handle = this.current
+    this.current = null
+    if (!handle) return
+    handle.ac.abort()
+    await Promise.race([handle.runPromise.catch(() => {}), delay(STOP_TIMEOUT_MS)])
   }
 
   private pairerFor(account: RemoteAccount): PlatformPairer {

--- a/packages/desktop-electron/src/main/remote-bridge.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.ts
@@ -83,7 +83,7 @@ interface ServerInfo {
  * tests can supply a fake bridge against the same contract. */
 export interface BridgeApp {
   run(signal?: AbortSignal, onReady?: () => void, onStatus?: (status: PlatformStatus) => void): Promise<void>
-  addPlatform(config: PlatformConfig): Promise<void>
+  addPlatform(config: PlatformConfig, beforeCommit?: () => void | Promise<void>): Promise<void>
   removePlatform(name: string): Promise<void>
 }
 
@@ -228,12 +228,13 @@ export class RemoteBridgeRuntime {
   /**
    * Approve the pending account for `platform` and connect it. On a cold bridge this
    * builds the whole bridge; on a live bridge it connects just this channel, leaving
-   * the shared event stream and the other channels running. A live re-pair is
-   * prepare-first: the new channel is built and connected before the saved credential
-   * is replaced, so a failed re-pair leaves the working channel and its stored
-   * credential exactly as they were (the in-memory account swap is rolled back and the
-   * error rethrown). The secret was captured main-side, so the renderer approves the
-   * captured identity without resending it.
+   * the shared event stream and the other channels running. A live re-pair (or adding a
+   * second channel) is prepare-first: the new channel is built and its credential saved
+   * before the old loop is swapped out, so any failure — a bad build or an unwritable
+   * credential store — leaves the working channel and its stored credential exactly as
+   * they were (the in-memory account swap is rolled back and the error rethrown). The
+   * secret was captured main-side, so the renderer approves the captured identity
+   * without resending it.
    */
   async confirmPairing(platform: RemotePlatform): Promise<void> {
     const pending = this.pending
@@ -250,16 +251,17 @@ export class RemoteBridgeRuntime {
         await this.startBridge()
         return
       }
-      // Live bridge: prepare-first. Build + connect the new channel BEFORE persisting
-      // the new credential, so a failed re-pair keeps the working channel and its
-      // saved credential intact. Swap accounts in memory first so the new channel's
-      // status renders the new identity; persist only once addPlatform succeeds, and
-      // roll the swap back (leaving the old channel untouched) on failure.
+      // Live bridge: prepare-first. addPlatform builds the new channel and runs the
+      // commit hook — which persists the credential — BEFORE it swaps out the old loop,
+      // so a save failure (locked keyring, unwritable file) aborts the swap with the old
+      // channel still serving, never a live new channel backed by a stale stored
+      // credential. Swap accounts in memory first so the hook persists the new list and
+      // the new channel's status renders the new identity; roll the swap back (leaving
+      // the old channel untouched) on any failure.
       const previousAccounts = this.accounts
       this.accounts = nextAccounts
       try {
-        await app.addPlatform(this.platformConfig(pending))
-        this.deps.credentials.save(this.accounts)
+        await app.addPlatform(this.platformConfig(pending), () => this.deps.credentials.save(this.accounts))
       } catch (err) {
         this.accounts = previousAccounts
         throw err

--- a/packages/desktop-electron/src/main/remote-bridge.ts
+++ b/packages/desktop-electron/src/main/remote-bridge.ts
@@ -276,6 +276,12 @@ export class RemoteBridgeRuntime {
           throw err
         }
         if (!(err instanceof BridgeClosedError)) throw err
+        // The credential is already persisted. A user-initiated stop aborts the live handle
+        // before this BridgeClosedError surfaces, so if the handle is aborted, don't rebuild
+        // a bridge the queued stop is about to tear down — let it shut down cleanly; the next
+        // launch builds from the persisted accounts. A fatal stream (handle not aborted)
+        // still rebuilds to recover the connection.
+        if (handle.ac.signal.aborted) return
         await this.startBridge()
       }
     })
@@ -318,8 +324,10 @@ export class RemoteBridgeRuntime {
       } catch (err) {
         if (!(err instanceof BridgeClosedError)) throw err
         // The shared stream went fatal mid-remove; the survivors went down with it. The
-        // trimmed accounts are already persisted, so rebuild them into a fresh bridge.
-        await this.startBridge()
+        // trimmed accounts are already persisted, so rebuild them into a fresh bridge — unless
+        // a user-initiated stop aborted the handle, in which case the queued stop is tearing
+        // the bridge down and a rebuild during shutdown would only flap it; let stop take over.
+        if (!handle?.ac.signal.aborted) await this.startBridge()
       }
       this.statusMap.delete(platform)
       this.emitStatus()

--- a/packages/remote-bridge/src/engine.test.ts
+++ b/packages/remote-bridge/src/engine.test.ts
@@ -338,6 +338,27 @@ test("restores the reply target after a restart", async () => {
   expect(platform.replies).toHaveLength(0)
 })
 
+test("unregisterPlatform drops a platform's active delivery and routing on disconnect", async () => {
+  const sidecar = new FakeSidecar()
+  const platform = new FakePlatform("slack")
+  const engine = new Engine(sidecar)
+  engine.registerPlatform(platform)
+  // An inbound makes this platform the active delivery target for its session.
+  await engine.handleMessage(platform, { sessionKey: "slack:dm:alice", content: "what changed?" })
+  await engine.handleAssistantText("ses_new", "first answer")
+  expect(platform.replies).toEqual(["first answer"])
+
+  // Disconnect the channel: the active target is dropped and it is removed from the
+  // reconstruct index, so a later assistant event is not pushed to the stopped
+  // platform (neither as a live reply nor restored via reconstructReplyCtx).
+  engine.unregisterPlatform("slack")
+  platform.reconstructKey = ""
+  await engine.handleAssistantText("ses_new", "after disconnect")
+  expect(platform.replies).toEqual(["first answer"])
+  expect(platform.sends).toEqual([])
+  expect(platform.reconstructKey).toBe("")
+})
+
 test("surfaces a pending permission and answers it", async () => {
   const sidecar = new FakeSidecar()
   const platform = new FakePlatform()

--- a/packages/remote-bridge/src/engine.ts
+++ b/packages/remote-bridge/src/engine.ts
@@ -55,6 +55,22 @@ export class Engine implements EventHandler {
     this.platforms.set(platform.name, platform)
   }
 
+  /**
+   * Drop a platform from routing when its channel disconnects: remove it from the
+   * reconstruct-reply index and discard any active delivery target pointing at it,
+   * so a later assistant event for one of its sessions can't push to a stopped
+   * platform. Liveness of *inbound* messages is enforced by the gateway's message
+   * handler (it owns the live platform set); the remoteKey→session pointers are
+   * pruned separately, since they outlive the live platform.
+   */
+  unregisterPlatform(name: string): void {
+    if (name.trim() === "") return
+    this.platforms.delete(name)
+    for (const [sessionID, delivery] of this.active) {
+      if (delivery.platform.name === name) this.active.delete(sessionID)
+    }
+  }
+
   async registerSession(session: Session): Promise<void> {
     if (session.id === "" || session.parentID === "") return
     await this.pointers.setParent(session.id, session.parentID)

--- a/packages/remote-bridge/src/gateway.test.ts
+++ b/packages/remote-bridge/src/gateway.test.ts
@@ -798,6 +798,71 @@ test("removePlatform stops only that channel, leaving the stream and the others 
   }
 })
 
+test("a re-pair whose factory throws retires the old channel instead of leaving it live", async () => {
+  // addPlatform must retire any live same-name instance BEFORE building the
+  // replacement: a factory failure must not leave the old loop serving while the
+  // caller has already committed the new identity. Without retire-first the old
+  // platform would still be running (stops === 0) and still in the live set.
+  const original = new FakePlatform("rt-repair")
+  let builds = 0
+  const server = mockServer((_req, url) => {
+    switch (url.pathname) {
+      case "/experimental/session":
+      case "/permission":
+      case "/external-result":
+        return jsonBody([])
+      case "/global/event":
+        return openEventStream()
+    }
+    return undefined
+  })
+  const controller = new AbortController()
+  try {
+    const app = await createApp(
+      {
+        pawWorkBaseURL: server.url,
+        statePath: await tempStatePath(),
+        platforms: [{ name: "rt-repair", enabled: true, options: { allow_from: "U1" } }],
+      },
+      (name) => {
+        builds++
+        if (builds === 1) return original
+        throw new Error("rebuild boom") // the re-pair's build fails
+      },
+    )
+    const runPromise = app.run(controller.signal)
+    await original.started.promise
+
+    // Re-pair the same name; the second build throws.
+    await expect(
+      app.addPlatform({ name: "rt-repair", enabled: true, options: { allow_from: "U2" } }),
+    ).rejects.toThrow("rebuild boom")
+
+    // The old instance was retired first: stopped and dropped from the live set, so
+    // it is no longer serving and its late inbound is dropped by the liveness guard.
+    expect(original.stops).toBe(1)
+    expect(app.platformNames()).toEqual([])
+
+    let warned = false
+    const originalWarn = console.warn
+    console.warn = () => {
+      warned = true
+    }
+    try {
+      app.messageHandler()(original, { sessionKey: "rt-repair:dm:alice", content: "late" })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      expect(warned).toBe(false)
+    } finally {
+      console.warn = originalWarn
+    }
+
+    controller.abort()
+    await runPromise
+  } finally {
+    server.stop()
+  }
+})
+
 test("addPlatform refuses a wildcard audience on a running app", async () => {
   const platform = new FakePlatform("rt-wildcard-add")
   const server = mockServer((_req, url) => {

--- a/packages/remote-bridge/src/gateway.test.ts
+++ b/packages/remote-bridge/src/gateway.test.ts
@@ -13,6 +13,7 @@ import {
   type Config,
 } from "./gateway.ts"
 import { PawWorkClient } from "./pawwork-client.ts"
+import { SessionPointers } from "./session-pointers.ts"
 import type { Message, MessageHandler, Platform, Sidecar } from "./types.ts"
 
 // Zero the delivery backoff so the hydrate retry path runs instantly.
@@ -43,6 +44,7 @@ class FakePlatform implements Platform {
   reconstructKey = ""
   startedAfterStream = false
   readyCalls = 0
+  stops = 0
   fireReady: () => void = () => {}
   readonly started = deferred<void>()
   private readonly stopped = deferred<void>()
@@ -88,6 +90,7 @@ class FakePlatform implements Platform {
     return "restored-reply-context"
   }
   async stop(): Promise<void> {
+    this.stops++
     this.stopped.resolve()
   }
 }
@@ -653,17 +656,180 @@ test("messageHandler logs engine failures", async () => {
     warnings.push(args)
   }
   try {
+    const platform = new FakePlatform("runtime-test-message-log")
     const app = new App({
       client: undefined as unknown as PawWorkClient,
       engine: new Engine(new FailingSidecar()),
-      platforms: [],
+      pointers: SessionPointers.memory(),
+      factory: () => platform,
     })
-    const platform = new FakePlatform("runtime-test-message-log")
+    // Register the platform as the live instance, so the handler's liveness guard
+    // lets the message through to the (failing) engine.
+    await app.addPlatform({ name: platform.name, enabled: true, options: { allow_from: "U123" } })
     const msg: Message = { sessionKey: "runtime-test-message-log:dm:alice", content: "start" }
     app.messageHandler()(platform, msg)
     await waitUntil(() => warnings.length > 0)
     expect(warnings.some((args) => String(args[0]).includes("remote bridge failed to handle inbound message"))).toBe(true)
   } finally {
     console.warn = originalWarn
+  }
+})
+
+test("messageHandler drops an inbound from a platform that is no longer the live instance", async () => {
+  // A removed or replaced channel's in-flight message must not create a session or
+  // send a prompt: the gateway owns the live set, so a stale instance is ignored.
+  const platform = new FakePlatform("runtime-test-stale-inbound")
+  const app = new App({
+    client: undefined as unknown as PawWorkClient,
+    engine: new Engine(new FailingSidecar()),
+    pointers: SessionPointers.memory(),
+    factory: () => platform,
+  })
+  await app.addPlatform({ name: platform.name, enabled: true, options: { allow_from: "U123" } })
+  await app.removePlatform(platform.name)
+
+  let warned = false
+  const originalWarn = console.warn
+  console.warn = () => {
+    warned = true
+  }
+  try {
+    // The same instance delivers after removal: a live handler would hit the
+    // FailingSidecar and warn; the guard drops it, so nothing is logged.
+    app.messageHandler()(platform, { sessionKey: "runtime-test-stale-inbound:dm:alice", content: "late" })
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    expect(warned).toBe(false)
+  } finally {
+    console.warn = originalWarn
+  }
+})
+
+test("addPlatform connects a new channel without restarting the shared event stream", async () => {
+  let streamConnects = 0
+  const first = new FakePlatform("rt-add-first")
+  const second = new FakePlatform("rt-add-second")
+  const built: Record<string, FakePlatform> = { "rt-add-first": first, "rt-add-second": second }
+  const server = mockServer((_req, url) => {
+    switch (url.pathname) {
+      case "/experimental/session":
+      case "/permission":
+      case "/external-result":
+        return jsonBody([])
+      case "/global/event":
+        streamConnects++
+        return openEventStream()
+    }
+    return undefined
+  })
+  const controller = new AbortController()
+  try {
+    const ready = deferred<void>()
+    const app = await createApp(
+      {
+        pawWorkBaseURL: server.url,
+        statePath: await tempStatePath(),
+        platforms: [{ name: "rt-add-first", enabled: true, options: { allow_from: "U1" } }],
+      },
+      (name) => built[name],
+    )
+    const runPromise = app.run(controller.signal, () => ready.resolve())
+    await ready.promise
+    await first.started.promise
+    expect(streamConnects).toBe(1)
+
+    // Connect a second channel on the running app: it starts, the shared stream is
+    // not restarted, and the first channel is never stopped.
+    await app.addPlatform({ name: "rt-add-second", enabled: true, options: { allow_from: "U2" } })
+    await second.started.promise
+    expect(app.platformNames().sort()).toEqual(["rt-add-first", "rt-add-second"])
+    expect(streamConnects).toBe(1)
+    expect(first.stops).toBe(0)
+    controller.abort()
+    await runPromise
+  } finally {
+    server.stop()
+  }
+})
+
+test("removePlatform stops only that channel, leaving the stream and the others up", async () => {
+  let streamConnects = 0
+  const keep = new FakePlatform("rt-keep")
+  const drop = new FakePlatform("rt-drop")
+  const built: Record<string, FakePlatform> = { "rt-keep": keep, "rt-drop": drop }
+  const server = mockServer((_req, url) => {
+    switch (url.pathname) {
+      case "/experimental/session":
+      case "/permission":
+      case "/external-result":
+        return jsonBody([])
+      case "/global/event":
+        streamConnects++
+        return openEventStream()
+    }
+    return undefined
+  })
+  const controller = new AbortController()
+  try {
+    const app = await createApp(
+      {
+        pawWorkBaseURL: server.url,
+        statePath: await tempStatePath(),
+        platforms: [
+          { name: "rt-keep", enabled: true, options: { allow_from: "U1" } },
+          { name: "rt-drop", enabled: true, options: { allow_from: "U2" } },
+        ],
+      },
+      (name) => built[name],
+    )
+    const runPromise = app.run(controller.signal)
+    await keep.started.promise
+    await drop.started.promise
+    expect(streamConnects).toBe(1)
+
+    await app.removePlatform("rt-drop")
+    expect(app.platformNames()).toEqual(["rt-keep"])
+    expect(drop.stops).toBe(1) // the removed channel's loop was stopped
+    expect(keep.stops).toBe(0) // the survivor was untouched
+    expect(streamConnects).toBe(1) // shared stream never restarted
+    controller.abort()
+    await runPromise
+  } finally {
+    server.stop()
+  }
+})
+
+test("addPlatform refuses a wildcard audience on a running app", async () => {
+  const platform = new FakePlatform("rt-wildcard-add")
+  const server = mockServer((_req, url) => {
+    switch (url.pathname) {
+      case "/experimental/session":
+      case "/permission":
+      case "/external-result":
+        return jsonBody([])
+      case "/global/event":
+        return openEventStream()
+    }
+    return undefined
+  })
+  const controller = new AbortController()
+  try {
+    const app = await createApp(
+      {
+        pawWorkBaseURL: server.url,
+        statePath: await tempStatePath(),
+        platforms: [{ name: "rt-wildcard-add", enabled: true, options: { allow_from: "U1" } }],
+      },
+      () => platform,
+    )
+    const runPromise = app.run(controller.signal)
+    await platform.started.promise
+    await expect(
+      app.addPlatform({ name: "rt-evil", enabled: true, options: { allow_from: "*" } }),
+    ).rejects.toThrow("specific allow_from")
+    expect(app.platformNames()).toEqual(["rt-wildcard-add"])
+    controller.abort()
+    await runPromise
+  } finally {
+    server.stop()
   }
 })

--- a/packages/remote-bridge/src/gateway.test.ts
+++ b/packages/remote-bridge/src/gateway.test.ts
@@ -805,6 +805,41 @@ test("removePlatform stops only that channel, leaving the stream and the others 
   }
 })
 
+test("removePlatform commits the retire even when forgetting session pointers fails", async () => {
+  // The live retire is the disconnect's commit: once the channel's loop is stopped and it has
+  // left routing, the disconnect is durably done. Forgetting its session pointers is best-effort
+  // cleanup, so a pointer-store write failure is logged, not thrown — otherwise the desktop would
+  // surface a failed disconnect and strand the UI showing a channel that has already stopped.
+  const platform = new FakePlatform("rt-ptr-fail")
+  const pointers = {
+    clearPlatform: async () => {
+      throw new Error("pointer store write failed")
+    },
+  } as unknown as SessionPointers
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnings.push(String(args[0]))
+  }
+  try {
+    const app = new App({
+      client: undefined as unknown as PawWorkClient,
+      engine: new Engine(new FailingSidecar()),
+      pointers,
+      factory: () => platform,
+    })
+    await app.addPlatform({ name: platform.name, enabled: true, options: { allow_from: "U1" } })
+
+    // The pointer cleanup throws, but removePlatform must still resolve: the retire already
+    // committed, so the channel is gone and the failure is only logged.
+    await app.removePlatform(platform.name)
+    expect(app.platformNames()).toEqual([])
+    expect(warnings.some((line) => line.includes("could not forget session pointers"))).toBe(true)
+  } finally {
+    console.warn = originalWarn
+  }
+})
+
 test("a re-pair whose factory throws leaves the existing channel serving (prepare-first)", async () => {
   // Prepare-first: the replacement is built BEFORE the old loop is retired, so a
   // factory failure on a re-pair leaves the working channel up — not stopped, and

--- a/packages/remote-bridge/src/gateway.test.ts
+++ b/packages/remote-bridge/src/gateway.test.ts
@@ -798,11 +798,11 @@ test("removePlatform stops only that channel, leaving the stream and the others 
   }
 })
 
-test("a re-pair whose factory throws retires the old channel instead of leaving it live", async () => {
-  // addPlatform must retire any live same-name instance BEFORE building the
-  // replacement: a factory failure must not leave the old loop serving while the
-  // caller has already committed the new identity. Without retire-first the old
-  // platform would still be running (stops === 0) and still in the live set.
+test("a re-pair whose factory throws leaves the existing channel serving (prepare-first)", async () => {
+  // Prepare-first: the replacement is built BEFORE the old loop is retired, so a
+  // factory failure on a re-pair leaves the working channel up — not stopped, and
+  // still the live instance. The caller rolls back its saved account instead of
+  // losing the connection.
   const original = new FakePlatform("rt-repair")
   let builds = 0
   const server = mockServer((_req, url) => {
@@ -838,23 +838,9 @@ test("a re-pair whose factory throws retires the old channel instead of leaving 
       app.addPlatform({ name: "rt-repair", enabled: true, options: { allow_from: "U2" } }),
     ).rejects.toThrow("rebuild boom")
 
-    // The old instance was retired first: stopped and dropped from the live set, so
-    // it is no longer serving and its late inbound is dropped by the liveness guard.
-    expect(original.stops).toBe(1)
-    expect(app.platformNames()).toEqual([])
-
-    let warned = false
-    const originalWarn = console.warn
-    console.warn = () => {
-      warned = true
-    }
-    try {
-      app.messageHandler()(original, { sessionKey: "rt-repair:dm:alice", content: "late" })
-      await new Promise((resolve) => setTimeout(resolve, 5))
-      expect(warned).toBe(false)
-    } finally {
-      console.warn = originalWarn
-    }
+    // The old instance was never touched: still serving, still the live instance.
+    expect(original.stops).toBe(0)
+    expect(app.platformNames()).toEqual(["rt-repair"])
 
     controller.abort()
     await runPromise
@@ -863,12 +849,10 @@ test("a re-pair whose factory throws retires the old channel instead of leaving 
   }
 })
 
-test("a re-pair with an invalid audience retires the old channel instead of leaving it live", async () => {
-  // The retire-first ordering must also cover the audience-gate failure path: once
-  // the caller has committed the new account, a same-name re-pair that fails the
-  // audience gate must not leave the old loop serving under the new identity. (A
-  // *new* name that fails the gate still leaves existing channels untouched — see the
-  // next test.)
+test("a re-pair with an invalid audience leaves the existing channel serving (prepare-first)", async () => {
+  // The audience gate fails before any swap, so a same-name re-pair with a wildcard
+  // audience leaves the working channel serving and untouched. (A *new* name that
+  // fails the gate also leaves existing channels untouched — see the next test.)
   const original = new FakePlatform("rt-repair-audience")
   const server = mockServer((_req, url) => {
     switch (url.pathname) {
@@ -899,22 +883,9 @@ test("a re-pair with an invalid audience retires the old channel instead of leav
       app.addPlatform({ name: "rt-repair-audience", enabled: true, options: { allow_from: "*" } }),
     ).rejects.toThrow("specific allow_from")
 
-    // Retired first: stopped and dropped from the live set, not left serving.
-    expect(original.stops).toBe(1)
-    expect(app.platformNames()).toEqual([])
-
-    let warned = false
-    const originalWarn = console.warn
-    console.warn = () => {
-      warned = true
-    }
-    try {
-      app.messageHandler()(original, { sessionKey: "rt-repair-audience:dm:alice", content: "late" })
-      await new Promise((resolve) => setTimeout(resolve, 5))
-      expect(warned).toBe(false)
-    } finally {
-      console.warn = originalWarn
-    }
+    // Untouched: still serving, still the live instance.
+    expect(original.stops).toBe(0)
+    expect(app.platformNames()).toEqual(["rt-repair-audience"])
 
     controller.abort()
     await runPromise

--- a/packages/remote-bridge/src/gateway.test.ts
+++ b/packages/remote-bridge/src/gateway.test.ts
@@ -863,6 +863,66 @@ test("a re-pair whose factory throws retires the old channel instead of leaving 
   }
 })
 
+test("a re-pair with an invalid audience retires the old channel instead of leaving it live", async () => {
+  // The retire-first ordering must also cover the audience-gate failure path: once
+  // the caller has committed the new account, a same-name re-pair that fails the
+  // audience gate must not leave the old loop serving under the new identity. (A
+  // *new* name that fails the gate still leaves existing channels untouched — see the
+  // next test.)
+  const original = new FakePlatform("rt-repair-audience")
+  const server = mockServer((_req, url) => {
+    switch (url.pathname) {
+      case "/experimental/session":
+      case "/permission":
+      case "/external-result":
+        return jsonBody([])
+      case "/global/event":
+        return openEventStream()
+    }
+    return undefined
+  })
+  const controller = new AbortController()
+  try {
+    const app = await createApp(
+      {
+        pawWorkBaseURL: server.url,
+        statePath: await tempStatePath(),
+        platforms: [{ name: "rt-repair-audience", enabled: true, options: { allow_from: "U1" } }],
+      },
+      () => original,
+    )
+    const runPromise = app.run(controller.signal)
+    await original.started.promise
+
+    // Re-pair the same name with a wildcard audience: the gate rejects it.
+    await expect(
+      app.addPlatform({ name: "rt-repair-audience", enabled: true, options: { allow_from: "*" } }),
+    ).rejects.toThrow("specific allow_from")
+
+    // Retired first: stopped and dropped from the live set, not left serving.
+    expect(original.stops).toBe(1)
+    expect(app.platformNames()).toEqual([])
+
+    let warned = false
+    const originalWarn = console.warn
+    console.warn = () => {
+      warned = true
+    }
+    try {
+      app.messageHandler()(original, { sessionKey: "rt-repair-audience:dm:alice", content: "late" })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      expect(warned).toBe(false)
+    } finally {
+      console.warn = originalWarn
+    }
+
+    controller.abort()
+    await runPromise
+  } finally {
+    server.stop()
+  }
+})
+
 test("addPlatform refuses a wildcard audience on a running app", async () => {
   const platform = new FakePlatform("rt-wildcard-add")
   const server = mockServer((_req, url) => {

--- a/packages/remote-bridge/src/gateway.test.ts
+++ b/packages/remote-bridge/src/gateway.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { deliveryConfig, Engine } from "./engine.ts"
 import {
   App,
+  BridgeClosedError,
   createApp,
   decodeConfig,
   hasRemoteAudience,
@@ -951,6 +952,57 @@ test("a re-pair whose new platform fails to start retires the old and surfaces t
 
     controller.abort()
     await runPromise
+  } finally {
+    server.stop()
+  }
+})
+
+test("addPlatform that finishes building after teardown throws BridgeClosedError, not a silent no-op", async () => {
+  // The fatal-stream race: the shared stream can die while a re-pair is still building. Once
+  // run() tears down (supervisor cleared), the live supervise would silently no-op and report
+  // a success the channel never honored. addPlatform must instead throw, so the caller rebuilds
+  // from the persisted accounts rather than trusting an add that never took effect.
+  const original = new FakePlatform("rt-teardown")
+  let releaseBuild!: () => void
+  const buildGate = new Promise<void>((resolve) => (releaseBuild = resolve))
+  let builds = 0
+  const server = mockServer((_req, url) => {
+    switch (url.pathname) {
+      case "/experimental/session":
+      case "/permission":
+      case "/external-result":
+        return jsonBody([])
+      case "/global/event":
+        return openEventStream()
+    }
+    return undefined
+  })
+  const controller = new AbortController()
+  try {
+    const app = await createApp(
+      {
+        pawWorkBaseURL: server.url,
+        statePath: await tempStatePath(),
+        platforms: [{ name: "rt-teardown", enabled: true, options: { allow_from: "U1" } }],
+      },
+      () => {
+        builds++
+        // The re-pair's build blocks until the test releases it — letting us tear the bridge
+        // down while addPlatform is mid-await, exactly the window the guard must catch.
+        return builds === 1 ? original : buildGate.then(() => new FakePlatform("rt-teardown"))
+      },
+    )
+    const runPromise = app.run(controller.signal)
+    await original.started.promise
+
+    // Start a re-pair; its factory is still awaiting the build gate.
+    const repair = app.addPlatform({ name: "rt-teardown", enabled: true, options: { allow_from: "U2" } })
+    // Tear the bridge down while the build is in flight, then let the build finish.
+    controller.abort()
+    await runPromise
+    releaseBuild()
+
+    await expect(repair).rejects.toBeInstanceOf(BridgeClosedError)
   } finally {
     server.stop()
   }

--- a/packages/remote-bridge/src/gateway.test.ts
+++ b/packages/remote-bridge/src/gateway.test.ts
@@ -11,6 +11,7 @@ import {
   hydrateSessionLimit,
   loadConfig,
   type Config,
+  type PlatformStatus,
 } from "./gateway.ts"
 import { PawWorkClient } from "./pawwork-client.ts"
 import { SessionPointers } from "./session-pointers.ts"
@@ -53,6 +54,7 @@ class FakePlatform implements Platform {
     readonly name: string,
     private readonly opts: {
       sendErr?: Error
+      startErr?: Error
       streamConnected?: () => boolean
       startResolvesImmediately?: boolean
       readyMode?: "auto" | "double" | "manual"
@@ -62,6 +64,10 @@ class FakePlatform implements Platform {
   async start(_handler: MessageHandler, onReady?: () => void): Promise<void> {
     this.startedAfterStream = this.opts.streamConnected ? this.opts.streamConnected() : false
     this.started.resolve()
+    // A platform that connects but then fails (e.g. a revoked token rejected by the
+    // upstream after the handshake) rejects start() before reaching "serving". The
+    // supervisor degrades and retries it; it never reaches onReady.
+    if (this.opts.startErr) throw this.opts.startErr
     // A real platform signals readiness once it is past startup and serving; model
     // that here so the gateway's run-level onReady fires in tests. "double" models a
     // misbehaving adapter; "manual" lets a test drive the moment via fireReady.
@@ -886,6 +892,62 @@ test("a re-pair with an invalid audience leaves the existing channel serving (pr
     // Untouched: still serving, still the live instance.
     expect(original.stops).toBe(0)
     expect(app.platformNames()).toEqual(["rt-repair-audience"])
+
+    controller.abort()
+    await runPromise
+  } finally {
+    server.stop()
+  }
+})
+
+test("a re-pair whose new platform fails to start retires the old and surfaces the new as degraded", async () => {
+  // Build-success semantics, not connected-success: addPlatform retires the old loop and
+  // supervises the new one once it is built (and any beforeCommit persists), NOT once it
+  // is serving. So a re-pair whose new platform start() rejects replaces the old channel
+  // and shows the new one degraded (the supervisor retries it) — it does not keep the old
+  // channel serving. The pairing flow already proved the new token live, so the residual
+  // failure window is a transient the supervisor retries, not a lost working connection.
+  const original = new FakePlatform("rt-repair-start")
+  const replacement = new FakePlatform("rt-repair-start", { startErr: new Error("token revoked") })
+  let builds = 0
+  const server = mockServer((_req, url) => {
+    switch (url.pathname) {
+      case "/experimental/session":
+      case "/permission":
+      case "/external-result":
+        return jsonBody([])
+      case "/global/event":
+        return openEventStream()
+    }
+    return undefined
+  })
+  const statuses: PlatformStatus[] = []
+  const controller = new AbortController()
+  try {
+    const app = await createApp(
+      {
+        pawWorkBaseURL: server.url,
+        statePath: await tempStatePath(),
+        platforms: [{ name: "rt-repair-start", enabled: true, options: { allow_from: "U1" } }],
+      },
+      () => {
+        builds++
+        return builds === 1 ? original : replacement
+      },
+    )
+    app.platformRetryDelayMs = 5 // keep the degraded retry loop tight for the test
+    const runPromise = app.run(controller.signal, undefined, (status) => statuses.push(status))
+    await original.started.promise
+
+    // Re-pair the same name; the build succeeds, so the old loop is retired and the new
+    // platform supervised — then its start() rejects.
+    await app.addPlatform({ name: "rt-repair-start", enabled: true, options: { allow_from: "U2" } })
+    await replacement.started.promise
+
+    expect(original.stops).toBe(1) // old channel retired on the successful build
+    expect(app.platformNames()).toEqual(["rt-repair-start"]) // the new platform is the live one
+    // The new channel surfaces degraded (and keeps retrying); the old one is gone.
+    await waitUntil(() => statuses.some((s) => s.name === "rt-repair-start" && s.phase === "degraded"))
 
     controller.abort()
     await runPromise

--- a/packages/remote-bridge/src/gateway.ts
+++ b/packages/remote-bridge/src/gateway.ts
@@ -92,6 +92,19 @@ export async function createApp(config: Config, createPlatform: PlatformFactory)
 // most recently active sessions, not the full history.
 export const hydrateSessionLimit = 100
 
+/**
+ * Thrown by addPlatform / removePlatform when the shared event stream went fatal and the
+ * App is tearing down, so the incremental change could not be applied to a live bridge.
+ * The persisted account set is authoritative, so the caller recovers by rebuilding the
+ * bridge from it rather than trusting a change that silently did not take effect.
+ */
+export class BridgeClosedError extends Error {
+  constructor(platform: string) {
+    super(`remote bridge is closed; cannot apply change to ${platform}`)
+    this.name = "BridgeClosedError"
+  }
+}
+
 export class App {
   private readonly client: PawWorkClient
   private readonly engine: Engine
@@ -103,6 +116,11 @@ export class App {
   private readonly desiredPlatforms = new Map<string, Platform>()
   /** Set after the event stream is up; null before run() and after teardown. */
   private supervisor: PlatformSupervisor | null = null
+  /** True once run() has begun tearing down (fatal stream or abort). Distinguishes a
+   * null supervisor during teardown (incremental ops must fail) from one during startup
+   * (the platform is adopted by run()'s initial snapshot). Set in the same synchronous
+   * step as `supervisor = null`, so the two are never observed out of agreement. */
+  private tearingDown = false
   /** Base backoff between event-stream reconnect attempts; lowered in tests. */
   eventRetryDelayMs = 1000
   /** Base backoff before restarting a failed platform; lowered in tests. */
@@ -157,6 +175,16 @@ export class App {
     const platform = await this.factory(config.name, options)
     await beforeCommit?.()
     if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
+    // Commit point. Every await above is a yield where the shared stream can go fatal and
+    // tear the bridge down (tearingDown set, supervisor cleared). If that happened, the
+    // live supervise below would silently no-op and we'd report success for a channel that
+    // never starts — so fail loudly and let the caller rebuild from the persisted accounts.
+    // A null supervisor during STARTUP is fine (tearingDown is false): the platform sits in
+    // desiredPlatforms and run()'s initial snapshot adopts it. Since tearingDown and
+    // supervisor=null are set in one synchronous teardown step, "tearingDown false + null
+    // supervisor" only ever means startup, never teardown. No await below: the check and
+    // the live swap are one atomic step.
+    if (this.tearingDown) throw new BridgeClosedError(config.name)
     this.engine.registerPlatform(platform)
     this.desiredPlatforms.set(config.name, platform)
     this.supervisor?.add(platform)
@@ -170,6 +198,10 @@ export class App {
   async removePlatform(name: string): Promise<void> {
     await this.retirePlatform(name)
     await this.pointers.clearPlatform(name)
+    // The channel is retired and its pointers forgotten. If the bridge tore down while we
+    // were doing it, the surviving channels went down with it — signal the caller to
+    // rebuild them from the persisted accounts (which no longer include this one).
+    if (this.tearingDown) throw new BridgeClosedError(name)
   }
 
   /**
@@ -271,7 +303,10 @@ export class App {
       // supervisor never came up; the built-but-unstarted platforms hold no
       // resources, but stop() them too for symmetry.
       const supervisor = this.supervisor
+      // Set together, in this one synchronous step, so an incremental op awaiting across
+      // teardown sees both: tearingDown true means "fail loudly", not a startup null.
       this.supervisor = null
+      this.tearingDown = true
       if (supervisor) await supervisor.stopAll()
       else await this.stopUnstartedPlatforms()
       await streamLoop

--- a/packages/remote-bridge/src/gateway.ts
+++ b/packages/remote-bridge/src/gateway.ts
@@ -165,25 +165,16 @@ export class App {
     if (!hasRemoteAudience(config.name, options)) {
       throw new Error(`${config.name} platform requires a specific allow_from or Feishu/Lark allow_chat with group_only`)
     }
-    // Prepare-first / swap-after-success: validate the audience, build the replacement,
-    // and run beforeCommit BEFORE touching any live same-name instance, so a failed
-    // re-pair (rejected audience, a factory throw, or a beforeCommit that can't persist)
-    // leaves the existing channel serving and lets the caller roll back without losing a
-    // working connection. Only once all three succeed do we retire the old loop (keeping
-    // its session pointers, since a re-pair continues the conversation), register the new
-    // one, and supervise it.
+    // Prepare-first (see the method doc): build the replacement and run beforeCommit before
+    // retiring the live same-name instance, so a failed re-pair leaves the existing channel
+    // serving and the caller can roll back.
     const platform = await this.factory(config.name, options)
     await beforeCommit?.()
     if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
-    // Commit point. Every await above is a yield where the shared stream can go fatal and
-    // tear the bridge down (tearingDown set, supervisor cleared). If that happened, the
-    // live supervise below would silently no-op and we'd report success for a channel that
-    // never starts — so fail loudly and let the caller rebuild from the persisted accounts.
-    // A null supervisor during STARTUP is fine (tearingDown is false): the platform sits in
-    // desiredPlatforms and run()'s initial snapshot adopts it. Since tearingDown and
-    // supervisor=null are set in one synchronous teardown step, "tearingDown false + null
-    // supervisor" only ever means startup, never teardown. No await below: the check and
-    // the live swap are one atomic step.
+    // Commit point (no await below, so the check and the live swap are atomic): an await above
+    // could have let the stream go fatal and tear the bridge down. tearingDown and supervisor=null
+    // are set together, so tearingDown distinguishes teardown — fail loudly and let the caller
+    // rebuild — from a legitimate startup null, which run()'s initial snapshot adopts.
     if (this.tearingDown) throw new BridgeClosedError(config.name)
     this.engine.registerPlatform(platform)
     this.desiredPlatforms.set(config.name, platform)
@@ -197,12 +188,10 @@ export class App {
    */
   async removePlatform(name: string): Promise<void> {
     await this.retirePlatform(name)
-    // The retire is the commit: the channel has stopped serving and left routing, so the
-    // disconnect is durably done. Forgetting its session pointers is best-effort cleanup (a
-    // later reconnect starts fresh), so a failed pointer write is logged and swallowed, not
-    // thrown — a thrown cleanup error would surface as a failed disconnect and strand the
-    // caller's UI showing a channel that has already stopped. A stale on-disk pointer
-    // self-heals on the next pointer save and is never resurfaced by a live channel.
+    // The retire is the commit; forgetting session pointers is best-effort, so a failed write is
+    // logged, not thrown (it would surface as a failed disconnect and strand the UI on an
+    // already-stopped channel). A stale write self-heals on the next save; the rare exit-before-
+    // save revival on reconnect is accepted as best-effort (see session-pointers.test.ts).
     try {
       await this.pointers.clearPlatform(name)
     } catch (err) {

--- a/packages/remote-bridge/src/gateway.ts
+++ b/packages/remote-bridge/src/gateway.ts
@@ -7,7 +7,7 @@ export { normalizeLocale }
 import { isFatalStreamError, PawWorkClient } from "./pawwork-client.ts"
 import type { EventHandler } from "./pawwork-events.ts"
 import { SessionPointers } from "./session-pointers.ts"
-import { type PlatformStatus, supervisePlatforms } from "./supervisor.ts"
+import { PlatformSupervisor, type PlatformStatus } from "./supervisor.ts"
 import type { MessageHandler, Platform } from "./types.ts"
 
 // Re-exported so the desktop runtime can render per-channel connection status.
@@ -77,21 +77,14 @@ export async function createApp(config: Config, createPlatform: PlatformFactory)
   client.setEventCursorStore(pointers)
   const engine = new Engine(client, pointers, normalizeLocale(config.locale))
 
-  const platforms: Platform[] = []
+  const app = new App({ client, engine, pointers, factory: createPlatform })
   for (const item of config.platforms ?? []) {
     if (!item.enabled) continue
-    if (!item.name) throw new Error("enabled platform name is required")
-    const options = item.options ?? {}
-    if (!hasRemoteAudience(item.name, options)) {
-      throw new Error(`${item.name} platform requires a specific allow_from or Feishu/Lark allow_chat with group_only`)
-    }
-    const platform = await createPlatform(item.name, options)
-    engine.registerPlatform(platform)
-    platforms.push(platform)
+    await app.addPlatform(item)
   }
-  if (platforms.length === 0) throw new Error("at least one platform must be enabled")
+  if (app.platformNames().length === 0) throw new Error("at least one platform must be enabled")
 
-  return new App({ client, engine, platforms })
+  return app
 }
 
 // Bounds the warm-up scan on startup and reconnect. Parent links come from the
@@ -102,7 +95,14 @@ export const hydrateSessionLimit = 100
 export class App {
   private readonly client: PawWorkClient
   private readonly engine: Engine
-  private readonly platforms: Platform[]
+  private readonly pointers: SessionPointers
+  private readonly factory: PlatformFactory
+  /** The live platform set and source of truth for "which platforms should run".
+   * Built eagerly (a constructed-but-unstarted platform holds no resources); the
+   * supervisor mirrors this set once run() brings it up. */
+  private readonly desiredPlatforms = new Map<string, Platform>()
+  /** Set after the event stream is up; null before run() and after teardown. */
+  private supervisor: PlatformSupervisor | null = null
   /** Base backoff between event-stream reconnect attempts; lowered in tests. */
   eventRetryDelayMs = 1000
   /** Base backoff before restarting a failed platform; lowered in tests. */
@@ -111,19 +111,66 @@ export class App {
   constructor(opts: {
     client: PawWorkClient
     engine: Engine
-    platforms: Platform[]
+    pointers: SessionPointers
+    factory: PlatformFactory
     eventRetryDelayMs?: number
     platformRetryDelayMs?: number
   }) {
     this.client = opts.client
     this.engine = opts.engine
-    this.platforms = opts.platforms
+    this.pointers = opts.pointers
+    this.factory = opts.factory
     if (opts.eventRetryDelayMs !== undefined) this.eventRetryDelayMs = opts.eventRetryDelayMs
     if (opts.platformRetryDelayMs !== undefined) this.platformRetryDelayMs = opts.platformRetryDelayMs
   }
 
   platformNames(): string[] {
-    return this.platforms.map((platform) => platform.name)
+    return [...this.desiredPlatforms.keys()]
+  }
+
+  /**
+   * Add one platform to the live set (and start it if the bridge is already up).
+   * Same gate as cold start: the audience is validated and the platform built via
+   * the injected factory here in the gateway, so an incrementally-added channel
+   * can never bypass the audience check. If a platform of the same name is already
+   * live (a re-pair), its loop is retired first — but its session pointers are
+   * kept, since a re-pair continues the conversation rather than forgetting it.
+   * Registered with the Engine before it is supervised, so its first inbound routes.
+   */
+  async addPlatform(config: PlatformConfig): Promise<void> {
+    if (!config.name) throw new Error("enabled platform name is required")
+    const options = config.options ?? {}
+    if (!hasRemoteAudience(config.name, options)) {
+      throw new Error(`${config.name} platform requires a specific allow_from or Feishu/Lark allow_chat with group_only`)
+    }
+    const platform = await this.factory(config.name, options)
+    if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
+    this.engine.registerPlatform(platform)
+    this.desiredPlatforms.set(config.name, platform)
+    this.supervisor?.add(platform)
+  }
+
+  /**
+   * Disconnect one platform: retire its loop, then forget its persisted session
+   * pointers, so a later reconnect of the same platform starts fresh. The shared
+   * event stream and the other platforms keep running.
+   */
+  async removePlatform(name: string): Promise<void> {
+    await this.retirePlatform(name)
+    await this.pointers.clearPlatform(name)
+  }
+
+  /**
+   * Stop one platform's loop and drop it from routing, leaving the shared event
+   * stream and siblings running. Liveness and routing are invalidated synchronously
+   * (so a late inbound from this instance is dropped before the async stop), then
+   * the loop is aborted, stopped, and awaited. Shared by disconnect (removePlatform,
+   * which also forgets pointers) and re-pair (addPlatform, which keeps them).
+   */
+  private async retirePlatform(name: string): Promise<void> {
+    this.desiredPlatforms.delete(name)
+    this.engine.unregisterPlatform(name)
+    await this.supervisor?.remove(name)
   }
 
   /**
@@ -148,7 +195,6 @@ export class App {
     failure.promise.catch(() => {})
     const ready = createDeferred<void>()
     let readyResolved = false
-    let supervised: Promise<void> = Promise.resolve()
 
     const handler = this.streamHandler(childSignal, () => {
       if (!readyResolved) {
@@ -168,27 +214,37 @@ export class App {
 
       await this.hydrate(childSignal)
 
-      // Fire onReady only once every platform has drained its backlog and is
-      // serving, so a caller's "connected" can't precede live message delivery.
-      // A platform's failure is isolated and retried by the supervisor — it never
-      // routes to `failure`, so a single dead channel cannot tear the bridge down.
-      const total = this.platforms.length
-      let readyCount = 0
+      // Fire onReady only once every platform present at cold start has drained
+      // its backlog and is serving, so a caller's "connected" can't precede live
+      // message delivery. The bar is frozen to this initial snapshot: a channel
+      // added later (incremental connect) reports its own status but never moves
+      // the cold-start gate. A platform's failure is isolated and retried by the
+      // supervisor — it never routes to `failure`, so one dead channel cannot tear
+      // the bridge down.
+      const initialPlatforms = [...this.desiredPlatforms.values()]
+      const initialNames = new Set(initialPlatforms.map((platform) => platform.name))
+      const readyNames = new Set<string>()
       const allReady = createDeferred<void>()
-      if (total === 0) allReady.resolve()
-      const onPlatformReady = () => {
-        if (++readyCount >= total) allReady.resolve()
+      if (initialNames.size === 0) allReady.resolve()
+      const onPlatformReady = (platform: Platform) => {
+        if (!initialNames.has(platform.name) || readyNames.has(platform.name)) return
+        readyNames.add(platform.name)
+        if (readyNames.size >= initialNames.size) allReady.resolve()
       }
       void Promise.race([allReady.promise, onAbort(childSignal)]).then(() => {
         if (!childSignal.aborted) onReady?.()
       })
 
-      supervised = supervisePlatforms(this.platforms, this.messageHandler(), childSignal, {
+      // Create the supervisor, then seed it synchronously from the live set — no
+      // await in between, so an incremental addPlatform can't interleave and
+      // double-add. Once it exists, add/removePlatform drive it directly.
+      const supervisor = new PlatformSupervisor(this.messageHandler(), childSignal, {
         onPlatformReady,
         onStatus,
         backoffMs: this.platformRetryDelayMs,
       })
-      supervised.catch(() => {})
+      this.supervisor = supervisor
+      for (const platform of initialPlatforms) supervisor.add(platform)
       await Promise.race([onAbort(childSignal), failure.promise])
     } catch (err) {
       // An abort is a requested stop, not a failure: any error it triggered
@@ -198,10 +254,14 @@ export class App {
     } finally {
       ac.abort()
       signal?.removeEventListener("abort", onParentAbort)
-      // Stop platforms first (unblocks any start() the supervisor is awaiting),
-      // then let the supervision loops wind down.
-      await this.stopPlatforms()
-      await supervised
+      // Stop every supervised platform (unblocks any start() its loop is awaiting)
+      // and let the loops wind down. If the run aborted during connect/hydrate the
+      // supervisor never came up; the built-but-unstarted platforms hold no
+      // resources, but stop() them too for symmetry.
+      const supervisor = this.supervisor
+      this.supervisor = null
+      if (supervisor) await supervisor.stopAll()
+      else await this.stopUnstartedPlatforms()
       await streamLoop
     }
   }
@@ -240,9 +300,13 @@ export class App {
     }
   }
 
-  /** Forward inbound chat messages to the engine, logging handler failures. */
+  /** Forward inbound chat messages to the engine, logging handler failures.
+   * Drops an inbound from a platform that is no longer the live instance for its
+   * name (removed, or replaced by a re-pair): the gateway owns the live set, so a
+   * stale loop's in-flight message can't create a session or send a prompt. */
   messageHandler(): MessageHandler {
     return (platform, msg) => {
+      if (this.desiredPlatforms.get(platform.name) !== platform) return
       this.engine.handleMessage(platform, msg).catch((err) =>
         console.warn("remote bridge failed to handle inbound message", {
           platform: platform.name,
@@ -286,8 +350,8 @@ export class App {
     }
   }
 
-  private async stopPlatforms(): Promise<void> {
-    await Promise.all(this.platforms.map((platform) => platform.stop().catch(() => {})))
+  private async stopUnstartedPlatforms(): Promise<void> {
+    await Promise.all([...this.desiredPlatforms.values()].map((platform) => platform.stop().catch(() => {})))
   }
 }
 

--- a/packages/remote-bridge/src/gateway.ts
+++ b/packages/remote-bridge/src/gateway.ts
@@ -197,10 +197,23 @@ export class App {
    */
   async removePlatform(name: string): Promise<void> {
     await this.retirePlatform(name)
-    await this.pointers.clearPlatform(name)
-    // The channel is retired and its pointers forgotten. If the bridge tore down while we
-    // were doing it, the surviving channels went down with it — signal the caller to
-    // rebuild them from the persisted accounts (which no longer include this one).
+    // The retire is the commit: the channel has stopped serving and left routing, so the
+    // disconnect is durably done. Forgetting its session pointers is best-effort cleanup (a
+    // later reconnect starts fresh), so a failed pointer write is logged and swallowed, not
+    // thrown — a thrown cleanup error would surface as a failed disconnect and strand the
+    // caller's UI showing a channel that has already stopped. A stale on-disk pointer
+    // self-heals on the next pointer save and is never resurfaced by a live channel.
+    try {
+      await this.pointers.clearPlatform(name)
+    } catch (err) {
+      console.warn("remote bridge could not forget session pointers for a removed platform", {
+        platform: name,
+        error: message(err),
+      })
+    }
+    // If the bridge tore down while we retired, the surviving channels went down with it —
+    // signal the caller to rebuild them from the persisted accounts (which no longer include
+    // this one).
     if (this.tearingDown) throw new BridgeClosedError(name)
   }
 

--- a/packages/remote-bridge/src/gateway.ts
+++ b/packages/remote-bridge/src/gateway.ts
@@ -139,16 +139,18 @@ export class App {
    */
   async addPlatform(config: PlatformConfig): Promise<void> {
     if (!config.name) throw new Error("enabled platform name is required")
+    // Retire any live same-name instance FIRST — before the audience gate and the
+    // factory build — so that once the caller has committed the new account/identity,
+    // a failed re-pair (a rejected audience OR a factory throw) can never leave the
+    // old loop serving under the new label. A new name that fails the gate still
+    // leaves the existing channels untouched (nothing to retire). retirePlatform
+    // keeps the session pointers (only removePlatform prunes them), so a re-pair
+    // continues the conversation rather than forgetting it.
+    if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
     const options = config.options ?? {}
     if (!hasRemoteAudience(config.name, options)) {
       throw new Error(`${config.name} platform requires a specific allow_from or Feishu/Lark allow_chat with group_only`)
     }
-    // Retire any live same-name instance BEFORE building the replacement, so a
-    // factory failure can't leave the old loop serving while the caller has already
-    // switched the saved account/UI to the new identity. retirePlatform keeps the
-    // session pointers (only removePlatform prunes them), so a re-pair continues the
-    // conversation rather than forgetting it.
-    if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
     const platform = await this.factory(config.name, options)
     this.engine.registerPlatform(platform)
     this.desiredPlatforms.set(config.name, platform)

--- a/packages/remote-bridge/src/gateway.ts
+++ b/packages/remote-bridge/src/gateway.ts
@@ -133,25 +133,25 @@ export class App {
    * Same gate as cold start: the audience is validated and the platform built via
    * the injected factory here in the gateway, so an incrementally-added channel
    * can never bypass the audience check. If a platform of the same name is already
-   * live (a re-pair), its loop is retired first — but its session pointers are
-   * kept, since a re-pair continues the conversation rather than forgetting it.
+   * live (a re-pair), the replacement is built first and the old loop retired only on
+   * success — keeping its session pointers, since a re-pair continues the conversation
+   * rather than forgetting it; a failed build leaves the old channel serving.
    * Registered with the Engine before it is supervised, so its first inbound routes.
    */
   async addPlatform(config: PlatformConfig): Promise<void> {
     if (!config.name) throw new Error("enabled platform name is required")
-    // Retire any live same-name instance FIRST — before the audience gate and the
-    // factory build — so that once the caller has committed the new account/identity,
-    // a failed re-pair (a rejected audience OR a factory throw) can never leave the
-    // old loop serving under the new label. A new name that fails the gate still
-    // leaves the existing channels untouched (nothing to retire). retirePlatform
-    // keeps the session pointers (only removePlatform prunes them), so a re-pair
-    // continues the conversation rather than forgetting it.
-    if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
     const options = config.options ?? {}
     if (!hasRemoteAudience(config.name, options)) {
       throw new Error(`${config.name} platform requires a specific allow_from or Feishu/Lark allow_chat with group_only`)
     }
+    // Prepare-first / swap-after-success: validate the audience and build the
+    // replacement BEFORE touching any live same-name instance, so a failed re-pair
+    // (rejected audience or a factory throw) leaves the existing channel serving and
+    // lets the caller roll back without losing a working connection. Only once the new
+    // platform is built do we retire the old loop (keeping its session pointers, since
+    // a re-pair continues the conversation), register the new one, and supervise it.
     const platform = await this.factory(config.name, options)
+    if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
     this.engine.registerPlatform(platform)
     this.desiredPlatforms.set(config.name, platform)
     this.supervisor?.add(platform)

--- a/packages/remote-bridge/src/gateway.ts
+++ b/packages/remote-bridge/src/gateway.ts
@@ -135,22 +135,27 @@ export class App {
    * can never bypass the audience check. If a platform of the same name is already
    * live (a re-pair), the replacement is built first and the old loop retired only on
    * success — keeping its session pointers, since a re-pair continues the conversation
-   * rather than forgetting it; a failed build leaves the old channel serving.
+   * rather than forgetting it; a failed build leaves the old channel serving. The
+   * optional `beforeCommit` hook runs at that same safe point — after the build, before
+   * any live change — so a caller that must durably commit the new channel (the desktop
+   * saves its credential) can fail there and still leave the old channel serving.
    * Registered with the Engine before it is supervised, so its first inbound routes.
    */
-  async addPlatform(config: PlatformConfig): Promise<void> {
+  async addPlatform(config: PlatformConfig, beforeCommit?: () => void | Promise<void>): Promise<void> {
     if (!config.name) throw new Error("enabled platform name is required")
     const options = config.options ?? {}
     if (!hasRemoteAudience(config.name, options)) {
       throw new Error(`${config.name} platform requires a specific allow_from or Feishu/Lark allow_chat with group_only`)
     }
-    // Prepare-first / swap-after-success: validate the audience and build the
-    // replacement BEFORE touching any live same-name instance, so a failed re-pair
-    // (rejected audience or a factory throw) leaves the existing channel serving and
-    // lets the caller roll back without losing a working connection. Only once the new
-    // platform is built do we retire the old loop (keeping its session pointers, since
-    // a re-pair continues the conversation), register the new one, and supervise it.
+    // Prepare-first / swap-after-success: validate the audience, build the replacement,
+    // and run beforeCommit BEFORE touching any live same-name instance, so a failed
+    // re-pair (rejected audience, a factory throw, or a beforeCommit that can't persist)
+    // leaves the existing channel serving and lets the caller roll back without losing a
+    // working connection. Only once all three succeed do we retire the old loop (keeping
+    // its session pointers, since a re-pair continues the conversation), register the new
+    // one, and supervise it.
     const platform = await this.factory(config.name, options)
+    await beforeCommit?.()
     if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
     this.engine.registerPlatform(platform)
     this.desiredPlatforms.set(config.name, platform)

--- a/packages/remote-bridge/src/gateway.ts
+++ b/packages/remote-bridge/src/gateway.ts
@@ -143,8 +143,13 @@ export class App {
     if (!hasRemoteAudience(config.name, options)) {
       throw new Error(`${config.name} platform requires a specific allow_from or Feishu/Lark allow_chat with group_only`)
     }
-    const platform = await this.factory(config.name, options)
+    // Retire any live same-name instance BEFORE building the replacement, so a
+    // factory failure can't leave the old loop serving while the caller has already
+    // switched the saved account/UI to the new identity. retirePlatform keeps the
+    // session pointers (only removePlatform prunes them), so a re-pair continues the
+    // conversation rather than forgetting it.
     if (this.desiredPlatforms.has(config.name)) await this.retirePlatform(config.name)
+    const platform = await this.factory(config.name, options)
     this.engine.registerPlatform(platform)
     this.desiredPlatforms.set(config.name, platform)
     this.supervisor?.add(platform)

--- a/packages/remote-bridge/src/session-pointers.test.ts
+++ b/packages/remote-bridge/src/session-pointers.test.ts
@@ -115,3 +115,30 @@ test("file store persists the event cursor alongside sessions", async () => {
   expect(reloaded.get("feishu:dm:alice")).toBe("ses_1")
   expect(reloaded.eventCursor()).toBe("cursor-2")
 })
+
+test("clearPlatform drops one platform's mappings but keeps the cursor and other platforms", async () => {
+  const pointers = SessionPointers.memory()
+  await pointers.set("wechat:dm:u1", "ses_wx_a")
+  await pointers.set("wechat:dm:u2", "ses_wx_b")
+  await pointers.set("telegram:dm:t1", "ses_tg")
+  await pointers.setEventCursor("cursor-123")
+
+  await pointers.clearPlatform("wechat")
+
+  expect(pointers.get("wechat:dm:u1")).toBe("")
+  expect(pointers.get("wechat:dm:u2")).toBe("")
+  expect(pointers.get("telegram:dm:t1")).toBe("ses_tg") // a sibling platform is untouched
+  expect(pointers.eventCursor()).toBe("cursor-123") // the global cursor survives
+})
+
+test("clearPlatform persists the pruned set to disk", async () => {
+  const path = await tempFile()
+  const pointers = await SessionPointers.fromFile(path)
+  await pointers.set("wechat:dm:u1", "ses_wx")
+  await pointers.set("telegram:dm:t1", "ses_tg")
+  await pointers.clearPlatform("wechat")
+
+  const reloaded = await SessionPointers.fromFile(path)
+  expect(reloaded.get("wechat:dm:u1")).toBe("")
+  expect(reloaded.get("telegram:dm:t1")).toBe("ses_tg")
+})

--- a/packages/remote-bridge/src/session-pointers.test.ts
+++ b/packages/remote-bridge/src/session-pointers.test.ts
@@ -143,33 +143,37 @@ test("clearPlatform persists the pruned set to disk", async () => {
   expect(reloaded.get("telegram:dm:t1")).toBe("ses_tg")
 })
 
-test("a clearPlatform whose disk write fails leaves the stale pointer to revive on restart", async () => {
-  // removePlatform's pointer cleanup is best-effort: clearPlatform prunes the in-memory map and
-  // then writes atomically (unique temp + rename), so a write failure leaves memory pruned but the
-  // on-disk snapshot intact. If the app exits before any later save heals the file, the next launch
-  // reloads the stale mapping — and a reconnect of the same platform (addPlatform keeps pointers)
-  // resurfaces it. This pins that accepted behavior so a future reader knows it is deliberate, not a
-  // latent bug; a self-healing tombstone is tracked as follow-up, not blocking the incremental path.
-  if (process.getuid?.() === 0) return // a read-only dir cannot block root; skip the forced failure
-  const path = await tempFile()
-  const live = await SessionPointers.fromFile(path)
-  await live.set("wechat:dm:u1", "ses_wx")
-  await live.set("telegram:dm:t1", "ses_tg")
+// Skipped on Windows (chmod cannot make a directory unwritable) and under root (a read-only dir
+// cannot block writes) — both would leave the forced-failure step unable to fail as expected.
+test.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+  "a clearPlatform whose disk write fails leaves the stale pointer to revive on restart",
+  async () => {
+    // removePlatform's pointer cleanup is best-effort: clearPlatform prunes the in-memory map and
+    // then writes atomically (unique temp + rename), so a write failure leaves memory pruned but the
+    // on-disk snapshot intact. If the app exits before any later save heals the file, the next launch
+    // reloads the stale mapping — and a reconnect of the same platform (addPlatform keeps pointers)
+    // resurfaces it. This pins that accepted behavior so a future reader knows it is deliberate, not a
+    // latent bug; a self-healing tombstone is tracked as follow-up, not blocking the incremental path.
+    const path = await tempFile()
+    const live = await SessionPointers.fromFile(path)
+    await live.set("wechat:dm:u1", "ses_wx")
+    await live.set("telegram:dm:t1", "ses_tg")
 
-  // Freeze the directory so the next atomic write cannot create its temp file; the existing
-  // snapshot is left untouched (the rename never runs).
-  const dir = dirname(path)
-  await chmod(dir, 0o500)
-  try {
-    await expect(live.clearPlatform("wechat")).rejects.toBeDefined() // the write failed
-    expect(live.get("wechat:dm:u1")).toBe("") // but the in-memory map was already pruned
-  } finally {
-    await chmod(dir, 0o700) // restore so the snapshot stays intact and the dir is cleanable
-  }
+    // Freeze the directory so the next atomic write cannot create its temp file; the existing
+    // snapshot is left untouched (the rename never runs).
+    const dir = dirname(path)
+    await chmod(dir, 0o500)
+    try {
+      await expect(live.clearPlatform("wechat")).rejects.toBeDefined() // the write failed
+      expect(live.get("wechat:dm:u1")).toBe("") // but the in-memory map was already pruned
+    } finally {
+      await chmod(dir, 0o700) // restore so the snapshot stays intact and the dir is cleanable
+    }
 
-  // Restart: the on-disk snapshot never lost wechat, so reloading it (a reconnect of the same
-  // platform) revives the stale pointer.
-  const reloaded = await SessionPointers.fromFile(path)
-  expect(reloaded.get("wechat:dm:u1")).toBe("ses_wx") // stale pointer revived after restart
-  expect(reloaded.get("telegram:dm:t1")).toBe("ses_tg")
-})
+    // Restart: the on-disk snapshot never lost wechat, so reloading it (a reconnect of the same
+    // platform) revives the stale pointer.
+    const reloaded = await SessionPointers.fromFile(path)
+    expect(reloaded.get("wechat:dm:u1")).toBe("ses_wx") // stale pointer revived after restart
+    expect(reloaded.get("telegram:dm:t1")).toBe("ses_tg")
+  },
+)

--- a/packages/remote-bridge/src/session-pointers.test.ts
+++ b/packages/remote-bridge/src/session-pointers.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test"
-import { mkdtemp, readdir, stat, writeFile } from "node:fs/promises"
+import { chmod, mkdtemp, readdir, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, dirname, join } from "node:path"
 import { SessionPointers } from "./session-pointers.ts"
@@ -140,5 +140,36 @@ test("clearPlatform persists the pruned set to disk", async () => {
 
   const reloaded = await SessionPointers.fromFile(path)
   expect(reloaded.get("wechat:dm:u1")).toBe("")
+  expect(reloaded.get("telegram:dm:t1")).toBe("ses_tg")
+})
+
+test("a clearPlatform whose disk write fails leaves the stale pointer to revive on restart", async () => {
+  // removePlatform's pointer cleanup is best-effort: clearPlatform prunes the in-memory map and
+  // then writes atomically (unique temp + rename), so a write failure leaves memory pruned but the
+  // on-disk snapshot intact. If the app exits before any later save heals the file, the next launch
+  // reloads the stale mapping — and a reconnect of the same platform (addPlatform keeps pointers)
+  // resurfaces it. This pins that accepted behavior so a future reader knows it is deliberate, not a
+  // latent bug; a self-healing tombstone is tracked as follow-up, not blocking the incremental path.
+  if (process.getuid?.() === 0) return // a read-only dir cannot block root; skip the forced failure
+  const path = await tempFile()
+  const live = await SessionPointers.fromFile(path)
+  await live.set("wechat:dm:u1", "ses_wx")
+  await live.set("telegram:dm:t1", "ses_tg")
+
+  // Freeze the directory so the next atomic write cannot create its temp file; the existing
+  // snapshot is left untouched (the rename never runs).
+  const dir = dirname(path)
+  await chmod(dir, 0o500)
+  try {
+    await expect(live.clearPlatform("wechat")).rejects.toBeDefined() // the write failed
+    expect(live.get("wechat:dm:u1")).toBe("") // but the in-memory map was already pruned
+  } finally {
+    await chmod(dir, 0o700) // restore so the snapshot stays intact and the dir is cleanable
+  }
+
+  // Restart: the on-disk snapshot never lost wechat, so reloading it (a reconnect of the same
+  // platform) revives the stale pointer.
+  const reloaded = await SessionPointers.fromFile(path)
+  expect(reloaded.get("wechat:dm:u1")).toBe("ses_wx") // stale pointer revived after restart
   expect(reloaded.get("telegram:dm:t1")).toBe("ses_tg")
 })

--- a/packages/remote-bridge/src/session-pointers.ts
+++ b/packages/remote-bridge/src/session-pointers.ts
@@ -102,6 +102,23 @@ export class SessionPointers {
     await this.save()
   }
 
+  /**
+   * Drop every session mapping for one platform (remote keys prefixed
+   * `<platform>:`), keeping the event cursor and other platforms' mappings. Called
+   * when a single channel disconnects, so a later reconnect of the same platform
+   * starts fresh instead of resurrecting a stale conversation (`restoreDelivery`)
+   * or colliding on a session root. Orphaned parent links are left as-is: no
+   * remaining remote key references them, so `rootSession` walks never reach them.
+   */
+  async clearPlatform(platform: string): Promise<void> {
+    if (platform === "") return
+    const prefix = `${platform}:`
+    const stale = [...this.sessions.keys()].filter((key) => key.startsWith(prefix))
+    if (stale.length === 0) return
+    for (const key of stale) this.sessions.delete(key)
+    await this.save()
+  }
+
   private save(): Promise<void> {
     if (this.path === "") return Promise.resolve()
     // Snapshot synchronously so the queued write reflects this call's state.

--- a/packages/remote-bridge/src/supervisor.test.ts
+++ b/packages/remote-bridge/src/supervisor.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { type PlatformStatus, supervisePlatforms } from "./supervisor.ts"
+import { PlatformSupervisor, type PlatformStatus, supervisePlatforms } from "./supervisor.ts"
 import type { MessageHandler, Platform } from "./types.ts"
 
 // An outcome the scripted platform replays on each successive start() call; the
@@ -15,6 +15,7 @@ type Outcome =
 class ScriptedPlatform implements Platform {
   starts = 0
   readyCalls = 0
+  stops = 0
   private unblock: (() => void) | null = null
 
   constructor(
@@ -41,6 +42,31 @@ class ScriptedPlatform implements Platform {
   async reply(): Promise<void> {}
   async send(): Promise<void> {}
   async stop(): Promise<void> {
+    this.stops++
+    this.unblock?.()
+    this.unblock = null
+  }
+}
+
+/** A Platform that blocks in start() until stop() and exposes its onReady so a
+ * test can fire readiness on demand (and fire a retired loop's stale callback). */
+class ManualPlatform implements Platform {
+  starts = 0
+  stops = 0
+  onReady: () => void = () => {}
+  private unblock: (() => void) | null = null
+  constructor(readonly name: string) {}
+  async start(_handler: MessageHandler, onReady?: () => void): Promise<void> {
+    this.starts++
+    this.onReady = onReady ?? (() => {})
+    return new Promise<void>((resolve) => {
+      this.unblock = resolve
+    })
+  }
+  async reply(): Promise<void> {}
+  async send(): Promise<void> {}
+  async stop(): Promise<void> {
+    this.stops++
     this.unblock?.()
     this.unblock = null
   }
@@ -187,35 +213,44 @@ test("a synchronous throw in start() degrades and retries instead of crashing", 
 })
 
 test("a perpetually failing platform does not accumulate abort listeners", async () => {
-  const controller = new AbortController()
-  const signal = controller.signal
+  // The retry loop now runs on the platform's own child signal, so count "abort"
+  // listeners across ALL signals (patch the prototype) rather than just the run
+  // signal — the per-attempt race + backoff still register and clean up there.
   let added = 0
   let removed = 0
-  const realAdd = signal.addEventListener.bind(signal)
-  const realRemove = signal.removeEventListener.bind(signal)
-  ;(signal as unknown as { addEventListener: typeof signal.addEventListener }).addEventListener = ((type, ...rest) => {
+  const proto = AbortSignal.prototype as unknown as {
+    addEventListener: AbortSignal["addEventListener"]
+    removeEventListener: AbortSignal["removeEventListener"]
+  }
+  const realAdd = proto.addEventListener
+  const realRemove = proto.removeEventListener
+  proto.addEventListener = function (this: AbortSignal, type, ...rest) {
     if (type === "abort") added++
-    return (realAdd as (...a: unknown[]) => unknown)(type, ...rest)
-  }) as typeof signal.addEventListener
-  ;(signal as unknown as { removeEventListener: typeof signal.removeEventListener }).removeEventListener = ((
-    type,
-    ...rest
-  ) => {
+    return (realAdd as (...a: unknown[]) => unknown).call(this, type, ...rest)
+  } as AbortSignal["addEventListener"]
+  proto.removeEventListener = function (this: AbortSignal, type, ...rest) {
     if (type === "abort") removed++
-    return (realRemove as (...a: unknown[]) => unknown)(type, ...rest)
-  }) as typeof signal.removeEventListener
+    return (realRemove as (...a: unknown[]) => unknown).call(this, type, ...rest)
+  } as AbortSignal["removeEventListener"]
 
-  const bad = new ScriptedPlatform("bad", [{ kind: "reject", error: "down" }])
-  const supervised = supervisePlatforms([bad], noopHandler, signal, { backoffMs: 1, maxBackoffMs: 2 })
+  const controller = new AbortController()
+  try {
+    const bad = new ScriptedPlatform("bad", [{ kind: "reject", error: "down" }])
+    const supervised = supervisePlatforms([bad], noopHandler, controller.signal, { backoffMs: 1, maxBackoffMs: 2 })
 
-  await waitUntil(() => bad.starts >= 6)
-  // Each attempt's race + backoff register an abort listener but clean it up, so
-  // the live count stays bounded rather than growing one-per-retry.
-  expect(added).toBeGreaterThan(5)
-  expect(added - removed).toBeLessThanOrEqual(2)
+    await waitUntil(() => bad.starts >= 6)
+    // Each attempt's race + backoff register an abort listener but clean it up, so
+    // the live count stays bounded (one run-signal forwarder + the current phase),
+    // not one-per-retry.
+    expect(added).toBeGreaterThan(5)
+    expect(added - removed).toBeLessThanOrEqual(3)
 
-  controller.abort()
-  await supervised
+    controller.abort()
+    await supervised
+  } finally {
+    proto.addEventListener = realAdd
+    proto.removeEventListener = realRemove
+  }
 })
 
 test("resolves promptly on abort even while a platform is blocked in start()", async () => {
@@ -233,4 +268,78 @@ test("resolves promptly on abort even while a platform is blocked in start()", a
   await supervised
   // Abort is a requested stop, not a degradation.
   expect(statuses.some((s) => s.phase === "degraded")).toBe(false)
+})
+
+test("PlatformSupervisor.add starts a platform on an already-running supervisor", async () => {
+  const controller = new AbortController()
+  const ready: string[] = []
+  const supervisor = new PlatformSupervisor(noopHandler, controller.signal, {
+    onPlatformReady: (platform) => ready.push(platform.name),
+    backoffMs: 5,
+  })
+  supervisor.add(new ScriptedPlatform("first", [{ kind: "serve" }]))
+  await waitUntil(() => ready.includes("first"))
+
+  // A second platform added later starts on its own loop, with the first untouched.
+  supervisor.add(new ScriptedPlatform("second", [{ kind: "serve" }]))
+  await waitUntil(() => ready.includes("second"))
+  expect(supervisor.has("first")).toBe(true)
+  expect(supervisor.has("second")).toBe(true)
+
+  controller.abort()
+  await supervisor.stopAll()
+})
+
+test("PlatformSupervisor.remove stops only that platform, leaving the others serving", async () => {
+  const controller = new AbortController()
+  const ready: string[] = []
+  const supervisor = new PlatformSupervisor(noopHandler, controller.signal, {
+    onPlatformReady: (platform) => ready.push(platform.name),
+    backoffMs: 5,
+  })
+  const keep = new ScriptedPlatform("keep", [{ kind: "serve" }])
+  const drop = new ScriptedPlatform("drop", [{ kind: "serve" }])
+  supervisor.add(keep)
+  supervisor.add(drop)
+  await waitUntil(() => ready.includes("keep") && ready.includes("drop"))
+
+  await supervisor.remove("drop")
+  expect(supervisor.has("drop")).toBe(false)
+  expect(drop.stops).toBe(1) // the removed platform's loop was stopped
+  // The survivor is untouched: still supervised, started once, never stopped.
+  expect(supervisor.has("keep")).toBe(true)
+  expect(keep.starts).toBe(1)
+  expect(keep.stops).toBe(0)
+
+  controller.abort()
+  await supervisor.stopAll()
+})
+
+test("a retired loop's late ready cannot satisfy a replacement under the same name", async () => {
+  // Generation-token guard: after remove + a same-name add, the old loop's late
+  // ready must be dropped so it can't be counted as the new entry serving.
+  const controller = new AbortController()
+  const statuses: PlatformStatus[] = []
+  const supervisor = new PlatformSupervisor(noopHandler, controller.signal, { onStatus: (status) => statuses.push(status) })
+  const servingCount = () => statuses.filter((status) => status.name === "dupe" && status.phase === "serving").length
+
+  const retired = new ManualPlatform("dupe")
+  supervisor.add(retired)
+  await waitUntil(() => retired.starts === 1)
+  const staleReady = retired.onReady // the retired loop's ready callback
+
+  await supervisor.remove("dupe")
+  const fresh = new ManualPlatform("dupe")
+  supervisor.add(fresh) // a new entry takes the name, with a new token
+  await waitUntil(() => fresh.starts === 1)
+
+  // The replacement serves normally...
+  fresh.onReady()
+  await waitUntil(() => servingCount() === 1)
+  // ...but the retired loop's late ready is ignored, not counted as another serve.
+  staleReady()
+  expect(servingCount()).toBe(1)
+
+  controller.abort()
+  await supervisor.stopAll()
 })

--- a/packages/remote-bridge/src/supervisor.test.ts
+++ b/packages/remote-bridge/src/supervisor.test.ts
@@ -346,7 +346,9 @@ test("remove is time-bounded when a platform's stop() never resolves", async () 
 
   const start = performance.now()
   await supervisor.remove("wedged")
-  expect(performance.now() - start).toBeLessThan(2000) // returned, not hung
+  // Tight enough to catch a hardcoded second-scale wait (it honors removeTimeoutMs:
+  // 20), loose enough for CI scheduling jitter.
+  expect(performance.now() - start).toBeLessThan(250)
   expect(wedged.stops).toBe(1) // stop() was requested
   expect(supervisor.has("wedged")).toBe(false) // and the name is free again
 

--- a/packages/remote-bridge/src/supervisor.test.ts
+++ b/packages/remote-bridge/src/supervisor.test.ts
@@ -72,6 +72,25 @@ class ManualPlatform implements Platform {
   }
 }
 
+/** A Platform whose stop() never resolves — models a wedged adapter (e.g. a
+ *  long-poll fetch that won't abort), used to prove remove() is time-bounded. */
+class StuckStopPlatform implements Platform {
+  starts = 0
+  stops = 0
+  constructor(readonly name: string) {}
+  async start(_handler: MessageHandler, onReady?: () => void): Promise<void> {
+    this.starts++
+    onReady?.()
+    return new Promise<void>(() => {}) // blocks until the loop is aborted
+  }
+  async reply(): Promise<void> {}
+  async send(): Promise<void> {}
+  stop(): Promise<void> {
+    this.stops++
+    return new Promise<void>(() => {}) // never resolves
+  }
+}
+
 const noopHandler: MessageHandler = () => {}
 
 async function waitUntil(cond: () => boolean, timeoutMs = 2000): Promise<void> {
@@ -310,6 +329,26 @@ test("PlatformSupervisor.remove stops only that platform, leaving the others ser
   expect(supervisor.has("keep")).toBe(true)
   expect(keep.starts).toBe(1)
   expect(keep.stops).toBe(0)
+
+  controller.abort()
+  await supervisor.stopAll()
+})
+
+test("remove is time-bounded when a platform's stop() never resolves", async () => {
+  // A wedged adapter (stop() hangs) must not block remove(): the entry is already
+  // dropped and the loop aborted, so the caller — a disconnect or re-pair — returns
+  // within the backstop instead of hanging the desktop's serial lifecycle queue.
+  const controller = new AbortController()
+  const supervisor = new PlatformSupervisor(noopHandler, controller.signal, { removeTimeoutMs: 20 })
+  const wedged = new StuckStopPlatform("wedged")
+  supervisor.add(wedged)
+  await waitUntil(() => wedged.starts === 1)
+
+  const start = performance.now()
+  await supervisor.remove("wedged")
+  expect(performance.now() - start).toBeLessThan(2000) // returned, not hung
+  expect(wedged.stops).toBe(1) // stop() was requested
+  expect(supervisor.has("wedged")).toBe(false) // and the name is free again
 
   controller.abort()
   await supervisor.stopAll()

--- a/packages/remote-bridge/src/supervisor.ts
+++ b/packages/remote-bridge/src/supervisor.ts
@@ -35,10 +35,14 @@ export interface SuperviseOptions {
   backoffMs?: number
   /** Ceiling on the restart backoff, so a permanently-dead channel idles, not spins. */
   maxBackoffMs?: number
+  /** Backstop for `remove`: the longest it waits for one platform's wind-down after
+   *  the loop is aborted, so a wedged stop() can't block a disconnect / re-pair. */
+  removeTimeoutMs?: number
 }
 
 const DEFAULT_BACKOFF_MS = 1000
 const DEFAULT_MAX_BACKOFF_MS = 60_000
+const DEFAULT_REMOVE_TIMEOUT_MS = 3000
 
 interface SupervisedEntry {
   platform: Platform
@@ -117,8 +121,17 @@ export class PlatformSupervisor {
     if (!entry) return
     this.entries.delete(name)
     entry.ac.abort()
-    await entry.platform.stop().catch(() => {})
-    await entry.done
+    // The entry is already dropped and the loop aborted, so this name's routing and
+    // status are dead the instant we return. Bound the wait for the actual wind-down:
+    // a wedged stop() (e.g. a long-poll that won't abort) must not block the caller —
+    // a disconnect or re-pair — or wedge the desktop's serial lifecycle queue. Past
+    // the backstop the detached stop() finishes (or leaks) on its own.
+    const woundDown = entry.platform
+      .stop()
+      .catch(() => {})
+      .then(() => entry.done)
+      .catch(() => {})
+    await Promise.race([woundDown, sleep(this.options.removeTimeoutMs ?? DEFAULT_REMOVE_TIMEOUT_MS, this.signal)])
   }
 
   /** Tear down every supervised platform — run shutdown / fatal-stream restart. */

--- a/packages/remote-bridge/src/supervisor.ts
+++ b/packages/remote-bridge/src/supervisor.ts
@@ -7,10 +7,12 @@
 // A dead *channel* must not take the bridge down; a dead PawWork *event stream*
 // still does — that failure path lives in the gateway, not here.
 //
-// No per-platform AbortController: `Platform` has no start-time signal (teardown
-// is `stop()`), and Wave 1 disconnects a single channel by restarting the whole
-// bridge, so an independent abort would have no consumer. Isolation comes from
-// the independent loops below, not from a per-platform signal.
+// Each platform gets its own child AbortController linked to the run signal, so a
+// single channel can be added to or removed from a running supervisor without
+// touching the others (Wave 2: connect/disconnect one channel restarts only it,
+// never the shared stream or its siblings). A removed/replaced entry carries a
+// generation token, so its in-flight loop can no longer write status after a
+// newer entry takes its name.
 
 import type { MessageHandler, Platform } from "./types.ts"
 
@@ -38,13 +40,108 @@ export interface SuperviseOptions {
 const DEFAULT_BACKOFF_MS = 1000
 const DEFAULT_MAX_BACKOFF_MS = 60_000
 
+interface SupervisedEntry {
+  platform: Platform
+  /** Aborts just this platform's loop (linked to the run signal). */
+  ac: AbortController
+  /** Resolves when this platform's supervise loop has fully wound down. */
+  done: Promise<void>
+  /** Monotonic token; a stale loop's late callbacks are dropped once superseded. */
+  token: number
+}
+
 /**
- * Run every platform under independent supervision. Each gets its own restart
- * loop, so one platform's failure is isolated: it reports "degraded" and restarts
- * with exponential backoff while the others keep serving. A clean self-stop (an
- * event-driven adapter that registers its callback and returns) ends that
- * platform's loop without a restart. Resolves only when `signal` aborts; never
- * rejects for a single platform's failure.
+ * A live registry of supervised platforms. Each `add` starts one platform's
+ * restart loop under a child AbortController linked to the run signal; `remove`
+ * aborts, stops, and awaits just that platform; aborting the run signal (or
+ * `stopAll`) winds them all down. This is the seam that lets the desktop runtime
+ * connect or disconnect a single channel without rebuilding the shared bridge.
+ */
+export class PlatformSupervisor {
+  private readonly entries = new Map<string, SupervisedEntry>()
+  private nextToken = 0
+
+  constructor(
+    private readonly handler: MessageHandler,
+    /** The run signal: aborting it tears down every supervised platform. */
+    private readonly signal: AbortSignal,
+    private readonly options: SuperviseOptions = {},
+  ) {}
+
+  /** Whether a platform with this name is currently supervised. */
+  has(name: string): boolean {
+    return this.entries.has(name)
+  }
+
+  /**
+   * Start supervising one platform. Idempotent per name: a second add for a name
+   * already present is ignored (callers replace via `remove` then `add`). A no-op
+   * once the run signal has aborted.
+   */
+  add(platform: Platform): void {
+    if (this.signal.aborted || this.entries.has(platform.name)) return
+    const ac = new AbortController()
+    const onParentAbort = () => ac.abort()
+    this.signal.addEventListener("abort", onParentAbort, { once: true })
+    const token = ++this.nextToken
+    // Guard every callback by the live entry's token, so a removed or replaced
+    // platform's late status / ready can't clobber a newer entry under its name.
+    const current = () => this.entries.get(platform.name)?.token === token
+    const guarded: SuperviseOptions = {
+      ...this.options,
+      onStatus: (status) => {
+        if (current()) this.options.onStatus?.(status)
+      },
+      onPlatformReady: (ready) => {
+        if (current()) this.options.onPlatformReady?.(ready)
+      },
+    }
+    // Register the entry BEFORE starting the loop, so the first status superviseOne
+    // emits synchronously (`starting`) passes the token guard. `done` is filled on
+    // the same tick — no await before it — so remove/stopAll always await the loop.
+    const entry: SupervisedEntry = { platform, ac, done: Promise.resolve(), token }
+    this.entries.set(platform.name, entry)
+    entry.done = superviseOne(platform, this.handler, ac.signal, guarded).finally(() =>
+      this.signal.removeEventListener("abort", onParentAbort),
+    )
+  }
+
+  /**
+   * Stop supervising one platform: abort its loop, stop the platform to unblock a
+   * hanging start(), then await the loop's wind-down. The entry is removed first,
+   * so any final callback the loop emits is dropped by the token guard. No-op if
+   * the name is not supervised.
+   */
+  async remove(name: string): Promise<void> {
+    const entry = this.entries.get(name)
+    if (!entry) return
+    this.entries.delete(name)
+    entry.ac.abort()
+    await entry.platform.stop().catch(() => {})
+    await entry.done
+  }
+
+  /** Tear down every supervised platform — run shutdown / fatal-stream restart. */
+  async stopAll(): Promise<void> {
+    const entries = [...this.entries.values()]
+    this.entries.clear()
+    for (const entry of entries) entry.ac.abort()
+    await Promise.all(entries.map((entry) => entry.platform.stop().catch(() => {})))
+    await Promise.all(entries.map((entry) => entry.done))
+  }
+
+  /** Resolves when every currently-supervised loop has wound down (e.g. on abort),
+   *  without stopping the platforms — the run-loop's clean "await the loops" path. */
+  whenIdle(): Promise<void> {
+    return Promise.all([...this.entries.values()].map((entry) => entry.done)).then(() => {})
+  }
+}
+
+/**
+ * Run a fixed set of platforms under one supervisor for the lifetime of `signal`.
+ * Thin wrapper over {@link PlatformSupervisor} for callers that never add or
+ * remove a platform mid-run. Resolves only when `signal` aborts; never rejects
+ * for a single platform's failure.
  */
 export function supervisePlatforms(
   platforms: Platform[],
@@ -52,7 +149,9 @@ export function supervisePlatforms(
   signal: AbortSignal,
   options: SuperviseOptions = {},
 ): Promise<void> {
-  return Promise.all(platforms.map((platform) => superviseOne(platform, handler, signal, options))).then(() => {})
+  const supervisor = new PlatformSupervisor(handler, signal, options)
+  for (const platform of platforms) supervisor.add(platform)
+  return supervisor.whenIdle()
 }
 
 async function superviseOne(


### PR DESCRIPTION
## Summary

Connecting or disconnecting one remote channel no longer restarts the shared PawWork event stream or the other channels — only the affected channel starts or stops. Per-channel lifecycle becomes a first-class operation across three layers, and the UI flap-suppression that #1404 added as an interim is removed now that unaffected channels genuinely stay up.

- **`remote-bridge/supervisor.ts`** — a `PlatformSupervisor` registry replaces the one-shot `Promise.all`. Each platform runs under its own child `AbortController` linked to the run signal; `add()` / `remove()` / `stopAll()` start, stop, and await a single platform without touching the others. Each entry carries a generation token so a retired or replaced loop's late status can't clobber a newer entry under the same name. A thin `supervisePlatforms()` wrapper is kept for fixed-set callers.
- **`remote-bridge/gateway.ts`** — `App` is now a platform registry holding the injected factory and a `desiredPlatforms` source-of-truth map. `addPlatform(config)` runs the same `hasRemoteAudience` gate as cold start (so an incrementally-added channel can't bypass it), builds via the factory, registers with the Engine, and supervises it; a same-name re-pair retires the old loop but keeps its pointers. `removePlatform(name)` retires the loop and prunes that platform's session pointers. `run()` seeds the supervisor synchronously after hydrate and freezes the cold-start `onReady` set to that snapshot. The message handler drops an inbound from a platform that is no longer the live instance.
- **`remote-bridge/engine.ts`** — `unregisterPlatform(name)` drops the platform from the reconstruct index and discards active deliveries targeting it.
- **`remote-bridge/session-pointers.ts`** — `clearPlatform(name)` prunes one platform's mappings by remote-key prefix, keeping the event cursor and other platforms. On a successful write this lets a disconnect→reconnect of the same platform start fresh. The cleanup is best-effort: clearPlatform prunes in memory and then writes atomically, so a write failure leaves the on-disk snapshot intact and a stale pointer can revive after an immediate restart — an accepted behavior pinned by a `session-pointers` test, with a self-healing tombstone/retry left as follow-up.
- **`desktop-electron/remote-bridge.ts`** — `confirmPairing` / `disconnect` go incremental on a live bridge; a full `startBridge()` is kept only for cold start, last-channel teardown, and recovery after a fatal stream. The live bridge is one `{ app, ac, runPromise }` handle cleared whenever `run()` settles, so a post-fatal `confirmPairing` rebuilds instead of adding onto a dead app. Both flap-suppressions (the `startBridge` pre-mark skip and the `onStatus` connected→connecting guard) are deleted.

## Why

The whole-bridge restart on every connect/disconnect was the root cause of the UI flap that #1404 suppressed at the UI layer. Suppression only hid the blink; it could not fix the real cost — restarting the shared event stream and re-draining every channel whenever one is added or removed (a window in which messages can be missed). This is the root fix #1404's review deferred to Wave 2: don't restart the unaffected channels, and the suppression becomes unnecessary.

A second-AI design pass (first-principles review) surfaced three correctness points folded in here: the audience gate must run on incremental add (kept in the gateway, not bypassable); a removed/replaced platform's in-flight inbound must be dropped (gateway message-handler liveness guard) and its routing/active delivery dropped (`unregisterPlatform`); and a single-platform disconnect prunes that platform's session pointers so a same-platform reconnect normally starts fresh (best-effort: a failed pointer write can revive a stale pointer after a restart, pinned by tests).

## Related Issue

Closes #1414. Part of #1188. Follow-up sibling: #1426 (WeChat session auto-relogin) is intentionally out of scope here.

## Human Review Status

Pending

## Review Focus

- **`PlatformSupervisor` lifecycle correctness** (`supervisor.ts`): the entry is registered before the loop starts (so the first synchronous `starting` passes the token guard) and `done` is filled on the same tick (so `remove`/`stopAll` always await the real loop); the generation token drops a retired loop's late callbacks.
- **The live-handle clearing on `run()` settle** (`desktop remote-bridge.ts`): this is what makes "is a bridge live?" reliable, so a fatal stream rebuilds rather than adds onto a dead app.
- **The audience gate staying inside `App.addPlatform`** (`gateway.ts`): an incrementally-added channel goes through the same `hasRemoteAudience` check as cold start.
- **`addPlatform` vs `removePlatform` pointer semantics**: re-pair (addPlatform replacing a live same-name channel) keeps session pointers; disconnect (removePlatform) prunes them.

## Risk Notes

- **Deletion / credentials behavior**: `removePlatform` now prunes a single platform's session pointers via `clearPlatform` (orphaned parent links are left as-is; no remaining remote key references them). The last-channel teardown (stop bridge → `credentials.clear()` → `rmSync(statePath)`) is unchanged.
- **Platform/packaging surface**: none touched (no packaging, updater, signing, paths, shell, or permissions changes) — the change is OS-agnostic Electron main-process async logic, identical on macOS and Windows. The macOS/Windows checklist item is left unticked for that reason.
- **No visible UI or copy change**: the channel rows and status pills render exactly as before; only the underlying restart behavior changed. The UI/copy checklist item is left unticked for that reason.
- **Manual real-app regression deferred (needs a live WeChat scan)**: `bun run dev:desktop` walk — with Telegram connected, connect/disconnect WeChat and confirm Telegram keeps serving (its poll is never aborted) — is not yet run, as it requires a live WeChat pairing, same constraint as #1404. The behavior is covered by unit tests asserting the shared stream is never rebuilt and the survivor is never stopped.

## How To Verify

```text
remote-bridge typecheck (tsgo --noEmit): exit 0
remote-bridge unit (bun test ./src): 174 pass, 0 fail (12 files)
  - supervisor: add on running supervisor; remove stops only target; retired loop's late ready dropped; no abort-listener accumulation
  - engine: unregisterPlatform drops active delivery + reconstruct routing
  - gateway: addPlatform keeps shared stream up (one /global/event connect); removePlatform stops only target; wildcard-audience add refused; stale-instance inbound dropped
  - session-pointers: clearPlatform prunes one prefix, keeps cursor + other platforms (memory + on-disk)
desktop-electron typecheck (tsgo -b): exit 0
desktop-electron unit (bun test ./src): 375 pass, 0 fail (55 files)
  - two channels: connect adds incrementally (build=1, events=[add:wechat]); disconnect removes only one (build=1)
  - connecting a second channel leaves the first's stream + status untouched (no flap)
  - fatal stream degrades all + clears the handle, so the next connect rebuilds (build=2)
eslint (changed in-scope file desktop-electron/src/main/remote-bridge.ts): 0 errors
```

## Screenshots or Recordings

No visible UI change (main-process / gateway logic only).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

https://claude.ai/code/session_01WVUVErxQ1AEf2mYT2bJ5hT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Incremental platform connect/disconnect while the bridge stays online, including prepare-first replacements.
  * Per-platform supervision with lifecycle phases (starting/serving/degraded) and more detailed serving status.
  * Runtime support for unregistering/removing a platform and keeping the rest online.
* **Bug Fixes**
  * Dropped stale inbound messages from removed platforms and prevented routing to disconnected targets.
  * Improved teardown/shutdown safety, including retry behavior after transient disconnect failures.
  * Isolated credential save failures so incremental joins/adds/removes don’t overwrite persisted credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
