### PR TITLE
fix(opencode): classify provider billing/quota failures instead of masking them

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -171,24 +171,32 @@ function message(providerID: ProviderID, e: APICallError) {
       return "Unknown error"
     }
 
+    // Surface the provider's nested reason from a structured body first — even
+    // when the SDK message is a custom string rather than the bare HTTP reason
+    // phrase. Otherwise a message like "API call failed" would early-return and
+    // suppress the real {error:{message}} reason (e.g. DeepSeek's "Insufficient
+    // Balance"). Many providers wrap it as {error:{message}} where body.error is
+    // an object, so checking body.error before body.error.message would
+    // short-circuit on the object and dump the raw body instead of the string.
+    if (e.responseBody) {
+      try {
+        const body = JSON.parse(e.responseBody)
+        const nested = typeof body?.error?.message === "string" ? body.error.message : undefined
+        const top = typeof body?.message === "string" ? body.message : undefined
+        const errString = typeof body?.error === "string" ? body.error : undefined
+        const errMsg = nested ?? top ?? errString
+        if (errMsg) {
+          // Avoid "msg: msg" duplication when the SDK message already carries it.
+          return msg.includes(errMsg) ? msg : `${msg}: ${errMsg}`
+        }
+      } catch {}
+    }
+
+    // No structured reason to surface. A non-reason-phrase SDK message stands on
+    // its own; a bare reason phrase with a body falls through to HTML/raw below.
     if (!e.responseBody || (e.statusCode && msg !== STATUS_CODES[e.statusCode])) {
       return msg
     }
-
-    try {
-      const body = JSON.parse(e.responseBody)
-      // Prefer the nested provider message first: many providers wrap it as
-      // {error:{message}} where body.error is an object, so checking body.error
-      // before body.error.message would short-circuit on the object and dump the
-      // raw body instead of the human-readable string.
-      const nested = typeof body?.error?.message === "string" ? body.error.message : undefined
-      const top = typeof body?.message === "string" ? body.message : undefined
-      const errString = typeof body?.error === "string" ? body.error : undefined
-      const errMsg = nested ?? top ?? errString
-      if (errMsg) {
-        return `${msg}: ${errMsg}`
-      }
-    } catch {}
 
     // If responseBody is HTML (e.g. from a gateway or proxy error page),
     // provide a human-readable message instead of dumping raw markup

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -28,6 +28,10 @@ function apiCallErrorKind(statusCode: number | undefined, code: string | undefin
   if (code === "server_error" || code === "server_is_overloaded") return "server_overload"
   if (statusCode === 401 || statusCode === 403) return "auth"
   if (statusCode === 429) return "rate_limit"
+  // 402 Payment Required = account can no longer pay for the call. Same user
+  // action as a depleted quota (top up or switch model), so it reuses
+  // quota_exhausted rather than adding a near-duplicate payment_required kind.
+  if (statusCode === 402) return "quota_exhausted"
   // 400/422 are client-side request rejections. Overflow 4xx is already routed
   // to context_overflow before this runs, so what reaches here is a genuine
   // invalid request rather than an over-long prompt.
@@ -78,6 +82,83 @@ function isOverflow(message: string) {
   return /^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message)
 }
 
