### PR TITLE
refactor(opencode): retire UI static Hono wrapper

### DIFF
--- a/packages/opencode/script/route-inventory.ts
+++ b/packages/opencode/script/route-inventory.ts
@@ -67,10 +67,6 @@ const honoRouteSources = [
   ["packages/opencode/src/server/instance/event.ts", ""],
 ] as const
 
-const supplementalHonoRouteSources = [
-  "packages/opencode/src/server/ui/index.ts",
-] as const
-
 const honoRouteModuleSearchRoots = [
   "packages/opencode/src/server/control",
   "packages/opencode/src/server/instance",
@@ -101,6 +97,7 @@ const nativeSpecialRoutes = new Set([
 
 const nativeSpecialRouteEntries: Route[] = [
   { method: "GET", path: "/__workspace_ws", source: "packages/opencode/src/server/websocket-compatibility.ts" },
+  { method: "ALL", path: "/*", source: "packages/opencode/src/server/ui/index.ts" },
 ]
 
 const compatibilityBoundaryRoutes = new Set<string>()
@@ -245,9 +242,7 @@ async function discoverHonoRouteModules(root: string): Promise<string[]> {
 }
 
 export function getMissingHonoRouteSources(expected: string[]): string[] {
-  const covered = [...honoRouteSources.map(([relative]) => relative), ...supplementalHonoRouteSources].map(
-    normalizeRouteSourcePath,
-  )
+  const covered = honoRouteSources.map(([relative]) => normalizeRouteSourcePath(relative))
   const coveredSet = new Set<string>(covered)
   return expected.map(normalizeRouteSourcePath).filter((relative) => !coveredSet.has(relative))
 }
@@ -255,9 +250,7 @@ export function getMissingHonoRouteSources(expected: string[]): string[] {
 export async function getHonoRouteSourceCoverage(rootInput?: string): Promise<HonoRouteSourceCoverage> {
   const root = repoRoot(rootInput)
   const expected = await discoverHonoRouteModules(root)
-  const covered = [...honoRouteSources.map(([relative]) => relative), ...supplementalHonoRouteSources]
-    .map(normalizeRouteSourcePath)
-    .sort()
+  const covered = honoRouteSources.map(([relative]) => normalizeRouteSourcePath(relative)).sort()
   return {
     expected,
     covered,
@@ -279,8 +272,6 @@ async function discoverHonoRoutes(root: string): Promise<Route[]> {
       routes.push({ method, path: joinRoute(prefix, routePath), source: relative })
     }
   }
-  // These runtime routes are wired through UI/proxy setup instead of ordinary route modules.
-  routes.push({ method: "ALL", path: "/*", source: "packages/opencode/src/server/ui/index.ts" })
   return uniqueRoutes(routes)
 }
 

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -1,1 +1,0 @@
-export { UIRoutes } from "../ui"

--- a/packages/opencode/src/server/ui/index.ts
+++ b/packages/opencode/src/server/ui/index.ts
@@ -1,6 +1,4 @@
 import { Flag } from "@opencode-ai/core/flag/flag"
-import { Hono } from "hono"
-import { getMimeType } from "hono/utils/mime"
 import { createHash } from "node:crypto"
 import fs from "node:fs/promises"
 
@@ -25,6 +23,70 @@ const HOP_BY_HOP_HEADERS = [
   "transfer-encoding",
   "upgrade",
 ] as const
+
+const STATIC_MIME_TYPES: Record<string, string> = {
+  aac: "audio/aac",
+  avi: "video/x-msvideo",
+  avif: "image/avif",
+  av1: "video/av1",
+  bin: "application/octet-stream",
+  bmp: "image/bmp",
+  css: "text/css; charset=utf-8",
+  csv: "text/csv; charset=utf-8",
+  eot: "application/vnd.ms-fontobject",
+  epub: "application/epub+zip",
+  gif: "image/gif",
+  gz: "application/gzip",
+  htm: "text/html; charset=utf-8",
+  html: "text/html; charset=utf-8",
+  ico: "image/x-icon",
+  ics: "text/calendar; charset=utf-8",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  js: "text/javascript; charset=utf-8",
+  json: "application/json",
+  jsonld: "application/ld+json",
+  map: "application/json",
+  mid: "audio/x-midi",
+  midi: "audio/x-midi",
+  mjs: "text/javascript; charset=utf-8",
+  mp3: "audio/mpeg",
+  mp4: "video/mp4",
+  mpeg: "video/mpeg",
+  oga: "audio/ogg",
+  ogv: "video/ogg",
+  ogx: "application/ogg",
+  opus: "audio/opus",
+  otf: "font/otf",
+  pdf: "application/pdf",
+  png: "image/png",
+  rtf: "application/rtf",
+  svg: "image/svg+xml; charset=utf-8",
+  tif: "image/tiff",
+  tiff: "image/tiff",
+  ts: "video/mp2t",
+  ttf: "font/ttf",
+  txt: "text/plain; charset=utf-8",
+  wasm: "application/wasm",
+  webm: "video/webm",
+  weba: "audio/webm",
+  webmanifest: "application/manifest+json",
+  webp: "image/webp",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  xhtml: "application/xhtml+xml; charset=utf-8",
+  xml: "application/xml; charset=utf-8",
+  zip: "application/zip",
+  "3gp": "video/3gpp",
+  "3g2": "video/3gpp2",
+  gltf: "model/gltf+json",
+  glb: "model/gltf-binary",
+}
+
+function getStaticMimeType(file: string) {
+  const match = file.match(/\.([a-zA-Z0-9]+?)$/)
+  return match ? STATIC_MIME_TYPES[match[1]!.toLowerCase()] : undefined
+}
 
 function proxyRequestHeaders(request: Request) {
   const headers = new Headers(request.headers)
@@ -57,7 +119,7 @@ export async function handleUIRequest(request: Request) {
     if (!match) return Response.json({ error: "Not Found" }, { status: 404 })
 
     if (await fs.exists(match)) {
-      const mime = getMimeType(match) ?? "text/plain"
+      const mime = getStaticMimeType(match) ?? "text/plain"
       const headers = new Headers({ "content-type": mime })
       if (mime.startsWith("text/html")) {
         headers.set("content-security-policy", DEFAULT_CSP)
@@ -93,8 +155,3 @@ export async function handleUIRequest(request: Request) {
     headers,
   })
 }
-
-export const UIRoutes = (): Hono =>
-  new Hono().all("/*", async (c) => {
-    return handleUIRequest(c.req.raw)
-  })

--- a/packages/opencode/test/server/production-boundary.test.ts
+++ b/packages/opencode/test/server/production-boundary.test.ts
@@ -189,6 +189,22 @@ describe("production server boundary", () => {
     expect(bunAdapter).not.toMatch(/create\(app:\s*Hono/)
   })
 
+  test("keeps UI static handling on the native Web handler boundary", async () => {
+    const ui = await readFile(path.join(import.meta.dir, "../../src/server/ui/index.ts"), "utf8")
+
+    expect(ui).not.toMatch(/from\s+["']hono["']/)
+    expect(ui).not.toMatch(/\bnew\s+Hono\s*\(/)
+    expect(ui).not.toContain("export const UIRoutes")
+    expect(existsSync(path.join(import.meta.dir, "../../src/server/routes/ui.ts"))).toBe(false)
+    expect(ui).toContain("export async function handleUIRequest")
+    expect(ui).not.toContain("mime-types")
+    expect(ui).toContain('html: "text/html; charset=utf-8"')
+    expect(ui).toContain('css: "text/css; charset=utf-8"')
+    expect(ui).toContain('js: "text/javascript; charset=utf-8"')
+    expect(ui).toContain('svg: "image/svg+xml; charset=utf-8"')
+    expect(ui).toContain('return match ? STATIC_MIME_TYPES[match[1]!.toLowerCase()] : undefined')
+  })
+
   test("does not keep a legacy Hono documentation route tree", () => {
     const openapi = path.join(import.meta.dir, "../../src/server/openapi.ts")
 

--- a/packages/opencode/test/server/route-inventory-harness.test.ts
+++ b/packages/opencode/test/server/route-inventory-harness.test.ts
@@ -554,7 +554,7 @@ describe("route inventory harness", () => {
     }
 
     expect(inventory.rows.find((row) => row.method === "ALL" && row.path === "/*")).toMatchObject({
-      hono: true,
+      hono: false,
       localHttpApi: false,
       nativeSpecial: true,
       compatibilityBoundary: false,
@@ -658,7 +658,7 @@ describe("route inventory harness", () => {
   test("matches discovered Hono route modules when Windows uses backslash separators", () => {
     expect(
       getMissingHonoRouteSources([
-        "packages\\opencode\\src\\server\\ui\\index.ts",
+        "packages\\opencode\\src\\server\\instance\\event.ts",
       ]),
     ).toEqual([])
   })


### PR DESCRIPTION
## Summary

Retire the legacy Hono UI static wrapper while keeping UI static/proxy handling on the existing native Web `Request`/`Response` handler.

## Why

The production server already reaches UI fallback through `special.handleUI(request)`, not by mounting `new Hono().all("/*", ...)`. This removes the stale Hono wrapper and keeps the route inventory honest for the #936 Effect/HttpApi migration tail.

## Related Issue

Related to #936

## Human Review Status

Pending

## Review Focus

Please focus on whether the UI fallback remains behavior-preserving: embedded static MIME mapping, CSP behavior, proxy fallback headers, and the `ALL /*` inventory classification.

Fresh-eye result: no P0/P1 findings after the final diff. A P2 MIME-regression risk was fixed by preserving the retired Hono MIME table locally instead of using broader `mime-types` guessing. A P3 stale shim concern was fixed by deleting `packages/opencode/src/server/routes/ui.ts` after direct inventory showed no callers.

## Risk Notes

Low migration risk. This deletes a stale Hono route shim and preserves the current native handler behavior. No visible UI/copy changed, so no screenshot is included. No platform, packaging, dependency, permission, credential, generated-content, or docs surface was touched.

## How To Verify

```text
RED: bun test test/server/production-boundary.test.ts test/server/route-inventory-harness.test.ts failed before implementation for the expected UI Hono wrapper and ALL /* Hono inventory assertions.
Focused server tests: bun test test/server/production-boundary.test.ts test/server/route-inventory-harness.test.ts test/server/ui-routes.test.ts -> 56 pass, 0 fail.
Typecheck: GOMAXPROCS=2 bun run typecheck -> pass.
Diff check: git diff --check -> pass.
Direct inventory: rg "server/routes/ui|routes/ui|UIRoutes|handleUIRequest" packages/opencode/src packages/opencode/test packages/opencode/script -> only native handleUIRequest production references and tests remain.
```

## Screenshots or Recordings

Not applicable. No visible UI changed.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.