### PR TITLE
fix(desktop): route WebSearch/LSP/ToolRegistry IPC through Effect services

### DIFF
--- a/packages/desktop-electron/src/main/env.d.ts
+++ b/packages/desktop-electron/src/main/env.d.ts
@@ -57,18 +57,33 @@ declare module "virtual:opencode-server" {
       needsAttention: boolean
       quotaExceeded: boolean
     }
-    export function status(): Promise<Status>
-    export function saveKey(key: string): Promise<Status>
-    export function removeKey(): Promise<Status>
+    export type ServiceApi = {
+      status: () => unknown
+      saveKey: (key: string) => unknown
+      removeKey: () => unknown
+    }
+    export const Service: {
+      use: <A>(fn: (auth: ServiceApi) => A) => A
+    }
   }
 
   export namespace LSP {
-    export function shutdownAll(): Promise<void>
-    export function invalidate(): Promise<void>
+    export type ServiceApi = {
+      shutdownAll: () => unknown
+      invalidate: () => unknown
+    }
+    export const Service: {
+      use: <A>(fn: (lsp: ServiceApi) => A) => A
+    }
   }
 
   export namespace ToolRegistry {
-    export function invalidate(): Promise<void>
+    export type ServiceApi = {
+      invalidate: () => unknown
+    }
+    export const Service: {
+      use: <A>(fn: (registry: ServiceApi) => A) => A
+    }
   }
 
   export namespace Instance {

--- a/packages/desktop-electron/src/main/env.d.ts
+++ b/packages/desktop-electron/src/main/env.d.ts
@@ -9,6 +9,12 @@ interface ImportMeta {
 }
 
 declare module "virtual:opencode-server" {
+  // A typed handle for an opencode Effect crossing the virtual-module boundary.
+  // The desktop side never inspects it; AppRuntime.runPromise unwraps it to the
+  // Result type, so a handler that returns the wrong shape — or a callback that
+  // calls the wrong service method — fails typecheck instead of only at runtime.
+  export type ServerEffect<Result> = { readonly __result?: Result }
+
   export namespace Server {
     export type Listener = {
       hostname: string
@@ -36,10 +42,10 @@ declare module "virtual:opencode-server" {
 
   export namespace Settings {
     export type ServiceApi = {
-      lspEnabled: () => unknown
-      setLspEnabled: (value: boolean) => unknown
-      webSearchEnabled: () => unknown
-      setWebSearchEnabled: (value: boolean) => unknown
+      lspEnabled: () => ServerEffect<boolean>
+      setLspEnabled: (value: boolean) => ServerEffect<void>
+      webSearchEnabled: () => ServerEffect<boolean>
+      setWebSearchEnabled: (value: boolean) => ServerEffect<void>
     }
     export const Service: {
       use: <A>(fn: (settings: ServiceApi) => A) => A
@@ -47,7 +53,7 @@ declare module "virtual:opencode-server" {
   }
 
   export namespace AppRuntime {
-    export function runPromise(effect: unknown, options?: unknown): Promise<unknown>
+    export function runPromise<Result>(effect: ServerEffect<Result>, options?: unknown): Promise<Result>
   }
 
   export namespace WebSearchAuth {
@@ -58,9 +64,9 @@ declare module "virtual:opencode-server" {
       quotaExceeded: boolean
     }
     export type ServiceApi = {
-      status: () => unknown
-      saveKey: (key: string) => unknown
-      removeKey: () => unknown
+      status: () => ServerEffect<Status>
+      saveKey: (key: string) => ServerEffect<Status>
+      removeKey: () => ServerEffect<Status>
     }
     export const Service: {
       use: <A>(fn: (auth: ServiceApi) => A) => A
@@ -69,8 +75,8 @@ declare module "virtual:opencode-server" {
 
   export namespace LSP {
     export type ServiceApi = {
-      shutdownAll: () => unknown
-      invalidate: () => unknown
+      shutdownAll: () => ServerEffect<void>
+      invalidate: () => ServerEffect<void>
     }
     export const Service: {
       use: <A>(fn: (lsp: ServiceApi) => A) => A
@@ -79,7 +85,7 @@ declare module "virtual:opencode-server" {
 
   export namespace ToolRegistry {
     export type ServiceApi = {
-      invalidate: () => unknown
+      invalidate: () => ServerEffect<void>
     }
     export const Service: {
       use: <A>(fn: (registry: ServiceApi) => A) => A

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -211,10 +211,11 @@ export function registerIpcHandlers(deps: Deps) {
     const setLspEnabled = (next: boolean) =>
       AppRuntime.runPromise(Settings.Service.use((settings) => settings.setLspEnabled(next))) as Promise<void>
     await setLspEnabled(value)
-    // LSP.invalidate / ToolRegistry.invalidate / LSP.shutdownAll all read
-    // InstanceState.directory, which requires an Instance scope. Process every
-    // active instance with isolation so a single failure does not leave the
-    // remaining projects stuck on stale cache state.
+    // The LSP and ToolRegistry invalidate/shutdownAll effects all read
+    // InstanceState.directory, which resolves from the Instance scope (InstanceRef
+    // ?? Instance.current ALS). Run them inside Instance.provide so each effect
+    // sees the right directory, and process every active instance with isolation
+    // so a single failure does not leave the remaining projects on stale cache.
     const directories = Instance.directories()
     const results = await Promise.allSettled(
       directories.map((directory) =>
@@ -222,10 +223,10 @@ export function registerIpcHandlers(deps: Deps) {
           directory,
           fn: async () => {
             if (!value) {
-              await LSP.shutdownAll()
+              await AppRuntime.runPromise(LSP.Service.use((lsp) => lsp.shutdownAll()))
             }
-            await LSP.invalidate()
-            await ToolRegistry.invalidate()
+            await AppRuntime.runPromise(LSP.Service.use((lsp) => lsp.invalidate()))
+            await AppRuntime.runPromise(ToolRegistry.Service.use((registry) => registry.invalidate()))
           },
         }),
       ),
@@ -253,7 +254,7 @@ export function registerIpcHandlers(deps: Deps) {
         targetDirectories.map((directory) =>
           Instance.provide({
             directory,
-            fn: () => ToolRegistry.invalidate(),
+            fn: () => AppRuntime.runPromise(ToolRegistry.Service.use((registry) => registry.invalidate())),
           }),
         ),
       )
@@ -285,18 +286,18 @@ export function registerIpcHandlers(deps: Deps) {
   })
 
   ipcMain.handle("websearch-status", async () => {
-    const { WebSearchAuth } = await import("virtual:opencode-server")
-    return WebSearchAuth.status()
+    const { AppRuntime, WebSearchAuth } = await import("virtual:opencode-server")
+    return AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.status()))
   })
 
   ipcMain.handle("websearch-save-exa-key", async (_event: IpcMainInvokeEvent, key: string) => {
-    const { WebSearchAuth } = await import("virtual:opencode-server")
-    return WebSearchAuth.saveKey(key)
+    const { AppRuntime, WebSearchAuth } = await import("virtual:opencode-server")
+    return AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.saveKey(key)))
   })
 
   ipcMain.handle("websearch-remove-exa-key", async () => {
-    const { WebSearchAuth } = await import("virtual:opencode-server")
-    return WebSearchAuth.removeKey()
+    const { AppRuntime, WebSearchAuth } = await import("virtual:opencode-server")
+    return AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.removeKey()))
   })
 
   ipcMain.handle(

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -25,6 +25,9 @@ import {
   SESSION_EXPORT_RENDERER_DIAGNOSTICS_MAX_BYTES,
   type RendererDiagnosticsSlice,
 } from "./renderer-diagnostics"
+// Type-only: pins each Web Search credential handler to the Status shape the
+// preload promises the renderer, so a wrong service return fails typecheck.
+import type { WebSearchAuth as WebSearchAuthApi } from "virtual:opencode-server"
 
 const pickerFilters = (ext?: string[]) => {
   if (!ext || ext.length === 0) return undefined
@@ -285,17 +288,17 @@ export function registerIpcHandlers(deps: Deps) {
     }
   })
 
-  ipcMain.handle("websearch-status", async () => {
+  ipcMain.handle("websearch-status", async (): Promise<WebSearchAuthApi.Status> => {
     const { AppRuntime, WebSearchAuth } = await import("virtual:opencode-server")
     return AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.status()))
   })
 
-  ipcMain.handle("websearch-save-exa-key", async (_event: IpcMainInvokeEvent, key: string) => {
+  ipcMain.handle("websearch-save-exa-key", async (_event: IpcMainInvokeEvent, key: string): Promise<WebSearchAuthApi.Status> => {
     const { AppRuntime, WebSearchAuth } = await import("virtual:opencode-server")
     return AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.saveKey(key)))
   })
 
-  ipcMain.handle("websearch-remove-exa-key", async () => {
+  ipcMain.handle("websearch-remove-exa-key", async (): Promise<WebSearchAuthApi.Status> => {
     const { AppRuntime, WebSearchAuth } = await import("virtual:opencode-server")
     return AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.removeKey()))
   })

--- a/packages/desktop-electron/src/main/websearch-ipc-source.test.ts
+++ b/packages/desktop-electron/src/main/websearch-ipc-source.test.ts
@@ -8,6 +8,16 @@ const preloadTypes = readFileSync(resolve(import.meta.dir, "../preload/types.ts"
 const envTypes = readFileSync(resolve(import.meta.dir, "env.d.ts"), "utf8")
 const nodeEntry = readFileSync(resolve(import.meta.dir, "../../../opencode/src/node.ts"), "utf8")
 
+// Slice a single ipcMain.handle body out of ipc.ts so a channel can be asserted
+// against the exact service method it wires to (not just "the string appears
+// somewhere in the file"). Mirrors the store-get slice in ipc-window-config.test.
+function handlerBody(channel: string) {
+  const start = mainIpc.indexOf(`ipcMain.handle("${channel}"`)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const next = mainIpc.indexOf("ipcMain.handle(", start + 1)
+  return next > start ? mainIpc.slice(start, next) : mainIpc.slice(start)
+}
+
 describe("websearch IPC source contract", () => {
   test("exposes Web Search runtime toggle and credential channels to the sandboxed renderer", () => {
     for (const channel of [
@@ -38,11 +48,11 @@ describe("websearch IPC source contract", () => {
     expect(mainIpc).toContain("AppRuntime.runPromise(Settings.Service.use")
   })
 
-  test("credential and tool-invalidation handlers use Effect services instead of retired facades", () => {
+  test("no handler calls a retired top-level facade anywhere in the file", () => {
     // These namespaces became Effect services in the settings migration; the
     // top-level Promise facades no longer exist and throw "is not a function"
-    // at runtime (the 2026.6.10 Settings crash). Keep every handler on
-    // AppRuntime.runPromise(<Service>.use(...)).
+    // at runtime (the 2026.6.10 Settings crash). None of these strings may
+    // reappear in any handler.
     for (const deadFacade of [
       "WebSearchAuth.status(",
       "WebSearchAuth.saveKey(",
@@ -53,25 +63,47 @@ describe("websearch IPC source contract", () => {
     ]) {
       expect(mainIpc).not.toContain(deadFacade)
     }
-    for (const effectCall of [
-      "AppRuntime.runPromise(WebSearchAuth.Service.use",
-      "AppRuntime.runPromise(LSP.Service.use",
-      "AppRuntime.runPromise(ToolRegistry.Service.use",
-    ]) {
-      expect(mainIpc).toContain(effectCall)
-    }
   })
 
-  test("virtual module types expose Effect services, not retired facades", () => {
-    // env.d.ts is the only typecheck guard for the virtual:opencode-server
-    // boundary. If it keeps declaring the dead facades as functions, a handler
-    // that calls them typechecks clean and only fails at runtime.
+  test("each settings IPC channel wires to its specific Effect service method", () => {
+    // Per-handler, not whole-file: a channel swapped onto the wrong method
+    // (e.g. websearch-save-exa-key calling auth.status()) must fail here even
+    // though the wrong method's string still exists in a sibling handler.
+    expect(handlerBody("websearch-status")).toContain(
+      "AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.status()))",
+    )
+    expect(handlerBody("websearch-save-exa-key")).toContain(
+      "AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.saveKey(key)))",
+    )
+    expect(handlerBody("websearch-remove-exa-key")).toContain(
+      "AppRuntime.runPromise(WebSearchAuth.Service.use((auth) => auth.removeKey()))",
+    )
+
+    const lspHandler = handlerBody("lsp-set-enabled")
+    expect(lspHandler).toContain("AppRuntime.runPromise(LSP.Service.use((lsp) => lsp.shutdownAll()))")
+    expect(lspHandler).toContain("AppRuntime.runPromise(LSP.Service.use((lsp) => lsp.invalidate()))")
+    expect(lspHandler).toContain("AppRuntime.runPromise(ToolRegistry.Service.use((registry) => registry.invalidate()))")
+
+    expect(handlerBody("websearch-set-enabled")).toContain(
+      "AppRuntime.runPromise(ToolRegistry.Service.use((registry) => registry.invalidate()))",
+    )
+  })
+
+  test("virtual module types expose typed Effect services, not retired facades", () => {
+    // env.d.ts is the typecheck guard for the virtual:opencode-server boundary.
+    // Dead facades declared as functions would let a retired call typecheck
+    // clean; bare `unknown` returns would let a wrong result shape through. Keep
+    // the credential/invalidation methods on typed ServerEffect results so the
+    // Settings API-key path fails at compile time, not at runtime.
     for (const namespace of ["WebSearchAuth", "LSP", "ToolRegistry"]) {
       expect(envTypes).toContain(`namespace ${namespace}`)
     }
     expect(envTypes).not.toContain("export function status(")
     expect(envTypes).not.toContain("export function shutdownAll(")
     expect(envTypes).not.toContain("export function invalidate(")
+    expect(envTypes).toContain("status: () => ServerEffect<Status>")
+    expect(envTypes).toContain("saveKey: (key: string) => ServerEffect<Status>")
+    expect(envTypes).toContain("runPromise<Result>(effect: ServerEffect<Result>")
   })
 
   test("web search toggle rejects when live tool invalidation fails", () => {

--- a/packages/desktop-electron/src/main/websearch-ipc-source.test.ts
+++ b/packages/desktop-electron/src/main/websearch-ipc-source.test.ts
@@ -38,6 +38,42 @@ describe("websearch IPC source contract", () => {
     expect(mainIpc).toContain("AppRuntime.runPromise(Settings.Service.use")
   })
 
+  test("credential and tool-invalidation handlers use Effect services instead of retired facades", () => {
+    // These namespaces became Effect services in the settings migration; the
+    // top-level Promise facades no longer exist and throw "is not a function"
+    // at runtime (the 2026.6.10 Settings crash). Keep every handler on
+    // AppRuntime.runPromise(<Service>.use(...)).
+    for (const deadFacade of [
+      "WebSearchAuth.status(",
+      "WebSearchAuth.saveKey(",
+      "WebSearchAuth.removeKey(",
+      "LSP.shutdownAll(",
+      "LSP.invalidate(",
+      "ToolRegistry.invalidate(",
+    ]) {
+      expect(mainIpc).not.toContain(deadFacade)
+    }
+    for (const effectCall of [
+      "AppRuntime.runPromise(WebSearchAuth.Service.use",
+      "AppRuntime.runPromise(LSP.Service.use",
+      "AppRuntime.runPromise(ToolRegistry.Service.use",
+    ]) {
+      expect(mainIpc).toContain(effectCall)
+    }
+  })
+
+  test("virtual module types expose Effect services, not retired facades", () => {
+    // env.d.ts is the only typecheck guard for the virtual:opencode-server
+    // boundary. If it keeps declaring the dead facades as functions, a handler
+    // that calls them typechecks clean and only fails at runtime.
+    for (const namespace of ["WebSearchAuth", "LSP", "ToolRegistry"]) {
+      expect(envTypes).toContain(`namespace ${namespace}`)
+    }
+    expect(envTypes).not.toContain("export function status(")
+    expect(envTypes).not.toContain("export function shutdownAll(")
+    expect(envTypes).not.toContain("export function invalidate(")
+  })
+
   test("web search toggle rejects when live tool invalidation fails", () => {
     expect(mainIpc).toContain("const previous = await readWebSearchEnabled()")
     expect(mainIpc).toContain("await setWebSearchEnabled(previous)")

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -42,6 +42,7 @@ import { McpAuth } from "@/mcp/auth"
 import { Command } from "@/command"
 import { Truncate } from "@/tool/truncate"
 import { ToolRegistry } from "@/tool/registry"
+import { WebSearchAuth } from "@/tool/websearch-auth"
 import { Project } from "@/project/project"
 import { Vcs } from "@/project/vcs"
 import { Worktree } from "@/worktree"
@@ -98,6 +99,10 @@ export const AppLayer = Layer.suspend(() =>
     Command.defaultLayer,
     Truncate.defaultLayer,
     ToolRegistry.defaultLayer,
+    // Desktop settings IPC drives WebSearchAuth.status/saveKey/removeKey through
+    // AppRuntime; expose the service here (Auth is shared via the memo map) so
+    // the embedded server boundary can resolve it the same way as Settings.
+    WebSearchAuth.defaultLayer,
     Project.defaultLayer,
     Vcs.defaultLayer,
     Worktree.defaultLayer,


### PR DESCRIPTION
## Summary

After the Effect settings migration, the desktop main process still called the retired top-level Promise facades on the `WebSearchAuth`, `LSP`, and `ToolRegistry` namespaces. `4338ba7ce5` migrated only the `Settings.Service` half, leaving six live IPC call sites pointing at functions that no longer exist. This routes all of them through `AppRuntime.runPromise(<Service>.use(...))`, exposes `WebSearchAuth.Service` on the app runtime, and stops `env.d.ts` from declaring the dead facades.

## Why

Opening **Settings** on 2026.6.10 crashed the renderer:

```
Error invoking remote method 'websearch-status':
TypeError: WebSearchAuth.status is not a function
```

`websearch-status` fires on Settings open, so the whole page hit the error boundary ("Something broke") and users could not reach the API-key fields. The same dead-facade pattern also broke:

- `websearch-save-exa-key` / `websearch-remove-exa-key` → `WebSearchAuth.saveKey/removeKey`
- `lsp-set-enabled` → `LSP.shutdownAll` / `LSP.invalidate` / `ToolRegistry.invalidate` (crash on toggling LSP)
- `websearch-set-enabled` → `ToolRegistry.invalidate` (crash on toggling Web Search; the throw also rolled the setting back)

Two guards missed it: `env.d.ts` still typed the facades as top-level functions (so typecheck passed against a type that lied about runtime), and the source-contract test only covered the Settings handlers.

## Related Issue

Closes #1460

## Human Review Status

`Pending`

## Review Focus

- `app-runtime.ts`: adding `WebSearchAuth.defaultLayer` to `AppLayer`. `Auth` is shared via the runtime memo map, so no duplicate `Auth`/storage instance is created — please confirm that reasoning.
- `ipc.ts`: the `LSP`/`ToolRegistry` invalidate effects still run inside `Instance.provide`, relying on `InstanceState.directory` resolving via the `InstanceRef ?? Instance.current` ALS fallback (the same scope the retired facades used).
- `env.d.ts`: the virtual-module shapes now mirror the real `Service.use` API, which is what turns a future dead-facade call into a typecheck failure.

## Risk Notes

Touches the core `AppLayer` composition (all platforms) by adding one service layer; verified the full runtime still constructs (see How To Verify). No dependency, credential, or migration surface changed. No visible UI/copy change — the renderer code path is unchanged; only the broken main-process handler bodies were fixed.

## How To Verify

```text
bun test src/main/websearch-ipc-source.test.ts: 6 pass (extended contract; was red before the fix)
bun test (packages/desktop-electron): 580 pass, 0 fail
bun run typecheck (packages/desktop-electron): passed against the corrected env.d.ts
GOMAXPROCS=2 bun run typecheck (packages/opencode): passed — proves WebSearchAuth.Service is now provided by AppLayer
Real runtime check (temp HOME): AppRuntime.runPromise(WebSearchAuth.Service.use((a) => a.status()))
  returned {source:"anonymous",configured:false,needsAttention:false,quotaExceeded:false}
  instead of throwing — confirms the layer wiring and that AppLayer still builds with the added service
eslint (changed files): 0 errors
```

Not verified: a full packaged-app click-through of the Settings page. The renderer path is unchanged and the broken handler bodies are runtime-proven.

## Screenshots or Recordings

N/A — no visible UI or copy change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

https://claude.ai/code/session_01AvBXNmkRoGBkZBkPMmQSTS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal service architecture for authentication, language protocol, and tool management systems. Services now use a standardized access pattern for improved code maintainability and consistency.
  * Added tests to validate the new service patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->