### PR TITLE
fix(desktop): bound problem report size with per-component byte budgets

### DIFF
--- a/packages/desktop-electron/src/main/logging.test.ts
+++ b/packages/desktop-electron/src/main/logging.test.ts
@@ -141,4 +141,42 @@ describe("desktop logging", () => {
     expect(tail).toContain("Backend log")
     expect(tail).toContain("backend failed")
   })
+
+  test("bounds the tail to the most recent bytes of a large file", async () => {
+    logDir = mkdtempSync(join(tmpdir(), "pawwork-logging-test-"))
+    const mainPath = join(logDir, "main.log")
+    // Larger than the 512 KB byte cap so the oldest content falls outside the tail.
+    const filler = Array.from({ length: 60_000 }, (_, i) => `entry ${i}`).join("\n")
+    writeFileSync(mainPath, ["OLDEST_LINE", filler, "NEWEST_LINE"].join("\n"))
+    fakeLog.transports.file = {
+      maxSize: 0,
+      getFile: () => ({ path: mainPath }),
+    }
+
+    const { diagnosticsLogTail } = await import(`./logging?logging-test=${crypto.randomUUID()}`)
+    const tail = diagnosticsLogTail({})
+
+    expect(tail).toContain("NEWEST_LINE")
+    expect(tail).not.toContain("OLDEST_LINE")
+    // The main-log section is bounded by the byte-tail read (plus the section header), not the file.
+    expect(Buffer.byteLength(tail, "utf8")).toBeLessThanOrEqual(512 * 1024 + 4_096)
+  })
+
+  test("drops a mid-line fragment instead of emitting it before redaction", async () => {
+    logDir = mkdtempSync(join(tmpdir(), "pawwork-logging-test-"))
+    const mainPath = join(logDir, "main.log")
+    // A single line larger than the 512 KB byte cap with no newline: the byte tail starts mid-line.
+    // Emitting that fragment would feed redaction a prefix-less secret, so it must be dropped.
+    writeFileSync(mainPath, "S".repeat(600_000))
+    fakeLog.transports.file = {
+      maxSize: 0,
+      getFile: () => ({ path: mainPath }),
+    }
+
+    const { diagnosticsLogTail } = await import(`./logging?logging-test=${crypto.randomUUID()}`)
+    const tail = diagnosticsLogTail({})
+
+    expect(tail).toContain("(empty)")
+    expect(tail).not.toContain("S".repeat(100))
+  })
 })

--- a/packages/desktop-electron/src/main/logging.ts
+++ b/packages/desktop-electron/src/main/logging.ts
@@ -1,9 +1,14 @@
 import log from "electron-log/main.js"
-import { readFileSync, readdirSync, statSync, unlinkSync } from "node:fs"
+import { closeSync, fstatSync, openSync, readdirSync, readSync, statSync, unlinkSync } from "node:fs"
 import { dirname, join } from "node:path"
 
 const MAX_LOG_AGE_DAYS = 7
 const TAIL_LINES = 1000