+// Billing/quota failures providers report under inconsistent status codes and
+// codes (e.g. DeepSeek returns 402 *or* 400 with "Insufficient Balance"). The
+// strong patterns are unambiguous and match regardless of status; the weak
+// patterns ("quota exceeded") overlap with transient rate limits, so they only
+// apply on a billing-shaped status with no rate-limit signal.
+const STRONG_BILLING_PATTERNS = [
+  /insufficient balance/i, // DeepSeek
+  /out of credits?/i, // OpenRouter and others
+  /payment required/i,
+  /in arrears/i,
+  /余额不足/, // zh: insufficient balance
+  /欠费/, // zh: in arrears
+]
+const WEAK_BILLING_PATTERNS = [
+  /quota.{0,16}(exceed|exhaust)/i,
+  /(exceed|exhaust).{0,16}quota/i,
+  /billing (issue|problem|error)/i,
+  /add (credits?|funds?|balance)/i,
+  /out of funds?/i,
+]
+// 429 is deliberately excluded: it is Too Many Requests, so even "quota
+// exceeded" wording (e.g. Google's per-minute request quota) is a retryable
+// rate limit, not a terminal billing failure. Genuine depleted-balance/hard
+// quota arrives as 402/403 or a known code (insufficient_quota) handled above.
+const WEAK_BILLING_STATUS = new Set([400, 402, 403])
+
+// opencode's free-tier limit reuses a 429 with a billing-ish marker, but it must
+// stay a retry-time free_quota_exhausted concept (countdown card), never the
+// terminal quota_exhausted kind. Excluded from billing classification here.
+function isFreeUsageLimit(text: string) {
+  return /FreeUsageLimitError/.test(text)
+}
+
+function hasRateLimitSignal(text: string, headers?: Record<string, string>) {
+  if (headers && (headers["retry-after"] || headers["retry-after-ms"])) return true
+  return /rate[ _-]?limit/i.test(text) || /too many requests/i.test(text)
+}
+
+function billingKindFor(opts: {
+  text: string
+  statusCode?: number
+  headers?: Record<string, string>
+}): ProviderFailureKind | undefined {
+  if (isFreeUsageLimit(opts.text)) return undefined
+  if (STRONG_BILLING_PATTERNS.some((p) => p.test(opts.text))) return "quota_exhausted"
+  const statusOk = opts.statusCode !== undefined && WEAK_BILLING_STATUS.has(opts.statusCode)
+  if (statusOk && !hasRateLimitSignal(opts.text, opts.headers) && WEAK_BILLING_PATTERNS.some((p) => p.test(opts.text))) {
+    return "quota_exhausted"
+  }
+  return undefined
+}
+
+// Transient signals in the provider *code* that the retry classifier treats as
+// retryable. Scans the code only, never the free-text message, so a terminal
+// error whose message merely mentions "unavailable"/"exhausted" is not wrongly
+// retried. The "exhausted" match is scoped to resource_exhausted (Google's
+// transient overload) — a terminal quota_exhausted/insufficient_quota code must
+// NOT be treated as transient.
+const TRANSIENT_CODE_PATTERN = /resource[ _-]?exhausted|unavailable|overloaded|rate[ _-]?limit|too[ _-]?many[ _-]?requests/i
+function looksTransientCode(code: string | undefined) {
+  return code !== undefined && TRANSIENT_CODE_PATTERN.test(code)
+}
+
+// Single place that pulls a provider error code out of a parsed body, covering
+// the shapes providers actually use: OpenAI-style error.code, top-level code,
+// error.type, and Google-style status (error.status / status).
+function extractProviderCode(body: unknown): string | undefined {
+  if (!isRecord(body)) return undefined
+  const error = isRecord(body.error) ? body.error : undefined
+  if (error && typeof error.code === "string") return error.code
+  if (typeof body.code === "string") return body.code
+  if (error && typeof error.type === "string") return error.type
+  if (error && typeof error.status === "string") return error.status
+  if (typeof body.status === "string") return body.status
+  return undefined
+}
+
 function message(providerID: ProviderID, e: APICallError) {
   return iife(() => {
     const msg = e.message
@@ -96,9 +177,15 @@ function message(providerID: ProviderID, e: APICallError) {
 
     try {
       const body = JSON.parse(e.responseBody)
-      // try to extract common error message fields
-      const errMsg = body.message || body.error || body.error?.message
-      if (errMsg && typeof errMsg === "string") {
+      // Prefer the nested provider message first: many providers wrap it as
+      // {error:{message}} where body.error is an object, so checking body.error
+      // before body.error.message would short-circuit on the object and dump the
+      // raw body instead of the human-readable string.
+      const nested = typeof body?.error?.message === "string" ? body.error.message : undefined
+      const top = typeof body?.message === "string" ? body.message : undefined
+      const errString = typeof body?.error === "string" ? body.error : undefined
+      const errMsg = nested ?? top ?? errString
+      if (errMsg) {
         return `${msg}: ${errMsg}`
       }
     } catch {}
@@ -177,8 +264,12 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   const error = body.type === "error" && isRecord(body.error) ? body.error : isBareProviderError(body) ? body : undefined
   if (!error) return
 
-  const code = typeof error?.code === "string" ? error.code : undefined
-  switch (error?.code) {
+  // Read code from the resolved error only (never dig into an untyped body —
+  // that is the over-match guard `if (!error) return` above protects). Fall back
+  // to error.type so providers that put the code under `type` still classify.
+  const code =
+    typeof error.code === "string" ? error.code : typeof error.type === "string" ? error.type : undefined
+  switch (code) {
     case "context_length_exceeded":
       return {
         type: "context_overflow",
@@ -222,6 +313,64 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
         kind: "server_overload",
         code,
       }
+    case "authentication_error":
+    case "invalid_api_key":
+    case "permission_denied":
+      return {
+        type: "api_error",
+        message: typeof error.message === "string" ? error.message : "Authentication failed.",
+        isRetryable: false,
+        responseBody,
+        kind: "auth",
+        code,
+      }
+    case "rate_limit_exceeded":
+    case "too_many_requests":
+    case "rate_limited":
+      return {
+        type: "api_error",
+        message: typeof error.message === "string" ? error.message : "Rate limit exceeded.",
+        isRetryable: true,
+        responseBody,
+        kind: "rate_limit",
+        code,
+      }
+  }
+
+  const providerMessage = typeof error.message === "string" ? error.message : undefined
+  const text = `${providerMessage ?? ""}\n${responseBody}`
+  // No statusCode on the stream path, so only the unconditional strong billing
+  // patterns can match here (weak patterns are status-gated).
+  const billingKind = billingKindFor({ text })
+  if (billingKind) {
+    return {
+      type: "api_error",
+      message: providerMessage ?? "Quota exceeded. Check your plan and billing details.",
+      isRetryable: false,
+      responseBody,
+      kind: billingKind,
+      code,
+    }
+  }
+
+  // PR1c middle path: a typed provider error envelope ({type:"error"} + error
+  // object) with an unhandled code becomes a structured APIError(kind="unknown")
+  // so the frontend gets code/responseBody instead of an opaque UnknownError. A
+  // bare {code} body is intentionally NOT upgraded: it is indistinguishable from
+  // a Node runtime error (e.g. EACCES) and stays UnknownError as before, keeping
+  // its classifyRetry text-heuristic retry verdict unchanged.
+  if (body.type !== "error") return
+  return {
+    type: "api_error",
+    message: providerMessage ?? responseBody,
+    // Retry verdict from the code only (never free-text): FreeUsageLimitError is
+    // marked retryable so classifyRetry can route it to free_quota_exhausted;
+    // otherwise a transient-looking code (exhausted/unavailable/rate limit) stays
+    // retryable, matching the prior UnknownError verdict.
+    isRetryable: isFreeUsageLimit(text) ? true : looksTransientCode(code),
+    responseBody,
+    kind: "unknown",
+    code,
   }
 }
 
@@ -246,7 +395,8 @@ export type ParsedAPICallError =
 export function parseAPICallError(input: { providerID: ProviderID; error: APICallError }): ParsedAPICallError {
   const m = message(input.providerID, input.error)
   const body = json(input.error.responseBody)
-  if (isOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
+  const code = extractProviderCode(body)
+  if (isOverflow(m) || input.error.statusCode === 413 || code === "context_length_exceeded") {
     return {
       type: "context_overflow",
       message: m,
@@ -255,7 +405,15 @@ export function parseAPICallError(input: { providerID: ProviderID; error: APICal
   }
 
   const metadata = input.error.url ? { url: input.error.url } : undefined
-  const code = typeof body?.error?.code === "string" ? body.error.code : undefined
+  // Billing failures arrive under inconsistent statuses (DeepSeek 402 or a
+  // generic 400). The billing override runs ahead of the status/code fallback so
+  // an "Insufficient Balance" body classifies as quota_exhausted instead of the
+  // invalid_request the bare status would imply.
+  const billingKind = billingKindFor({
+    text: `${m}\n${input.error.responseBody ?? ""}`,
+    statusCode: input.error.statusCode,
+    headers: input.error.responseHeaders,
+  })
   return {
     type: "api_error",
     message: m,
@@ -264,7 +422,7 @@ export function parseAPICallError(input: { providerID: ProviderID; error: APICal
     responseHeaders: input.error.responseHeaders,
     responseBody: input.error.responseBody,
     metadata,
-    kind: apiCallErrorKind(input.error.statusCode, code),
+    kind: billingKind ?? apiCallErrorKind(input.error.statusCode, code),
     code,
   }
 }

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -134,15 +134,29 @@ function billingKindFor(opts: {
   return undefined
 }
 
-// Transient signals in the provider *code* that the retry classifier treats as
-// retryable. Scans the code only, never the free-text message, so a terminal
-// error whose message merely mentions "unavailable"/"exhausted" is not wrongly
-// retried. The "exhausted" match is scoped to resource_exhausted (Google's
-// transient overload) — a terminal quota_exhausted/insufficient_quota code must
-// NOT be treated as transient.
-const TRANSIENT_CODE_PATTERN = /resource[ _-]?exhausted|unavailable|overloaded|rate[ _-]?limit|too[ _-]?many[ _-]?requests/i
+// Provider *codes* the typed-unknown fallback treats as retryable. Deny-by-
+// default: an exact allowlist, never a substring scan. Substring matching turned
+// terminal codes like `model_unavailable_for_account` into infinite retries
+// because they contain "unavailable" — and the set of such terminal spellings
+// (`*_unavailable_for_plan`, `*_not_available`, ...) is open-ended, so the only
+// safe default for an *unrecognized* code is non-retryable (surface it, don't
+// loop). Read the code only, never the free-text message. The high-frequency
+// transients (server_error, server_is_overloaded, rate_limit, too_many_requests)
+// are already classified by the switch above and never reach here; this list is
+// just the long-tail. resource_exhausted stays retryable to preserve Google's
+// transient-overload semantics. Compared case-insensitively (gRPC uppercases).
+const TRANSIENT_CODES = new Set([
+  "resource_exhausted",
+  "unavailable",
+  "service_unavailable",
+  "server_unavailable",
+  "temporarily_unavailable",
+  "overloaded",
+  "overloaded_error",
+  "server_overloaded",
+])
 function looksTransientCode(code: string | undefined) {
-  return code !== undefined && TRANSIENT_CODE_PATTERN.test(code)
+  return code !== undefined && TRANSIENT_CODES.has(code.toLowerCase())
 }
 
 // Single place that pulls a provider error code out of a parsed body, covering
@@ -373,8 +387,9 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
     message: providerMessage ?? responseBody,
     // Retry verdict from the code only (never free-text): FreeUsageLimitError is
     // marked retryable so classifyRetry can route it to free_quota_exhausted;
-    // otherwise a transient-looking code (exhausted/unavailable/rate limit) stays
-    // retryable, matching the prior UnknownError verdict.
+    // otherwise only an allowlisted transient code stays retryable. Any
+    // unrecognized code defaults to non-retryable, so a terminal error is
+    // surfaced to the user rather than retried in a loop.
     isRetryable: isFreeUsageLimit(text) ? true : looksTransientCode(code),
     responseBody,
     kind: "unknown",

--- a/packages/opencode/src/session/retry.test.ts
+++ b/packages/opencode/src/session/retry.test.ts
@@ -56,6 +56,17 @@ describe("classifyRetry — free_quota_exhausted positive", () => {
       expect(classification.resetAt).toBeDefined()
     }
   })
+
+  test("typed FreeUsageLimitError stream body still routes to free_quota_exhausted", () => {
+    // Real FreeUsageLimitError arrives as an APICallError 429, but the typed
+    // stream shape must classify end-to-end too: fromError keeps it kind=unknown
+    // and retryable, so classifyRetry can reach the free-quota branch.
+    const error = MessageV2.fromError(
+      { type: "error", error: { type: "FreeUsageLimitError", message: "FreeUsageLimitError" } },
+      { providerID: ProviderID.opencode },
+    )
+    expect(classifyRetry(error)?.kind).toBe("free_quota_exhausted")
+  })
 })
 
 describe("classifyRetry — reverse guards", () => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -2113,6 +2113,22 @@ describe("session.message-v2.fromError — PR1 classification completeness", () 
     expect(data.message).not.toContain("invalid_request_error")
   })
 
+  test("surfaces the nested balance reason even when the SDK message is not the HTTP reason phrase", () => {
+    // Regression guard: message() used to early-return whenever the SDK message
+    // differed from the bare status phrase, which dropped the nested
+    // {error:{message}} reason for any provider/SDK that sets a custom message
+    // (e.g. "API call failed"). The real reason must still reach the user.
+    const result = MessageV2.fromError(
+      makeApiError({ message: "API call failed", statusCode: 402, responseBody: deepseekBalanceBody }),
+      { providerID },
+    )
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    const data = (result as MessageV2.APIError).data
+    expect(data.message).toContain("Insufficient Balance")
+    expect(data.providerFailure?.kind).toBe("quota_exhausted")
+  })
+
   test("classifies a DeepSeek balance error as quota_exhausted even when it arrives as 400", () => {
     // Some providers return billing failures under a generic 400. The strong
     // billing pattern must override apiCallErrorKind's invalid_request verdict.

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -2285,6 +2285,31 @@ describe("session.message-v2.fromError — PR1 classification completeness", () 
     expect((result as MessageV2.APIError).data.isRetryable).toBe(false)
   })
 
+  test("does not retry typed terminal codes that merely contain 'unavailable' as a substring", () => {
+    // The transient check is an exact allowlist, not a substring scan: a code
+    // like model_unavailable_for_account / feature_unavailable_for_plan is a
+    // terminal plan/account limit and must NOT be retried just because it
+    // contains "unavailable". Substring matching here caused infinite retries.
+    for (const code of ["model_unavailable_for_account", "feature_unavailable_for_plan"]) {
+      const body = { type: "error", error: { code, message: "Not available on your plan." } }
+      const result = MessageV2.fromError(body, { providerID })
+
+      expect((result as MessageV2.APIError).data.providerFailure).toStrictEqual({ kind: "unknown", code })
+      expect((result as MessageV2.APIError).data.isRetryable).toBe(false)
+    }
+  })
+
+  test("keeps an allowlisted transient code (gRPC UNAVAILABLE) retryable in the typed-unknown fallback", () => {
+    // The exact allowlist must still admit genuine transients beyond
+    // resource_exhausted. Bare gRPC UNAVAILABLE is transient and stays
+    // retryable; the case-insensitive match handles the uppercase spelling.
+    const body = { type: "error", error: { code: "UNAVAILABLE", message: "The service is currently unavailable." } }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("unknown")
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+  })
+
   test("treats a 429 'quota exceeded' rate limit as rate_limit, not terminal quota_exhausted", () => {
     // Google reports per-minute request limits as 429 "Quota exceeded for quota
     // metric ... per minute". 429 is Too Many Requests, so it must stay a

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -2141,6 +2141,44 @@ describe("session.message-v2.fromError — PR1 classification completeness", () 
     expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("rate_limit")
   })
 
+  test("does not let a rate-limit signal on a billing-shaped status become terminal quota_exhausted", () => {
+    // The weak billing patterns ("quota exceeded") fire only on a 400/402/403
+    // with no rate-limit signal. A Retry-After header means the provider is
+    // asking us to back off, not that the account is out of money — so the
+    // incidental "quota" wording must not flip the rejection into terminal
+    // quota_exhausted (which would wrongly prompt a top-up). It stays the base
+    // status kind.
+    const result = MessageV2.fromError(
+      makeApiError({
+        message: "Bad Request",
+        statusCode: 400,
+        responseBody: JSON.stringify({ error: { message: "Quota exceeded for this request window." } }),
+        responseHeaders: { "content-type": "application/json", "retry-after": "30" },
+      }),
+      { providerID },
+    )
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("invalid_request")
+  })
+
+  test("does not let weak billing wording override a 5xx server error", () => {
+    // WEAK_BILLING_STATUS is {400,402,403}; a 5xx stays server_overload (and
+    // retryable). Incidental "quota exceeded" wording in a transient 503 must
+    // not be read as a terminal billing failure, which would stop retries on a
+    // recoverable error.
+    const result = MessageV2.fromError(
+      makeApiError({
+        message: "Service Unavailable",
+        statusCode: 503,
+        responseBody: JSON.stringify({ error: { message: "Service temporarily unavailable; quota exceeded." } }),
+        isRetryable: true,
+      }),
+      { providerID },
+    )
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("server_overload")
+  })
+
   test("classifies stream authentication errors as auth (non-retryable)", () => {
     const body = { code: "authentication_error", message: "Invalid API key provided." }
     const result = MessageV2.fromError(body, { providerID })

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1858,16 +1858,24 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
-  test("leaves Error-wrapped payloads with unhandled codes as UnknownError", () => {
-    // Guard against the stream parser over-matching: an Error whose JSON message
-    // carries a code the parser does not handle must stay Unknown, not become a
-    // mislabeled APIError.
+  test("upgrades typed Error-wrapped payloads with unhandled codes to APIError(unknown)", () => {
+    // A typed provider error body (type:"error" + error object) is a recognized
+    // failure shape, so even an unhandled code becomes a structured APIError that
+    // preserves code/responseBody for the frontend — rather than an opaque
+    // UnknownError blob. The code is unknown (not transient), so it stays
+    // non-retryable, matching the prior Unknown -> classifyRetry verdict.
     const payload = JSON.stringify({ type: "error", error: { code: "bad_request" } })
     const result = MessageV2.fromError(new Error(payload), { providerID })
 
     expect(result).toStrictEqual({
-      name: "UnknownError",
-      data: { message: payload },
+      name: "APIError",
+      data: {
+        message: payload,
+        isRetryable: false,
+        responseBody: payload,
+        providerID,
+        providerFailure: { kind: "unknown", code: "bad_request" },
+      },
     })
   })
 
@@ -2047,6 +2055,7 @@ describe("session.message-v2.fromError", () => {
     const cases = [
       { statusCode: 400, kind: "invalid_request" },
       { statusCode: 401, kind: "auth" },
+      { statusCode: 402, kind: "quota_exhausted" },
       { statusCode: 403, kind: "auth" },
       { statusCode: 422, kind: "invalid_request" },
       { statusCode: 429, kind: "rate_limit" },
@@ -2069,6 +2078,208 @@ describe("session.message-v2.fromError", () => {
         kind,
         code: undefined,
       })
+    })
+  })
+})
+
+describe("session.message-v2.fromError — PR1 classification completeness", () => {
+  const deepseekBalanceBody = JSON.stringify({
+    error: { message: "Insufficient Balance", code: "invalid_request_error", type: "unknown_error" },
+  })
+
+  const makeApiError = (overrides: Partial<ConstructorParameters<typeof APICallError>[0]>) =>
+    new APICallError({
+      message: "",
+      url: "https://api.deepseek.com/chat/completions",
+      requestBodyValues: {},
+      responseHeaders: { "content-type": "application/json" },
+      isRetryable: false,
+      ...overrides,
+    })
+
+  test("classifies a DeepSeek 402 balance error as quota_exhausted and surfaces the real reason", () => {
+    // 402 + nested {error:{message}} is the reported bug: it was shown as
+    // "Connection lost". The nested provider message must be extracted (not the
+    // raw responseBody dump) and the kind must be quota_exhausted.
+    const result = MessageV2.fromError(
+      makeApiError({ message: "Payment Required", statusCode: 402, responseBody: deepseekBalanceBody }),
+      { providerID },
+    )
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    const data = (result as MessageV2.APIError).data
+    expect(data.providerFailure?.kind).toBe("quota_exhausted")
+    expect(data.message).toContain("Insufficient Balance")
+    expect(data.message).not.toContain("invalid_request_error")
+  })
+
+  test("classifies a DeepSeek balance error as quota_exhausted even when it arrives as 400", () => {
+    // Some providers return billing failures under a generic 400. The strong
+    // billing pattern must override apiCallErrorKind's invalid_request verdict.
+    const result = MessageV2.fromError(
+      makeApiError({ message: "Bad Request", statusCode: 400, responseBody: deepseekBalanceBody }),
+      { providerID },
+    )
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("quota_exhausted")
+  })
+
+  test("does not reclassify opencode FreeUsageLimitError 429 as quota_exhausted", () => {
+    // Invariant: FreeUsageLimitError must keep flowing to free_quota_exhausted ->
+    // rate_limit_blocked. quota_exhausted is terminal and would stop classifyRetry
+    // before the free-quota branch, breaking the countdown card.
+    const result = MessageV2.fromError(
+      makeApiError({
+        message: "Too Many Requests",
+        statusCode: 429,
+        responseBody: '{"error":{"type":"FreeUsageLimitError"}}',
+        responseHeaders: { "retry-after": "70" },
+      }),
+      { providerID: ProviderID.opencode },
+    )
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("rate_limit")
+  })
+
+  test("classifies stream authentication errors as auth (non-retryable)", () => {
+    const body = { code: "authentication_error", message: "Invalid API key provided." }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: body.message,
+        isRetryable: false,
+        responseBody: JSON.stringify(body),
+        providerID,
+        providerFailure: { kind: "auth", code: "authentication_error" },
+      },
+    })
+  })
+
+  test("classifies stream rate-limit errors as rate_limit (retryable)", () => {
+    const body = { code: "rate_limit_exceeded", message: "Rate limit reached for requests." }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: body.message,
+        isRetryable: true,
+        responseBody: JSON.stringify(body),
+        providerID,
+        providerFailure: { kind: "rate_limit", code: "rate_limit_exceeded" },
+      },
+    })
+  })
+
+  test("classifies a stream billing message as quota_exhausted regardless of code", () => {
+    const body = { code: "some_provider_code", message: "Insufficient Balance" }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("quota_exhausted")
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(false)
+  })
+
+  test("upgrades a typed stream body with an unknown code to APIError(unknown)", () => {
+    const body = { type: "error", error: { code: "teapot_error", message: "I am a teapot." } }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: "I am a teapot.",
+        isRetryable: false,
+        responseBody: JSON.stringify(body),
+        providerID,
+        providerFailure: { kind: "unknown", code: "teapot_error" },
+      },
+    })
+  })
+
+  test("keeps a typed resource_exhausted body retryable when upgraded to APIError(unknown)", () => {
+    // resource_exhausted stays unchanged in PR1: it keeps its retryable
+    // "overloaded" semantics. The middle-path upgrade derives retryability from
+    // the transient-looking code, so it stays retryable.
+    const body = { type: "error", error: { code: "resource_exhausted", message: "Resource has been exhausted." } }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect((result as MessageV2.APIError).data.providerFailure).toStrictEqual({
+      kind: "unknown",
+      code: "resource_exhausted",
+    })
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+  })
+
+  test("does not treat a typed terminal quota_exhausted code as retryable", () => {
+    // The transient-code heuristic must not match a terminal quota code just
+    // because it contains "exhausted" — only resource_exhausted is transient.
+    const body = { type: "error", error: { code: "quota_exhausted", message: "Your quota has been exhausted." } }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(false)
+  })
+
+  test("does not retry a typed unknown error whose message merely mentions 'unavailable'", () => {
+    // Regression: retryability is read from the code only. A terminal error
+    // (code bad_request) whose free-text message says "unavailable" must NOT be
+    // upgraded to retryable.
+    const body = { type: "error", error: { code: "bad_request", message: "Model unavailable for your account." } }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("unknown")
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(false)
+  })
+
+  test("treats a 429 'quota exceeded' rate limit as rate_limit, not terminal quota_exhausted", () => {
+    // Google reports per-minute request limits as 429 "Quota exceeded for quota
+    // metric ... per minute". 429 is Too Many Requests, so it must stay a
+    // retryable rate_limit rather than a terminal billing failure.
+    const responseBody = JSON.stringify({
+      error: { message: "Quota exceeded for quota metric 'GenerateContent request limit per minute'." },
+    })
+    const result = MessageV2.fromError(
+      makeApiError({
+        message: "Too Many Requests",
+        statusCode: 429,
+        responseBody,
+        isRetryable: true,
+      }),
+      { providerID },
+    )
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("rate_limit")
+  })
+
+  test("leaves a bare {code} body (e.g. a Node EACCES error) as UnknownError", () => {
+    // A bare top-level code is indistinguishable from a Node runtime error, so
+    // the middle path must not wrap it as a provider APIError.
+    const nodeError = Object.assign(new Error("permission denied reading local config"), { code: "EACCES" })
+    const result = MessageV2.fromError(nodeError, { providerID })
+
+    expect(result.name).toBe("UnknownError")
+  })
+
+  test("marks a typed opencode FreeUsageLimitError stream body retryable for free-quota routing", () => {
+    // Real FreeUsageLimitError arrives as an APICallError (429); this guards the
+    // typed-stream shape too: it must stay kind=unknown (not quota_exhausted) and
+    // retryable so classifyRetry can reach the free_quota_exhausted branch.
+    const body = { type: "error", error: { type: "FreeUsageLimitError", message: "FreeUsageLimitError" } }
+    const result = MessageV2.fromError(body, { providerID: ProviderID.opencode })
+
+    expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("unknown")
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+  })
+
+  test("leaves untyped nested error envelopes as UnknownError (over-match guard)", () => {
+    // A body with no top-level type/code is not a recognized provider error
+    // shape, so it must stay Unknown.
+    const body = { error: { code: "teapot_error", message: "nope" } }
+    const result = MessageV2.fromError(body, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "UnknownError",
+      data: { message: JSON.stringify(body) },
     })
   })
 })

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -521,7 +521,11 @@ describe("session.message-v2.fromError", () => {
     expect(retryableRaw(result)).toBe("Server error.")
   })
 
-  test("does not convert unknown OpenAI stream error chunks to retryable APIError", () => {
+  test("classifies unknown OpenAI stream error chunks as a non-retryable APIError", () => {
+    // PR1c middle path: a typed provider error body is now surfaced as a
+    // structured APIError(kind="unknown") so the frontend gets code/responseBody
+    // instead of an opaque UnknownError. The guarantee that matters here is
+    // preserved: an unknown code is NOT retryable (classifyRetry returns nothing).
     const result = MessageV2.fromError(
       {
         message: JSON.stringify({
@@ -535,7 +539,12 @@ describe("session.message-v2.fromError", () => {
       { providerID: ProviderID.make("openai") },
     )
 
-    expect(MessageV2.APIError.isInstance(result)).toBe(false)
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.providerFailure).toStrictEqual({
+      kind: "unknown",
+      code: "bad_request",
+    })
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(false)
     expect(retryableRaw(result)).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Fixes the first defect behind the "Connection lost. Please check whether the last operation completed before resending." misreport: provider billing/quota failures (DeepSeek 402 "Insufficient Balance" and friends) were classified as `unknown`, and the nested provider message was dropped — so the real reason never reached the UI. This PR is classification-only (`packages/opencode/src/provider/error.ts`); the run-incident halt overwrite that finishes masking the message is PR2.

Changes in `provider/error.ts`:
- **402 → `quota_exhausted`** — account can no longer pay = same user action as a depleted quota (top up or switch model); no new `payment_required` kind.
- **Strong/weak `BILLING_PATTERNS`** so billing failures reported under inconsistent statuses still classify as `quota_exhausted`. Strong patterns (`insufficient balance` / `out of credits` / `payment required` / `arrears` / `余额不足` / `欠费`) match unconditionally; weak patterns (`quota exceeded` / `billing issue`) only on a billing-shaped status `{400,402,403}` with no rate-limit signal. **429 is excluded** — it is Too Many Requests, so "quota exceeded" wording (e.g. Google's per-minute request quota) stays a retryable `rate_limit`.
- **Exclude opencode `FreeUsageLimitError`** from billing: it must stay a retry-time `free_quota_exhausted` concept (countdown card), never the terminal `quota_exhausted` kind, which would stop `classifyRetry` before the free-quota branch.
- **Fix `message()`** to prefer the nested `{error:{message}}` string so DeepSeek's "Insufficient Balance" surfaces instead of dumping the raw body (`body.error` is an object and short-circuited the old `||` chain).
- **Unify provider code extraction** (`error.code` / `code` / `error.type` / Google-style `status`) behind `extractProviderCode`.
- **`parseStreamError`** now classifies known auth (`authentication_error` / `invalid_api_key` / `permission_denied`) and rate-limit (`rate_limit_exceeded` / `too_many_requests` / `rate_limited`) codes, plus strong-billing messages.
- **Typed-error middle path**: a typed (`{type:"error"}` + error object) provider error body with an unhandled code now becomes a structured `APIError(kind="unknown")` preserving `code`/`responseBody` for the frontend, instead of an opaque `UnknownError`. A bare `{code}` body is **not** upgraded (indistinguishable from a Node runtime error like `EACCES`) and stays `UnknownError`. Retryability is read from the **code only** (never the free-text message), so a terminal error whose message merely mentions "unavailable" is not wrongly retried; a transient code (`resource_exhausted`/`unavailable`/`overloaded`/rate-limit) stays retryable, and a typed `FreeUsageLimitError` stays retryable so `classifyRetry` routes it to `free_quota_exhausted`.

`resource_exhausted` retry semantics are intentionally left unchanged.

## Why

A Windows user on DeepSeek (out of balance) saw repeated "Connection lost" messages. Root cause is a 3-layer defect; the classification layer is fixed here: 402 fell through `apiCallErrorKind` to `unknown`, and `message()` dropped the nested "Insufficient Balance" string. The goal is to classify all common provider error types correctly and pass the real reason through, not just patch 402.

## Scope — why the stream path and the typed-unknown fallback are in this PR

A reviewer may reasonably ask why this PR also touches `parseStreamError` (auth/rate-limit branches, strong-billing match) and adds the typed-error → `APIError(kind="unknown")` fallback, instead of landing only the 402/billing change in `parseAPICallError`. These are one classification surface for the same defect, not separable concerns:

- **The misreport reproduces on both entry points.** `parseAPICallError` handles HTTP-shaped `APICallError`s; `parseStreamError` handles the typed `{type:"error"}` envelope the AI SDK emits mid-stream. A provider billing/auth/rate-limit failure surfaces through either depending on when it lands, so fixing only the HTTP path leaves the same "Connection lost" bug live on the stream path — a split that cannot be verified end-to-end on its own.
- **The typed-unknown fallback is what lets a classified stream error reach the frontend at all.** Before it, a typed envelope with any code we don't special-case collapsed into an opaque `UnknownError` that carries no `code`/`responseBody`, so the frontend decoder (PR3 #1469) would have nothing structured to read. It is the minimum needed to prove the passthrough, not a speculative generalization: a **bare** `{code}` body is deliberately left as `UnknownError` (indistinguishable from a Node runtime error like `EACCES`), so the upgrade is scoped to genuinely typed provider envelopes only.

**On the transient-code retryability (`looksTransientCode`):** this runs *only* in the typed-unknown fallback, reads the provider **code only** (never the free-text message), and uses a **deny-by-default exact allowlist** of transient codes (`resource_exhausted`, gRPC `unavailable`, `overloaded`, …). An unrecognized code defaults to non-retryable, so a terminal error is surfaced rather than retried in a loop.

- This replaced a substring scan that matched `unavailable`/`exhausted` anywhere in the code, which wrongly retried terminal codes like `model_unavailable_for_account`. The set of such terminal spellings (`*_unavailable_for_plan`, `*_not_available`, …) is open-ended, so a blocklist would be an endless game of catch-up; an allowlist's failure mode — a missed transient is *surfaced*, not looped — is the safe one.
- The high-frequency transients (`server_error`, `server_is_overloaded`, `rate_limit_exceeded`, `too_many_requests`) are classified by the explicit switch *before* this fallback and never reach it; the allowlist only covers the long tail. `resource_exhausted` stays retryable to preserve Google's transient-overload semantics.
- A terminal error whose *message* merely mentions "unavailable"/"exhausted" is also not retried, since only the code is read. Regression-guarded by tests for `model_unavailable_for_account` / `feature_unavailable_for_plan` (non-retryable) and bare `UNAVAILABLE` (retryable).

## Related Issue

Refs #1123 (classify-then-render umbrella), #1105 (classification spine).

## Human Review Status

Pending

## Review Focus

- The retry-safety invariants: `FreeUsageLimitError` must stay `free_quota_exhausted`; `resource_exhausted` must stay retryable; a terminal `quota_exhausted` code must not be retried.
- The strong/weak billing split and the 429 exclusion (false-positive risk).
- The typed-vs-bare middle-path boundary (typed upgrades to `APIError`; bare stays `UnknownError`).

## Risk Notes

Behavior/contract change (intentional, covered by tests): typed provider error bodies with unhandled codes now serialize as `APIError(kind="unknown")` instead of `UnknownError`; two existing guard tests were updated to the new contract, with the meaningful guarantee (such errors stay non-retryable) preserved. No data migration. No UI in this PR (Risk Notes "Screenshots" item N/A — backend classification only).

## How To Verify

```text
bun test test/session/message-v2.test.ts src/session/retry.test.ts → 105 pass, 0 fail
bun test test/session src/session test/provider src/provider → 1332 pass, 4 skip, 1 todo, 0 fail
tsgo --noEmit (packages/opencode) → clean
codex review (xhigh, 4 rounds) → final fresh-eye pass: no P0/P1/P2/P3
```

Key regressions pinned: 402 → `quota_exhausted`; DeepSeek "Insufficient Balance" at 402 and 400 → `quota_exhausted`; `FreeUsageLimitError` 429 stays `rate_limit` and routes to `free_quota_exhausted`; 429 "quota exceeded" stays `rate_limit`; typed terminal `quota_exhausted` code not retried; "unavailable" in message stays non-retryable; bare Node `EACCES` error stays `UnknownError`; untyped envelope stays `UnknownError`.

## Screenshots or Recordings

N/A — backend error-classification change, no UI.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.

https://claude.ai/code/session_015bW9JQSkuB156gkNQdxCzi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and classification of billing and quota exhaustion errors
  * Enhanced authentication error handling in API responses
  * Improved error message extraction from API responses
  * Fixed retryability logic for various error scenarios

* **Tests**
  * Expanded error classification test coverage for provider API failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
