### PR TITLE
fix(desktop): redact secrets and structure session export in problem report

### DIFF
--- a/packages/desktop-electron/src/main/feedback.ts
+++ b/packages/desktop-electron/src/main/feedback.ts
@@ -208,6 +208,10 @@ export function createFeedbackHandler(deps: FeedbackDeps) {
 
     const id = defaultReportId()
     const generatedAt = new Date().toISOString()
+    // Compute the exact runtime terms (home dir, OS username) once and share them across BOTH the
+    // full report and the clipboard summary — the summary is the same outbound channel, so it must
+    // scrub the same bare identifiers no regex can infer.
+    const redactTerms = localRedactTerms()
     let diagnostics: ProblemReportDiagnostics
     let logTail = ""
     let sessionExport: SessionExport = { status: "none" }
@@ -245,7 +249,7 @@ export function createFeedbackHandler(deps: FeedbackDeps) {
       try {
         const report = buildProblemReport(
           { diagnostics, logTail, sessionExport, rendererDiagnostics, rendererError: input.rendererError },
-          { reportId: id, generatedAt, maxBytes: DEFAULT_PROBLEM_REPORT_MAX_BYTES, redactTerms: localRedactTerms() },
+          { reportId: id, generatedAt, maxBytes: DEFAULT_PROBLEM_REPORT_MAX_BYTES, redactTerms },
         )
         savedReport = await deps.saveReport({ reportId: id, generatedAt, markdown: report.markdown })
       } catch (error) {
@@ -264,6 +268,7 @@ export function createFeedbackHandler(deps: FeedbackDeps) {
       recentErrors: recentKeyErrors(logTail),
       rendererDiagnostics,
       rendererError: input.rendererError,
+      redactTerms,
     })
 
     await deps.copy(summary)

--- a/packages/desktop-electron/src/main/feedback.ts
+++ b/packages/desktop-electron/src/main/feedback.ts
@@ -1,3 +1,4 @@
+import { homedir, userInfo } from "node:os"
 import { dirname } from "node:path"
 import type { ReportProblemInput, ReportProblemResult } from "@opencode-ai/app/desktop-api"
 import {
@@ -126,6 +127,26 @@ function fallbackDiagnostics(): ProblemReportDiagnostics {
   }
 }
 
+// Exact local identifiers no regex can infer (home directory, OS username) — redacted verbatim
+// from the report. Best-effort: userInfo() can throw on some platforms, so a failure just
+// contributes no extra term rather than blocking the report.
+function localRedactTerms(): string[] {
+  const terms: string[] = []
+  try {
+    const home = homedir()
+    if (home) terms.push(home)
+  } catch {
+    // ignore — no home term
+  }
+  try {
+    const name = userInfo().username
+    if (name) terms.push(name)
+  } catch {
+    // ignore — no username term
+  }
+  return terms
+}
+
 function recentKeyErrors(logTail: string) {
   return logTail
     .split(/\r?\n/)
@@ -224,7 +245,7 @@ export function createFeedbackHandler(deps: FeedbackDeps) {
       try {
         const report = buildProblemReport(
           { diagnostics, logTail, sessionExport, rendererDiagnostics, rendererError: input.rendererError },
-          { reportId: id, generatedAt, maxBytes: DEFAULT_PROBLEM_REPORT_MAX_BYTES },
+          { reportId: id, generatedAt, maxBytes: DEFAULT_PROBLEM_REPORT_MAX_BYTES, redactTerms: localRedactTerms() },
         )
         savedReport = await deps.saveReport({ reportId: id, generatedAt, markdown: report.markdown })
       } catch (error) {

--- a/packages/desktop-electron/src/main/problem-report-redact.test.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.test.ts
@@ -208,6 +208,17 @@ describe("makeRedactor", () => {
     const empty = makeRedactor(["", "   "])
     expect(empty("grab a cab")).toBe("grab a cab")
   })
+
+  test("redacts short non-ASCII usernames that JS \\b word boundaries miss", () => {
+    // JS \b is an ASCII word boundary: \b张\b never matches, so a 1–2 char CJK/JP username would
+    // leak. These must be redacted as exact terms instead.
+    expect(makeRedactor(["山田"])("user 山田 failed")).toBe("user [user] failed")
+    expect(makeRedactor(["张"])("user 张 failed")).toBe("user [user] failed")
+    expect(makeRedactor(["张三"])("at /home/张三/x and 张三 again")).not.toContain("张三")
+    // The ASCII whole-word sparing still holds (regression guard for the boundary split).
+    expect(makeRedactor(["x"])("0x1f and example")).toBe("0x1f and example")
+    expect(makeRedactor(["yu"])("the yuan dropped")).toBe("the yuan dropped")
+  })
 })
 
 describe("sanitizeSessionMessages", () => {

--- a/packages/desktop-electron/src/main/problem-report-redact.test.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.test.ts
@@ -1,0 +1,521 @@
+import { describe, expect, test } from "bun:test"
+import { buildProblemReport, type ProblemReportDiagnostics, parseProblemReportPayload } from "./problem-report"
+import {
+  makeRedactor,
+  sanitizeSessionInfo,
+  sanitizeSessionMessages,
+  SESSION_PART_TEXT_MAX_CHARS,
+} from "./problem-report-redact"
+
+// Bare secret values (no quotes), so the assertions test the secret itself, not JSON escaping.
+// The provider prefixes are split with `+` so these dummy fixtures do not trip GitHub push
+// protection's secret scanner — the concatenated runtime value still matches the redaction rules.
+const TOKENS = {
+  anthropic: "sk-ant-" + "api03-AAAABBBBCCCCDDDDEEEEFFFFGGGG",
+  openaiProject: "sk-proj-" + "abcdefGHIJKL1234567890mnopqrst",
+  openrouter: "sk-or-v1-" + "abcdef0123456789abcdef0123456789",
+  aws: "AKIA" + "IOSFODNN7EXAMPLE",
+  google: "AIza" + "SyA1234567890abcdefghijklmnopqrstuv",
+  gitlab: "glpat-" + "abcdefGHIJKL1234567890",
+  github: "ghp_" + "abcdefghijklmnopqrstuvwxyz0123456789",
+  huggingface: "hf_" + "abcdefghijklmnopqrstuvwx",
+  npm: "npm_" + "abcdefghijklmnopqrstuvwxyz0123456789",
+  slack: "xoxb-" + "1234567890-abcdefghijkl",
+  stripe: "sk_live_" + "abcdefghijklmnopqrstuvwx",
+  jwt: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk",
+  password: "hunter2-secret-pw",
+  bearer: "abcdef0123456789ABCDEFtokenvalue",
+  basicPass: "p4ssw0rd",
+}
+const PATHS = {
+  win: "C:\\Users\\alice\\secret\\app.log",
+  posix: "/Users/alice/workspace/project/index.ts",
+  home: "/home/alice/.config/PawWork/key.dat",
+  unc: "\\\\server\\share\\alice\\secret.log",
+  file: "file:///Users/alice/notes.md",
+  tilde: "~/secrets/config.json",
+  tildeUser: "~bob/private/notes.txt",
+  root: "/root/.ssh/id_rsa",
+  etc: "/etc/shadow.bak",
+  usrLocal: "/usr/local/secret/keys.txt",
+  library: "/Library/Application/PawWork/state.json",
+  workspace: "/workspace/private/repo/.env",
+  nix: "/nix/store/abcd-secret-pkg/bin",
+  system: "/System/Library/Caches/com.app/secret.db",
+}
+const USERNAME = "alice"
+const EMAIL = "alice@corp.example.com"
+
+function validDiagnostics(overrides: Partial<ProblemReportDiagnostics> = {}): ProblemReportDiagnostics {
+  return {
+    appVersion: "2026.6.11",
+    channel: "stable",
+    packaged: true,
+    updaterEnabled: true,
+    platform: "win32",
+    osVersion: "Windows 10",
+    arch: "x64",
+    electronVersion: "40.0.0",
+    locale: "en",
+    route: "/session/ses_1",
+    directory: PATHS.win,
+    sessionID: "ses_1",
+    logPath: PATHS.posix,
+    ...overrides,
+  }
+}
+
+describe("makeRedactor", () => {
+  const redact = makeRedactor([USERNAME, "/home/alice"])
+
+  // Self-identifying tokens carry their own prefix, so they redact even as bare values.
+  const selfIdentifying = [
+    "anthropic",
+    "openaiProject",
+    "openrouter",
+    "aws",
+    "google",
+    "gitlab",
+    "github",
+    "huggingface",
+    "npm",
+    "slack",
+    "stripe",
+    "jwt",
+  ] as const
+
+  test("redacts self-identifying tokens even as bare values", () => {
+    for (const name of selfIdentifying) {
+      const token = TOKENS[name]
+      expect(redact(`prefix ${token} suffix`), name).not.toContain(token)
+    }
+  })
+
+  test("redacts context-bearing credentials in their assignment/auth forms", () => {
+    expect(redact(`password="${TOKENS.password}"`)).not.toContain(TOKENS.password)
+    expect(redact(`Authorization: Bearer ${TOKENS.bearer}`)).not.toContain(TOKENS.bearer)
+    expect(redact(`url https://${USERNAME}:${TOKENS.basicPass}@host/api`)).not.toContain(TOKENS.basicPass)
+    expect(redact("-----BEGIN RSA PRIVATE KEY-----\nMIIabc\n-----END RSA PRIVATE KEY-----")).toBe("[redacted-key]")
+  })
+
+  test("redacts HTTP Basic auth credentials, not just the scheme word", () => {
+    // The base64 must not survive past the scheme; the generic key=value rule alone would stop at "Basic".
+    expect(redact("Authorization: Basic dXNlcjpwYXNzd29yZA==")).not.toContain("dXNlcjpwYXNzd29yZA")
+    expect(redact("Proxy-Authorization: Basic Zm9vOmJhcg==")).not.toContain("Zm9vOmJhcg")
+    // Prose that merely mentions the scheme is left alone.
+    expect(redact("server supports Basic Authentication")).toContain("Basic Authentication")
+  })
+
+  test("redacts vendor-prefixed and camelCase credential field names", () => {
+    expect(redact("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY")).not.toContain("wJalrXUtnFEMIK")
+    expect(redact('clientSecret: "abcd1234efgh5678"')).not.toContain("abcd1234efgh5678")
+    expect(redact('"accessToken":"tok_abcdefghijklmnop"')).not.toContain("tok_abcdefghijklmnop")
+  })
+
+  test("redacts a multi-word quoted secret without leaking its tail", () => {
+    // The value matcher consumes the whole quoted string, not just the first word.
+    expect(redact('password="correct horse battery staple"')).not.toContain("horse battery staple")
+  })
+
+  test("does not over-redact 'tokens'/'tokenizer' assignments (diagnostic, not secrets)", () => {
+    expect(redact("tokens=1234")).toBe("tokens=1234")
+    expect(redact("tokenizer=vocab.json")).toContain("tokenizer=")
+  })
+
+  test("redacts internal/local-domain emails but not npm version syntax", () => {
+    expect(redact("from root@machine here")).toBe("from [email] here")
+    expect(redact("ping alice@corp now")).toBe("ping [email] now")
+    expect(redact("installed react@18.2.0 ok")).toBe("installed react@18.2.0 ok")
+  })
+
+  test("redacts a private key that was truncated before its END line", () => {
+    expect(redact("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAA")).toBe("[redacted-key]")
+  })
+
+  test("redacts PGP private key blocks (KEY BLOCK label) and empty-username basic-auth", () => {
+    expect(redact("-----BEGIN PGP PRIVATE KEY BLOCK-----\nlQOYBF\n-----END PGP PRIVATE KEY BLOCK-----")).toBe(
+      "[redacted-key]",
+    )
+    expect(redact("url https://:plainsecretvalue@127.0.0.1/api")).not.toContain("plainsecretvalue")
+  })
+
+  test("redacts an over-long basic-auth password to an IP host (no length cap on the credential)", () => {
+    const longPass = "S".repeat(300)
+    expect(redact(`url https://user:${longPass}@127.0.0.1/api`)).not.toContain(longPass)
+  })
+
+  test("redacts URL userinfo in every form, including bare user@ to an IP host", () => {
+    expect(redact("fetch https://ci-user:@127.0.0.1/api")).not.toContain("ci-user")
+    expect(redact("fetch https://ci-user@127.0.0.1/api")).not.toContain("ci-user")
+    expect(redact("fetch https://:plainsecret@127.0.0.1/api")).not.toContain("plainsecret")
+  })
+
+  test("redacts a quoted credential value containing an escaped quote", () => {
+    // The quoted-value branch consumes escapes, so the tail after \" is not left behind.
+    expect(redact('password="abc\\"tailsecretvalue"')).not.toContain("tailsecretvalue")
+    expect(redact('clientSecret: "ab\\"cd\\"ef-secret-9"')).not.toContain("secret-9")
+  })
+
+  test("redacts cookie values in singular and plural forms", () => {
+    expect(redact("Set-Cookie: sid=abc123private")).not.toContain("abc123private")
+    expect(redact("request cookies: sid=abc123private")).not.toContain("abc123private")
+  })
+
+  test("redacts a JWT whose header has whitespace (encodes to eyA…, not eyJ…)", () => {
+    const spaced = "eyAiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk"
+    expect(redact(`token ${spaced} end`)).not.toContain(spaced)
+  })
+
+  test("does not backtrack on a long non-private BEGIN block", () => {
+    // Regression: a bounded label charset keeps this near-instant instead of super-linear.
+    const huge = `-----BEGIN ${"A".repeat(200_000)} PUBLIC KEY-----`
+    const start = performance.now()
+    redact(huge)
+    expect(performance.now() - start).toBeLessThan(500)
+  })
+
+  test("redacts a 1-char username term as a whole word", () => {
+    const oneChar = makeRedactor(["x"])
+    expect(oneChar("user x did thing")).not.toContain(" x ")
+    expect(oneChar("0x1f and example")).toBe("0x1f and example")
+  })
+
+  test("redacts absolute paths and the usernames in them", () => {
+    for (const [name, path] of Object.entries(PATHS)) {
+      expect(redact(`see ${path} now`), name).not.toContain(path)
+    }
+    expect(redact(`hello ${EMAIL}`)).toBe("hello [email]")
+    expect(redact(`user is ${USERNAME} here`)).not.toContain(`${USERNAME} here`)
+  })
+
+  test("leaves ordinary text untouched", () => {
+    expect(redact("line one\nline two")).toBe("line one\nline two")
+    expect(redact("/session/ses_1")).toBe("/session/ses_1")
+  })
+
+  test("matches extra terms case-insensitively", () => {
+    expect(redact(`user ALICE logged in`)).not.toContain("ALICE")
+    expect(redact(`path /HOME/ALICE/x`)).not.toContain("ALICE")
+  })
+
+  test("redacts a 2-char username as a whole word but not inside other words", () => {
+    const shortUser = makeRedactor(["yu"])
+    expect(shortUser("logged in as yu today")).not.toContain("as yu ")
+    expect(shortUser("the yuan dropped")).toBe("the yuan dropped")
+  })
+
+  test("drops empty / whitespace-only terms", () => {
+    const empty = makeRedactor(["", "   "])
+    expect(empty("grab a cab")).toBe("grab a cab")
+  })
+})
+
+describe("sanitizeSessionMessages", () => {
+  const redact = makeRedactor([])
+
+  test("keeps allowlisted structure and omits the system prompt", () => {
+    const [message] = sanitizeSessionMessages(
+      [
+        {
+          info: { id: "m1", sessionID: "s", role: "user", time: { created: 1 }, agent: "build", system: "SYSTEM_PROMPT" },
+          parts: [{ id: "p1", type: "text", text: "hello world" }],
+        },
+      ],
+      { redact },
+    ) as Array<{ info: Record<string, unknown>; parts: Array<Record<string, unknown>> }>
+
+    expect(message.info.role).toBe("user")
+    expect(message.info.id).toBe("m1")
+    expect(message.info.agent).toBe("build")
+    expect(message.info).not.toHaveProperty("system")
+    expect(message.parts[0]).toEqual({ type: "text", bytes: 11, text: "hello world" })
+  })
+
+  test("caps oversized part bodies but records true byte size", () => {
+    const big = "x".repeat(SESSION_PART_TEXT_MAX_CHARS + 5_000)
+    const [message] = sanitizeSessionMessages(
+      [{ info: { role: "assistant" }, parts: [{ type: "text", text: big }] }],
+      { redact },
+    ) as Array<{ parts: Array<{ bytes: number; text: string }> }>
+
+    expect(message.parts[0].bytes).toBe(big.length)
+    expect(message.parts[0].text.length).toBeLessThanOrEqual(SESSION_PART_TEXT_MAX_CHARS + 40)
+    expect(message.parts[0].text).toContain("chars]")
+  })
+
+  test("allowlists tool parts and drops file content", () => {
+    const [message] = sanitizeSessionMessages(
+      [
+        {
+          info: { role: "assistant" },
+          parts: [
+            {
+              type: "tool",
+              tool: "webfetch",
+              callID: "c1",
+              state: { status: "completed", input: { url: "https://x" }, output: "fetched body" },
+            },
+            {
+              type: "file",
+              mime: "text/plain",
+              filename: "notes.md",
+              url: "data:text/plain;base64,SECRETBODY",
+              source: { type: "file", path: "/home/alice/notes.md", text: { value: "FILE_CONTENT_LEAK" } },
+            },
+          ],
+        },
+      ],
+      { redact },
+    ) as Array<{ parts: Array<Record<string, unknown>> }>
+
+    expect(message.parts[0]).toMatchObject({ type: "tool", tool: "webfetch", status: "completed", output: "fetched body" })
+    expect(JSON.stringify(message.parts[1])).not.toContain("FILE_CONTENT_LEAK")
+    expect(JSON.stringify(message.parts[1])).not.toContain("SECRETBODY")
+  })
+
+  test("redacts secrets that appear as tool-input object keys", () => {
+    const [message] = sanitizeSessionMessages(
+      [
+        {
+          info: { role: "assistant" },
+          parts: [
+            {
+              type: "tool",
+              tool: "exec",
+              callID: "c1",
+              state: {
+                status: "completed",
+                input: { [`env ${TOKENS.anthropic}`]: "value", path: PATHS.posix },
+                output: "ok",
+              },
+            },
+          ],
+        },
+      ],
+      { redact: makeRedactor([USERNAME]) },
+    ) as Array<{ parts: Array<Record<string, unknown>> }>
+
+    const serialized = JSON.stringify(message.parts[0])
+    expect(serialized).not.toContain(TOKENS.anthropic)
+    expect(serialized).not.toContain(PATHS.posix)
+  })
+
+  test("redacts a bare secret value carried under a sensitive field name", () => {
+    // No prefix/shape for the scrubber to catch — the field name is the only signal.
+    const [message] = sanitizeSessionMessages(
+      [
+        {
+          info: { role: "assistant" },
+          parts: [
+            {
+              type: "tool",
+              tool: "exec",
+              callID: "c1",
+              state: {
+                status: "completed",
+                input: {
+                  apiKey: "plain1234value5678",
+                  clientSecret: "nopattern9999",
+                  // Suffix-matched names with no fixed-list entry — caught by the *Token/*Key suffix.
+                  apiToken: "vendortoken4321",
+                  sshKey: "rawkeymaterial8888",
+                  harmless: "keep-me",
+                },
+                output: "ok",
+              },
+            },
+          ],
+        },
+      ],
+      { redact: makeRedactor([]) },
+    ) as Array<{ parts: Array<{ input: string }> }>
+
+    expect(message.parts[0].input).not.toContain("plain1234value5678")
+    expect(message.parts[0].input).not.toContain("nopattern9999")
+    expect(message.parts[0].input).not.toContain("vendortoken4321")
+    expect(message.parts[0].input).not.toContain("rawkeymaterial8888")
+    expect(message.parts[0].input).toContain("keep-me")
+  })
+
+  test("keeps token-usage counts (a 'tokens' field is not an auth token)", () => {
+    const [message] = sanitizeSessionMessages(
+      [{ info: { role: "assistant", tokens: { input: 12, output: 34 } }, parts: [] }],
+      { redact: makeRedactor([]) },
+    ) as Array<{ info: { tokens: { input: number; output: number } } }>
+    expect(message.info.tokens).toEqual({ input: 12, output: 34 })
+  })
+
+  test("drops the parts of a system-role message (the system prompt)", () => {
+    const [message] = sanitizeSessionMessages(
+      [{ info: { role: "system" }, parts: [{ type: "text", text: "SYSTEM PROMPT BODY" }] }],
+      { redact },
+    ) as Array<{ info: { role: string }; parts: unknown[]; omitted?: string }>
+    expect(message.info.role).toBe("system")
+    expect(message.parts).toEqual([])
+    expect(message.omitted).toBe("system-prompt")
+    expect(JSON.stringify(message)).not.toContain("SYSTEM PROMPT BODY")
+  })
+
+  test("reports unknown message shapes instead of passing them through", () => {
+    const [message] = sanitizeSessionMessages([{ body: "raw leak", token: TOKENS.github }], { redact }) as Array<{
+      unrecognized: boolean
+    }>
+    expect(message).toMatchObject({ unrecognized: true })
+    expect(JSON.stringify(message)).not.toContain("raw leak")
+    expect(JSON.stringify(message)).not.toContain(TOKENS.github)
+  })
+})
+
+describe("sanitizeSessionInfo", () => {
+  const redact = makeRedactor([])
+
+  test("allowlists metadata, caps the title, and drops content-heavy fields", () => {
+    const info = sanitizeSessionInfo(
+      {
+        id: "ses_1",
+        slug: "my-session",
+        version: "1.2.3",
+        title: "user typed title",
+        directory: PATHS.posix,
+        summary: { additions: 3, deletions: 1, files: 2, diffs: [{ leak: "CODE_DIFF_CONTENT" }] },
+        revert: { messageID: "m9", partID: "p1", diff: "REVERT_DIFF_CONTENT", snapshot: "SNAP" },
+        permission: { rules: ["SECRET_RULE"] },
+        share: { url: "https://share.example/abc" },
+        unknownField: "DROP_ME",
+      },
+      { redact },
+    ) as Record<string, unknown>
+
+    expect(info.id).toBe("ses_1")
+    expect(info.title).toBe("user typed title")
+    expect(info.directory).toBe("[path]")
+    expect(info.summary).toEqual({ additions: 3, deletions: 1, files: 2 })
+    expect(info.revert).toEqual({ messageID: "m9", partID: "p1" })
+    expect(info).not.toHaveProperty("permission")
+    expect(info).not.toHaveProperty("share")
+    expect(info).not.toHaveProperty("unknownField")
+    const serialized = JSON.stringify(info)
+    expect(serialized).not.toContain("CODE_DIFF_CONTENT")
+    expect(serialized).not.toContain("REVERT_DIFF_CONTENT")
+    expect(serialized).not.toContain("SECRET_RULE")
+    expect(serialized).not.toContain("DROP_ME")
+  })
+})
+
+describe("buildProblemReport redaction gate", () => {
+  test("the full uploaded report contains no seeded secret, path, username, or email", () => {
+    const logTail = [
+      `anthropic ${TOKENS.anthropic}`,
+      `aws ${TOKENS.aws} google ${TOKENS.google}`,
+      `gitlab ${TOKENS.gitlab} github ${TOKENS.github} hf ${TOKENS.huggingface} npm ${TOKENS.npm}`,
+      `slack ${TOKENS.slack} stripe ${TOKENS.stripe}`,
+      `jwt ${TOKENS.jwt}`,
+      `Authorization: Bearer ${TOKENS.bearer}`,
+      `password="${TOKENS.password}"`,
+      `url https://${USERNAME}:${TOKENS.basicPass}@internal.example.com/api`,
+      `email ${EMAIL}`,
+      `paths ${Object.values(PATHS).join(" ")}`,
+    ].join("\n")
+
+    const report = buildProblemReport(
+      {
+        diagnostics: validDiagnostics(),
+        logTail,
+        sessionExport: {
+          status: "ok",
+          info: { id: "ses_1", directory: PATHS.home },
+          messages: [
+            {
+              info: { id: "m1", sessionID: "ses_1", role: "user", time: { created: 1 }, system: TOKENS.anthropic },
+              parts: [
+                { type: "text", text: `prompt with ${TOKENS.jwt} and ${EMAIL}` },
+                {
+                  type: "tool",
+                  tool: "webfetch",
+                  callID: "c1",
+                  state: {
+                    status: "completed",
+                    input: { url: `https://${USERNAME}:${TOKENS.basicPass}@host`, path: PATHS.win },
+                    output: `body ${TOKENS.aws} ${TOKENS.stripe}`,
+                  },
+                },
+                {
+                  type: "file",
+                  mime: "text/plain",
+                  filename: PATHS.win,
+                  url: "data:text/plain;base64,x",
+                  source: { type: "file", path: PATHS.posix, text: { value: TOKENS.github } },
+                },
+              ],
+            },
+            { body: "freeform", apiKey: TOKENS.gitlab },
+          ],
+        },
+        rendererDiagnostics: {
+          status: "ok",
+          source: "renderer-diagnostics",
+          generated_at: "2026-06-22T01:02:03.004Z",
+          events: [
+            {
+              time: "2026-06-22T01:02:03.004Z",
+              level: "info",
+              "event.name": "incident.test",
+              app_launch_id: "al1",
+              window_id: "w1",
+              // Top-level event ID strings must be scrubbed too, not just `data`.
+              trace_id: TOKENS.stripe,
+              route_session_id: EMAIL,
+              // Secret in a value, and a path used as a data key — both must be scrubbed.
+              data: { note: `reach ${EMAIL} token ${TOKENS.npm}`, [PATHS.tilde]: "seen" },
+            },
+          ],
+          summary: {
+            event_count: 1,
+            incident_count: 1,
+            // A secret-shaped status only disappears if summary is scrubbed too, not just events.
+            statuses: ["ok", "sk-ant-statusleak0000000000000000" as unknown as "ok"],
+            omitted_event_count: 0,
+            omitted_bytes: 0,
+          },
+        },
+        // `extra` is not part of RendererErrorDetails; the untyped IPC boundary could still send it.
+        // It must be dropped, not spread into the payload.
+        rendererError: {
+          summary: `renderer failed password="${TOKENS.password}"`,
+          details: `${PATHS.unc} ${PATHS.file} ${PATHS.tilde} ${EMAIL}`,
+          extra: "extra-field-secret-7f3a",
+        } as { summary: string; details: string },
+      },
+      { reportId: "pwr_redact", generatedAt: "2026-06-22T01:02:03.004Z", redactTerms: [USERNAME, "/home/alice"] },
+    )
+
+    const samples = [...Object.values(TOKENS), ...Object.values(PATHS), USERNAME, EMAIL]
+    for (const sample of samples) {
+      expect(report.markdown, sample).not.toContain(sample)
+    }
+    // The rogue rendererError field was dropped, not carried through.
+    expect(report.markdown).not.toContain("extra-field-secret-7f3a")
+    // The renderer summary (not just events) is scrubbed.
+    expect(report.markdown).not.toContain("sk-ant-statusleak0000000000000000")
+    // The report is still a valid, parseable payload after redaction.
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(payload.sessionExport.status).toBe("ok")
+  })
+
+  test("scrubs a non-string rendererError field arriving from the untyped IPC boundary", () => {
+    const report = buildProblemReport(
+      {
+        diagnostics: validDiagnostics(),
+        logTail: "",
+        sessionExport: { status: "none" },
+        // summary is typed string but the IPC boundary could send an object carrying a secret.
+        rendererError: { summary: { nested: TOKENS.anthropic }, details: "ok" } as unknown as {
+          summary: string
+          details: string
+        },
+      },
+      { reportId: "pwr_nonstring", generatedAt: "2026-06-22T01:02:03.004Z" },
+    )
+    expect(report.markdown).not.toContain(TOKENS.anthropic)
+  })
+})

--- a/packages/desktop-electron/src/main/problem-report-redact.test.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.test.ts
@@ -364,6 +364,21 @@ describe("sanitizeSessionMessages", () => {
     expect(JSON.stringify(message)).not.toContain("raw leak")
     expect(JSON.stringify(message)).not.toContain(TOKENS.github)
   })
+
+  test("shape-tokens a file part source path even under a non-allowlisted root", () => {
+    const [message] = sanitizeSessionMessages(
+      [
+        {
+          info: { role: "user" },
+          parts: [{ type: "file", source: { type: "file", path: "/customroot/alice/secret-plan.pdf" } }],
+        },
+      ],
+      { redact: makeRedactor([]) },
+    ) as Array<{ parts: Array<{ source_path?: string }> }>
+    expect(message.parts[0].source_path).toBe("[path]")
+    expect(JSON.stringify(message)).not.toContain("customroot")
+    expect(JSON.stringify(message)).not.toContain("secret-plan")
+  })
 })
 
 describe("sanitizeSessionInfo", () => {
@@ -399,6 +414,40 @@ describe("sanitizeSessionInfo", () => {
     expect(serialized).not.toContain("REVERT_DIFF_CONTENT")
     expect(serialized).not.toContain("SECRET_RULE")
     expect(serialized).not.toContain("DROP_ME")
+  })
+
+  test("allowlists executionContext: shape-tokens every path, keeps worktree name/branch, drops unknown", () => {
+    const info = sanitizeSessionInfo(
+      {
+        id: "ses_1",
+        executionContext: {
+          ownerDirectory: "/customroot/alice/owner",
+          activeDirectory: "/customroot/alice/active",
+          activeWorktree: {
+            directory: "/customroot/alice/wt",
+            name: "acme-worktree",
+            branch: "main",
+            source: "created",
+            extra: "DROP_WT_FIELD",
+          },
+          lastChangedAt: 123,
+          build: "DROP_BUILD",
+          nested: { leak: "/customroot/alice/leak" },
+        },
+      },
+      { redact: makeRedactor([]) },
+    ) as Record<string, unknown>
+
+    expect(info.executionContext).toEqual({
+      ownerDirectory: "[path]",
+      activeDirectory: "[path]",
+      activeWorktree: { directory: "[path]", name: "acme-worktree", branch: "main", source: "created" },
+      lastChangedAt: 123,
+    })
+    const serialized = JSON.stringify(info)
+    expect(serialized).not.toContain("customroot")
+    expect(serialized).not.toContain("DROP_BUILD")
+    expect(serialized).not.toContain("DROP_WT_FIELD")
   })
 })
 
@@ -500,6 +549,27 @@ describe("buildProblemReport redaction gate", () => {
     // The report is still a valid, parseable payload after redaction.
     const payload = parseProblemReportPayload(report.markdown)
     expect(payload.sessionExport.status).toBe("ok")
+  })
+
+  test("shape-tokens diagnostics directory and logPath even under a non-allowlisted root", () => {
+    // The path regex only catches allowlisted roots; a project under a custom mount would otherwise
+    // leak its directory/project name. These fields are known paths, so they map to [path] wholesale.
+    const report = buildProblemReport(
+      {
+        diagnostics: validDiagnostics({
+          directory: "/customroot/alice/project",
+          logPath: "/customroot/alice/logs/main.log",
+        }),
+        logTail: "",
+        sessionExport: { status: "none" },
+      },
+      { reportId: "pwr_custompath", generatedAt: "2026-06-22T01:02:03.004Z" },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(payload.diagnostics.directory).toBe("[path]")
+    expect(payload.diagnostics.logPath).toBe("[path]")
+    expect(report.markdown).not.toContain("customroot")
   })
 
   test("scrubs a non-string rendererError field arriving from the untyped IPC boundary", () => {

--- a/packages/desktop-electron/src/main/problem-report-redact.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.ts
@@ -137,11 +137,14 @@ export function makeRedactor(extraTerms: string[] = []): Redactor {
     new Set(extraTerms.map((term) => (typeof term === "string" ? term.trim() : "")).filter((term) => term.length >= 1)),
   )
   // Case-insensitive so a username cased differently in a path than in os.userInfo() still matches.
-  // Short terms (a 1–2 char OS username) match only as whole words: this still redacts a bare
-  // standalone username while sparing single letters embedded in other tokens (hex, identifiers).
+  // A short (1–2 char) ASCII-word username matches only as a whole word, sparing single letters
+  // embedded in other tokens (the "x" in "0x1f", the "yu" in "yuan"). But JS `\b` is an ASCII word
+  // boundary: a short non-ASCII username ("张"/"山田") has no `\b` next to it and would leak, so it
+  // is redacted as an exact term instead. (Terms of length >2 were always exact.)
   const termPatterns = terms.map((term) => {
     const escaped = escapeRegExp(term)
-    return new RegExp(term.length <= 2 ? `\\b${escaped}\\b` : escaped, "gi")
+    const shortAsciiWord = /^[A-Za-z0-9_]{1,2}$/.test(term)
+    return new RegExp(shortAsciiWord ? `\\b${escaped}\\b` : escaped, "gi")
   })
   return (value: string) => {
     if (typeof value !== "string" || value.length === 0) return value

--- a/packages/desktop-electron/src/main/problem-report-redact.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.ts
@@ -1,0 +1,394 @@
+// Strip secrets and local identifiers from a problem report before it leaves the machine.
+//
+// Two regimes, by data shape (see docs/architecture/2026-06-22-diagnostics-package-design.md §2):
+//   - Free text (logs, error details, message text): a blacklist scrubber. Logs are not
+//     structured, so allowlisting is impossible; we redact known credential and path shapes.
+//   - Session messages: a field allowlist mirroring the renderer-diagnostics paradigm. The
+//     /session/{id}/message payload is structured, so we keep role/time/part-type/tool-name/
+//     byte-size + per-part length-capped body, redact the kept text, and omit unknown fields.
+//
+// The blacklist is best-effort by nature (it covers common, enumerable secret shapes, not every
+// possible one); user-authored content is kept and gated by the in-app review step, not redaction.
+
+export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[]
+
+export type Redactor = (value: string) => string
+
+// Per-part body cap so a single message never dominates the report and review stays meaningful.
+// PR2 layers cross-component total budgets on top of this fixed per-part limit.
+export const SESSION_PART_TEXT_MAX_CHARS = 4_000
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+function byteLength(value: string) {
+  return Buffer.byteLength(value, "utf8")
+}
+
+export function toJsonSafe(value: unknown, seen = new WeakSet<object>()): JsonValue {
+  if (value === null) return null
+  if (typeof value === "string" || typeof value === "boolean") return value
+  if (typeof value === "number") return Number.isFinite(value) ? value : String(value)
+  if (typeof value === "bigint") return value.toString()
+  if (typeof value === "undefined" || typeof value === "function" || typeof value === "symbol") return String(value)
+  if (typeof value !== "object") return String(value)
+  if (seen.has(value)) return "[Circular]"
+  seen.add(value)
+  if (Array.isArray(value)) {
+    const result = value.map((item) => toJsonSafe(item, seen))
+    seen.delete(value)
+    return result
+  }
+  const result: { [key: string]: JsonValue } = {}
+  for (const [key, nested] of Object.entries(value)) result[key] = toJsonSafe(nested, seen)
+  seen.delete(value)
+  return result
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+// Credential shapes, most specific first. Each runs over a single text value; path patterns are
+// line-greedy on purpose (a local path or its trailing context should not survive on its log line).
+const SECRET_REPLACERS: Array<(value: string) => string> = [
+  // PEM/PGP private key blocks. The label charset is bounded ([A-Z0-9 ]{0,40}) so non-matching input
+  // (e.g. a huge "-----BEGIN <200k chars> PUBLIC KEY-----") fails fast instead of backtracking across
+  // the whole string. Covers RSA/EC/OPENSSH PRIVATE KEY and PGP PRIVATE KEY BLOCK. The END line is
+  // optional: a truncated log tail may keep only the BEGIN marker + partial body, so consume to END
+  // when present, else to end of string.
+  (v) =>
+    v.replace(
+      /-----BEGIN[A-Z0-9 ]{0,40}PRIVATE[A-Z0-9 ]{0,40}-----[\s\S]*?(?:-----END[A-Z0-9 ]{0,40}-----|$)/g,
+      "[redacted-key]",
+    ),
+  // URL basic-auth credentials. The username is optional ([^/@\s:]*) so `scheme://:pass@host` and
+  // IP hosts are covered, not only `scheme://user:pass@host`. ONLY the scheme length is bounded
+  // ([a-z0-9+.-]{0,40}): the scheme is unanchored, so an unbounded greedy run scans for "://" from
+  // every letter and goes quadratic on a long letter run. The credential parts run after "://" is
+  // already matched (one anchored O(n) pass), so they are left unbounded — a length cap there would
+  // let an over-long password slip past the rule entirely. The whole `:password` part is optional, so
+  // every userinfo form redacts: `user:pass@`, `:pass@`, `user:@`, and bare `user@` (the last leaks
+  // the username otherwise, since the email rule skips IP hosts that have no letter in the domain).
+  (v) => v.replace(/([a-z][a-z0-9+.-]{0,40}:\/\/)[^/@\s:]*(?::[^/@\s]*)?@/gi, "$1[redacted]@"),
+  // JWT (header.payload.signature). Anchored on "ey" (base64 of "{…") rather than "eyJ", so a header
+  // with whitespace after the brace (encodes to "eyA…") is still caught.
+  (v) => v.replace(/\bey[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g, "[redacted-token]"),
+  // Known provider token prefixes. The sk- class allows hyphen/underscore segments so newer
+  // OpenAI/OpenRouter keys (sk-proj-…, sk-or-v1-…) are caught, not just classic sk- keys.
+  (v) =>
+    v.replace(
+      /\b(?:sk-[A-Za-z0-9_-]{16,}|AKIA[0-9A-Z]{12,}|ASIA[0-9A-Z]{12,}|AIza[0-9A-Za-z_-]{20,}|glpat-[0-9A-Za-z_-]{16,}|gh[posru]_[0-9A-Za-z]{20,}|github_pat_[0-9A-Za-z_]{20,}|hf_[0-9A-Za-z]{16,}|npm_[0-9A-Za-z]{20,}|xox[baprs]-[0-9A-Za-z-]{10,}|[rs]k_live_[0-9A-Za-z]{16,})\b/g,
+      "[redacted-token]",
+    ),
+  // Authorization / Proxy-Authorization headers: redact the whole credential after the scheme.
+  // The generic key=value rule below stops at the scheme word ("Basic"), leaking the base64 that
+  // follows, so this fully-consuming header rule must run first.
+  (v) =>
+    v.replace(
+      /\b((?:proxy-)?authorization)(["']?\s*[:=]\s*["']?)(?:basic|bearer|digest|negotiate)\s+[^\s"',;]+/gi,
+      "$1$2[redacted]",
+    ),
+  // Bearer tokens.
+  (v) => v.replace(/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi, "Bearer [redacted]"),
+  // Named credential assignments. The [\w-]* wrappers catch vendor-prefixed / camelCase names
+  // (AWS_SECRET_ACCESS_KEY, clientSecret, accessToken) that plain \b boundaries miss; token(?!s|ize)
+  // avoids eating "tokens=" usage counts and "tokenizer=" config. The quoted value branches consume
+  // escapes ((?:[^"\\]|\\.)*) so a value containing an escaped quote (password="abc\"…", common in
+  // JSON-in-logs) is redacted whole, not just up to the first inner quote.
+  (v) =>
+    v.replace(
+      /\b([\w-]*(?:password|passwd|pwd|passphrase|secret|token(?!s|ize)|api[_-]?key|access[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|api[_-]?secret|session[_-]?token|credential)[\w-]*)(["']?\s*[:=]\s*)(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|["']?[^\s"',;&}\])]{4,})/gi,
+      "$1$2[redacted]",
+    ),
+  // Bare "storage"/"key" assignments — kept word-bounded so "monkey"/"keyboard" are not redacted.
+  (v) => v.replace(/\b(storage|key)\b(["']?\s*[:=]\s*["']?)[^\s"',;&}\])]{4,}/gi, "$1$2[redacted]"),
+  // Cookies. `cookies?` covers the plural / "request cookies:" forms, not just the singular header.
+  (v) => v.replace(/\b(set-cookies?|cookies?)\b(["']?\s*[:=]\s*)[^\n\r]+/gi, "$1$2[redacted]"),
+  // Absolute paths and the usernames embedded in them.
+  (v) => v.replace(/[A-Za-z]:\\[^\r\n"']*/g, "[path]"),
+  (v) => v.replace(/\\\\[^\\\s"']+\\[^\r\n"']*/g, "[path]"),
+  (v) => v.replace(/file:\/\/\/?[^\s"'<>]*/gi, "[path]"),
+  // ~ or ~username followed by a path.
+  (v) => v.replace(/~[^\s/\\"']*[\\/][^\r\n"']*/g, "[path]"),
+  // Absolute POSIX paths under a common system/home/dev root. The leading directory is allowlisted
+  // (a fully general "/a/b" rule would shred URLs and route strings); the user's home dir and
+  // username are additionally redacted as exact terms, so an out-of-list root never leaks identity.
+  (v) =>
+    v.replace(
+      /\/(?:Users|home|root|tmp|opt|srv|etc|usr|var|mnt|media|private|Applications|Library|System|Network|Volumes|bin|sbin|dev|run|proc|lib|lib64|boot|sys|nix|workspace|data|snap|host)[\\/][^\r\n"']*/g,
+      "[path]",
+    ),
+  // (No general "any path ending in filename.ext" rule: it over-redacted diagnostic URLs/routes and
+  // had a super-linear backtracking path. Non-allowlisted-root paths carry no identity — the username
+  // and home dir are redacted as exact terms — so they fall under the documented best-effort residual,
+  // backstopped by in-app human review. See the design doc §2.2 known-boundaries note.)
+  // Email addresses, including internal/local domains (alice@corp, root@host). The lookahead
+  // requires a letter in the domain so npm version syntax (react@18.2.0) is not mistaken for email.
+  (v) => v.replace(/\b[A-Za-z0-9._%+-]+@(?=[A-Za-z0-9-]*[A-Za-z])[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\b/g, "[email]"),
+]
+
+// Build a free-text redactor. `extraTerms` are exact strings known to be sensitive at runtime
+// (the OS username, the home directory) — the surest way to catch a bare username that no regex
+// can infer. Short terms are dropped to avoid nuking common substrings.
+export function makeRedactor(extraTerms: string[] = []): Redactor {
+  const terms = Array.from(
+    new Set(extraTerms.map((term) => (typeof term === "string" ? term.trim() : "")).filter((term) => term.length >= 1)),
+  )
+  // Case-insensitive so a username cased differently in a path than in os.userInfo() still matches.
+  // Short terms (a 1–2 char OS username) match only as whole words: this still redacts a bare
+  // standalone username while sparing single letters embedded in other tokens (hex, identifiers).
+  const termPatterns = terms.map((term) => {
+    const escaped = escapeRegExp(term)
+    return new RegExp(term.length <= 2 ? `\\b${escaped}\\b` : escaped, "gi")
+  })
+  return (value: string) => {
+    if (typeof value !== "string" || value.length === 0) return value
+    let next = value
+    // Pattern shapes first (email/path matches stay intact), then exact terms catch any bare
+    // username the regexes could not infer.
+    for (const replace of SECRET_REPLACERS) next = replace(next)
+    for (const pattern of termPatterns) next = next.replace(pattern, "[user]")
+    return next
+  }
+}
+
+// Field names that mark their value as a secret regardless of its shape. A bare value
+// (`{ apiKey: "plain-token" }`) carries no pattern for the string scrubber to match, so the field
+// name is the only signal. Substring matches are normalized (case-folded, separators stripped) so
+// `AWS_SECRET_ACCESS_KEY`, `clientSecret`, and `accessToken` all hit; exact matches cover short
+// ambiguous names without catching their plurals/compounds (`token` yes, `tokens`/`tokenizer` no).
+const SENSITIVE_KEY_SUBSTRING =
+  /password|passphrase|passwd|secret|apikey|accesskey|secretkey|privatekey|signingkey|sshkey|accesstoken|refreshtoken|sessiontoken|idtoken|authtoken|apitoken|bearertoken|bottoken|clientsecret|apisecret|credential|authorization|cookie/
+// Suffix match catches the open-ended vendor space (apiToken, botToken, sshKey, signingKey) that no
+// fixed list can enumerate. `token$` deliberately does not match "tokens"/"tokenizer" — those are
+// usage counts / config, not auth tokens, and are diagnostically useful.
+const SENSITIVE_KEY_SUFFIX = /(?:token|key|secret|password|passphrase|credential)$/
+const SENSITIVE_KEY_EXACT = new Set(["token", "key", "auth", "pwd", "bearer", "secret", "password"])
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase().replace(/[^a-z]/g, "")
+  if (normalized === "tokens" || normalized === "tokenizer") return false
+  return (
+    SENSITIVE_KEY_EXACT.has(normalized) ||
+    SENSITIVE_KEY_SUFFIX.test(normalized) ||
+    SENSITIVE_KEY_SUBSTRING.test(normalized)
+  )
+}
+
+// Deep-redact an already-json-safe value. Used for structured data (session info, tool input
+// objects, error objects). Three guarantees: every string leaf runs through the scrubber, object
+// keys are scrubbed too (a key can itself be a secret/path), and a sensitive field name redacts its
+// whole value wholesale (the bare value would otherwise slip past every pattern).
+export function redactJsonValue(value: JsonValue, redact: Redactor): JsonValue {
+  if (typeof value === "string") return redact(value)
+  if (Array.isArray(value)) return value.map((item) => redactJsonValue(item, redact))
+  if (value && typeof value === "object") {
+    const result: { [key: string]: JsonValue } = {}
+    for (const [key, nested] of Object.entries(value)) {
+      result[redact(key)] = isSensitiveKey(key) ? "[redacted]" : redactJsonValue(nested, redact)
+    }
+    return result
+  }
+  return value
+}
+
+type SanitizeContext = {
+  redact: Redactor
+  textMax: number
+}
+
+function redactCap(value: string, ctx: SanitizeContext): string {
+  const redacted = ctx.redact(value)
+  if (redacted.length <= ctx.textMax) return redacted
+  return `${redacted.slice(0, ctx.textMax)}…[+${redacted.length - ctx.textMax} chars]`
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined
+}
+
+function structuredText(value: unknown, ctx: SanitizeContext): { bytes: number; text: string } | undefined {
+  if (value === undefined) return undefined
+  const json = JSON.stringify(redactJsonValue(toJsonSafe(value), ctx.redact)) ?? ""
+  return { bytes: byteLength(json), text: json.length <= ctx.textMax ? json : `${json.slice(0, ctx.textMax)}…` }
+}
+
+function sanitizePart(part: unknown, ctx: SanitizeContext): JsonValue {
+  if (!isObject(part)) return { unrecognized: true }
+  const type = stringField(part.type) ?? "unknown"
+  const out: { [key: string]: JsonValue } = { type }
+
+  const textBody = (raw: unknown) => {
+    const text = stringField(raw) ?? ""
+    out.bytes = byteLength(text)
+    out.text = redactCap(text, ctx)
+  }
+
+  switch (type) {
+    case "text":
+    case "reasoning":
+      textBody(part.text)
+      break
+    case "tool": {
+      if (part.tool !== undefined) out.tool = stringField(part.tool) ?? null
+      const state = isObject(part.state) ? part.state : {}
+      if (state.status !== undefined) out.status = stringField(state.status) ?? null
+      const input = structuredText(state.input, ctx)
+      const output = stringField(state.output)
+      const error = stringField(state.error)
+      out.bytes = (input?.bytes ?? 0) + byteLength(output ?? "") + byteLength(error ?? "")
+      if (input) out.input = input.text
+      if (output !== undefined) out.output = redactCap(output, ctx)
+      if (error !== undefined) out.error = redactCap(error, ctx)
+      break
+    }
+    case "file": {
+      if (part.mime !== undefined) out.mime = stringField(part.mime) ?? null
+      if (part.filename !== undefined) out.filename = ctx.redact(String(part.filename))
+      const source = isObject(part.source) ? part.source : undefined
+      const sourceText = isObject(source?.text) ? stringField(source.text.value) : undefined
+      out.bytes = byteLength(stringField(part.url) ?? "") + byteLength(sourceText ?? "")
+      if (source && source.path !== undefined) out.source_path = ctx.redact(String(source.path))
+      break
+    }
+    case "subtask": {
+      if (part.agent !== undefined) out.agent = stringField(part.agent) ?? null
+      if (part.status !== undefined) out.status = stringField(part.status) ?? null
+      if (part.description !== undefined) out.description = redactCap(String(part.description), ctx)
+      if (part.result_summary !== undefined) out.result_summary = redactCap(String(part.result_summary), ctx)
+      out.bytes =
+        byteLength(stringField(part.prompt) ?? "") +
+        byteLength(stringField(part.result_text) ?? "") +
+        byteLength(stringField(part.partial_result) ?? "")
+      break
+    }
+    case "patch":
+      if (typeof part.hash === "string") out.hash = part.hash
+      if (Array.isArray(part.files)) out.files = part.files.map((file) => ctx.redact(String(file)))
+      break
+    case "step-finish":
+      if (typeof part.reason === "string") out.reason = part.reason
+      if (typeof part.cost === "number") out.cost = part.cost
+      if (part.tokens !== undefined) out.tokens = toJsonSafe(part.tokens)
+      break
+    case "agent":
+    case "skill":
+      if (part.name !== undefined) out.name = stringField(part.name) ?? null
+      break
+    case "retry": {
+      if (typeof part.attempt === "number") out.attempt = part.attempt
+      const error = structuredText(part.error, ctx)
+      if (error) out.error = error.text
+      break
+    }
+    case "notice":
+      if (typeof part.kind === "string") out.kind = part.kind
+      if (typeof part.sideEffect === "boolean") out.sideEffect = part.sideEffect
+      break
+    case "compaction":
+      if (typeof part.auto === "boolean") out.auto = part.auto
+      if (typeof part.overflow === "boolean") out.overflow = part.overflow
+      break
+    default:
+      // step-start, snapshot, source-url, and unknown types: keep only the type tag.
+      break
+  }
+  return out
+}
+
+function sanitizeMessageInfo(info: unknown, ctx: SanitizeContext): JsonValue {
+  if (!isObject(info)) return {}
+  const out: { [key: string]: JsonValue } = {}
+  if (typeof info.role === "string") out.role = info.role
+  if (typeof info.id === "string") out.id = info.id
+  if (info.time !== undefined) out.time = toJsonSafe(info.time)
+  if (typeof info.agent === "string") out.agent = info.agent
+  if (typeof info.providerID === "string") out.providerID = info.providerID
+  if (typeof info.modelID === "string") out.modelID = info.modelID
+  if (isObject(info.model)) {
+    out.model = {
+      providerID: stringField(info.model.providerID) ?? null,
+      modelID: stringField(info.model.modelID) ?? null,
+    }
+  }
+  if (typeof info.cost === "number") out.cost = info.cost
+  if (info.tokens !== undefined) out.tokens = toJsonSafe(info.tokens)
+  if (typeof info.finish === "string") out.finish = info.finish
+  if (typeof info.automationID === "string") out.automationID = info.automationID
+  // Absolute working-directory paths — keep the shape, drop the value.
+  if (info.path !== undefined) out.path = "[path]"
+  if (info.error !== undefined) {
+    const error = structuredText(info.error, ctx)
+    if (error) out.error = error.text
+  }
+  if (isObject(info.summary) && typeof info.summary.title === "string") {
+    out.summary_title = redactCap(info.summary.title, ctx)
+  }
+  // Omitted on purpose: system (system prompt), structured output, tools map, raw summary body.
+  return out
+}
+
+// Structure-aware allowlist for the top-level session info object, mirroring the message-info
+// discipline: keep metadata scalars, cap the user-authored title, map working directories to a
+// shape token, and drop content-heavy fields (diffs, revert diff/snapshot, permission ruleset, the
+// share URL) rather than scrubbing them in place. Unknown fields never pass through.
+export function sanitizeSessionInfo(info: unknown, options: { redact: Redactor; textMax?: number }): JsonValue {
+  const ctx: SanitizeContext = { redact: options.redact, textMax: options.textMax ?? SESSION_PART_TEXT_MAX_CHARS }
+  if (!isObject(info)) return redactJsonValue(toJsonSafe(info), ctx.redact)
+  const out: { [key: string]: JsonValue } = {}
+  for (const key of ["id", "slug", "projectID", "workspaceID", "parentID", "subagentType", "skill", "version"]) {
+    const value = stringField(info[key])
+    if (value !== undefined) out[key] = value
+  }
+  if (typeof info.createdByAgentTool === "boolean") out.createdByAgentTool = info.createdByAgentTool
+  if (info.title !== undefined) out.title = redactCap(String(info.title), ctx)
+  // Working-directory paths — keep the shape, drop the value.
+  if (info.directory !== undefined) out.directory = "[path]"
+  if (info.time !== undefined) out.time = toJsonSafe(info.time)
+  if (isObject(info.summary)) {
+    out.summary = {
+      additions: typeof info.summary.additions === "number" ? info.summary.additions : null,
+      deletions: typeof info.summary.deletions === "number" ? info.summary.deletions : null,
+      files: typeof info.summary.files === "number" ? info.summary.files : null,
+    }
+  }
+  if (isObject(info.executionContext)) {
+    // Every field here is a directory/worktree path; redactJsonValue maps them to [path].
+    out.executionContext = redactJsonValue(toJsonSafe(info.executionContext), ctx.redact)
+  }
+  if (isObject(info.revert) && typeof info.revert.messageID === "string") {
+    out.revert = { messageID: info.revert.messageID }
+    if (typeof info.revert.partID === "string") out.revert.partID = info.revert.partID
+  }
+  // Final uniform pass: scrub every kept metadata string (id/slug/projectID/…) too, so the guarantee
+  // does not hinge on which scalar was copied — matching the whole-tree pass on session messages.
+  return redactJsonValue(out, ctx.redact)
+}
+
+// Structure-aware allowlist for session export messages. Unknown shapes are reported, never
+// passed through, so a non-{info,parts} payload cannot smuggle raw content into the report.
+export function sanitizeSessionMessages(messages: unknown[], options: { redact: Redactor; textMax?: number }): JsonValue[] {
+  const ctx: SanitizeContext = { redact: options.redact, textMax: options.textMax ?? SESSION_PART_TEXT_MAX_CHARS }
+  return messages.map((message): JsonValue => {
+    if (!isObject(message)) return { unrecognized: true }
+    if (message.info === undefined && message.parts === undefined) {
+      return { unrecognized: true, bytes: byteLength(JSON.stringify(toJsonSafe(message)) ?? "") }
+    }
+    // A system-role message is the system prompt; drop its parts entirely (only the role survives),
+    // matching the omission of the User.system field elsewhere.
+    if (isObject(message.info) && stringField(message.info.role) === "system") {
+      return { info: { role: "system" }, parts: [], omitted: "system-prompt" }
+    }
+    // The allowlist selects which fields survive and caps their bodies; this final pass guarantees
+    // every surviving string (including kept enums/IDs and any key) goes through the scrubber, so a
+    // leak can never hinge on whether one specific field was redacted at selection time.
+    return redactJsonValue(
+      {
+        info: sanitizeMessageInfo(message.info, ctx),
+        parts: Array.isArray(message.parts) ? message.parts.map((part) => sanitizePart(part, ctx)) : [],
+      },
+      ctx.redact,
+    )
+  })
+}

--- a/packages/desktop-electron/src/main/problem-report-redact.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.ts
@@ -249,7 +249,9 @@ function sanitizePart(part: unknown, ctx: SanitizeContext): JsonValue {
       const source = isObject(part.source) ? part.source : undefined
       const sourceText = isObject(source?.text) ? stringField(source.text.value) : undefined
       out.bytes = byteLength(stringField(part.url) ?? "") + byteLength(sourceText ?? "")
-      if (source && source.path !== undefined) out.source_path = ctx.redact(String(source.path))
+      // A file source path is a known filesystem path: shape-token it wholesale rather than letting
+      // the free-text scrubber guess (it only catches allowlisted roots, so a non-listed root leaks).
+      if (source && source.path !== undefined) out.source_path = "[path]"
       break
     }
     case "subtask": {
@@ -329,6 +331,28 @@ function sanitizeMessageInfo(info: unknown, ctx: SanitizeContext): JsonValue {
   return out
 }
 
+// Structure-aware allowlist for the session executionContext object. Every directory/worktree field
+// is a known path, so paths map to the [path] shape token wholesale — never guessed by the free-text
+// scrubber, which only catches allowlisted roots and would leak a path under a non-listed root or a
+// newly added field. Unknown fields are dropped, not spread through. Worktree name/branch are kept
+// (capped + scrubbed) as low-risk diagnostic identifiers.
+function sanitizeExecutionContext(value: Record<string, unknown>, ctx: SanitizeContext): JsonValue {
+  const out: { [key: string]: JsonValue } = {}
+  if (value.ownerDirectory !== undefined) out.ownerDirectory = "[path]"
+  if (value.activeDirectory !== undefined) out.activeDirectory = "[path]"
+  if (isObject(value.activeWorktree)) {
+    const worktree = value.activeWorktree
+    const worktreeOut: { [key: string]: JsonValue } = {}
+    if (worktree.directory !== undefined) worktreeOut.directory = "[path]"
+    if (worktree.name !== undefined) worktreeOut.name = redactCap(String(worktree.name), ctx)
+    if (worktree.branch !== undefined) worktreeOut.branch = redactCap(String(worktree.branch), ctx)
+    if (worktree.source !== undefined) worktreeOut.source = stringField(worktree.source) ?? null
+    out.activeWorktree = worktreeOut
+  }
+  if (typeof value.lastChangedAt === "number") out.lastChangedAt = value.lastChangedAt
+  return out
+}
+
 // Structure-aware allowlist for the top-level session info object, mirroring the message-info
 // discipline: keep metadata scalars, cap the user-authored title, map working directories to a
 // shape token, and drop content-heavy fields (diffs, revert diff/snapshot, permission ruleset, the
@@ -354,8 +378,7 @@ export function sanitizeSessionInfo(info: unknown, options: { redact: Redactor; 
     }
   }
   if (isObject(info.executionContext)) {
-    // Every field here is a directory/worktree path; redactJsonValue maps them to [path].
-    out.executionContext = redactJsonValue(toJsonSafe(info.executionContext), ctx.redact)
+    out.executionContext = sanitizeExecutionContext(info.executionContext, ctx)
   }
   if (isObject(info.revert) && typeof info.revert.messageID === "string") {
     out.revert = { messageID: info.revert.messageID }

--- a/packages/desktop-electron/src/main/problem-report.test.ts
+++ b/packages/desktop-electron/src/main/problem-report.test.ts
@@ -308,6 +308,29 @@ describe("problem report", () => {
     expect(summary).not.toContain("secret.log")
   })
 
+  test("summary scrubs the bare OS username and non-allowlisted home via shared redactTerms", () => {
+    // The summary is the same outbound channel as the full report, so it must apply the caller's
+    // exact runtime terms. Under a non-allowlisted root, only the exact term catches the leak — the
+    // path regex (allowlisted roots only) does not, and the username is a bare word no regex infers.
+    const summary = buildProblemReportSummary({
+      reportId: "pwr_terms",
+      generatedAt: "2026-04-23T01:02:03.004Z",
+      diagnostics: base.diagnostics,
+      reportFileName: "r.md",
+      reportLocationHint: "hint",
+      fullReportStatus: "ready",
+      recentErrors: [
+        "[error] failed reading /customroot/zoe/project/app.ts",
+        "[warn] user zoe could not write cache",
+      ],
+      rendererError: { summary: "crash under /customroot/zoe/project", details: "" },
+      redactTerms: ["/customroot/zoe", "zoe"],
+    })
+
+    expect(summary).not.toContain("zoe")
+    expect(summary).not.toContain("/customroot/zoe")
+  })
+
   test("keeps no-session reports useful", () => {
     const report = buildProblemReport({
       ...base,
@@ -411,8 +434,8 @@ describe("problem report", () => {
       ...base,
       sessionExport: {
         status: "ok",
-        // Top-level info is allowlisted: `size` is an unknown field and is dropped; the surviving
-        // executionContext still has bigint/circular values made JSON-safe and paths shape-tokened.
+        // Both info and executionContext are field allowlists: top-level `size` and executionContext's
+        // `build`/`circular` are unknown fields and dropped; the kept `activeDirectory` is shape-tokened.
         info: { id: "ses_1", size: 123n, executionContext: { activeDirectory: "/Users/x/p", build: 789n, circular } },
         messages: [{ body: 456n, circular }],
       },
@@ -423,7 +446,7 @@ describe("problem report", () => {
     if (payload.sessionExport.status === "ok") {
       expect(payload.sessionExport.info).toEqual({
         id: "ses_1",
-        executionContext: { activeDirectory: "[path]", build: "789", circular: { id: "root", self: "[Circular]" } },
+        executionContext: { activeDirectory: "[path]" },
       })
       // A non-{info,parts} message shape is reported, not passed through, so it cannot smuggle
       // raw content into the report (PR1 structure-aware allowlist).
@@ -462,13 +485,13 @@ describe("problem report", () => {
         logTail: "",
         sessionExport: {
           status: "ok",
-          // Bulk lives in an allowlisted field (executionContext is uncapped) so the omission ladder
-          // still has something large to drop after sanitize.
-          info: { executionContext: { activeWorktree: "z".repeat(20_000) } },
+          // Bulk lives in the capped title: even after the per-field cap it stays large enough to
+          // exceed this small budget, so the omission ladder still has session info to drop.
+          info: { title: "z".repeat(20_000) },
           messages: [],
         },
       },
-      { maxBytes: 5_000 },
+      { maxBytes: 3_000 },
     )
 
     expect(Buffer.byteLength(report.markdown, "utf8")).toBeLessThanOrEqual(5_000)

--- a/packages/desktop-electron/src/main/problem-report.test.ts
+++ b/packages/desktop-electron/src/main/problem-report.test.ts
@@ -331,6 +331,25 @@ describe("problem report", () => {
     expect(summary).not.toContain("/customroot/zoe")
   })
 
+  test("summary redacts a short non-ASCII username and identity-bearing report metadata", () => {
+    // A 1–2 char CJK username slips past JS \b word boundaries, and the report file/location were
+    // inserted raw — both must be scrubbed before the summary hits the clipboard.
+    const summary = buildProblemReportSummary({
+      reportId: "pwr_cjk",
+      generatedAt: "2026-04-23T01:02:03.004Z",
+      diagnostics: base.diagnostics,
+      reportFileName: "problem.md",
+      reportLocationHint: "/customroot/山田/problem-reports/problem.md",
+      fullReportStatus: "ready",
+      recentErrors: ["[error] failed for user 山田"],
+      rendererError: { summary: "crash for 山田", details: "" },
+      redactTerms: ["山田"],
+    })
+
+    expect(summary).not.toContain("山田")
+    expect(summary).not.toContain("/customroot/山田")
+  })
+
   test("keeps no-session reports useful", () => {
     const report = buildProblemReport({
       ...base,

--- a/packages/desktop-electron/src/main/problem-report.test.ts
+++ b/packages/desktop-electron/src/main/problem-report.test.ts
@@ -147,7 +147,13 @@ describe("problem report", () => {
       rendererError,
     })
 
-    expect(payload.rendererError).toEqual(rendererError)
+    // The full report now redacts the same secret/path shapes as the summary (PR1), so the
+    // uploaded file no longer carries raw credentials or local paths in rendererError.
+    expect(payload.rendererError?.summary).toContain("storage=[redacted]")
+    expect(payload.rendererError?.summary).toContain("key=[redacted]")
+    expect(report.markdown).not.toContain("pawwork.workspace.project.abc123.dat")
+    expect(report.markdown).not.toContain("workspace:vcs")
+    expect(report.markdown).not.toContain("/Users/test/project")
     expect(summary).toContain("Renderer error: PawWork hit a local state problem.")
     expect(summary).toContain("storage=[redacted]")
     expect(summary).toContain("key=[redacted]")
@@ -405,7 +411,9 @@ describe("problem report", () => {
       ...base,
       sessionExport: {
         status: "ok",
-        info: { size: 123n, circular },
+        // Top-level info is allowlisted: `size` is an unknown field and is dropped; the surviving
+        // executionContext still has bigint/circular values made JSON-safe and paths shape-tokened.
+        info: { id: "ses_1", size: 123n, executionContext: { activeDirectory: "/Users/x/p", build: 789n, circular } },
         messages: [{ body: 456n, circular }],
       },
     })
@@ -413,11 +421,15 @@ describe("problem report", () => {
     const payload = parseProblemReportPayload(report.markdown)
     expect(payload.sessionExport.status).toBe("ok")
     if (payload.sessionExport.status === "ok") {
-      expect(payload.sessionExport.info).toEqual({ size: "123", circular: { id: "root", self: "[Circular]" } })
-      expect(payload.sessionExport.messages[0]).toEqual({
-        body: "456",
-        circular: { id: "root", self: "[Circular]" },
+      expect(payload.sessionExport.info).toEqual({
+        id: "ses_1",
+        executionContext: { activeDirectory: "[path]", build: "789", circular: { id: "root", self: "[Circular]" } },
       })
+      // A non-{info,parts} message shape is reported, not passed through, so it cannot smuggle
+      // raw content into the report (PR1 structure-aware allowlist).
+      const message = payload.sessionExport.messages[0] as { unrecognized?: boolean; bytes?: number }
+      expect(message.unrecognized).toBe(true)
+      expect(message.bytes).toBeGreaterThan(0)
     }
   })
 
@@ -450,7 +462,9 @@ describe("problem report", () => {
         logTail: "",
         sessionExport: {
           status: "ok",
-          info: { snapshot: "z".repeat(20_000) },
+          // Bulk lives in an allowlisted field (executionContext is uncapped) so the omission ladder
+          // still has something large to drop after sanitize.
+          info: { executionContext: { activeWorktree: "z".repeat(20_000) } },
           messages: [],
         },
       },

--- a/packages/desktop-electron/src/main/problem-report.ts
+++ b/packages/desktop-electron/src/main/problem-report.ts
@@ -444,8 +444,10 @@ export function buildProblemReportSummary(input: ProblemReportSummaryInput) {
     input.fullReportStatus === "ready"
       ? [
           "Full report: ready for manual upload",
-          `Report file: ${input.reportFileName ?? "unknown"}`,
-          `Report location: ${input.reportLocationHint ?? "unknown"}`,
+          // saveReport's filename/hint are not trusted to be identity-free — run them through the
+          // same path-fragment + term scrubber as the rest of the summary, not raw into the clipboard.
+          `Report file: ${redactLocalPathFragments(input.reportFileName ?? "unknown", redact)}`,
+          `Report location: ${redactLocalPathFragments(input.reportLocationHint ?? "unknown", redact)}`,
         ]
       : [
           "Full report: not generated",

--- a/packages/desktop-electron/src/main/problem-report.ts
+++ b/packages/desktop-electron/src/main/problem-report.ts
@@ -152,9 +152,12 @@ function redactDiagnostics(diagnostics: ProblemReportDiagnostics, redact: Redact
   return {
     ...diagnostics,
     route: redact(diagnostics.route),
-    directory: diagnostics.directory === null ? null : redact(diagnostics.directory),
+    // directory and logPath are known to be filesystem paths: shape-token them wholesale instead of
+    // letting the free-text scrubber guess (it only catches allowlisted roots, so a path under a
+    // non-listed root would leak the project/dir name). Empty/null stay as-is so "no path" reads true.
+    directory: diagnostics.directory ? "[path]" : diagnostics.directory,
     sessionID: diagnostics.sessionID === null ? null : redact(diagnostics.sessionID),
-    logPath: redact(diagnostics.logPath),
+    logPath: diagnostics.logPath ? "[path]" : diagnostics.logPath,
   }
 }
 
@@ -374,6 +377,10 @@ type ProblemReportSummaryInput = {
   recentErrors: string[]
   rendererError?: RendererErrorDetails
   rendererDiagnostics?: RendererDiagnosticsSlice
+  // Exact strings (OS username, home directory) the caller knows are sensitive at runtime but no
+  // regex can infer. The summary is the same outbound channel as the full report, so it must share
+  // these terms — otherwise a bare username or non-allowlisted home leaks through recentErrors.
+  redactTerms?: string[]
 }
 
 function oneLine(value: string) {
@@ -382,11 +389,10 @@ function oneLine(value: string) {
 
 // The clipboard summary is the same outbound channel as the report file, so it gets the full
 // secret scrubber too. Path/storage fragments run first (keeps the [storage] .dat shape), then the
-// shared redactor strips tokens, Bearer/basic-auth, and emails the old summary rules missed.
-const summaryRedactor = makeRedactor()
-
-function redactLocalPathFragments(value: string) {
-  return summaryRedactor(
+// caller's redactor strips tokens, Bearer/basic-auth, emails, AND the exact runtime terms (OS
+// username, home directory) the old module-level redactor missed.
+function redactLocalPathFragments(value: string, redact: Redactor) {
+  return redact(
     value
       .replace(/[A-Za-z]:\\[^\r\n]*/g, "[path]")
       .replace(/\\\\[^\\\s]+\\[^\r\n]*/g, "[path]")
@@ -400,39 +406,40 @@ function truncateSummaryLine(value: string, maxChars: number) {
   return value.length > maxChars ? `${value.slice(0, maxChars)}...` : value
 }
 
-function safeSummaryRoute(route: string) {
+function safeSummaryRoute(route: string, redact: Redactor) {
   const pathOnly = oneLine(route).split(/[?#]/)[0] || "/"
-  return truncateSummaryLine(redactLocalPathFragments(pathOnly), SUMMARY_ROUTE_MAX_CHARS)
+  return truncateSummaryLine(redactLocalPathFragments(pathOnly, redact), SUMMARY_ROUTE_MAX_CHARS)
 }
 
-function safeSummarySession(sessionID: string | null) {
+function safeSummarySession(sessionID: string | null, redact: Redactor) {
   if (sessionID === null) return "none"
-  return truncateSummaryLine(oneLine(redactLocalPathFragments(sessionID)), SUMMARY_SESSION_MAX_CHARS)
+  return truncateSummaryLine(oneLine(redactLocalPathFragments(sessionID, redact)), SUMMARY_SESSION_MAX_CHARS)
 }
 
-function safeFailureReason(value: string | undefined) {
+function safeFailureReason(value: string | undefined, redact: Redactor) {
   if (!value) return "unknown"
-  return truncateSummaryLine(oneLine(redactLocalPathFragments(value)), SUMMARY_FAILURE_REASON_MAX_CHARS)
+  return truncateSummaryLine(oneLine(redactLocalPathFragments(value, redact)), SUMMARY_FAILURE_REASON_MAX_CHARS)
 }
 
-function summaryRecentErrors(recentErrors: string[]) {
+function summaryRecentErrors(recentErrors: string[], redact: Redactor) {
   const lines = recentErrors
-    .map((line) => truncateSummaryLine(oneLine(redactLocalPathFragments(line)), SUMMARY_ERROR_LINE_MAX_CHARS))
+    .map((line) => truncateSummaryLine(oneLine(redactLocalPathFragments(line, redact)), SUMMARY_ERROR_LINE_MAX_CHARS))
     .filter(Boolean)
     .slice(0, 10)
   return lines.length > 0 ? lines : ["No recent errors found"]
 }
 
-function safeRendererErrorSummary(rendererError: RendererErrorDetails | undefined) {
+function safeRendererErrorSummary(rendererError: RendererErrorDetails | undefined, redact: Redactor) {
   if (!rendererError?.summary) return
   return truncateSummaryLine(
-    oneLine(redactLocalPathFragments(rendererError.summary)),
+    oneLine(redactLocalPathFragments(rendererError.summary, redact)),
     SUMMARY_RENDERER_ERROR_MAX_CHARS,
   )
 }
 
 export function buildProblemReportSummary(input: ProblemReportSummaryInput) {
-  const rendererError = safeRendererErrorSummary(input.rendererError)
+  const redact = makeRedactor(input.redactTerms)
+  const rendererError = safeRendererErrorSummary(input.rendererError, redact)
   const fullReportLines =
     input.fullReportStatus === "ready"
       ? [
@@ -442,7 +449,7 @@ export function buildProblemReportSummary(input: ProblemReportSummaryInput) {
         ]
       : [
           "Full report: not generated",
-          `Full report failure: ${safeFailureReason(input.failureReason)}`,
+          `Full report failure: ${safeFailureReason(input.failureReason, redact)}`,
           "Submit this summary without an attachment if needed.",
         ]
 
@@ -454,8 +461,8 @@ export function buildProblemReportSummary(input: ProblemReportSummaryInput) {
     `PawWork: ${input.diagnostics.appVersion} (${input.diagnostics.channel})`,
     `Platform: ${input.diagnostics.platform} ${input.diagnostics.osVersion} ${input.diagnostics.arch}`,
     `Electron: ${input.diagnostics.electronVersion}`,
-    `Route: ${safeSummaryRoute(input.diagnostics.route)}`,
-    `Session: ${safeSummarySession(input.diagnostics.sessionID)}`,
+    `Route: ${safeSummaryRoute(input.diagnostics.route, redact)}`,
+    `Session: ${safeSummarySession(input.diagnostics.sessionID, redact)}`,
     ...(input.rendererDiagnostics
       ? [
           `Renderer diagnostics: ${input.rendererDiagnostics.status}, events=${input.rendererDiagnostics.summary.event_count}, incidents=${input.rendererDiagnostics.summary.incident_count}`,
@@ -465,7 +472,7 @@ export function buildProblemReportSummary(input: ProblemReportSummaryInput) {
     ...fullReportLines,
     "",
     "Recent key errors:",
-    ...summaryRecentErrors(input.recentErrors).map((line) => `- ${line}`),
+    ...summaryRecentErrors(input.recentErrors, redact).map((line) => `- ${line}`),
     "",
   ].join("\n")
 }

--- a/packages/desktop-electron/src/main/problem-report.ts
+++ b/packages/desktop-electron/src/main/problem-report.ts
@@ -2,6 +2,15 @@
 // Default full report payload limit: 5 MB.
 import type { RendererErrorDetails } from "@opencode-ai/app/desktop-api"
 import type { RendererDiagnosticEvent, RendererDiagnosticsSlice } from "./renderer-diagnostics"
+import {
+  type JsonValue,
+  makeRedactor,
+  type Redactor,
+  redactJsonValue,
+  sanitizeSessionInfo,
+  sanitizeSessionMessages,
+  toJsonSafe,
+} from "./problem-report-redact"
 
 export const DEFAULT_PROBLEM_REPORT_MAX_BYTES = 5 * 1024 * 1024
 const SUMMARY_ERROR_LINE_MAX_CHARS = 220
@@ -26,8 +35,6 @@ export type ProblemReportDiagnostics = {
   logPath: string
 }
 
-type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[]
-
 export type SessionExport =
   | { status: "none" }
   | { status: "failed"; error: string }
@@ -50,6 +57,9 @@ type Options = {
   maxBytes?: number
   reportId?: string
   generatedAt?: string
+  // Exact strings (OS username, home directory) the caller knows are sensitive at runtime but
+  // no regex can infer. Redacted verbatim wherever they appear in the report.
+  redactTerms?: string[]
 }
 
 type Payload = {
@@ -101,8 +111,8 @@ function markdown(payload: Payload) {
   ].join("\n")
 }
 
-function sessionMessages(sessionExport: SessionExport) {
-  return sessionExport.status === "ok" ? sessionExport.messages.map((message) => toJsonSafe(message)) : []
+function sessionMessages(sessionExport: SafeSessionExport): JsonValue[] {
+  return sessionExport.status === "ok" ? sessionExport.messages : []
 }
 
 function withMessages(sessionExport: SafeSessionExport, messages: JsonValue[]): SafeSessionExport {
@@ -120,33 +130,46 @@ function withFailedExportError(sessionExport: SafeSessionExport, error: string |
   return { ...sessionExport, error: error ?? "" }
 }
 
-function toJsonSafe(value: unknown, seen = new WeakSet<object>()): JsonValue {
-  if (value === null) return null
-  if (typeof value === "string" || typeof value === "boolean") return value
-  if (typeof value === "number") return Number.isFinite(value) ? value : String(value)
-  if (typeof value === "bigint") return value.toString()
-  if (typeof value === "undefined" || typeof value === "function" || typeof value === "symbol") return String(value)
-  if (typeof value !== "object") return String(value)
-  if (seen.has(value)) return "[Circular]"
-  seen.add(value)
-  if (Array.isArray(value)) {
-    const result = value.map((item) => toJsonSafe(item, seen))
-    seen.delete(value)
-    return result
-  }
-  const result: { [key: string]: JsonValue } = {}
-  for (const [key, nested] of Object.entries(value)) result[key] = toJsonSafe(nested, seen)
-  seen.delete(value)
-  return result
-}
-
-function sanitizeSessionExport(sessionExport: SessionExport): SafeSessionExport {
+function sanitizeSessionExport(sessionExport: SessionExport, redact: Redactor): SafeSessionExport {
   if (sessionExport.status === "none") return sessionExport
-  if (sessionExport.status === "failed") return sessionExport
+  if (sessionExport.status === "failed") return { status: "failed", error: redact(sessionExport.error) }
   return {
     status: "ok",
-    info: toJsonSafe(sessionExport.info),
-    messages: sessionExport.messages.map((message) => toJsonSafe(message)),
+    info: sanitizeSessionInfo(sessionExport.info, { redact }),
+    messages: sanitizeSessionMessages(sessionExport.messages, { redact }),
+  }
+}
+
+// Redact a value that should be text but, coming from the untyped IPC boundary, might not be. A
+// non-string is JSON-serialized (deep-scrubbed first) so a secret nested in a stray object value is
+// still removed rather than passed through by redact()'s non-string no-op.
+function redactField(value: unknown, redact: Redactor): string {
+  if (typeof value === "string") return redact(value)
+  return redact(JSON.stringify(redactJsonValue(toJsonSafe(value), redact)) ?? "")
+}
+
+function redactDiagnostics(diagnostics: ProblemReportDiagnostics, redact: Redactor): ProblemReportDiagnostics {
+  return {
+    ...diagnostics,
+    route: redact(diagnostics.route),
+    directory: diagnostics.directory === null ? null : redact(diagnostics.directory),
+    sessionID: diagnostics.sessionID === null ? null : redact(diagnostics.sessionID),
+    logPath: redact(diagnostics.logPath),
+  }
+}
+
+// Renderer diagnostics pass a strict upstream allowlist, but that allowlist keeps trace/session IDs
+// and `data` as plain strings without stripping emails, paths, or secrets. Run the structured
+// redactor over the WHOLE event (every top-level string field AND every data key/value), so the
+// renderer slice carries the same redaction guarantee the rest of the report has. event.name (used
+// later for incident filtering) is an enum the redactor leaves untouched.
+function redactRendererDiagnostics(slice: RendererDiagnosticsSlice, redact: Redactor): RendererDiagnosticsSlice {
+  return {
+    ...slice,
+    events: slice.events.map((event) => redactJsonValue(toJsonSafe(event), redact) as RendererDiagnosticEvent),
+    // summary.statuses is a fixed enum on the production path, but scrub it too so the guarantee
+    // covers the whole slice, not only events.
+    summary: redactJsonValue(toJsonSafe(slice.summary), redact) as RendererDiagnosticsSlice["summary"],
   }
 }
 
@@ -208,14 +231,26 @@ export function buildProblemReport(input: Input, options: Options = {}) {
   const generatedAt = options.generatedAt ?? new Date().toISOString()
   if (reportId.trim().length === 0) throw new Error("reportId must be a non-empty string")
   if (!isCanonicalIsoTimestamp(generatedAt)) throw new Error("generatedAt must be a valid ISO timestamp")
-  const sessionExport = sanitizeSessionExport(input.sessionExport)
-  let diagnostics = input.diagnostics
-  let logTail = input.logTail
+  // Redact before truncation: cutting first could split a secret across the boundary, and the
+  // ladder only ever drops or shortens already-redacted data.
+  const redact = makeRedactor(options.redactTerms)
+  const sessionExport = sanitizeSessionExport(input.sessionExport, redact)
+  const redactedDiagnostics = redactDiagnostics(input.diagnostics, redact)
+  let diagnostics = redactedDiagnostics
+  let logTail = redact(input.logTail)
   let messages = sessionMessages(sessionExport)
   let sessionInfo = sessionExport.status === "ok" ? sessionExport.info : undefined
   let failedExportError = sessionExport.status === "failed" ? sessionExport.error : undefined
   let rendererDiagnostics = input.rendererDiagnostics
+    ? redactRendererDiagnostics(input.rendererDiagnostics, redact)
+    : undefined
   let rendererError = input.rendererError
+    ? // Construct from the two known fields only — never spread the IPC input, which is untyped at
+      // the boundary and could carry extra unredacted fields. Each field is coerced through the
+      // redactor as text even when the runtime value is not a string (redact() no-ops on non-strings,
+      // so a stray object value would otherwise pass un-scrubbed).
+      { summary: redactField(input.rendererError.summary, redact), details: redactField(input.rendererError.details, redact) }
+    : undefined
   let omittedMessages = 0
   let omittedLogBytes = 0
   let omittedSessionInfoBytes = 0
@@ -314,8 +349,8 @@ export function buildProblemReport(input: Input, options: Options = {}) {
 
   let diagnosticStringLimit = 512
   while (bytes(output) > maxBytes && diagnosticStringLimit >= 0) {
-    diagnostics = truncateDiagnostics(input.diagnostics, diagnosticStringLimit)
-    omittedDiagnosticsBytes = Math.max(0, jsonBytes(input.diagnostics) - jsonBytes(diagnostics))
+    diagnostics = truncateDiagnostics(redactedDiagnostics, diagnosticStringLimit)
+    omittedDiagnosticsBytes = Math.max(0, jsonBytes(redactedDiagnostics) - jsonBytes(diagnostics))
     output = markdown(makePayload())
     if (diagnosticStringLimit === 0) break
     diagnosticStringLimit = Math.floor(diagnosticStringLimit / 2)
@@ -345,13 +380,20 @@ function oneLine(value: string) {
   return (value.split(/\r?\n/)[0] ?? "").replace(/\s+/g, " ").trim()
 }
 
+// The clipboard summary is the same outbound channel as the report file, so it gets the full
+// secret scrubber too. Path/storage fragments run first (keeps the [storage] .dat shape), then the
+// shared redactor strips tokens, Bearer/basic-auth, and emails the old summary rules missed.
+const summaryRedactor = makeRedactor()
+
 function redactLocalPathFragments(value: string) {
-  return value
-    .replace(/[A-Za-z]:\\[^\r\n]*/g, "[path]")
-    .replace(/\\\\[^\\\s]+\\[^\r\n]*/g, "[path]")
-    .replace(/\/(?:Users|home|tmp|var\/folders|private\/tmp)\/[^\r\n]*/g, "[path]")
-    .replace(/\bpawwork\.workspace\.[\w.-]+\.dat\b/gi, "[storage]")
-    .replace(/\b(storage|key)\s*=\s*[^,\s]+/gi, "$1=[redacted]")
+  return summaryRedactor(
+    value
+      .replace(/[A-Za-z]:\\[^\r\n]*/g, "[path]")
+      .replace(/\\\\[^\\\s]+\\[^\r\n]*/g, "[path]")
+      .replace(/\/(?:Users|home|tmp|var\/folders|private\/tmp)\/[^\r\n]*/g, "[path]")
+      .replace(/\bpawwork\.workspace\.[\w.-]+\.dat\b/gi, "[storage]")
+      .replace(/\b(storage|key)\s*=\s*[^,\s]+/gi, "$1=[redacted]"),
+  )
 }
 
 function truncateSummaryLine(value: string, maxChars: number) {


### PR DESCRIPTION
## Summary

Add structure-aware privacy redaction to the "Prepare Diagnostics Package" export — PR1 of the diagnostics-package rebuild (#1465). Two redaction regimes, chosen by data shape, applied to **every** report component (diagnostics, `logTail`, `sessionExport` info + messages, `rendererDiagnostics`, `rendererError`, and the clipboard summary):

- **Structured session data → allowlist** (`sanitizeSessionMessages`, `sanitizeSessionInfo`): keep role / time / part-type / tool-name / byte-size + a per-part length-capped body; omit the system prompt; drop unknown shapes (reported as `{ unrecognized, bytes }`, never passed through); drop diffs / permission / share. A final `redactJsonValue` pass scrubs every surviving string **and object key**, and redacts a value wholesale when its field name is sensitive (`apiKey`, `clientSecret`, `Authorization`, … — `tokens` / `tokenizer` usage counts are deliberately preserved).
- **Free text → best-effort blacklist** (`makeRedactor`): PEM/PGP private keys, URL basic-auth (all userinfo forms), JWT, provider token prefixes, `Authorization: Basic/Bearer`, named credential assignments, cookies, absolute paths, and emails (incl. local domains). The OS **username and home dir are always redacted as exact terms** — the hard identity guarantee.

**Known path / structured fields are shape-tokened, not regex-guessed** (the path regex only catches allowlisted roots, so a non-listed root would leak the project/dir name):

- `diagnostics.directory` / `diagnostics.logPath` → `[path]` wholesale.
- file part `source.path` → `[path]` wholesale.
- session `executionContext` → field allowlist: every directory/worktree path → `[path]`, worktree `name`/`branch` kept (capped + scrubbed), unknown fields dropped (previously the whole subtree was spread through).
- the clipboard summary now shares the **same exact runtime redact terms** (OS username, home dir) as the full report, so a bare username can no longer survive there.

## Why

A Windows user exported a problem report that **leaked private data** and was unreviewable. `rendererDiagnostics` already used a strict allowlist, but `logTail` and `sessionExport.messages` had **zero redaction** — API keys, `Bearer …`, `C:\Users\<name>\…`, usernames, and emails went straight into the file the user hands us. Several **known** path/structured fields were also redacted only by regex (allowlisted roots), so a path under a non-listed root or a newly added `executionContext` field leaked the project/dir name; and the clipboard summary did not apply the username/home exact terms.

This is privacy redaction first, standalone and format-agnostic. Size budgets (PR2 #1471), flow + in-app review panel (PR3 #1472), and structural cleanup (PR4) follow.

## Related Issue

Refs #1465 (umbrella). This is PR1; PR2 #1471 and PR3 #1472 follow.

## Human Review Status

`Pending`

## Review Focus

- Whether the allowlist + shape-token approach actually closes the leaks, especially the structured path fields (`diagnostics.directory`/`logPath`, file `source.path`, `executionContext`) under a non-allowlisted root.
- The `executionContext` field allowlist: paths → `[path]`, worktree `name`/`branch` kept, unknown fields dropped — confirm nothing useful is lost and nothing identifying is kept.
- The best-effort free-text blacklist residual and whether the documented boundary is acceptable (the in-app review panel in PR3 is the human backstop).
- Prior review: the original PR went through 9 `/codex` rounds (final fresh-eye, no P0/P1). This revision additionally addresses the Web GPT Pro "needs fixes" verdict and CodeRabbit's 4 Major path-field findings (all 3 review threads resolved).

## Risk Notes

- The free-text blacklist is **best-effort** (covers enumerable secret/path shapes, not every possible one); the **in-app review panel (PR3) is the backstop** and the UI copy will not over-promise.
- Free-text path redaction is root-allowlist + identity-terms (a universal `/a/b` matcher would shred the diagnostics route and URLs); a non-allowlisted-root, identity-free path (e.g. a CI path) may remain in free text — it carries no secret or identity. Known **structured** path fields are now shape-tokened regardless of root.
- ReDoS: all unanchored greedy quantifiers are length-bounded (a 200k-char input dropped from ~18s to ~12ms).
- Platform: redaction handles Windows `C:\`, UNC `\\server\…`, and POSIX path shapes; considered macOS + Windows.
- **No visible UI in this PR** (the in-app review panel is PR3 #1472) — the UI/copy checklist item below is left unticked for that reason, and there are no screenshots.

## How To Verify

```text
bun test (packages/desktop-electron) — 626 pass, 0 fail
bun run typecheck (packages/desktop-electron, tsgo -b) — clean
eslint (changed source files) — clean
Redaction gate (problem-report-redact.test.ts): asserts no seeded secret/path/username/email
  survives the full report. New regressions cover non-allowlisted roots (diagnostics
  directory/logPath, file source.path), the executionContext allowlist (paths→[path],
  worktree name/branch kept, unknown fields dropped), and clipboard-summary redactTerms sharing.
```

## Screenshots or Recordings

None — no visible UI in this PR (the in-app review panel is PR3 #1472).

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

https://claude.ai/code/session_011KyY9wTxQu9oZLy4yPEi3W


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic redaction of sensitive information in problem reports, including credentials, paths, usernames, and tokens
  * Improved privacy by sanitizing session data and error diagnostics before generation

* **Tests**
  * Expanded test coverage for redaction and data sanitization pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->