+// Read at most this many bytes from the END of each log file. The main log rotates at 5 MB (maxSize
+// below), but the backend log path is external and unbounded — without this a multi-GB log would
+// load fully into memory just to take the tail. This also bounds any single line, so no separate
+// per-line cap is needed (and a pre-redaction per-line cut would risk slicing a secret's prefix off).
+const TAIL_MAX_BYTES = 512 * 1024
 const CONSOLE_TRANSPORT_INITIALIZED = Symbol.for("pawwork.consoleTransportInitialized")
 
 export function initLogging() {
@@ -29,10 +34,39 @@ export function diagnosticsLogTail(input: { backendLogPath?: string | null } = {
   return sections.join("\n\n")
 }
 
+// Read up to maxBytes from the end of the file without loading the whole thing. truncatedHead is
+// true when the file was larger, so the caller can drop the (likely partial) first line.
+function readTailBytes(path: string, maxBytes: number): { text: string; truncatedHead: boolean } {
+  let fd: number | undefined
+  try {
+    fd = openSync(path, "r")
+    const size = fstatSync(fd).size
+    const readBytes = Math.min(size, maxBytes)
+    const start = size - readBytes
+    const buffer = Buffer.allocUnsafe(readBytes)
+    let offset = 0
+    while (offset < readBytes) {
+      const read = readSync(fd, buffer, offset, readBytes - offset, start + offset)
+      if (read <= 0) break
+      offset += read
+    }
+    return { text: buffer.toString("utf8", 0, offset), truncatedHead: start > 0 }
+  } finally {
+    if (fd !== undefined) closeSync(fd)
+  }
+}
+
 function tailFile(path: string): string {
   try {
-    const contents = readFileSync(path, "utf8")
-    const lines = contents.split("\n")
+    const { text, truncatedHead } = readTailBytes(path, TAIL_MAX_BYTES)
+    const lines = text.split("\n")
+    // Started mid-file: the first line is a fragment (and may begin on a split multibyte char). Drop it
+    // even when it is the only line, so only COMPLETE lines are emitted — emitting a mid-line fragment,
+    // or head-cutting a long line here (before redaction), could leave a token with its recognizable
+    // prefix sliced off so the downstream redactor no longer matches it. A multi-line secret whose
+    // header (e.g. a PEM key's BEGIN) is stranded outside the window is handled at the redaction layer,
+    // which scrubs bare base64 key bodies directly (problem-report-redact.ts) — not by line surgery here.
+    if (truncatedHead) lines.shift()
     return lines.slice(Math.max(0, lines.length - TAIL_LINES)).join("\n")
   } catch {
     return ""

--- a/packages/desktop-electron/src/main/problem-report-redact.test.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.test.ts
@@ -139,6 +139,91 @@ describe("makeRedactor", () => {
     expect(redact("url https://:plainsecretvalue@127.0.0.1/api")).not.toContain("plainsecretvalue")
   })
 
+  test("redacts a bare multi-line base64 key body whose BEGIN header was truncated away", () => {
+    // A pre-redaction log tail can strand a key body without its header; the body-shape rule catches it.
+    const body = Array.from({ length: 8 }, () => "MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3").join("\n")
+    const out = redact(`some log line\n${body}\nmore log`)
+    expect(out).not.toContain("MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3")
+    expect(out).toContain("[redacted-key-body]")
+    expect(out).toContain("some log line")
+    expect(out).toContain("more log")
+  })
+
+  test("redacts a stranded key body after PGP armor / encrypted-PEM header lines", () => {
+    // Header-agnostic: the body rule matches the base64 directly, so Version/Proc-Type lines don't shield it.
+    const body = Array.from({ length: 8 }, () => "lQOYBFB2k3IBCADHmQE7AgEAAkEAq2u3MIIBVQIBADANBgkqhkiG9w0").join("\n")
+    const pgp = redact(`Version: GnuPG v2\nComment: a comment\n\n${body}`)
+    expect(pgp).toContain("[redacted-key-body]")
+    expect(pgp).not.toContain("lQOYBFB2k3IBCADHmQE7AgEAAkEAq2u3MIIBVQIBADANBgkqhkiG9w0")
+    const enc = redact(`Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,FEED\n\n${body}`)
+    expect(enc).toContain("[redacted-key-body]")
+  })
+
+  test("redacts a CRLF base64 key body", () => {
+    const body = Array.from({ length: 8 }, () => "MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3").join("\r\n")
+    expect(redact(body)).toContain("[redacted-key-body]")
+  })
+
+  test("redacts a single stranded body line terminated by an orphaned private-key END", () => {
+    // BEGIN truncated away, only one full body line + a short line + END survive: the END signals a key,
+    // so the body is redacted even though the multi-line block rule alone would not fire on one line.
+    const full = "MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3"
+    const out = redact([full, "AQAB", "-----END RSA PRIVATE KEY-----"].join("\n"))
+    expect(out).toContain("[redacted-key]")
+    expect(out).not.toContain(full)
+    // A public certificate END is not a secret marker — its body is left intact.
+    const cert = redact(["aGVsbG8gd29ybGQgZm9vYmFyYmF6", "-----END CERTIFICATE-----"].join("\n"))
+    expect(cert).toContain("aGVsbG8gd29ybGQgZm9vYmFyYmF6")
+  })
+
+  test("redacts a body and END that share one physical line (newline-stripped serialization)", () => {
+    const body = "MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3"
+    const out = redact(`${body}-----END RSA PRIVATE KEY-----`)
+    expect(out).toContain("[redacted-key]")
+    expect(out).not.toContain(body)
+  })
+
+  test("redacts a stranded PGP body whose END is preceded by a =CRC checksum line", () => {
+    // ASCII-armored PGP keys end the body with a "=<4 base64 chars>" CRC-24 line before the END.
+    // That line starts with "=", so the body/short-line groups can't traverse it; the rule must hop it.
+    const body = "MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3"
+    const out = redact([body, "=aBcD", "-----END PGP PRIVATE KEY BLOCK-----"].join("\n"))
+    expect(out).toContain("[redacted-key]")
+    expect(out).not.toContain(body)
+    // Armor headers above the body are not secret and stay; everything from the body through END goes.
+    const armored = redact(
+      ["Version: GnuPG v2", "", body, "=aBcD", "-----END PGP PRIVATE KEY BLOCK-----"].join("\n"),
+    )
+    expect(armored).toContain("Version: GnuPG v2")
+    expect(armored).toContain("[redacted-key]")
+    expect(armored).not.toContain(body)
+  })
+
+  test("redacts full body lines even when the last line is short (e.g. the AQAB exponent)", () => {
+    // A PEM body's final line is usually < 16 chars; it must not prevent matching the full lines above it.
+    const full = "MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3"
+    const out = redact([full, full, full, "AQAB"].join("\n"))
+    expect(out).toContain("[redacted-key-body]")
+    expect(out).not.toContain(full)
+  })
+
+  test("does not redact a single base64 line or inline base64 (a kept token/hash stays diagnostic)", () => {
+    // One base64 line is a token/id/hash; only a multi-line block is treated as a key body.
+    const inline = "id MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7 done"
+    expect(redact(inline)).toBe(inline)
+    const single = "MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3"
+    expect(redact(single)).toBe(single)
+    // A following plain word is not swallowed into the block.
+    expect(redact([single, single, "done note"].join("\n"))).toContain("done note")
+  })
+
+  test("does not backtrack on a long unbroken base64 run (no ReDoS)", () => {
+    const huge = "A".repeat(300_000)
+    const start = performance.now()
+    redact(huge)
+    expect(performance.now() - start).toBeLessThan(1_000)
+  })
+
   test("redacts an over-long basic-auth password to an IP host (no length cap on the credential)", () => {
     const longPass = "S".repeat(300)
     expect(redact(`url https://user:${longPass}@127.0.0.1/api`)).not.toContain(longPass)
@@ -464,6 +549,8 @@ describe("sanitizeSessionInfo", () => {
 
 describe("buildProblemReport redaction gate", () => {
   test("the full uploaded report contains no seeded secret, path, username, or email", () => {
+    // A private-key body whose BEGIN header was stranded outside a pre-redaction log-tail truncation.
+    const strandedKeyBody = "MIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEAq2u3leiyKeyBody"
     const logTail = [
       `anthropic ${TOKENS.anthropic}`,
       `aws ${TOKENS.aws} google ${TOKENS.google}`,
@@ -475,6 +562,10 @@ describe("buildProblemReport redaction gate", () => {
       `url https://${USERNAME}:${TOKENS.basicPass}@internal.example.com/api`,
       `email ${EMAIL}`,
       `paths ${Object.values(PATHS).join(" ")}`,
+      strandedKeyBody,
+      strandedKeyBody,
+      strandedKeyBody,
+      strandedKeyBody,
     ].join("\n")
 
     const report = buildProblemReport(
@@ -553,6 +644,8 @@ describe("buildProblemReport redaction gate", () => {
     for (const sample of samples) {
       expect(report.markdown, sample).not.toContain(sample)
     }
+    // A bare key body stranded in the log tail (header truncated away) is scrubbed end-to-end.
+    expect(report.markdown).not.toContain(strandedKeyBody)
     // The rogue rendererError field was dropped, not carried through.
     expect(report.markdown).not.toContain("extra-field-secret-7f3a")
     // The renderer summary (not just events) is scrubbed.

--- a/packages/desktop-electron/src/main/problem-report-redact.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.ts
@@ -63,6 +63,34 @@ const SECRET_REPLACERS: Array<(value: string) => string> = [
       /-----BEGIN[A-Z0-9 ]{0,40}PRIVATE[A-Z0-9 ]{0,40}-----[\s\S]*?(?:-----END[A-Z0-9 ]{0,40}-----|$)/g,
       "[redacted-key]",
     ),
+  // Bare multi-line base64 block (the wrapped body of a PEM/PGP key). The BEGIN-keyed rule above only
+  // fires when the header is present, but a pre-redaction truncation of an unbounded log (logging.ts
+  // byte/line tail) can strand a key body without its BEGIN — leaving headerless base64 the rule misses.
+  // Matching the body shape directly is header-agnostic: it covers a body stranded after armor lines
+  // (PGP Version/Comment, encrypted-PEM Proc-Type/DEK-Info), with or without an END, and CRLF logs. The
+  // run is >= 2 WHOLE lines of only base64 (>= 16 chars each), so a single base64 line (a token/hash/id
+  // kept for diagnostics) and inline base64 (a quoted literal) are untouched. Every MATCHED line needs
+  // >= 16 chars so a trailing word ("done") is never eaten; the line-start anchor plus the per-line
+  // length floor keep it linear (no catastrophic backtracking on a long non-base64 run). This runs
+  // before the orphan-END rule so a long body is consumed here as one match, not chewed line by line.
+  (v) =>
+    v.replace(
+      /(^|\n)(?:[A-Za-z0-9+/]{16,}={0,2}\r?\n){1,}[A-Za-z0-9+/]{16,}={0,2}(?=\r?\n|$)/g,
+      "$1[redacted-key-body]",
+    ),
+  // Orphaned private-key END: the BEGIN rule consumed every complete BEGIN..END block, so a surviving
+  // "-----END ... PRIVATE ... -----" had its BEGIN truncated away. Redact the contiguous body above it
+  // through the END — this catches even a SINGLE stranded body line that the >= 2-line block rule misses
+  // (the END is the signal). The body can be preceding whole lines, a short final line, an optional PGP
+  // "=CRC" checksum line, and a same-physical-line base64 run right before the END (a log that serialized
+  // the key without a newline between body and END). Anchored at a line start with per-line length floors
+  // so it stays linear; only a PRIVATE END triggers it (a public CERTIFICATE body is not secret), and a
+  // real private-key END never follows unrelated base64, so the body match cannot eat legitimate content.
+  (v) =>
+    v.replace(
+      /(^|\n)(?:[A-Za-z0-9+/]{16,}={0,2}\r?\n)*(?:[A-Za-z0-9+/]{1,}={0,2}\r?\n)?(?:=[A-Za-z0-9+/]{1,6}\r?\n)?[ \t]*[A-Za-z0-9+/]*={0,2}[ \t]*-----END[A-Z0-9 ]{0,40}PRIVATE[A-Z0-9 ]{0,40}-----/g,
+      "$1[redacted-key]",
+    ),
   // URL basic-auth credentials. The username is optional ([^/@\s:]*) so `scheme://:pass@host` and
   // IP hosts are covered, not only `scheme://user:pass@host`. ONLY the scheme length is bounded
   // ([a-z0-9+.-]{0,40}): the scheme is unanchored, so an unbounded greedy run scans for "://" from

--- a/packages/desktop-electron/src/main/problem-report.test.ts
+++ b/packages/desktop-electron/src/main/problem-report.test.ts
@@ -406,6 +406,8 @@ describe("problem report", () => {
     const payload = parseProblemReportPayload(report.markdown)
     expect(payload.rendererError?.summary).toBe("large renderer error")
     expect(payload.rendererError?.details.length).toBeLessThan(details.length)
+    // The ledger reflects what the overall ladder removed too, not only the component-budget cut.
+    expect(payload.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
   })
 
   test("truncates renderer diagnostics events to honor max bytes", () => {
@@ -551,9 +553,11 @@ describe("problem report", () => {
         sessionExport: { status: "none" },
         truncation: {
           omittedMessages: 0,
+          omittedMessagePartsBytes: 0,
           omittedLogBytes: 0,
           omittedSessionInfoBytes: 0,
           omittedFailedExportErrorBytes: 0,
+          omittedRendererErrorBytes: 0,
           omittedRendererDiagnosticsBytes: 0,
           omittedDiagnosticsBytes: 0,
         },
@@ -580,9 +584,11 @@ describe("problem report", () => {
         sessionExport: { status: "none" },
         truncation: {
           omittedMessages: 0,
+          omittedMessagePartsBytes: 0,
           omittedLogBytes: 0,
           omittedSessionInfoBytes: 0,
           omittedFailedExportErrorBytes: 0,
+          omittedRendererErrorBytes: 0,
           omittedRendererDiagnosticsBytes: 0,
           omittedDiagnosticsBytes: 0,
         },
@@ -608,9 +614,11 @@ describe("problem report", () => {
         sessionExport: { status: "none" },
         truncation: {
           omittedMessages: 0,
+          omittedMessagePartsBytes: 0,
           omittedLogBytes: 0,
           omittedSessionInfoBytes: 0,
           omittedFailedExportErrorBytes: 0,
+          omittedRendererErrorBytes: 0,
           omittedRendererDiagnosticsBytes: 0,
           omittedDiagnosticsBytes: 0,
         },
@@ -634,9 +642,11 @@ describe("problem report", () => {
         sessionExport: { status: "none" },
         truncation: {
           omittedMessages: 0,
+          omittedMessagePartsBytes: 0,
           omittedLogBytes: 0,
           omittedSessionInfoBytes: 0,
           omittedFailedExportErrorBytes: 0,
+          omittedRendererErrorBytes: 0,
           omittedRendererDiagnosticsBytes: 0,
           omittedDiagnosticsBytes: 0,
         },
@@ -658,9 +668,11 @@ describe("problem report", () => {
         sessionExport: { status: "none" },
         truncation: {
           omittedMessages: 0,
+          omittedMessagePartsBytes: 0,
           omittedLogBytes: 0,
           omittedSessionInfoBytes: 0,
           omittedFailedExportErrorBytes: 0,
+          omittedRendererErrorBytes: 0,
           omittedRendererDiagnosticsBytes: 0,
           omittedDiagnosticsBytes: 0,
         },
@@ -669,5 +681,230 @@ describe("problem report", () => {
     ].join("\n")
 
     expect(() => parseProblemReportPayload(report)).toThrow("Problem report JSON block not found")
+  })
+})
+
+describe("component budgets", () => {
+  test("caps the log tail to its component budget even under a large overall limit", () => {
+    const lines = ["OLDEST_LINE", ...Array.from({ length: 500 }, (_, i) => `log line ${i}`), "NEWEST_LINE"]
+    const report = buildProblemReport(
+      { ...base, logTail: lines.join("\n") },
+      { budgets: { logTailBytes: 200 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(Buffer.byteLength(payload.logTail, "utf8")).toBeLessThanOrEqual(200)
+    expect(payload.truncation.omittedLogBytes).toBeGreaterThan(0)
+    // Keeps the most recent lines, drops the oldest.
+    expect(payload.logTail).toContain("NEWEST_LINE")
+    expect(payload.logTail).not.toContain("OLDEST_LINE")
+  })
+
+  test("drops oldest session messages to honor the session budget under a large overall limit", () => {
+    const messages = Array.from({ length: 30 }, (_, i) => ({
+      info: { id: `msg_${i}`, sessionID: "ses_1", role: "user", time: { created: i } },
+      parts: [
+        {
+          id: `p_${i}`,
+          sessionID: "ses_1",
+          messageID: `msg_${i}`,
+          type: "text",
+          text: `${i === 0 ? "OLDESTMSG " : i === 29 ? "NEWESTMSG " : ""}body ${"x".repeat(200)}`,
+        },
+      ],
+    }))
+    const report = buildProblemReport(
+      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
+      { budgets: { sessionMessagesBytes: 1_500 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(payload.truncation.omittedMessages).toBeGreaterThan(0)
+    const kept = payload.sessionExport.status === "ok" ? JSON.stringify(payload.sessionExport.messages) : ""
+    expect(kept).toContain("NEWESTMSG")
+    expect(kept).not.toContain("OLDESTMSG")
+  })
+
+  test("trims parts of a single oversized message so one turn can't blow the session budget", () => {
+    const parts = Array.from({ length: 200 }, (_, i) => ({
+      id: `p_${i}`,
+      sessionID: "ses_1",
+      messageID: "msg_big",
+      type: "text",
+      text: `part ${i} ${"x".repeat(500)}`,
+    }))
+    const messages = [{ info: { id: "msg_big", sessionID: "ses_1", role: "assistant", time: { created: 1 } }, parts }]
+    const report = buildProblemReport(
+      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
+      { budgets: { sessionMessageBytes: 4_000 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
+    expect(kept.length).toBe(1)
+    const message = kept[0] as { omittedParts?: number }
+    expect(message.omittedParts).toBeGreaterThan(0)
+    expect(Buffer.byteLength(JSON.stringify(message), "utf8")).toBeLessThanOrEqual(4_000)
+    // Keeps the earliest parts (the start of the turn).
+    expect(JSON.stringify(message)).toContain("part 0 ")
+    // The in-message trim is also reflected in the top-level ledger.
+    expect(payload.truncation.omittedMessagePartsBytes).toBeGreaterThan(0)
+  })
+
+  test("keeps the recent tail of an oversized log line that ends in a newline", () => {
+    const report = buildProblemReport(
+      { ...base, logTail: `${"X".repeat(2_000)}\n` },
+      { budgets: { logTailBytes: 1_000 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    // A trailing newline must not collapse the result to an empty string; the recent bytes survive.
+    expect(payload.logTail.length).toBeGreaterThan(0)
+    expect(Buffer.byteLength(payload.logTail, "utf8")).toBeLessThanOrEqual(1_000)
+    expect(payload.truncation.omittedLogBytes).toBeGreaterThan(0)
+  })
+
+  test("bounds a single message with no parts but oversized info (true session cap)", () => {
+    const messages = [
+      {
+        info: { id: "msg_big", sessionID: "ses_1", role: "user", time: { created: 1, blob: "z".repeat(40_000) } },
+        parts: [],
+      },
+    ]
+    const report = buildProblemReport(
+      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
+      { budgets: { sessionMessageBytes: 2_000, sessionMessagesBytes: 2_000 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
+    expect(Buffer.byteLength(JSON.stringify(kept), "utf8")).toBeLessThanOrEqual(2_000)
+    // The oversized info was reduced to a stub rather than smuggled past the budget.
+    expect(JSON.stringify(kept)).not.toContain("z".repeat(100))
+    expect((kept[0] as { oversized?: boolean }).oversized).toBe(true)
+  })
+
+  test("byte-caps the stub identity so an oversized id can't escape under default budgets", () => {
+    const messages = [
+      { info: { id: `msg_${"x".repeat(1_200_000)}`, sessionID: "ses_1", role: "user" }, parts: [{ type: "text", text: "b" }] },
+    ]
+    const report = buildProblemReport({
+      ...base,
+      sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages },
+    })
+
+    const payload = parseProblemReportPayload(report.markdown)
+    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
+    // Even the stub's id is byte-capped, so the whole session stays well under the default budget.
+    expect(Buffer.byteLength(JSON.stringify(kept), "utf8")).toBeLessThanOrEqual(4_096)
+    expect((kept[0] as { oversized?: boolean }).oversized).toBe(true)
+  })
+
+  test("byte-bounds a single oversized log line without splitting a multibyte char", () => {
+    const report = buildProblemReport(
+      { ...base, logTail: "é".repeat(5_000) },
+      { budgets: { logTailBytes: 999 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(Buffer.byteLength(payload.logTail, "utf8")).toBeLessThanOrEqual(999)
+    expect(payload.logTail).not.toContain("�")
+    expect(payload.truncation.omittedLogBytes).toBeGreaterThan(0)
+  })
+
+  test("caps renderer error details to its component budget under a large overall limit", () => {
+    const details = "stack frame\n".repeat(10_000)
+    const report = buildProblemReport(
+      { ...base, rendererError: { summary: "boom", details } },
+      { budgets: { rendererErrorDetailsBytes: 1_024 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(payload.rendererError?.summary).toBe("boom")
+    expect(Buffer.byteLength(payload.rendererError?.details ?? "", "utf8")).toBeLessThanOrEqual(1_024)
+    expect(payload.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
+    // Keeps the head (error message + top of the stack), the useful part of an error.
+    expect(payload.rendererError?.details.startsWith("stack frame")).toBe(true)
+  })
+
+  test("caps an oversized renderer error summary, not just details", () => {
+    // summary derives from error.message, which an API error can balloon; it must be budgeted too.
+    const summary = `boom ${"S".repeat(50_000)}`
+    const report = buildProblemReport(
+      { ...base, rendererError: { summary, details: "short" } },
+      { budgets: { rendererErrorDetailsBytes: 1_024 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(Buffer.byteLength(payload.rendererError?.summary ?? "", "utf8")).toBeLessThanOrEqual(1_024)
+    expect(payload.rendererError?.summary.startsWith("boom ")).toBe(true)
+    expect(payload.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
+  })
+
+  test("ignores a non-finite budget override instead of disabling the cap", () => {
+    const lines = ["OLDEST_LINE", ...Array.from({ length: 500 }, (_, i) => `log line ${i}`), "NEWEST_LINE"]
+    const report = buildProblemReport(
+      { ...base, logTail: lines.join("\n") },
+      { budgets: { logTailBytes: Number.NaN } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    // NaN falls back to the 1 MB default, which leaves this small log untouched (no silent disable).
+    expect(payload.logTail).toContain("OLDEST_LINE")
+    expect(payload.logTail).toContain("NEWEST_LINE")
+    expect(payload.truncation.omittedLogBytes).toBe(0)
+  })
+
+  test("honors the session budget as a hard cap even when the newest message does not fit", () => {
+    const messages = Array.from({ length: 5 }, (_, i) => ({
+      info: { id: `msg_${i}`, sessionID: "ses_1", role: "user", time: { created: i } },
+      parts: [{ id: `p_${i}`, sessionID: "ses_1", messageID: `msg_${i}`, type: "text", text: `body ${i}` }],
+    }))
+    const report = buildProblemReport(
+      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
+      // A near-zero session budget that even a single identity stub overflows.
+      { budgets: { sessionMessagesBytes: 10 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
+    // Hard cap: the message array fits the budget, dropping the newest rather than overflowing.
+    expect(Buffer.byteLength(JSON.stringify(kept), "utf8")).toBeLessThanOrEqual(10)
+    expect(payload.truncation.omittedMessages).toBe(5)
+  })
+
+  test("does not count part-trim bytes for a message the overall ladder later drops whole", () => {
+    const bigParts = Array.from({ length: 200 }, (_, i) => ({
+      id: `p_${i}`,
+      sessionID: "ses_1",
+      messageID: "msg_old",
+      type: "text",
+      text: `part ${i} ${"x".repeat(1000)}`,
+    }))
+    const messages = [
+      { info: { id: "msg_old", sessionID: "ses_1", role: "assistant", time: { created: 1 } }, parts: bigParts },
+      { info: { id: "msg_new", sessionID: "ses_1", role: "user", time: { created: 2 } }, parts: [{ type: "text", text: "hi" }] },
+    ]
+    const report = buildProblemReport(
+      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
+      // The old message is part-trimmed (to 50 KB) but survives the session cap; a small overall maxBytes
+      // then drops it whole in the fallback ladder. Its trimmed bytes must not stay in the ledger.
+      { maxBytes: 10_000, budgets: { sessionMessageBytes: 50_000, sessionMessagesBytes: 500_000 } },
+    )
+
+    const payload = parseProblemReportPayload(report.markdown)
+    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
+    expect(JSON.stringify(kept)).toContain("msg_new")
+    expect(JSON.stringify(kept)).not.toContain("msg_old")
+    expect(payload.truncation.omittedMessages).toBeGreaterThan(0)
+    // The dropped message's part-trim is not double-counted; the surviving message had no trim.
+    expect(payload.truncation.omittedMessagePartsBytes).toBe(0)
+  })
+
+  test("leaves a small report untouched under default budgets", () => {
+    const payload = parseProblemReportPayload(buildProblemReport(base).markdown)
+    expect(payload.truncation.omittedLogBytes).toBe(0)
+    expect(payload.truncation.omittedMessages).toBe(0)
+    expect(payload.truncation.omittedRendererErrorBytes).toBe(0)
   })
 })

--- a/packages/desktop-electron/src/main/problem-report.test.ts
+++ b/packages/desktop-electron/src/main/problem-report.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test"
-import { buildProblemReport, buildProblemReportSummary, parseProblemReportPayload } from "./problem-report"
+import {
+  buildProblemReport,
+  buildProblemReportSummary,
+  capLogTailBytes,
+  capMessageParts,
+  capSessionMessagesBytes,
+  headBytes,
+  parseProblemReportPayload,
+} from "./problem-report"
 
 const base = {
   diagnostics: {
@@ -684,104 +692,111 @@ describe("problem report", () => {
   })
 })
 
-describe("component budgets", () => {
-  test("caps the log tail to its component budget even under a large overall limit", () => {
+// The size caps live in pure, exported helpers so their small-budget edge cases can be exercised
+// directly with tiny inputs, instead of forcing a production `budgets` override that only tests used.
+describe("component budgets — pure helpers", () => {
+  test("capLogTailBytes keeps the most recent lines and drops the oldest", () => {
     const lines = ["OLDEST_LINE", ...Array.from({ length: 500 }, (_, i) => `log line ${i}`), "NEWEST_LINE"]
-    const report = buildProblemReport(
-      { ...base, logTail: lines.join("\n") },
-      { budgets: { logTailBytes: 200 } },
-    )
+    const result = capLogTailBytes(lines.join("\n"), 200)
+    expect(Buffer.byteLength(result.value, "utf8")).toBeLessThanOrEqual(200)
+    expect(result.omittedBytes).toBeGreaterThan(0)
+    expect(result.value).toContain("NEWEST_LINE")
+    expect(result.value).not.toContain("OLDEST_LINE")
+  })
 
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(Buffer.byteLength(payload.logTail, "utf8")).toBeLessThanOrEqual(200)
+  test("capLogTailBytes keeps the recent tail of an oversized single line that ends in a newline", () => {
+    // A trailing newline leaves an empty last "line"; the byte-accurate fallback must still keep bytes.
+    const result = capLogTailBytes(`${"X".repeat(2_000)}\n`, 1_000)
+    expect(result.value.length).toBeGreaterThan(0)
+    expect(Buffer.byteLength(result.value, "utf8")).toBeLessThanOrEqual(1_000)
+    expect(result.omittedBytes).toBeGreaterThan(0)
+  })
+
+  test("capLogTailBytes byte-bounds a single oversized line without splitting a multibyte char", () => {
+    const result = capLogTailBytes("é".repeat(5_000), 999)
+    expect(Buffer.byteLength(result.value, "utf8")).toBeLessThanOrEqual(999)
+    expect(result.value).not.toContain("�")
+    expect(result.omittedBytes).toBeGreaterThan(0)
+  })
+
+  test("headBytes keeps the head within the byte budget without splitting a multibyte char", () => {
+    const head = headBytes("é".repeat(5_000), 999)
+    expect(Buffer.byteLength(head, "utf8")).toBeLessThanOrEqual(999)
+    expect(head).not.toContain("�")
+    expect(head.startsWith("é")).toBe(true)
+  })
+
+  test("capMessageParts keeps the LATEST parts of an oversized message, trimming the oldest", () => {
+    const parts = Array.from({ length: 200 }, (_, i) => ({ id: `p_${i}`, type: "text", text: `part ${i} ${"x".repeat(500)}` }))
+    const message = { info: { id: "msg_big", role: "assistant" }, parts }
+    const result = capMessageParts(message, 4_000)
+    expect(Buffer.byteLength(JSON.stringify(result.value), "utf8")).toBeLessThanOrEqual(4_000)
+    expect(result.omittedBytes).toBeGreaterThan(0)
+    expect((result.value as { omittedParts?: number }).omittedParts).toBeGreaterThan(0)
+    // Keeps the end of the turn (the tool output / error nearest the failure), trimming the start.
+    expect(JSON.stringify(result.value)).toContain("part 199 ")
+    expect(JSON.stringify(result.value)).not.toContain("part 0 ")
+  })
+
+  test("capMessageParts reduces a message whose info alone overflows to an identity stub", () => {
+    const message = { info: { id: "msg_big", role: "user", time: { created: 1, blob: "z".repeat(40_000) } }, parts: [] }
+    const result = capMessageParts(message, 2_000)
+    expect(Buffer.byteLength(JSON.stringify(result.value), "utf8")).toBeLessThanOrEqual(2_000)
+    // The oversized info was reduced to a stub rather than smuggled past the budget.
+    expect(JSON.stringify(result.value)).not.toContain("z".repeat(100))
+    expect((result.value as { oversized?: boolean }).oversized).toBe(true)
+  })
+
+  test("capSessionMessagesBytes drops the oldest messages, keeping the most recent", () => {
+    const messages = Array.from({ length: 30 }, (_, i) => ({
+      info: { id: `msg_${i}`, role: "user", time: { created: i } },
+      parts: [{ type: "text", text: `${i === 0 ? "OLDESTMSG " : i === 29 ? "NEWESTMSG " : ""}body ${"x".repeat(200)}` }],
+    }))
+    const result = capSessionMessagesBytes(messages, 1_500)
+    expect(result.omittedMessages).toBeGreaterThan(0)
+    expect(Buffer.byteLength(JSON.stringify(result.messages), "utf8")).toBeLessThanOrEqual(1_500)
+    expect(JSON.stringify(result.messages)).toContain("NEWESTMSG")
+    expect(JSON.stringify(result.messages)).not.toContain("OLDESTMSG")
+  })
+
+  test("capSessionMessagesBytes is a hard cap: drops even the newest message that does not fit", () => {
+    const messages = Array.from({ length: 5 }, (_, i) => ({
+      info: { id: `msg_${i}`, role: "user", time: { created: i } },
+      parts: [{ type: "text", text: `body ${i}` }],
+    }))
+    const result = capSessionMessagesBytes(messages, 10)
+    expect(Buffer.byteLength(JSON.stringify(result.messages), "utf8")).toBeLessThanOrEqual(10)
+    expect(result.omittedMessages).toBe(5)
+  })
+})
+
+// A few end-to-end checks that the helpers above are actually wired into buildProblemReport with the
+// real default budgets (1 MB log / 1 MB session / 256 KB per message / 64 KB per renderer-error field).
+describe("component budgets — wired into buildProblemReport", () => {
+  test("caps the log tail to the default budget, keeping the most recent lines", () => {
+    const lines = ["OLDEST_LINE", ...Array.from({ length: 150_000 }, () => "log line"), "NEWEST_LINE"]
+    const payload = parseProblemReportPayload(buildProblemReport({ ...base, logTail: lines.join("\n") }).markdown)
+    expect(Buffer.byteLength(payload.logTail, "utf8")).toBeLessThanOrEqual(1024 * 1024)
     expect(payload.truncation.omittedLogBytes).toBeGreaterThan(0)
-    // Keeps the most recent lines, drops the oldest.
     expect(payload.logTail).toContain("NEWEST_LINE")
     expect(payload.logTail).not.toContain("OLDEST_LINE")
   })
 
-  test("drops oldest session messages to honor the session budget under a large overall limit", () => {
-    const messages = Array.from({ length: 30 }, (_, i) => ({
-      info: { id: `msg_${i}`, sessionID: "ses_1", role: "user", time: { created: i } },
-      parts: [
-        {
-          id: `p_${i}`,
-          sessionID: "ses_1",
-          messageID: `msg_${i}`,
-          type: "text",
-          text: `${i === 0 ? "OLDESTMSG " : i === 29 ? "NEWESTMSG " : ""}body ${"x".repeat(200)}`,
-        },
-      ],
-    }))
-    const report = buildProblemReport(
-      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
-      { budgets: { sessionMessagesBytes: 1_500 } },
-    )
-
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.truncation.omittedMessages).toBeGreaterThan(0)
-    const kept = payload.sessionExport.status === "ok" ? JSON.stringify(payload.sessionExport.messages) : ""
-    expect(kept).toContain("NEWESTMSG")
-    expect(kept).not.toContain("OLDESTMSG")
-  })
-
-  test("trims parts of a single oversized message so one turn can't blow the session budget", () => {
-    const parts = Array.from({ length: 200 }, (_, i) => ({
-      id: `p_${i}`,
-      sessionID: "ses_1",
-      messageID: "msg_big",
-      type: "text",
-      text: `part ${i} ${"x".repeat(500)}`,
-    }))
+  test("part-trims a single oversized message to the per-message budget, keeping its latest parts", () => {
+    const parts = Array.from({ length: 200 }, (_, i) => ({ id: `p_${i}`, type: "text", text: `part ${i} ${"x".repeat(2_000)}` }))
     const messages = [{ info: { id: "msg_big", sessionID: "ses_1", role: "assistant", time: { created: 1 } }, parts }]
-    const report = buildProblemReport(
-      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
-      { budgets: { sessionMessageBytes: 4_000 } },
+    const payload = parseProblemReportPayload(
+      buildProblemReport({ ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } }).markdown,
     )
-
-    const payload = parseProblemReportPayload(report.markdown)
     const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
     expect(kept.length).toBe(1)
     const message = kept[0] as { omittedParts?: number }
     expect(message.omittedParts).toBeGreaterThan(0)
-    expect(Buffer.byteLength(JSON.stringify(message), "utf8")).toBeLessThanOrEqual(4_000)
-    // Keeps the earliest parts (the start of the turn).
-    expect(JSON.stringify(message)).toContain("part 0 ")
-    // The in-message trim is also reflected in the top-level ledger.
+    expect(Buffer.byteLength(JSON.stringify(message), "utf8")).toBeLessThanOrEqual(256 * 1024)
+    // The latest parts (nearest the failure) survive; the start of the turn is trimmed.
+    expect(JSON.stringify(message)).toContain("part 199 ")
+    expect(JSON.stringify(message)).not.toContain("part 0 ")
     expect(payload.truncation.omittedMessagePartsBytes).toBeGreaterThan(0)
-  })
-
-  test("keeps the recent tail of an oversized log line that ends in a newline", () => {
-    const report = buildProblemReport(
-      { ...base, logTail: `${"X".repeat(2_000)}\n` },
-      { budgets: { logTailBytes: 1_000 } },
-    )
-
-    const payload = parseProblemReportPayload(report.markdown)
-    // A trailing newline must not collapse the result to an empty string; the recent bytes survive.
-    expect(payload.logTail.length).toBeGreaterThan(0)
-    expect(Buffer.byteLength(payload.logTail, "utf8")).toBeLessThanOrEqual(1_000)
-    expect(payload.truncation.omittedLogBytes).toBeGreaterThan(0)
-  })
-
-  test("bounds a single message with no parts but oversized info (true session cap)", () => {
-    const messages = [
-      {
-        info: { id: "msg_big", sessionID: "ses_1", role: "user", time: { created: 1, blob: "z".repeat(40_000) } },
-        parts: [],
-      },
-    ]
-    const report = buildProblemReport(
-      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
-      { budgets: { sessionMessageBytes: 2_000, sessionMessagesBytes: 2_000 } },
-    )
-
-    const payload = parseProblemReportPayload(report.markdown)
-    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
-    expect(Buffer.byteLength(JSON.stringify(kept), "utf8")).toBeLessThanOrEqual(2_000)
-    // The oversized info was reduced to a stub rather than smuggled past the budget.
-    expect(JSON.stringify(kept)).not.toContain("z".repeat(100))
-    expect((kept[0] as { oversized?: boolean }).oversized).toBe(true)
   })
 
   test("byte-caps the stub identity so an oversized id can't escape under default budgets", () => {
@@ -800,77 +815,20 @@ describe("component budgets", () => {
     expect((kept[0] as { oversized?: boolean }).oversized).toBe(true)
   })
 
-  test("byte-bounds a single oversized log line without splitting a multibyte char", () => {
-    const report = buildProblemReport(
-      { ...base, logTail: "é".repeat(5_000) },
-      { budgets: { logTailBytes: 999 } },
-    )
+  test("caps both the renderer error summary and details to the default budget", () => {
+    // summary derives from error.message, which an API error can balloon, so both fields are budgeted.
+    const report = buildProblemReport({
+      ...base,
+      rendererError: { summary: `boom ${"S".repeat(100_000)}`, details: "stack frame\n".repeat(20_000) },
+    })
 
     const payload = parseProblemReportPayload(report.markdown)
-    expect(Buffer.byteLength(payload.logTail, "utf8")).toBeLessThanOrEqual(999)
-    expect(payload.logTail).not.toContain("�")
-    expect(payload.truncation.omittedLogBytes).toBeGreaterThan(0)
-  })
-
-  test("caps renderer error details to its component budget under a large overall limit", () => {
-    const details = "stack frame\n".repeat(10_000)
-    const report = buildProblemReport(
-      { ...base, rendererError: { summary: "boom", details } },
-      { budgets: { rendererErrorDetailsBytes: 1_024 } },
-    )
-
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.rendererError?.summary).toBe("boom")
-    expect(Buffer.byteLength(payload.rendererError?.details ?? "", "utf8")).toBeLessThanOrEqual(1_024)
-    expect(payload.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
-    // Keeps the head (error message + top of the stack), the useful part of an error.
-    expect(payload.rendererError?.details.startsWith("stack frame")).toBe(true)
-  })
-
-  test("caps an oversized renderer error summary, not just details", () => {
-    // summary derives from error.message, which an API error can balloon; it must be budgeted too.
-    const summary = `boom ${"S".repeat(50_000)}`
-    const report = buildProblemReport(
-      { ...base, rendererError: { summary, details: "short" } },
-      { budgets: { rendererErrorDetailsBytes: 1_024 } },
-    )
-
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(Buffer.byteLength(payload.rendererError?.summary ?? "", "utf8")).toBeLessThanOrEqual(1_024)
+    expect(Buffer.byteLength(payload.rendererError?.summary ?? "", "utf8")).toBeLessThanOrEqual(64 * 1024)
+    expect(Buffer.byteLength(payload.rendererError?.details ?? "", "utf8")).toBeLessThanOrEqual(64 * 1024)
+    // Both keep the head (the error message + top of the stack), the useful part of an error.
     expect(payload.rendererError?.summary.startsWith("boom ")).toBe(true)
+    expect(payload.rendererError?.details.startsWith("stack frame")).toBe(true)
     expect(payload.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
-  })
-
-  test("ignores a non-finite budget override instead of disabling the cap", () => {
-    const lines = ["OLDEST_LINE", ...Array.from({ length: 500 }, (_, i) => `log line ${i}`), "NEWEST_LINE"]
-    const report = buildProblemReport(
-      { ...base, logTail: lines.join("\n") },
-      { budgets: { logTailBytes: Number.NaN } },
-    )
-
-    const payload = parseProblemReportPayload(report.markdown)
-    // NaN falls back to the 1 MB default, which leaves this small log untouched (no silent disable).
-    expect(payload.logTail).toContain("OLDEST_LINE")
-    expect(payload.logTail).toContain("NEWEST_LINE")
-    expect(payload.truncation.omittedLogBytes).toBe(0)
-  })
-
-  test("honors the session budget as a hard cap even when the newest message does not fit", () => {
-    const messages = Array.from({ length: 5 }, (_, i) => ({
-      info: { id: `msg_${i}`, sessionID: "ses_1", role: "user", time: { created: i } },
-      parts: [{ id: `p_${i}`, sessionID: "ses_1", messageID: `msg_${i}`, type: "text", text: `body ${i}` }],
-    }))
-    const report = buildProblemReport(
-      { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
-      // A near-zero session budget that even a single identity stub overflows.
-      { budgets: { sessionMessagesBytes: 10 } },
-    )
-
-    const payload = parseProblemReportPayload(report.markdown)
-    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
-    // Hard cap: the message array fits the budget, dropping the newest rather than overflowing.
-    expect(Buffer.byteLength(JSON.stringify(kept), "utf8")).toBeLessThanOrEqual(10)
-    expect(payload.truncation.omittedMessages).toBe(5)
   })
 
   test("does not count part-trim bytes for a message the overall ladder later drops whole", () => {
@@ -879,7 +837,7 @@ describe("component budgets", () => {
       sessionID: "ses_1",
       messageID: "msg_old",
       type: "text",
-      text: `part ${i} ${"x".repeat(1000)}`,
+      text: `part ${i} ${"x".repeat(2_000)}`,
     }))
     const messages = [
       { info: { id: "msg_old", sessionID: "ses_1", role: "assistant", time: { created: 1 } }, parts: bigParts },
@@ -887,9 +845,9 @@ describe("component budgets", () => {
     ]
     const report = buildProblemReport(
       { ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } },
-      // The old message is part-trimmed (to 50 KB) but survives the session cap; a small overall maxBytes
-      // then drops it whole in the fallback ladder. Its trimmed bytes must not stay in the ledger.
-      { maxBytes: 10_000, budgets: { sessionMessageBytes: 50_000, sessionMessagesBytes: 500_000 } },
+      // msg_old is part-trimmed to the 256 KB per-message default but survives the session cap; a small
+      // overall maxBytes then drops it whole in the fallback ladder. Its trimmed bytes must leave the ledger.
+      { maxBytes: 10_000 },
     )
 
     const payload = parseProblemReportPayload(report.markdown)

--- a/packages/desktop-electron/src/main/problem-report.test.ts
+++ b/packages/desktop-electron/src/main/problem-report.test.ts
@@ -456,6 +456,59 @@ describe("problem report", () => {
     expect(payload.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
   })
 
+  test("drains all-protected renderer diagnostics to fit a tight max bytes (no throw)", () => {
+    const incident = {
+      ...base.rendererDiagnostics.events[0],
+      "event.name": "incident.session_timeline_remount",
+      data: { mount_count: 2, unmount_count: 1, note: "x".repeat(200) },
+    }
+    const report = buildProblemReport(
+      {
+        ...base,
+        logTail: "",
+        sessionExport: { status: "none" },
+        rendererDiagnostics: {
+          ...base.rendererDiagnostics,
+          events: Array.from({ length: 40 }, (_, index) => ({ ...incident, trace_id: `inc_${index}` })),
+          summary: { ...base.rendererDiagnostics.summary, event_count: 40, incident_count: 40 },
+        },
+      },
+      { maxBytes: 5_000 },
+    )
+
+    // Every event is a protected incident, yet the slice still drains to fit. The old fallback broke on
+    // the first protected event, so the report would have exceeded maxBytes (or thrown) here.
+    expect(Buffer.byteLength(report.markdown, "utf8")).toBeLessThanOrEqual(5_000)
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(payload.rendererDiagnostics?.status).toBe("truncated")
+    expect(payload.rendererDiagnostics?.summary.omitted_event_count).toBeGreaterThan(0)
+    expect(payload.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
+  })
+
+  test("re-bounds oversized renderer diagnostics to the component budget below the overall limit", () => {
+    // 1.2 MB of events — over the 1 MB renderer-diagnostics component budget but well under the 5 MB
+    // overall limit, so only the component cap (not the overall ladder) can have trimmed them.
+    const big = {
+      ...base.rendererDiagnostics.events[0],
+      data: { action: "submit", endpoint_kind: "prompt", blob: "x".repeat(20_000) },
+    }
+    const report = buildProblemReport({
+      ...base,
+      rendererDiagnostics: {
+        ...base.rendererDiagnostics,
+        events: Array.from({ length: 60 }, (_, index) => ({ ...big, trace_id: `e_${index}` })),
+        summary: { ...base.rendererDiagnostics.summary, event_count: 60 },
+      },
+    })
+
+    const payload = parseProblemReportPayload(report.markdown)
+    expect(payload.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
+    expect(payload.rendererDiagnostics?.summary.omitted_event_count).toBeGreaterThan(0)
+    expect(Buffer.byteLength(JSON.stringify(payload.rendererDiagnostics?.events ?? []), "utf8")).toBeLessThanOrEqual(
+      1024 * 1024,
+    )
+  })
+
   test("sanitizes non-json session export values", () => {
     const circular: Record<string, unknown> = { id: "root" }
     circular.self = circular

--- a/packages/desktop-electron/src/main/problem-report.ts
+++ b/packages/desktop-electron/src/main/problem-report.ts
@@ -2,6 +2,7 @@
 // Default full report payload limit: 5 MB.
 import type { RendererErrorDetails } from "@opencode-ai/app/desktop-api"
 import type { RendererDiagnosticEvent, RendererDiagnosticsSlice } from "./renderer-diagnostics"
+import { capEvents, SESSION_EXPORT_RENDERER_DIAGNOSTICS_MAX_BYTES } from "./renderer-diagnostics"
 import {
   type JsonValue,
   makeRedactor,
@@ -17,11 +18,11 @@ export const DEFAULT_PROBLEM_REPORT_MAX_BYTES = 5 * 1024 * 1024
 // Per-component byte budgets. Each source is bounded independently so one component (a giant log, a
 // long session, a huge renderer stack) can't fill the whole report and crowd out the rest. They sum
 // to well under DEFAULT_PROBLEM_REPORT_MAX_BYTES, leaving the overall maxBytes ladder below as a
-// final fallback rather than the primary bound. (Renderer diagnostics carry their own upstream byte
-// cap when the slice is built, so they are budgeted at the source, not here.)
+// final fallback rather than the primary bound.
 // Fixed, not configurable — there is no production caller that would tune these, so they are not a
 // public API surface. The capping logic is exercised in tests by calling the pure cap helpers
-// (capLogTailBytes / capMessageParts / capSessionMessagesBytes / headBytes) directly with small limits.
+// (capLogTailBytes / capMessageParts / capSessionMessagesBytes / headBytes / capEvents) directly with
+// small limits.
 const COMPONENT_BUDGETS = {
   logTailBytes: 1 * 1024 * 1024,
   sessionMessagesBytes: 1 * 1024 * 1024,
@@ -30,6 +31,9 @@ const COMPONENT_BUDGETS = {
   // Per renderer-error text field. Bounds BOTH summary and details: summary derives from
   // error.message, which an API error can balloon, so capping only details would leave a hole.
   rendererErrorDetailsBytes: 64 * 1024,
+  // Renderer diagnostics are byte-capped at the source (when the slice is built), but redaction here
+  // can re-expand them, so re-bound to the same ceiling after redaction — same capEvents() ruler.
+  rendererDiagnosticsBytes: SESSION_EXPORT_RENDERER_DIAGNOSTICS_MAX_BYTES,
 }
 
 const SUMMARY_ERROR_LINE_MAX_CHARS = 220
@@ -313,10 +317,6 @@ function redactRendererDiagnostics(slice: RendererDiagnosticsSlice, redact: Reda
   }
 }
 
-function isProtectedRendererDiagnosticEvent(event: RendererDiagnosticEvent) {
-  return event["event.name"].startsWith("incident.") || event["event.name"] === "session.identity.transition"
-}
-
 function withRendererDiagnosticsEvents(
   rendererDiagnostics: RendererDiagnosticsSlice,
   events: RendererDiagnosticEvent[],
@@ -384,6 +384,9 @@ export function buildProblemReport(input: Input, options: Options = {}) {
   let rendererDiagnostics = input.rendererDiagnostics
     ? redactRendererDiagnostics(input.rendererDiagnostics, redact)
     : undefined
+  // Immutable post-redaction baseline. Every renderer-diagnostics cap (the component budget below and
+  // the overall ladder) re-derives from this, so the omitted ledger stays correct across stages.
+  const redactedRendererDiagnostics = rendererDiagnostics
   let rendererError = input.rendererError
     ? // Construct from the two known fields only — never spread the IPC input, which is untyped at
       // the boundary and could carry extra unredacted fields. Each field is coerced through the
@@ -406,12 +409,25 @@ export function buildProblemReport(input: Input, options: Options = {}) {
   let omittedRendererDiagnosticsBytes = 0
   let omittedDiagnosticsBytes = 0
 
+  // Bound the renderer-diagnostics events to a byte budget using the same capEvents() as the source
+  // slice (drops non-incident events first, then incidents only if a single payload still overflows).
+  // Re-derives from the redacted baseline each call, so it is idempotent across the component-budget
+  // pass and the overall ladder, and the omitted ledger always reflects the total dropped from baseline.
+  const baselineRendererEvents = redactedRendererDiagnostics?.events ?? []
+  const baselineRendererEventsBytes = jsonBytes(baselineRendererEvents)
+  const capRendererDiagnostics = (maxEventBytes: number) => {
+    if (!redactedRendererDiagnostics) return
+    const capped = capEvents(baselineRendererEvents, maxEventBytes)
+    omittedRendererDiagnosticsBytes = Math.max(0, baselineRendererEventsBytes - jsonBytes(capped.events))
+    rendererDiagnostics =
+      capped.omittedEventCount > 0
+        ? withRendererDiagnosticsEvents(redactedRendererDiagnostics, capped.events, omittedRendererDiagnosticsBytes)
+        : redactedRendererDiagnostics
+  }
+
   // Per-component budgets: bound each source independently so one can't dominate the report. Runs
   // after redaction (cuts never split a secret) and before the overall maxBytes ladder, which is now
   // the fallback. Keeps the most recent context (log tail, latest messages) around the failure.
-  // Renderer diagnostics aren't re-budgeted here: their events array is bounded where the slice is
-  // built (capEvents, ~1 MB at the call site) — modulo a small fixed envelope — and the overall
-  // ladder below trims renderer events as the final backstop.
   const budgets = COMPONENT_BUDGETS
   const cappedLog = capLogTailBytes(logTail, budgets.logTailBytes)
   logTail = cappedLog.value
@@ -443,6 +459,9 @@ export function buildProblemReport(input: Input, options: Options = {}) {
       rendererError = { ...rendererError, summary, details }
     }
   }
+  // Re-bound renderer diagnostics post-redaction to their component budget, so a redaction that
+  // re-expanded the source-capped slice can't ride into the report above its per-component ceiling.
+  if (redactedRendererDiagnostics) capRendererDiagnostics(budgets.rendererDiagnosticsBytes)
 
   const makePayload = (): Payload => ({
     reportVersion: 1,
@@ -530,16 +549,16 @@ export function buildProblemReport(input: Input, options: Options = {}) {
     output = markdown(makePayload())
   }
 
-  if (bytes(output) > maxBytes && rendererDiagnostics) {
-    const original = rendererDiagnostics
-    let events = [...original.events]
-    while (bytes(output) > maxBytes && events.length > 0) {
-      const removeIndex = events.findIndex((event) => !isProtectedRendererDiagnosticEvent(event))
-      if (removeIndex < 0) break
-      events.splice(removeIndex, 1)
-      omittedRendererDiagnosticsBytes = Math.max(0, jsonBytes(original.events) - jsonBytes(events))
-      rendererDiagnostics = withRendererDiagnosticsEvents(original, events, omittedRendererDiagnosticsBytes)
+  // Final backstop: halve the renderer-diagnostics event budget until the report fits. Uses the same
+  // capEvents() ruler as above, which can drop even incident events once a tight maxBytes leaves no
+  // alternative — so an all-protected oversized slice drains to empty rather than overflowing.
+  if (bytes(output) > maxBytes && rendererDiagnostics && rendererDiagnostics.events.length > 0) {
+    let limit = Math.max(0, Math.floor(jsonBytes(rendererDiagnostics.events) / 2))
+    while (bytes(output) > maxBytes && limit >= 0) {
+      capRendererDiagnostics(limit)
       output = markdown(makePayload())
+      if (limit === 0) break
+      limit = Math.floor(limit / 2)
     }
   }
 

--- a/packages/desktop-electron/src/main/problem-report.ts
+++ b/packages/desktop-electron/src/main/problem-report.ts
@@ -19,7 +19,10 @@ export const DEFAULT_PROBLEM_REPORT_MAX_BYTES = 5 * 1024 * 1024
 // to well under DEFAULT_PROBLEM_REPORT_MAX_BYTES, leaving the overall maxBytes ladder below as a
 // final fallback rather than the primary bound. (Renderer diagnostics carry their own upstream byte
 // cap when the slice is built, so they are budgeted at the source, not here.)
-export const DEFAULT_COMPONENT_BUDGETS = {
+// Fixed, not configurable — there is no production caller that would tune these, so they are not a
+// public API surface. The capping logic is exercised in tests by calling the pure cap helpers
+// (capLogTailBytes / capMessageParts / capSessionMessagesBytes / headBytes) directly with small limits.
+const COMPONENT_BUDGETS = {
   logTailBytes: 1 * 1024 * 1024,
   sessionMessagesBytes: 1 * 1024 * 1024,
   // Per single message, so one long turn (many tool parts) can't consume the whole session budget.
@@ -27,24 +30,6 @@ export const DEFAULT_COMPONENT_BUDGETS = {
   // Per renderer-error text field. Bounds BOTH summary and details: summary derives from
   // error.message, which an API error can balloon, so capping only details would leave a hole.
   rendererErrorDetailsBytes: 64 * 1024,
-}
-export type ComponentBudgets = typeof DEFAULT_COMPONENT_BUDGETS
-
-// Apply overrides on top of the defaults, ignoring any non-finite or non-positive value. Budgets are
-// a hard floor; a bad override (NaN, undefined, 0) must fall back to the default, never silently
-// disable a cap — e.g. a NaN budget would make every size comparison false and keep everything. A tiny
-// but positive override is honored as far as the format allows: an empty message array is already 2
-// bytes of JSON framing and a retained message can be no smaller than its identity stub, so a budget
-// below those representational floors yields the minimal output, not a smaller one. No production
-// caller sets budgets (the defaults are sized for the report); overrides exist for tests.
-function resolveBudgets(overrides: Partial<ComponentBudgets> | undefined): ComponentBudgets {
-  const resolved = { ...DEFAULT_COMPONENT_BUDGETS }
-  if (!overrides) return resolved
-  for (const key of Object.keys(resolved) as (keyof ComponentBudgets)[]) {
-    const value = overrides[key]
-    if (typeof value === "number" && Number.isFinite(value) && value >= 1) resolved[key] = Math.floor(value)
-  }
-  return resolved
 }
 
 const SUMMARY_ERROR_LINE_MAX_CHARS = 220
@@ -94,8 +79,6 @@ type Options = {
   // Exact strings (OS username, home directory) the caller knows are sensitive at runtime but
   // no regex can infer. Redacted verbatim wherever they appear in the report.
   redactTerms?: string[]
-  // Override per-component byte budgets (mainly for tests). Missing keys fall back to defaults.
-  budgets?: Partial<ComponentBudgets>
 }
 
 type Payload = {
@@ -137,7 +120,7 @@ function jsonBytes(value: unknown) {
 }
 
 // Keep the leading maxBytes bytes of a string, backing off so a multibyte char is never split.
-function headBytes(value: string, maxBytes: number): string {
+export function headBytes(value: string, maxBytes: number): string {
   const buffer = Buffer.from(value, "utf8")
   if (buffer.length <= maxBytes) return value
   let end = maxBytes
@@ -158,7 +141,7 @@ function tailBytes(value: string, maxBytes: number): string {
 
 // Keep the most-recent bytes of a log, cutting whole lines off the front so the top is never a
 // fragment of an older line. Falls back to a hard byte cut only for a single oversized line.
-function capLogTailBytes(value: string, maxBytes: number): { value: string; omittedBytes: number } {
+export function capLogTailBytes(value: string, maxBytes: number): { value: string; omittedBytes: number } {
   const total = bytes(value)
   if (total <= maxBytes) return { value, omittedBytes: 0 }
   const lines = value.split("\n")
@@ -192,11 +175,12 @@ function messageIdentityStub(record: { [key: string]: JsonValue }, omittedParts:
   return { info: stub, parts: [], omittedParts, oversized: true }
 }
 
-// Trim a single message's trailing parts so its JSON fits the per-message budget, leaving an
-// omittedParts marker. Keeps the message info and the earliest parts (the start of the turn). This
-// bounds any one message so the newest message — always kept by capSessionMessagesBytes below — can
-// never blow the session budget on its own.
-function capMessageParts(message: JsonValue, maxBytes: number): { value: JsonValue; omittedBytes: number } {
+// Trim a single message's leading parts so its JSON fits the per-message budget, leaving an
+// omittedParts marker. Keeps the message info and the LATEST parts (the end of the turn — the tool
+// output / error nearest the failure), matching the rest of the ladder, which drops oldest-first to
+// keep the most recent context. This bounds any one message so the newest message — always kept by
+// capSessionMessagesBytes below — can never blow the session budget on its own.
+export function capMessageParts(message: JsonValue, maxBytes: number): { value: JsonValue; omittedBytes: number } {
   if (!isRecord(message)) return { value: message, omittedBytes: 0 }
   const record = message as { [key: string]: JsonValue }
   const original = jsonBytes(message)
@@ -206,13 +190,13 @@ function capMessageParts(message: JsonValue, maxBytes: number): { value: JsonVal
   const done = (value: JsonValue) => ({ value, omittedBytes: Math.max(0, original - jsonBytes(value)) })
   // No parts to trim — only the info is left, and it already overflows: stub it.
   if (!Array.isArray(parts) || parts.length === 0) return done(messageIdentityStub(record, partCount))
-  // Binary-search the largest leading run of parts that fits, so this stays O(log n) JSON renders.
+  // Binary-search the largest trailing run of parts that fits, so this stays O(log n) JSON renders.
   let lo = 0
   let hi = parts.length
   let kept = 0
   while (lo <= hi) {
     const mid = Math.floor((lo + hi) / 2)
-    const candidate = { ...record, parts: parts.slice(0, mid), omittedParts: parts.length - mid }
+    const candidate = { ...record, parts: parts.slice(parts.length - mid), omittedParts: parts.length - mid }
     if (jsonBytes(candidate) <= maxBytes) {
       kept = mid
       lo = mid + 1
@@ -220,7 +204,7 @@ function capMessageParts(message: JsonValue, maxBytes: number): { value: JsonVal
       hi = mid - 1
     }
   }
-  const trimmed = { ...record, parts: parts.slice(0, kept), omittedParts: parts.length - kept }
+  const trimmed = { ...record, parts: parts.slice(parts.length - kept), omittedParts: parts.length - kept }
   // Even zero parts didn't fit: the info itself is oversized. Reduce to an identity stub.
   return done(jsonBytes(trimmed) <= maxBytes ? trimmed : messageIdentityStub(record, parts.length))
 }
@@ -229,9 +213,9 @@ function capMessageParts(message: JsonValue, maxBytes: number): { value: JsonVal
 // around the failure. This is a hard cap: a message that does not fit is dropped even if it is the
 // newest, so the kept set never exceeds maxBytes. capMessageParts has already bounded each message to
 // the per-message budget (a ≤256-byte identity stub at worst), so under any realistic budget the newest
-// message always fits and the latest turn survives; only a pathologically tiny override yields an empty
+// message always fits and the latest turn survives; only a pathologically tiny budget yields an empty
 // set — the correct outcome for a near-zero budget.
-function capSessionMessagesBytes(
+export function capSessionMessagesBytes(
   messages: JsonValue[],
   maxBytes: number,
 ): { messages: JsonValue[]; omittedMessages: number } {
@@ -428,7 +412,7 @@ export function buildProblemReport(input: Input, options: Options = {}) {
   // Renderer diagnostics aren't re-budgeted here: their events array is bounded where the slice is
   // built (capEvents, ~1 MB at the call site) — modulo a small fixed envelope — and the overall
   // ladder below trims renderer events as the final backstop.
-  const budgets = resolveBudgets(options.budgets)
+  const budgets = COMPONENT_BUDGETS
   const cappedLog = capLogTailBytes(logTail, budgets.logTailBytes)
   logTail = cappedLog.value
   omittedLogBytes += cappedLog.omittedBytes

--- a/packages/desktop-electron/src/main/problem-report.ts
+++ b/packages/desktop-electron/src/main/problem-report.ts
@@ -13,6 +13,40 @@ import {
 } from "./problem-report-redact"
 
 export const DEFAULT_PROBLEM_REPORT_MAX_BYTES = 5 * 1024 * 1024
+
+// Per-component byte budgets. Each source is bounded independently so one component (a giant log, a
+// long session, a huge renderer stack) can't fill the whole report and crowd out the rest. They sum
+// to well under DEFAULT_PROBLEM_REPORT_MAX_BYTES, leaving the overall maxBytes ladder below as a
+// final fallback rather than the primary bound. (Renderer diagnostics carry their own upstream byte
+// cap when the slice is built, so they are budgeted at the source, not here.)
+export const DEFAULT_COMPONENT_BUDGETS = {
+  logTailBytes: 1 * 1024 * 1024,
+  sessionMessagesBytes: 1 * 1024 * 1024,
+  // Per single message, so one long turn (many tool parts) can't consume the whole session budget.
+  sessionMessageBytes: 256 * 1024,
+  // Per renderer-error text field. Bounds BOTH summary and details: summary derives from
+  // error.message, which an API error can balloon, so capping only details would leave a hole.
+  rendererErrorDetailsBytes: 64 * 1024,
+}
+export type ComponentBudgets = typeof DEFAULT_COMPONENT_BUDGETS
+
+// Apply overrides on top of the defaults, ignoring any non-finite or non-positive value. Budgets are
+// a hard floor; a bad override (NaN, undefined, 0) must fall back to the default, never silently
+// disable a cap — e.g. a NaN budget would make every size comparison false and keep everything. A tiny
+// but positive override is honored as far as the format allows: an empty message array is already 2
+// bytes of JSON framing and a retained message can be no smaller than its identity stub, so a budget
+// below those representational floors yields the minimal output, not a smaller one. No production
+// caller sets budgets (the defaults are sized for the report); overrides exist for tests.
+function resolveBudgets(overrides: Partial<ComponentBudgets> | undefined): ComponentBudgets {
+  const resolved = { ...DEFAULT_COMPONENT_BUDGETS }
+  if (!overrides) return resolved
+  for (const key of Object.keys(resolved) as (keyof ComponentBudgets)[]) {
+    const value = overrides[key]
+    if (typeof value === "number" && Number.isFinite(value) && value >= 1) resolved[key] = Math.floor(value)
+  }
+  return resolved
+}
+
 const SUMMARY_ERROR_LINE_MAX_CHARS = 220
 const SUMMARY_FAILURE_REASON_MAX_CHARS = 80
 const SUMMARY_ROUTE_MAX_CHARS = 120
@@ -60,6 +94,8 @@ type Options = {
   // Exact strings (OS username, home directory) the caller knows are sensitive at runtime but
   // no regex can infer. Redacted verbatim wherever they appear in the report.
   redactTerms?: string[]
+  // Override per-component byte budgets (mainly for tests). Missing keys fall back to defaults.
+  budgets?: Partial<ComponentBudgets>
 }
 
 type Payload = {
@@ -73,9 +109,11 @@ type Payload = {
   sessionExport: SafeSessionExport
   truncation: {
     omittedMessages: number
+    omittedMessagePartsBytes: number
     omittedLogBytes: number
     omittedSessionInfoBytes: number
     omittedFailedExportErrorBytes: number
+    omittedRendererErrorBytes: number
     omittedRendererDiagnosticsBytes: number
     omittedDiagnosticsBytes: number
   }
@@ -96,6 +134,121 @@ export function defaultReportId() {
 
 function jsonBytes(value: unknown) {
   return bytes(JSON.stringify(toJsonSafe(value)) ?? "")
+}
+
+// Keep the leading maxBytes bytes of a string, backing off so a multibyte char is never split.
+function headBytes(value: string, maxBytes: number): string {
+  const buffer = Buffer.from(value, "utf8")
+  if (buffer.length <= maxBytes) return value
+  let end = maxBytes
+  // 0b10xxxxxx are UTF-8 continuation bytes; step back until end sits on a char boundary.
+  while (end > 0 && (buffer[end] & 0xc0) === 0x80) end--
+  return buffer.toString("utf8", 0, end)
+}
+
+// Keep the trailing <= maxBytes bytes of a string, advancing to the next char boundary so the result
+// never starts mid-character (which would yield a replacement char and re-encode larger than maxBytes).
+function tailBytes(value: string, maxBytes: number): string {
+  const buffer = Buffer.from(value, "utf8")
+  if (buffer.length <= maxBytes) return value
+  let start = buffer.length - maxBytes
+  while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) start++
+  return buffer.toString("utf8", start)
+}
+
+// Keep the most-recent bytes of a log, cutting whole lines off the front so the top is never a
+// fragment of an older line. Falls back to a hard byte cut only for a single oversized line.
+function capLogTailBytes(value: string, maxBytes: number): { value: string; omittedBytes: number } {
+  const total = bytes(value)
+  if (total <= maxBytes) return { value, omittedBytes: 0 }
+  const lines = value.split("\n")
+  let acc = 0
+  let startIndex = lines.length
+  for (let i = lines.length - 1; i >= 0; i--) {
+    // +1 for the "\n" joining this line to the already-kept block (every kept line except the last).
+    const add = bytes(lines[i]) + (i < lines.length - 1 ? 1 : 0)
+    if (acc + add > maxBytes && startIndex < lines.length) break
+    acc += add
+    startIndex = i
+  }
+  let out = startIndex < lines.length ? lines.slice(startIndex).join("\n") : ""
+  // Whole-line selection kept nothing useful — the most recent line alone exceeds the budget, with or
+  // without a trailing newline (which leaves an empty last "line"). Fall back to a byte-accurate tail
+  // of the original so the report still carries the most recent bytes rather than an empty string.
+  if (out === "" || bytes(out) > maxBytes) out = tailBytes(value, maxBytes)
+  return { value: out, omittedBytes: Math.max(0, total - bytes(out)) }
+}
+
+// Reduce a message whose info alone exceeds the budget to an identity stub, so even a pathological
+// message — a malformed time/tokens blob, hundreds of parts, or an oversized id — can never break the
+// session budget. id/role are byte-capped too (they are normally short, but the IPC boundary is
+// untyped), bounding the stub to a small constant. The oversized marker keeps the reduction visible.
+const STUB_IDENTITY_MAX_BYTES = 256
+function messageIdentityStub(record: { [key: string]: JsonValue }, omittedParts: number): JsonValue {
+  const info = isRecord(record.info) ? record.info : {}
+  const stub: { [key: string]: JsonValue } = {}
+  if (typeof info.id === "string") stub.id = headBytes(info.id, STUB_IDENTITY_MAX_BYTES)
+  if (typeof info.role === "string") stub.role = headBytes(info.role, STUB_IDENTITY_MAX_BYTES)
+  return { info: stub, parts: [], omittedParts, oversized: true }
+}
+
+// Trim a single message's trailing parts so its JSON fits the per-message budget, leaving an
+// omittedParts marker. Keeps the message info and the earliest parts (the start of the turn). This
+// bounds any one message so the newest message — always kept by capSessionMessagesBytes below — can
+// never blow the session budget on its own.
+function capMessageParts(message: JsonValue, maxBytes: number): { value: JsonValue; omittedBytes: number } {
+  if (!isRecord(message)) return { value: message, omittedBytes: 0 }
+  const record = message as { [key: string]: JsonValue }
+  const original = jsonBytes(message)
+  const parts = record.parts
+  const partCount = Array.isArray(parts) ? parts.length : 0
+  if (original <= maxBytes) return { value: message, omittedBytes: 0 }
+  const done = (value: JsonValue) => ({ value, omittedBytes: Math.max(0, original - jsonBytes(value)) })
+  // No parts to trim — only the info is left, and it already overflows: stub it.
+  if (!Array.isArray(parts) || parts.length === 0) return done(messageIdentityStub(record, partCount))
+  // Binary-search the largest leading run of parts that fits, so this stays O(log n) JSON renders.
+  let lo = 0
+  let hi = parts.length
+  let kept = 0
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2)
+    const candidate = { ...record, parts: parts.slice(0, mid), omittedParts: parts.length - mid }
+    if (jsonBytes(candidate) <= maxBytes) {
+      kept = mid
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  const trimmed = { ...record, parts: parts.slice(0, kept), omittedParts: parts.length - kept }
+  // Even zero parts didn't fit: the info itself is oversized. Reduce to an identity stub.
+  return done(jsonBytes(trimmed) <= maxBytes ? trimmed : messageIdentityStub(record, parts.length))
+}
+
+// Drop oldest messages (from the front) until the array's JSON fits, keeping the most recent context
+// around the failure. This is a hard cap: a message that does not fit is dropped even if it is the
+// newest, so the kept set never exceeds maxBytes. capMessageParts has already bounded each message to
+// the per-message budget (a ≤256-byte identity stub at worst), so under any realistic budget the newest
+// message always fits and the latest turn survives; only a pathologically tiny override yields an empty
+// set — the correct outcome for a near-zero budget.
+function capSessionMessagesBytes(
+  messages: JsonValue[],
+  maxBytes: number,
+): { messages: JsonValue[]; omittedMessages: number } {
+  if (jsonBytes(messages) <= maxBytes) return { messages, omittedMessages: 0 }
+  const sizes = messages.map((message) => jsonBytes(message))
+  let acc = 2 // "[]" framing
+  let keptCount = 0
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const add = sizes[i] + (keptCount > 0 ? 1 : 0) // +1 for the joining comma
+    if (acc + add > maxBytes) break
+    acc += add
+    keptCount++
+  }
+  return {
+    messages: messages.slice(messages.length - keptCount),
+    omittedMessages: messages.length - keptCount,
+  }
 }
 
 function markdown(payload: Payload) {
@@ -254,12 +407,58 @@ export function buildProblemReport(input: Input, options: Options = {}) {
       // so a stray object value would otherwise pass un-scrubbed).
       { summary: redactField(input.rendererError.summary, redact), details: redactField(input.rendererError.details, redact) }
     : undefined
+  // Baseline of the redacted renderer-error text (summary + details) before any capping.
+  // omittedRendererErrorBytes is derived from this in makePayload, so it stays correct no matter which
+  // stage (component budget, overall ladder truncation, or full removal) shrinks either field.
+  const rendererErrorBaseline = rendererError ? bytes(rendererError.summary) + bytes(rendererError.details) : 0
   let omittedMessages = 0
+  // Bytes removed from WITHIN surviving messages by capMessageParts — trailing parts trimmed, or an
+  // oversized message reduced to an identity stub (which also drops its parts). Distinct from
+  // omittedMessages, which counts whole messages dropped to fit the session budget.
+  let omittedMessagePartsBytes = 0
   let omittedLogBytes = 0
   let omittedSessionInfoBytes = 0
   let omittedFailedExportErrorBytes = 0
   let omittedRendererDiagnosticsBytes = 0
   let omittedDiagnosticsBytes = 0
+
+  // Per-component budgets: bound each source independently so one can't dominate the report. Runs
+  // after redaction (cuts never split a secret) and before the overall maxBytes ladder, which is now
+  // the fallback. Keeps the most recent context (log tail, latest messages) around the failure.
+  // Renderer diagnostics aren't re-budgeted here: their events array is bounded where the slice is
+  // built (capEvents, ~1 MB at the call site) — modulo a small fixed envelope — and the overall
+  // ladder below trims renderer events as the final backstop.
+  const budgets = resolveBudgets(options.budgets)
+  const cappedLog = capLogTailBytes(logTail, budgets.logTailBytes)
+  logTail = cappedLog.value
+  omittedLogBytes += cappedLog.omittedBytes
+  // Bound each message first (trim parts of an oversized single turn), then drop oldest whole messages
+  // to the total budget — so neither one huge message nor many messages can dominate. The per-message
+  // budget never exceeds the total, so the kept set honors the session budget. survivorPartTrimBytes
+  // stays aligned with `messages` (oldest first) as both the session cap here and the overall ladder
+  // below drop from the front, so omittedMessagePartsBytes counts only part-trim of messages that
+  // actually remain — a message dropped whole is represented by omittedMessages, never double-counted.
+  const perMessageBudget = Math.min(budgets.sessionMessageBytes, budgets.sessionMessagesBytes)
+  const partTrimBytes: number[] = []
+  messages = messages.map((message) => {
+    const capped = capMessageParts(message, perMessageBudget)
+    partTrimBytes.push(capped.omittedBytes)
+    return capped.value
+  })
+  const cappedMessages = capSessionMessagesBytes(messages, budgets.sessionMessagesBytes)
+  messages = cappedMessages.messages
+  omittedMessages += cappedMessages.omittedMessages
+  let survivorPartTrimBytes = partTrimBytes.slice(cappedMessages.omittedMessages)
+  const sumPartTrim = () => survivorPartTrimBytes.reduce((total, value) => total + value, 0)
+  omittedMessagePartsBytes = sumPartTrim()
+  if (rendererError) {
+    // Cap both text fields: summary (from error.message) is as untrusted as details.
+    const summary = headBytes(rendererError.summary, budgets.rendererErrorDetailsBytes)
+    const details = headBytes(rendererError.details, budgets.rendererErrorDetailsBytes)
+    if (summary.length < rendererError.summary.length || details.length < rendererError.details.length) {
+      rendererError = { ...rendererError, summary, details }
+    }
+  }
 
   const makePayload = (): Payload => ({
     reportVersion: 1,
@@ -275,9 +474,16 @@ export function buildProblemReport(input: Input, options: Options = {}) {
     ),
     truncation: {
       omittedMessages,
+      omittedMessagePartsBytes,
       omittedLogBytes,
       omittedSessionInfoBytes,
       omittedFailedExportErrorBytes,
+      // Derived: whatever the renderer-error text (summary + details) lost across every truncation
+      // stage, including full removal.
+      omittedRendererErrorBytes: Math.max(
+        0,
+        rendererErrorBaseline - (rendererError ? bytes(rendererError.summary) + bytes(rendererError.details) : 0),
+      ),
       omittedRendererDiagnosticsBytes,
       omittedDiagnosticsBytes,
     },
@@ -290,6 +496,9 @@ export function buildProblemReport(input: Input, options: Options = {}) {
     const remove = Math.max(1, Math.ceil(messages.length / 2))
     omittedMessages += remove
     messages = messages.slice(remove)
+    // Keep the part-trim ledger consistent: the dropped messages are no longer in the report.
+    survivorPartTrimBytes = survivorPartTrimBytes.slice(remove)
+    omittedMessagePartsBytes = sumPartTrim()
     output = markdown(makePayload())
   }
 
@@ -540,9 +749,11 @@ function isTruncation(value: unknown): value is Payload["truncation"] {
   if (!isRecord(value)) return false
   return (
     isFiniteNumber(value.omittedMessages) &&
+    isFiniteNumber(value.omittedMessagePartsBytes) &&
     isFiniteNumber(value.omittedLogBytes) &&
     isFiniteNumber(value.omittedSessionInfoBytes) &&
     isFiniteNumber(value.omittedFailedExportErrorBytes) &&
+    isFiniteNumber(value.omittedRendererErrorBytes) &&
     isFiniteNumber(value.omittedRendererDiagnosticsBytes) &&
     isFiniteNumber(value.omittedDiagnosticsBytes)
   )

--- a/packages/desktop-electron/src/main/renderer-diagnostics-slice.test.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-slice.test.ts
@@ -78,6 +78,31 @@ describe("renderer diagnostics slices", () => {
     expect(JSON.stringify(slice)).not.toContain("x".repeat(1000))
   })
 
+  test("keeps a hours-old scoped incident with no implicit lower time bound", () => {
+    // Manual diagnostics triggers usually happen well after the incident. Scoped by session, there is
+    // no lower time bound: retention (events older than ~24h are already off disk) plus maxBytes bound
+    // the result, so a 7-hour-old incident — beyond any short lookback window — is still included.
+    const olderIncident = {
+      time: "2026-05-02T10:00:00.000Z",
+      level: "warn" as const,
+      "event.name": "incident.session_timeline_remount",
+      app_launch_id: "launch_1",
+      window_id: "1",
+      visible_session_id: "ses_target",
+      data: { timeline_mount_count: 2, timeline_unmount_count: 1 },
+    }
+
+    const slice = selectRendererDiagnosticsSlice([olderIncident], {
+      sessionID: "ses_target",
+      windowID: "1",
+      appLaunchID: "launch_1",
+      maxBytes: 10_000,
+      now: new Date("2026-05-02T17:00:00.000Z"), // 7h after the event, beyond any short lookback window
+    })
+
+    expect(slice.events.map((event) => event["event.name"])).toContain("incident.session_timeline_remount")
+  })
+
   test("global export wraps diagnostics as JSON and caps old events", async () => {
     const root = await tempRoot()
     const source = join(root, "renderer-diagnostics.jsonl")

--- a/packages/desktop-electron/src/main/renderer-diagnostics-slice.test.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-slice.test.ts
@@ -78,10 +78,10 @@ describe("renderer diagnostics slices", () => {
     expect(JSON.stringify(slice)).not.toContain("x".repeat(1000))
   })
 
-  test("keeps a hours-old scoped incident with no implicit lower time bound", () => {
-    // Manual diagnostics triggers usually happen well after the incident. Scoped by session, there is
-    // no lower time bound: retention (events older than ~24h are already off disk) plus maxBytes bound
-    // the result, so a 7-hour-old incident — beyond any short lookback window — is still included.
+  test("bounds a scoped slice to the default lookback, and an explicit `from` widens it", () => {
+    // Manual diagnostics triggers usually happen shortly after the incident, so both scoped and unscoped
+    // slices use the same bounded ~30-min lookback for minimal collection: a 7-hour-old incident from the
+    // same session is NOT pulled in by default, but an explicit `from` opens a wider window when needed.
     const olderIncident = {
       time: "2026-05-02T10:00:00.000Z",
       level: "warn" as const,
@@ -91,16 +91,19 @@ describe("renderer diagnostics slices", () => {
       visible_session_id: "ses_target",
       data: { timeline_mount_count: 2, timeline_unmount_count: 1 },
     }
-
-    const slice = selectRendererDiagnosticsSlice([olderIncident], {
+    const input = {
       sessionID: "ses_target",
       windowID: "1",
       appLaunchID: "launch_1",
       maxBytes: 10_000,
-      now: new Date("2026-05-02T17:00:00.000Z"), // 7h after the event, beyond any short lookback window
-    })
+      now: new Date("2026-05-02T17:00:00.000Z"), // 7h after the event, beyond the default lookback window
+    }
 
-    expect(slice.events.map((event) => event["event.name"])).toContain("incident.session_timeline_remount")
+    const bounded = selectRendererDiagnosticsSlice([olderIncident], input)
+    expect(bounded.events).toHaveLength(0)
+
+    const widened = selectRendererDiagnosticsSlice([olderIncident], { ...input, from: new Date("2026-05-02T09:00:00.000Z") })
+    expect(widened.events.map((event) => event["event.name"])).toContain("incident.session_timeline_remount")
   })
 
   test("global export wraps diagnostics as JSON and caps old events", async () => {

--- a/packages/desktop-electron/src/main/renderer-diagnostics-slice.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-slice.ts
@@ -6,11 +6,10 @@ import type {
 } from "./renderer-diagnostics-types"
 import { jsonBytes } from "./renderer-diagnostics-sanitize"
 
-// A diagnostics package is usually prepared AFTER the problem, so a short backward window misses the
-// incident. Unscoped slices keep a moderate lookback to avoid pulling unrelated noise; scoped
-// (session/trace) slices use NO lower time bound — the identity filter already keeps only matching
-// events, and retention (events older than ~24h are already off disk) plus maxBytes/capEvents bound
-// the result, so a session's incident from hours ago is still included.
+// A diagnostics package is usually prepared shortly AFTER the problem, so a moderate backward window
+// captures the incident. Both unscoped and scoped (session/trace) slices use the same bounded
+// lookback — minimal collection by default, so an old event from the same session hours ago is not
+// pulled in — and an explicit `from` opens a wider window when a reviewer needs older history.
 const SLICE_LOOKBACK_MS = 30 * 60 * 1000
 const SLICE_FORWARD_MS = 60 * 1000
 
@@ -94,8 +93,7 @@ export function selectRendererDiagnosticsSlice(
   input: InternalSliceInput,
 ): RendererDiagnosticsSlice {
   const windowID = input.windowID === undefined ? undefined : String(input.windowID)
-  const scoped = Boolean(input.sessionID || input.traceID)
-  const from = input.from?.getTime() ?? (scoped ? Number.NEGATIVE_INFINITY : input.now.getTime() - SLICE_LOOKBACK_MS)
+  const from = input.from?.getTime() ?? input.now.getTime() - SLICE_LOOKBACK_MS
   const to = input.to?.getTime() ?? input.now.getTime() + SLICE_FORWARD_MS
   const events = inputEvents
     .filter((event) => {

--- a/packages/desktop-electron/src/main/renderer-diagnostics-slice.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-slice.ts
@@ -6,6 +6,14 @@ import type {
 } from "./renderer-diagnostics-types"
 import { jsonBytes } from "./renderer-diagnostics-sanitize"
 
+// A diagnostics package is usually prepared AFTER the problem, so a short backward window misses the
+// incident. Unscoped slices keep a moderate lookback to avoid pulling unrelated noise; scoped
+// (session/trace) slices use NO lower time bound — the identity filter already keeps only matching
+// events, and retention (events older than ~24h are already off disk) plus maxBytes/capEvents bound
+// the result, so a session's incident from hours ago is still included.
+const SLICE_LOOKBACK_MS = 30 * 60 * 1000
+const SLICE_FORWARD_MS = 60 * 1000
+
 export function eventTime(event: RendererDiagnosticEvent) {
   const time = Date.parse(event.time)
   return Number.isFinite(time) ? time : 0
@@ -86,8 +94,9 @@ export function selectRendererDiagnosticsSlice(
   input: InternalSliceInput,
 ): RendererDiagnosticsSlice {
   const windowID = input.windowID === undefined ? undefined : String(input.windowID)
-  const from = input.from?.getTime() ?? input.now.getTime() - 5 * 60 * 1000
-  const to = input.to?.getTime() ?? input.now.getTime() + 60 * 1000
+  const scoped = Boolean(input.sessionID || input.traceID)
+  const from = input.from?.getTime() ?? (scoped ? Number.NEGATIVE_INFINITY : input.now.getTime() - SLICE_LOOKBACK_MS)
+  const to = input.to?.getTime() ?? input.now.getTime() + SLICE_FORWARD_MS
   const events = inputEvents
     .filter((event) => {
       const time = eventTime(event)


### PR DESCRIPTION
<!-- Checklist policy: the Checklist section below is policy. Do not edit, add, or remove items. Tick boxes only by replacing [ ] with [x]. -->

## Summary

Bound the "Prepare Diagnostics Package" export with **per-component byte budgets** — PR2 of the diagnostics-package rebuild (#1465). Each component is capped to its own budget **after redaction and before** the overall 5 MB truncation ladder (which becomes a fallback):

- **Per-component budgets** — fixed and private (not a configurable API; no production caller tunes them): `logTailBytes` 1 MB, `sessionMessagesBytes` 1 MB, `sessionMessageBytes` 256 KB, `rendererErrorDetailsBytes` 64 KB (bounds both the renderer-error **summary** and **details**), `rendererDiagnosticsBytes` 1 MB. The cap helpers (`capLogTailBytes` / `capMessageParts` / `capSessionMessagesBytes` / `headBytes` / `capEvents`) are exported and unit-tested directly at small limits, with a few default-budget tests covering the end-to-end wiring.
- **Hard caps, no force-keep:** `capSessionMessagesBytes` drops even the newest message if it does not fit, so the cap is a true ceiling; `capMessageParts` keeps the **latest** parts of an oversized turn (the tool output / error nearest the failure), matching the ladder's oldest-first drop order.
- **Renderer diagnostics re-budgeted after redaction:** the slice is byte-capped at the source, but redaction here can re-expand it, so it is re-bounded with the same `capEvents()` ruler. The component pass and the overall fallback share that one mechanism (incident events dropped only when a tight limit leaves no alternative), replacing a divergent bespoke fallback loop that could leave an all-protected oversized slice unbounded.
- **UTF-8-safe byte slicing** (`headBytes` / `tailBytes`) so capping never splits a multi-byte codepoint at the budget boundary.
- **Consistent truncation ledger:** every omitted-bytes counter is tracked identically in the component pass and the overall fallback ladder, validated by `isTruncation`.
- **Structure-agnostic private-key redaction** (`problem-report-redact.ts`): defense moved out of the truncation layer into the redactor as anchored, linear-time (ReDoS-safe) rules covering complete `BEGIN..END` blocks, `BEGIN`-truncated keys, markerless ≥2-line base64 bodies, orphaned `END` markers (separate line, same line, PGP `=CRC` checksum line), armor-headered bodies, and CRLF.

## Why

The export could grow without bound: a single huge log tail, one giant session message, or an oversized renderer-error blob could dominate the report or trip the overall 5 MB cap in a way that silently drops other components. Per-component budgets make each part's ceiling explicit and keep the report balanced, with the overall ladder only as a fallback. The budget/truncation work also surfaced a real redaction gap: a pre-redaction tail cut could strand a private-key body whose `BEGIN` marker was removed, defeating a `BEGIN`-keyed redactor — so private-key defense now lives entirely in the redactor.

## Related Issue

Refs #1465 (umbrella). This is PR2; PR1 #1470 is merged, PR3 #1472 follows. Rebased flat onto `dev` after #1470 merged.

## Human Review Status

`Pending`

## Review Focus

- The **redact-before-truncate invariant**: redaction runs on the full payload before any component capping; the only pre-redaction truncation is `tailFile` (byte + line tail of the log), which now only drops a partial first line — multi-line-secret defense lives entirely in the redactor.
- Hard caps are true ceilings (drop the newest message if it does not fit), and the omitted-bytes ledger stays consistent between the component pass and the fallback ladder.
- Renderer diagnostics now go through one `capEvents()` ruler in both the component pass and the overall fallback (re-derived from the redacted baseline so the omitted ledger stays correct), instead of a separate fallback loop that broke on protected events.
- UTF-8-safe byte slicing at budget boundaries.
- The structure-agnostic private-key redactor rules (anchored, linear-time) and whether the enumerated marker/armor/CRLF cases are complete.

## Risk Notes

Accepted residuals (confirmed by an independent adversarial review; left as documented tradeoffs rather than risking the ReDoS-safety / false-positive balance):

- A private-key body wrapped at **non-standard narrow widths (< 16 chars/line)** whose `BEGIN` marker was truncated away keeps the same `{16,}` per-line floor used everywhere else (the floor avoids redacting legitimate short base64 tokens/hashes). Real tools emit 64–76 char lines, so this only affects deliberately re-wrapped keys. PR3's human-review step is the backstop.
- The overall fallback ladder still uses UTF-16 `slice()` for log / renderer-error text. It is effectively unreachable under default budgets (component budgets sum well under 5 MB), so a lone-surrogate split there is cosmetic.
- **No visible UI in this PR** (the in-app review panel is PR3 #1472) — the UI/copy checklist item below is left unticked for that reason; no screenshots.

## How To Verify

```text
bun test (packages/desktop-electron) — 656 pass, 0 fail (full suite, latest head)
bun run typecheck (packages/desktop-electron, tsgo -b) — clean
eslint (changed files) — clean
Targeted coverage: pure-helper edge cases (each cap helper at small limits), default-budget
  end-to-end wiring, hard-cap ceilings, ledger consistency, renderer-diagnostics re-budget +
  all-protected drain, UTF-8 boundary slicing, and ReDoS-perf regression on the private-key redactor.
```

## Screenshots or Recordings

None — no visible UI in this PR (the in-app review panel is PR3 #1472).

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

