### PR TITLE
chore(release): bump desktop version to 2026.6.11

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.6.10",
+      "version": "2026.6.11",
       "dependencies": {
         "@opencode-ai/remote-bridge": "workspace:*",
         "@opencode-ai/util": "workspace:*",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.6.10",
+  "version": "2026.6.11",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the desktop release version from `2026.6.10` to `2026.6.11` so the next production build can ship the Settings IPC regression fix from #1461 and the already-merged remote bridge lifecycle work from #1454.

## Why

`2026.6.10` still has a real packaged Windows regression where opening Settings can fail when the page calls the retired WebSearch/LSP/ToolRegistry IPC facades. PR #1461 fixed the underlying IPC routing and closed #1460, so this release bump prepares a new build users can install.

## Related Issue

Follow-up release for #1460. Includes #1454 and #1461 since `v2026.6.10`.

## Human Review Status

Pending

## Review Focus

Confirm this PR only changes the desktop package version and the matching lockfile entry.

## Risk Notes

- Platform/release surface: this is intentionally a packaging/updater version bump for a production hotfix release.
- No visible UI or copy changed in this PR; the user-facing fix was reviewed in #1461.

## How To Verify

```text
bun install --frozen-lockfile: passed
bun install --lockfile-only: updated only the desktop package lockfile version
node -p "require('./packages/desktop-electron/package.json').version": 2026.6.11
git diff --check: passed
bun run typecheck (packages/desktop-electron): passed
post-merge dev CI for #1461 commit c509fafd4475983771014427e19bf70c2a07c690: ci, desktop-smoke, CodeQL, and Windows advisory passed before this release bump
```

## Screenshots or Recordings

No visible UI change in this PR.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
