### PR TITLE
feat(provider): fetch models from OpenAI-compatible providers in Settings

### DIFF
--- a/packages/app/e2e/snap/settings-models-fetch.snap.ts
+++ b/packages/app/e2e/snap/settings-models-fetch.snap.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "../fixtures"
+import { openSettings } from "../actions"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+// Visual contract for the Settings > Models "Fetch models" action (issue #1463): an OpenAI-compatible
+// provider group shows a ghost button with the refresh icon in its header, above the model rows. The
+// default OpenCode Zen provider is OpenAI-compatible, so the button renders without seeding anything.
+// Captured at rest — clicking would call the provider's live /models endpoint.
+test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
+
+test("settings-models-fetch", async ({ page, project }) => {
+  test.setTimeout(180_000)
+
+  await project.open()
+
+  // App-shell toasts (e.g. server health checks) float over the page and bleed into block screenshots;
+  // they are environment chrome, not the surface under test.
+  await page.addStyleTag({ content: '[data-component="toast-region"] { display: none; }' })
+
+  const settings = await openSettings(page)
+  await settings.getByRole("tab", { name: "Models" }).click()
+
+  const fetchButton = settings.getByRole("button", { name: "Fetch models" }).first()
+  await expect(fetchButton).toBeVisible({ timeout: 30_000 })
+  await fetchButton.scrollIntoViewIfNeeded()
+
+  // Frame the provider group (button -> header (..) -> group (..)) so the shot stays on the header +
+  // model rows rather than the providers list stacked above it.
+  const group = fetchButton.locator("xpath=../..")
+  await expect(group).toBeVisible({ timeout: 10_000 })
+
+  const shots: Shot[] = [{ name: "default", buf: await group.screenshot() }]
+  const out = snapOutputPath("settings-models-fetch")
+  await composeGrid(shots, out)
+  process.stdout.write(`\n[snap] settings-models-fetch grid -> ${out}\n\n`)
+})

--- a/packages/app/src/components/settings-models-fetch.test.ts
+++ b/packages/app/src/components/settings-models-fetch.test.ts
@@ -7,7 +7,7 @@ describe("mergeFetchedModels", () => {
       existingModelIDs: ["a"],
       fetched: [{ id: "a", name: "A" }, { id: "b", name: "B" }],
     })
-    expect(result).toEqual({ models: { b: { name: "B" } }, added: 1, skipped: 1 })
+    expect(result).toEqual({ models: { b: { name: "B" } }, addedModelIDs: ["b"], skipped: 1 })
   })
 
   test("preserves existing config models on re-fetch", () => {
@@ -17,14 +17,14 @@ describe("mergeFetchedModels", () => {
       fetched: [{ id: "x", name: "X" }, { id: "y", name: "Y" }],
     })
     expect(result.models).toEqual({ x: { name: "Existing X" }, y: { name: "Y" } })
-    expect(result.added).toBe(1)
+    expect(result.addedModelIDs).toEqual(["y"])
     expect(result.skipped).toBe(1)
   })
 
   test("defaults a blank name to the id", () => {
     const result = mergeFetchedModels({ existingModelIDs: [], fetched: [{ id: "model-z", name: "  " }] })
     expect(result.models).toEqual({ "model-z": { name: "model-z" } })
-    expect(result.added).toBe(1)
+    expect(result.addedModelIDs).toEqual(["model-z"])
   })
 
   test("dedups repeated fetched ids", () => {
@@ -33,7 +33,19 @@ describe("mergeFetchedModels", () => {
       fetched: [{ id: "dup", name: "first" }, { id: "dup", name: "second" }],
     })
     expect(result.models).toEqual({ dup: { name: "first" } })
-    expect(result.added).toBe(1)
+    expect(result.addedModelIDs).toEqual(["dup"])
+  })
+
+  test("reports the added ids so the caller can hide them by default", () => {
+    // The visibility gap (issue #1463): freshly fetched models have no release_date, and the model
+    // visibility default treats undated models as visible. The caller relies on addedModelIDs to mark
+    // exactly the new models hidden, so a large gateway never floods the picker.
+    const result = mergeFetchedModels({
+      existingModelIDs: ["a"],
+      fetched: [{ id: "a", name: "A" }, { id: "b", name: "B" }, { id: "c", name: "C" }],
+    })
+    expect(result.addedModelIDs).toEqual(["b", "c"])
+    expect(Object.keys(result.models)).toEqual(["b", "c"])
   })
 
   test("adds nothing when every fetched model already exists", () => {
@@ -43,7 +55,7 @@ describe("mergeFetchedModels", () => {
       fetched: [{ id: "a", name: "A" }, { id: "b", name: "B" }],
     })
     expect(result.models).toEqual({ a: { name: "A" } })
-    expect(result.added).toBe(0)
+    expect(result.addedModelIDs).toEqual([])
     expect(result.skipped).toBe(2)
   })
 })

--- a/packages/app/src/components/settings-models-fetch.test.ts
+++ b/packages/app/src/components/settings-models-fetch.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { mergeFetchedModels } from "./settings-models-fetch"
+
+describe("mergeFetchedModels", () => {
+  test("adds only models the provider does not already expose", () => {
+    const result = mergeFetchedModels({
+      existingModelIDs: ["a"],
+      fetched: [{ id: "a", name: "A" }, { id: "b", name: "B" }],
+    })
+    expect(result).toEqual({ models: { b: { name: "B" } }, added: 1, skipped: 1 })
+  })
+
+  test("preserves existing config models on re-fetch", () => {
+    const result = mergeFetchedModels({
+      existingModelIDs: ["x"],
+      configModels: { x: { name: "Existing X" } },
+      fetched: [{ id: "x", name: "X" }, { id: "y", name: "Y" }],
+    })
+    expect(result.models).toEqual({ x: { name: "Existing X" }, y: { name: "Y" } })
+    expect(result.added).toBe(1)
+    expect(result.skipped).toBe(1)
+  })
+
+  test("defaults a blank name to the id", () => {
+    const result = mergeFetchedModels({ existingModelIDs: [], fetched: [{ id: "model-z", name: "  " }] })
+    expect(result.models).toEqual({ "model-z": { name: "model-z" } })
+    expect(result.added).toBe(1)
+  })
+
+  test("dedups repeated fetched ids", () => {
+    const result = mergeFetchedModels({
+      existingModelIDs: [],
+      fetched: [{ id: "dup", name: "first" }, { id: "dup", name: "second" }],
+    })
+    expect(result.models).toEqual({ dup: { name: "first" } })
+    expect(result.added).toBe(1)
+  })
+
+  test("adds nothing when every fetched model already exists", () => {
+    const result = mergeFetchedModels({
+      existingModelIDs: ["a", "b"],
+      configModels: { a: { name: "A" } },
+      fetched: [{ id: "a", name: "A" }, { id: "b", name: "B" }],
+    })
+    expect(result.models).toEqual({ a: { name: "A" } })
+    expect(result.added).toBe(0)
+    expect(result.skipped).toBe(2)
+  })
+})

--- a/packages/app/src/components/settings-models-fetch.ts
+++ b/packages/app/src/components/settings-models-fetch.ts
@@ -11,7 +11,10 @@ export type MergeFetchedModelsInput = {
 export type MergeFetchedModelsResult = {
   // The next config.provider.<id>.models map to persist (existing config entries + newly added).
   models: Record<string, { name: string }>
-  added: number
+  // IDs of models added by this merge. The caller marks these hidden by default: a freshly fetched model
+  // carries no release_date, and the visibility default treats undated models as visible (see
+  // createModelsView.visible) — so without this a large gateway would flood the picker. Issue #1463.
+  addedModelIDs: string[]
   skipped: number
 }
 
@@ -27,7 +30,7 @@ export function mergeFetchedModels(input: MergeFetchedModelsInput): MergeFetched
     present.add(id)
   }
 
-  let added = 0
+  const addedModelIDs: string[] = []
   let skipped = 0
   const seen = new Set<string>()
   for (const model of input.fetched) {
@@ -40,8 +43,8 @@ export function mergeFetchedModels(input: MergeFetchedModelsInput): MergeFetched
     }
     models[id] = { name: model.name.trim() || id }
     present.add(id)
-    added++
+    addedModelIDs.push(id)
   }
 
-  return { models, added, skipped }
+  return { models, addedModelIDs, skipped }
 }

--- a/packages/app/src/components/settings-models-fetch.ts
+++ b/packages/app/src/components/settings-models-fetch.ts
@@ -1,0 +1,47 @@
+export type FetchedModel = { id: string; name: string }
+
+export type MergeFetchedModelsInput = {
+  // Model IDs the provider already exposes (catalog + existing config), used to decide what is new.
+  existingModelIDs: Iterable<string>
+  // Current config.provider.<id>.models, preserved so a re-fetch never drops prior additions.
+  configModels?: Record<string, { name?: string }>
+  fetched: FetchedModel[]
+}
+
+export type MergeFetchedModelsResult = {
+  // The next config.provider.<id>.models map to persist (existing config entries + newly added).
+  models: Record<string, { name: string }>
+  added: number
+  skipped: number
+}
+
+// Merge live-fetched models into a provider's config model overrides. Only models the provider does not
+// already expose are added (name defaults to id); existing config entries are preserved and duplicates
+// skipped. Catalog models are never written to config — they already resolve from the catalog. Issue #1463.
+export function mergeFetchedModels(input: MergeFetchedModelsInput): MergeFetchedModelsResult {
+  const present = new Set(input.existingModelIDs)
+  const models: Record<string, { name: string }> = {}
+
+  for (const [id, model] of Object.entries(input.configModels ?? {})) {
+    models[id] = { name: model.name ?? id }
+    present.add(id)
+  }
+
+  let added = 0
+  let skipped = 0
+  const seen = new Set<string>()
+  for (const model of input.fetched) {
+    const id = model.id.trim()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    if (present.has(id)) {
+      skipped++
+      continue
+    }
+    models[id] = { name: model.name.trim() || id }
+    present.add(id)
+    added++
+  }
+
+  return { models, added, skipped }
+}

--- a/packages/app/src/components/settings-models.tsx
+++ b/packages/app/src/components/settings-models.tsx
@@ -1,17 +1,27 @@
+import { Button } from "@opencode-ai/ui/button"
 import { useFilteredList } from "@opencode-ai/ui/hooks"
 import { ProviderIcon } from "@opencode-ai/ui/provider-icon"
 import { Switch } from "@opencode-ai/ui/switch"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { TextField } from "@opencode-ai/ui/text-field"
-import { type Component, For, Show } from "solid-js"
+import { showToast } from "@opencode-ai/ui/toast"
+import { type Component, createSignal, For, Show } from "solid-js"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useModels } from "@/context/models"
 import { popularProviders } from "@/hooks/use-providers"
+import { clientActionHeaders } from "@/utils/server"
+import { mergeFetchedModels } from "./settings-models-fetch"
 import { SettingsList } from "./settings-list"
 import { compareModelsForDisplay } from "@/utils/model-order"
 
 type ModelItem = ReturnType<ReturnType<typeof useModels>["list"]>[number]
+
+// Only OpenAI-compatible providers (custom providers + gateways like Kilo) expose a /models endpoint
+// we can discover from. Native SDKs (anthropic, etc.) do not, so the action stays hidden for them.
+const OPENAI_COMPATIBLE = "@ai-sdk/openai-compatible"
 
 const ListLoadingState: Component<{ label: string }> = (props) => {
   return (
@@ -35,6 +45,48 @@ const ListEmptyState: Component<{ message: string; filter: string }> = (props) =
 export const SettingsModels: Component = () => {
   const language = useLanguage()
   const models = useModels()
+  const globalSDK = useGlobalSDK()
+  const globalSync = useGlobalSync()
+  const [fetchingID, setFetchingID] = createSignal<string>()
+
+  // Live-fetch the provider's models and persist any the catalog/config does not already list. New models
+  // land disabled (visibility default), so a 300-model gateway never floods the picker. Issue #1463.
+  const fetchModels = async (provider: ModelItem["provider"]) => {
+    if (fetchingID()) return
+    setFetchingID(provider.id)
+    try {
+      const actionClient = globalSDK.createClient({
+        headers: clientActionHeaders({ kind: "settings.models.fetch" }),
+        throwOnError: true,
+      })
+      const response = await actionClient.provider.fetchModels({ providerID: provider.id })
+      const configProvider = globalSync.data.config.provider?.[provider.id]
+      const { models: nextModels, added, skipped } = mergeFetchedModels({
+        existingModelIDs: Object.keys(provider.models),
+        configModels: configProvider?.models,
+        fetched: response.data?.models ?? [],
+      })
+      if (added === 0) {
+        showToast({
+          title: language.t("provider.fetchModels.toast.none.title"),
+          description: language.t("provider.fetchModels.toast.none.description", { provider: provider.name }),
+        })
+        return
+      }
+      await globalSync.updateConfig({ provider: { [provider.id]: { ...configProvider, models: nextModels } } })
+      showToast({
+        variant: "success",
+        icon: "circle-check",
+        title: language.t("provider.fetchModels.toast.added.title"),
+        description: language.t("provider.fetchModels.toast.added.description", { added, skipped }),
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      showToast({ title: language.t("common.requestFailed"), description: message })
+    } finally {
+      setFetchingID(undefined)
+    }
+  }
 
   const list = useFilteredList<ModelItem>({
     items: (_filter) => models.list(),
@@ -101,6 +153,20 @@ export const SettingsModels: Component = () => {
                   <div class="flex items-center gap-2 pb-2">
                     <ProviderIcon id={group.category} class="size-5 shrink-0 text-icon-strong" />
                     <span class="text-h3 text-fg-strong">{group.items[0].provider.name}</span>
+                    <Show when={group.items.some((item) => item.api?.npm === OPENAI_COMPATIBLE)}>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        icon="refresh"
+                        class="ml-auto"
+                        disabled={fetchingID() === group.items[0].provider.id}
+                        onClick={() => void fetchModels(group.items[0].provider)}
+                      >
+                        {fetchingID() === group.items[0].provider.id
+                          ? language.t("provider.fetchModels.loading")
+                          : language.t("provider.fetchModels.action")}
+                      </Button>
+                    </Show>
                   </div>
                   <SettingsList>
                     <For each={group.items}>

--- a/packages/app/src/components/settings-models.tsx
+++ b/packages/app/src/components/settings-models.tsx
@@ -61,24 +61,31 @@ export const SettingsModels: Component = () => {
       })
       const response = await actionClient.provider.fetchModels({ providerID: provider.id })
       const configProvider = globalSync.data.config.provider?.[provider.id]
-      const { models: nextModels, added, skipped } = mergeFetchedModels({
+      const { models: nextModels, addedModelIDs, skipped } = mergeFetchedModels({
         existingModelIDs: Object.keys(provider.models),
         configModels: configProvider?.models,
         fetched: response.data?.models ?? [],
       })
-      if (added === 0) {
+      if (addedModelIDs.length === 0) {
         showToast({
           title: language.t("provider.fetchModels.toast.none.title"),
           description: language.t("provider.fetchModels.toast.none.description", { provider: provider.name }),
         })
         return
       }
+      // Mark new models hidden before they enter the catalog: they carry no release_date, and the model
+      // visibility default treats undated models as visible — so without this a large gateway would flood
+      // the picker. The user toggles on the ones they want. Issue #1463.
+      for (const modelID of addedModelIDs) models.setVisibility({ providerID: provider.id, modelID }, false)
       await globalSync.updateConfig({ provider: { [provider.id]: { ...configProvider, models: nextModels } } })
       showToast({
         variant: "success",
         icon: "circle-check",
         title: language.t("provider.fetchModels.toast.added.title"),
-        description: language.t("provider.fetchModels.toast.added.description", { added, skipped }),
+        description: language.t("provider.fetchModels.toast.added.description", {
+          added: addedModelIDs.length,
+          skipped,
+        }),
       })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -159,7 +166,7 @@ export const SettingsModels: Component = () => {
                         variant="ghost"
                         icon="refresh"
                         class="ml-auto"
-                        disabled={fetchingID() === group.items[0].provider.id}
+                        disabled={Boolean(fetchingID())}
                         onClick={() => void fetchModels(group.items[0].provider)}
                       >
                         {fetchingID() === group.items[0].provider.id

--- a/packages/app/src/components/settings-models.tsx
+++ b/packages/app/src/components/settings-models.tsx
@@ -49,8 +49,7 @@ export const SettingsModels: Component = () => {
   const globalSync = useGlobalSync()
   const [fetchingID, setFetchingID] = createSignal<string>()
 
-  // Live-fetch the provider's models and persist any the catalog/config does not already list. New models
-  // land disabled (visibility default), so a 300-model gateway never floods the picker. Issue #1463.
+  // Live-fetch the provider's models and persist any the catalog/config does not already list. Issue #1463.
   const fetchModels = async (provider: ModelItem["provider"]) => {
     if (fetchingID()) return
     setFetchingID(provider.id)

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -174,6 +174,13 @@ export const dict = {
   "provider.connect.toast.connected.deferredDescription":
     "{{provider}} is connected. Model refresh will finish after the current run.",
 
+  "provider.fetchModels.action": "Fetch models",
+  "provider.fetchModels.loading": "Fetching…",
+  "provider.fetchModels.toast.added.title": "Models updated",
+  "provider.fetchModels.toast.added.description": "Added {{added}} models, skipped {{skipped}} existing.",
+  "provider.fetchModels.toast.none.title": "No new models",
+  "provider.fetchModels.toast.none.description": "{{provider}} returned no models beyond the ones already listed.",
+
   "provider.custom.title": "Custom provider",
   "provider.custom.description.prefix": "Configure an OpenAI-compatible provider. See the ",
   "provider.custom.description.link": "provider config docs",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -192,6 +192,13 @@ export const dict = {
   "provider.connect.toast.connected.description": "现在可以使用 {{provider}} 模型了。",
   "provider.connect.toast.connected.deferredDescription": "{{provider}} 已连接。模型刷新会在当前任务结束后完成。",
 
+  "provider.fetchModels.action": "拉取模型",
+  "provider.fetchModels.loading": "拉取中…",
+  "provider.fetchModels.toast.added.title": "模型已更新",
+  "provider.fetchModels.toast.added.description": "新增 {{added}} 个模型，跳过 {{skipped}} 个已有。",
+  "provider.fetchModels.toast.none.title": "没有新模型",
+  "provider.fetchModels.toast.none.description": "{{provider}} 没有返回已列出之外的模型。",
+
   "provider.custom.title": "自定义提供商",
   "provider.custom.description.prefix": "配置与 OpenAI 兼容的提供商。请查看",
   "provider.custom.description.link": "提供商配置文档",

--- a/packages/opencode/src/provider/fetch-models.test.ts
+++ b/packages/opencode/src/provider/fetch-models.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test"
+import { FetchModels } from "@/provider/fetch-models"
+
+test("parses OpenAI-compatible { data: [...] } shape", () => {
+  expect(FetchModels.parse({ data: [{ id: "a" }, { id: "b", name: "Model B" }] })).toEqual([
+    { id: "a", name: "a" },
+    { id: "b", name: "Model B" },
+  ])
+})
+
+test("parses { models: [...] } shape", () => {
+  expect(FetchModels.parse({ models: [{ id: "m" }] })).toEqual([{ id: "m", name: "m" }])
+})
+
+test("parses a bare array shape", () => {
+  expect(FetchModels.parse([{ id: "x" }])).toEqual([{ id: "x", name: "x" }])
+})
+
+test("dedups repeated ids and keeps the first", () => {
+  expect(FetchModels.parse({ data: [{ id: "a", name: "first" }, { id: "a", name: "second" }] })).toEqual([
+    { id: "a", name: "first" },
+  ])
+})
+
+test("skips rows without a usable string id", () => {
+  expect(FetchModels.parse({ data: [{ id: "" }, { foo: 1 }, { id: 5 }, { id: "ok" }] })).toEqual([
+    { id: "ok", name: "ok" },
+  ])
+})
+
+test("returns an empty list for a valid but empty response", () => {
+  expect(FetchModels.parse({ data: [] })).toEqual([])
+})
+
+test("throws on an unrecognized response shape", () => {
+  expect(() => FetchModels.parse({ error: "unauthorized" })).toThrow()
+  expect(() => FetchModels.parse("nope")).toThrow()
+})
+
+test("builds the /models endpoint and normalizes trailing slashes", () => {
+  expect(FetchModels.endpoint("https://gateway.example/v1")).toBe("https://gateway.example/v1/models")
+  expect(FetchModels.endpoint("https://gateway.example/v1/")).toBe("https://gateway.example/v1/models")
+  expect(FetchModels.endpoint("  https://gateway.example/v1//  ")).toBe("https://gateway.example/v1/models")
+})
+
+test("request: base URL precedence is endpoint > baseURL > catalog", () => {
+  expect(
+    FetchModels.request({
+      configOptions: { endpoint: "https://endpoint.example", baseURL: "https://base.example" },
+      catalogBaseURL: "https://catalog.example",
+    })?.baseURL,
+  ).toBe("https://endpoint.example")
+  expect(
+    FetchModels.request({ configOptions: { baseURL: "https://base.example" }, catalogBaseURL: "https://catalog.example" })
+      ?.baseURL,
+  ).toBe("https://base.example")
+  expect(FetchModels.request({ catalogBaseURL: "https://catalog.example" })?.baseURL).toBe("https://catalog.example")
+})
+
+test("request: returns undefined when no base URL is known", () => {
+  expect(FetchModels.request({})).toBeUndefined()
+  expect(FetchModels.request({ configOptions: {} })).toBeUndefined()
+})
+
+test("request: copies string config headers and drops non-string values", () => {
+  const result = FetchModels.request({
+    catalogBaseURL: "https://catalog.example",
+    configOptions: { headers: { "X-Title": "pawwork", "X-Bad": 5 as unknown as string } },
+  })
+  expect(result?.headers).toEqual({ "X-Title": "pawwork" })
+})
+
+test("request: adds a Bearer header from the auth key, preferring it over a config apiKey", () => {
+  expect(
+    FetchModels.request({ catalogBaseURL: "https://catalog.example", authKey: "auth-key" })?.headers["Authorization"],
+  ).toBe("Bearer auth-key")
+  expect(
+    FetchModels.request({ catalogBaseURL: "https://catalog.example", configOptions: { apiKey: "config-key" } })?.headers[
+      "Authorization"
+    ],
+  ).toBe("Bearer config-key")
+  expect(
+    FetchModels.request({
+      catalogBaseURL: "https://catalog.example",
+      authKey: "auth-key",
+      configOptions: { apiKey: "config-key" },
+    })?.headers["Authorization"],
+  ).toBe("Bearer auth-key")
+})
+
+test("request: does not overwrite an explicit Authorization header from config", () => {
+  const result = FetchModels.request({
+    catalogBaseURL: "https://catalog.example",
+    authKey: "auth-key",
+    configOptions: { headers: { authorization: "Token preset" } },
+  })
+  expect(result?.headers).toEqual({ authorization: "Token preset" })
+})

--- a/packages/opencode/src/provider/fetch-models.ts
+++ b/packages/opencode/src/provider/fetch-models.ts
@@ -1,0 +1,81 @@
+import { z } from "zod"
+
+// Discover model IDs from an OpenAI-compatible provider/gateway `/models` endpoint.
+// Mirrors the fetch+parse precedent in plugin/github-copilot/models.ts, but stays
+// generic: we only keep id + display name, never infer capabilities from arbitrary
+// gateway IDs (wrong metadata would break agent behavior — see issue #1463).
+export namespace FetchModels {
+  const Item = z.object({ id: z.string(), name: z.string().optional() })
+  const Shape = z.union([
+    z.object({ data: z.array(z.unknown()) }),
+    z.object({ models: z.array(z.unknown()) }),
+    z.array(z.unknown()),
+  ])
+
+  export type Parsed = { id: string; name: string }
+
+  // Accept the three shapes seen in the wild: { data: [...] } (OpenAI), { models: [...] }, or a bare array.
+  // Throw on anything else so the caller can surface "this endpoint isn't a models API"; a valid but empty
+  // list is not an error — it just means there is nothing to add.
+  export function parse(json: unknown): Parsed[] {
+    const shaped = Shape.safeParse(json)
+    if (!shaped.success) throw new Error("Unexpected models response shape")
+    const rows = Array.isArray(shaped.data)
+      ? shaped.data
+      : "data" in shaped.data
+        ? shaped.data.data
+        : shaped.data.models
+
+    const seen = new Set<string>()
+    const result: Parsed[] = []
+    for (const row of rows) {
+      const item = Item.safeParse(row)
+      if (!item.success) continue
+      const id = item.data.id.trim()
+      if (!id || seen.has(id)) continue
+      seen.add(id)
+      result.push({ id, name: item.data.name?.trim() || id })
+    }
+    return result
+  }
+
+  export function endpoint(baseURL: string): string {
+    return `${baseURL.trim().replace(/\/+$/, "")}/models`
+  }
+
+  export type RequestInput = {
+    // Provider config `options` (user override): endpoint/baseURL/apiKey/headers.
+    configOptions?: {
+      endpoint?: string
+      baseURL?: string
+      apiKey?: string
+      headers?: Record<string, unknown>
+    }
+    // API key from the auth store (preferred over a config-embedded apiKey).
+    authKey?: string
+    // models.dev catalog base URL, used when the user has not overridden one.
+    catalogBaseURL?: string
+  }
+
+  // Resolve the base URL and request headers for the /models call. Base URL precedence: config
+  // endpoint, then config baseURL, then the catalog entry — so a connected provider like Kilo Gateway
+  // works untouched. Returns undefined when no base URL is known. Adds a Bearer header from the key
+  // unless the config already carries an explicit Authorization header.
+  export function request(input: RequestInput): { baseURL: string; headers: Record<string, string> } | undefined {
+    const options = input.configOptions
+    const baseURL = (options?.endpoint ?? options?.baseURL ?? input.catalogBaseURL ?? "").trim()
+    if (!baseURL) return undefined
+
+    const headers: Record<string, string> = {}
+    if (options?.headers) {
+      for (const [key, value] of Object.entries(options.headers)) {
+        if (typeof value === "string") headers[key] = value
+      }
+    }
+    const key = input.authKey ?? (typeof options?.apiKey === "string" ? options.apiKey : undefined)
+    if (key && !Object.keys(headers).some((header) => header.toLowerCase() === "authorization")) {
+      headers["Authorization"] = `Bearer ${key}`
+    }
+    return { baseURL, headers }
+  }
+}

--- a/packages/opencode/src/server/instance/provider-actions.ts
+++ b/packages/opencode/src/server/instance/provider-actions.ts
@@ -1,6 +1,8 @@
 import { Effect } from "effect"
 import { mapValues } from "remeda"
+import { Auth } from "../../auth"
 import { Config } from "../../config/config"
+import { FetchModels } from "../../provider/fetch-models"
 import { ModelState } from "../../provider/model-state"
 import { ModelsDev } from "../../provider/models"
 import { withPawWorkProviders } from "../../provider/pawwork-providers"
@@ -64,4 +66,66 @@ export const completeProviderAuth = Effect.fn("ProviderHttpApi.oauth.callback")(
 export const recordRecentModel = Effect.fn("ProviderHttpApi.recent.record")(function* (input: ModelState.ModelRef) {
   const modelState = yield* ModelState.Service
   yield* modelState.recordRecent(input)
+})
+
+export type FetchProviderModelsResult =
+  | { ok: true; models: FetchModels.Parsed[] }
+  | { ok: false; status: number; message: string }
+
+// Live-discover an OpenAI-compatible provider's models by calling its `/models` endpoint with the
+// provider's already-configured base URL + auth + headers. The base URL comes from the user's config
+// override when present, otherwise the models.dev catalog entry (so connected providers like Kilo
+// Gateway work without re-entering anything). This only reads and returns the parsed list; persisting
+// the chosen additions is the app's job (merge into config.provider.<id>.models). Issue #1463.
+export const fetchProviderModels = Effect.fn("ProviderHttpApi.models.fetch")(function* (input: {
+  providerID: ProviderID
+}) {
+  const config = yield* Config.Service
+  const auth = yield* Auth.Service
+  const modelsDev = yield* ModelsDev.Service
+
+  const [configInfo, authInfo, modelsDevProviders] = yield* Effect.all(
+    [
+      config.get(),
+      auth.get(input.providerID).pipe(Effect.orElseSucceed(() => undefined)),
+      modelsDev.data().pipe(Effect.orElseSucceed(() => ({}) as Record<string, ModelsDev.Provider>)),
+    ],
+    { concurrency: "unbounded" },
+  )
+
+  const catalog = withPawWorkProviders(modelsDevProviders)[input.providerID]
+  const resolved = FetchModels.request({
+    configOptions: configInfo.provider?.[input.providerID]?.options,
+    authKey: authInfo?.type === "api" ? authInfo.key : undefined,
+    catalogBaseURL: catalog?.api,
+  })
+  if (!resolved) {
+    return { ok: false as const, status: 400, message: "No base URL configured for this provider" }
+  }
+  const { baseURL, headers } = resolved
+
+  return yield* Effect.promise(async (): Promise<FetchProviderModelsResult> => {
+    try {
+      const response = await fetch(FetchModels.endpoint(baseURL), { headers, signal: AbortSignal.timeout(10_000) })
+      if (!response.ok) {
+        return {
+          ok: false,
+          status: response.status,
+          message: `Provider returned ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
+        }
+      }
+      let json: unknown
+      try {
+        json = await response.json()
+      } catch {
+        return { ok: false, status: 502, message: "Provider returned a non-JSON response" }
+      }
+      return { ok: true, models: FetchModels.parse(json) }
+    } catch (error) {
+      if (error instanceof Error && error.name === "TimeoutError") {
+        return { ok: false, status: 504, message: "Request timed out" }
+      }
+      return { ok: false, status: 502, message: error instanceof Error ? error.message : "Request failed" }
+    }
+  })
 })

--- a/packages/opencode/src/server/instance/provider-actions.ts
+++ b/packages/opencode/src/server/instance/provider-actions.ts
@@ -70,7 +70,9 @@ export const recordRecentModel = Effect.fn("ProviderHttpApi.recent.record")(func
 
 export type FetchProviderModelsResult =
   | { ok: true; models: FetchModels.Parsed[] }
-  | { ok: false; status: number; message: string }
+  // The message carries the human-readable cause (status text, timeout, non-JSON); the app surfaces it
+  // verbatim and does not branch on a code, so no numeric status is returned. Issue #1463.
+  | { ok: false; message: string }
 
 // Live-discover an OpenAI-compatible provider's models by calling its `/models` endpoint with the
 // provider's already-configured base URL + auth + headers. The base URL comes from the user's config
@@ -100,7 +102,7 @@ export const fetchProviderModels = Effect.fn("ProviderHttpApi.models.fetch")(fun
     catalogBaseURL: catalog?.api,
   })
   if (!resolved) {
-    return { ok: false as const, status: 400, message: "No base URL configured for this provider" }
+    return { ok: false as const, message: "No base URL configured for this provider" }
   }
   const { baseURL, headers } = resolved
 
@@ -110,7 +112,6 @@ export const fetchProviderModels = Effect.fn("ProviderHttpApi.models.fetch")(fun
       if (!response.ok) {
         return {
           ok: false,
-          status: response.status,
           message: `Provider returned ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
         }
       }
@@ -118,14 +119,14 @@ export const fetchProviderModels = Effect.fn("ProviderHttpApi.models.fetch")(fun
       try {
         json = await response.json()
       } catch {
-        return { ok: false, status: 502, message: "Provider returned a non-JSON response" }
+        return { ok: false, message: "Provider returned a non-JSON response" }
       }
       return { ok: true, models: FetchModels.parse(json) }
     } catch (error) {
       if (error instanceof Error && error.name === "TimeoutError") {
-        return { ok: false, status: 504, message: "Request timed out" }
+        return { ok: false, message: "Request timed out" }
       }
-      return { ok: false, status: 502, message: error instanceof Error ? error.message : "Request failed" }
+      return { ok: false, message: error instanceof Error ? error.message : "Request failed" }
     }
   })
 })

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/provider.ts
@@ -7,7 +7,7 @@ import {
 import { ListResult } from "@/provider/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Schema } from "effect"
-import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import { BadRequestError, WorkspaceRoutingQuery } from "./common"
 
 const root = "/provider"
@@ -20,6 +20,26 @@ export const RecentModelInput = Schema.Struct({
   providerID: ProviderID,
   modelID: ModelID,
 })
+
+export const FetchedModel = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+})
+
+export const FetchModelsResult = Schema.Struct({
+  models: Schema.Array(FetchedModel),
+})
+
+export const FetchModelsError = Schema.Struct({
+  message: Schema.String,
+}).pipe(
+  HttpApiSchema.status(400),
+  (schema) =>
+    schema.annotate({
+      identifier: "FetchModelsError",
+      description: "Failed to reach or parse the provider's models endpoint.",
+    }),
+)
 
 export const ProviderApi = HttpApi.make("provider")
   .add(
@@ -82,6 +102,19 @@ export const ProviderApi = HttpApi.make("provider")
             summary: "Record recent model",
             description:
               "Persist the user's picked model as the recent default that model-less sessions (e.g. a Telegram /new) inherit. Called by the desktop model picker on an explicit pick.",
+          }),
+        ),
+        HttpApiEndpoint.post("fetchModels", `${root}/:providerID/models`, {
+          params: ProviderParam,
+          query: WorkspaceRoutingQuery,
+          success: FetchModelsResult,
+          error: FetchModelsError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "provider.fetchModels",
+            summary: "Fetch provider models",
+            description:
+              "Discover an OpenAI-compatible provider's models live from its /models endpoint using the provider's configured base URL, auth, and headers. Returns the parsed list without persisting it.",
           }),
         ),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
@@ -1,4 +1,4 @@
-import { authorizeProvider, completeProviderAuth, getAuthMethods, listProviders, recordRecentModel } from "@/server/instance/provider-actions"
+import { authorizeProvider, completeProviderAuth, fetchProviderModels, getAuthMethods, listProviders, recordRecentModel } from "@/server/instance/provider-actions"
 import { ProviderAuth } from "@/provider/auth"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { NamedError } from "@opencode-ai/util/error"
@@ -105,6 +105,13 @@ export const providerHandlers = HttpApiBuilder.group(ProviderApi, "provider", (h
         if (HttpServerResponse.isHttpServerResponse(payload)) return payload
         yield* recordRecentModel(payload)
         return HttpServerResponse.jsonUnsafe(true)
+      }),
+    )
+    .handleRaw("fetchModels", (ctx) =>
+      Effect.gen(function* () {
+        const result = yield* fetchProviderModels({ providerID: ctx.params.providerID })
+        if (!result.ok) return HttpServerResponse.jsonUnsafe({ message: result.message }, { status: 400 })
+        return HttpServerResponse.jsonUnsafe({ models: result.models })
       }),
     ),
 )

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -120,6 +120,8 @@ import type {
   ProjectUpdateErrors,
   ProjectUpdateResponses,
   ProviderAuthResponses,
+  ProviderFetchModelsErrors,
+  ProviderFetchModelsResponses,
   ProviderListResponses,
   ProviderOauthAuthorizeErrors,
   ProviderOauthAuthorizeResponses,
@@ -3477,6 +3479,40 @@ export class Provider extends HeyApiClient {
         ...params.headers,
       },
     })
+  }
+
+  /**
+   * Fetch provider models
+   *
+   * Discover an OpenAI-compatible provider's models live from its /models endpoint using the provider's configured base URL, auth, and headers. Returns the parsed list without persisting it.
+   */
+  public fetchModels<ThrowOnError extends boolean = false>(
+    parameters: {
+      providerID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "providerID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ProviderFetchModelsResponses, ProviderFetchModelsErrors, ThrowOnError>(
+      {
+        url: "/provider/{providerID}/models",
+        ...options,
+        ...params,
+      },
+    )
   }
 
   private _oauth?: Oauth

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2177,6 +2177,13 @@ export type ProviderAuthAuthorization = {
 }
 
 /**
+ * Failed to reach or parse the provider's models endpoint.
+ */
+export type FetchModelsError = {
+  message: string
+}
+
+/**
  * Invalid PawWork memory file
  */
 export type InvalidMemoryFileError = {
@@ -5879,6 +5886,41 @@ export type ProviderRecordRecentResponses = {
 }
 
 export type ProviderRecordRecentResponse = ProviderRecordRecentResponses[keyof ProviderRecordRecentResponses]
+
+export type ProviderFetchModelsData = {
+  body?: never
+  path: {
+    providerID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/provider/{providerID}/models"
+}
+
+export type ProviderFetchModelsErrors = {
+  /**
+   * Failed to reach or parse the provider's models endpoint.
+   */
+  400: FetchModelsError
+}
+
+export type ProviderFetchModelsError = ProviderFetchModelsErrors[keyof ProviderFetchModelsErrors]
+
+export type ProviderFetchModelsResponses = {
+  /**
+   * Success
+   */
+  200: {
+    models: Array<{
+      id: string
+      name: string
+    }>
+  }
+}
+
+export type ProviderFetchModelsResponse = ProviderFetchModelsResponses[keyof ProviderFetchModelsResponses]
 
 export type MemoryGetData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8917,6 +8917,96 @@
         ]
       }
     },
+    "/provider/{providerID}/models": {
+      "post": {
+        "tags": [
+          "provider"
+        ],
+        "operationId": "provider.fetchModels",
+        "parameters": [
+          {
+            "name": "providerID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "models": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "models"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Failed to reach or parse the provider's models endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FetchModelsError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Discover an OpenAI-compatible provider's models live from its /models endpoint using the provider's configured base URL, auth, and headers. Returns the parsed list without persisting it.",
+        "summary": "Fetch provider models",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\"\n\nconst client = createOpencodeClient()\nawait client.provider.fetchModels({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/memory": {
       "get": {
         "tags": [
@@ -19338,6 +19428,19 @@
           "instructions"
         ],
         "additionalProperties": false
+      },
+      "FetchModelsError": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "Failed to reach or parse the provider's models endpoint."
       },
       "InvalidMemoryFileError": {
         "type": "object",


### PR DESCRIPTION
## Summary

Add a **Fetch models** action to each OpenAI-compatible provider group in Settings > Models. It calls the provider's live `/models` endpoint using the provider's already-configured base URL, auth, and headers, parses the returned model IDs, and merges any the catalog/config does not already list into `config.provider.<id>.models`. Newly added models are explicitly marked hidden, so a large gateway never floods the picker — the user toggles on the ones they want.

- Server: `provider/fetch-models.ts` pure helpers (`parse` for `{data:[]}` / `{models:[]}` / bare-array shapes with dedup; `request` for base-URL precedence + Bearer header; `endpoint`); `fetchProviderModels` action; `POST /provider/:providerID/models` route + handler; regenerated `openapi.json` and the v2 SDK client (`client.provider.fetchModels`).
- App: per-group button in `settings-models.tsx` reusing the in-house `refresh` icon; `mergeFetchedModels` helper; en/zh i18n; a focused `settings-models-fetch` snap target.

## Why

Reported in #1463: with the same Kilo Gateway API key, LobeHub listed models PawWork did not (e.g. `stepfun/step-3.7-flash:free`). PawWork's model list for a recognized gateway like Kilo comes from the static `models.dev` catalog, which lags what the gateway actually serves live. This adds the missing path — fetch the gateway's current `/models` on demand and merge in what the catalog is missing — without building a full model database. The base URL is resolved from the user's config override when present, otherwise the `models.dev` catalog entry, so a provider connected with just an API key (the reporter's case) works without re-entering anything.

## Related Issue

Resolves #1463

## Human Review Status

Pending

## Review Focus

- `fetchProviderModels` resolution + error mapping (`provider-actions.ts`): base-URL precedence (config `endpoint`/`baseURL` → `models.dev` `api`), Bearer injected from the auth store (never overwriting an explicit `Authorization` header), 10s timeout, and that API keys are never logged.
- The persistence merge: `mergeFetchedModels` only writes models the provider does not already expose, preserves existing config entries, and `config.update`'s `mergeDeep` makes the write additive/idempotent. A config-added model inherits the gateway's base URL and npm from the catalog (`provider.ts` "extend database from config"), so only `{ name }` is persisted per model.
- Default visibility of new models: a freshly fetched model carries no `release_date`, and the model visibility default treats undated models as **visible** (`createModelsView.visible`). So `mergeFetchedModels` returns `addedModelIDs` and the handler marks exactly those hidden (`setVisibility(false)`) before persisting config — without this, a large gateway would flood the picker. Confirmed by the existing visibility contract in `context/models.test.ts`.
  - Note on test coverage: this side-effect chain is covered by composition of unit tests — `mergeFetchedModels` returns the correct `addedModelIDs` (its own test), and undated + `hide` pref → not visible (`context/models.test.ts`). The remaining seam is the two-line application in `fetchModels` (the `setVisibility(false)` loop + `updateConfig`), guarded by typecheck. We deliberately did not add a mounted-and-mocked component test: this codebase tests config-writing flows by extracting a pure function and testing it (`validateCustomProvider`, `mergeFetchedModels`), with no precedent for mocking the SDK + global sync in a component, and that pure extraction is already done.
- Eligibility gate: the button shows only for groups whose models use `@ai-sdk/openai-compatible`.

## Risk Notes

- No tag/source regression for recognized providers: persistence writes `config.provider.<id>.models`, which marks the provider `source: "config"` in `database`, but the later api-key pass (`provider.ts:1382`) overwrites `source` back to `"api"` for any provider with a stored API key. So a key-connected provider like Kilo keeps its "API key" tag in Settings > Providers. The written config entry carries no `npm`, so `isConfigCustom` stays false and the disconnect path is unchanged.
- Capabilities are intentionally not inferred from arbitrary gateway IDs (only id + display name are stored); wrong capability metadata could break agent behavior.
- Scope limited to OpenAI-compatible providers; the custom-provider creation dialog is intentionally out of scope for this PR.

## How To Verify

```text
opencode unit (parse + request resolution): bun test src/provider/fetch-models.test.ts -> 13 pass
app unit (merge + addedModelIDs): bun test src/components/settings-models-fetch.test.ts -> 6 pass
app unit (visibility contract: undated+hide -> hidden, undated+no-pref -> visible): bun test src/context/models.test.ts -> 5 pass
openapi drift guard: bun test test/server/openapi-generation-source.test.ts -> 7 pass (checked-in openapi.json matches generation; error pipeline change is action-internal, wire contract unchanged)
opencode typecheck: bun run typecheck -> exit 0
app typecheck: bun run typecheck -> exit 0
eslint (changed app files): 0 errors
git diff --check: clean
visual: bun run snap settings-models-fetch -> real SettingsModels group renders the Fetch models button (refresh icon, right-aligned in the group header) above the model rows
```

## Screenshots or Recordings

Visual check via the added snap target `settings-models-fetch` (`bun run snap settings-models-fetch`; grid PNG under `docs/design/preview/screenshots/`). It captures the real Settings > Models provider group with the **Fetch models** button (in-house `refresh` icon, right-aligned in the group header) above the model rows with their visibility toggles.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live “Fetch models” for OpenAI-compatible providers in Settings → Models, including a per-provider refresh button and “loading” state.
  * Fetched results are merged/deduplicated into the existing catalog; newly added models are hidden by default.
  * Added success and “no new models” toasts (with counts), plus error handling for fetch failures.
  * Introduced a backend endpoint and OpenAPI contract for provider model discovery.
* **Tests**
  * Added unit tests for model parsing and merge behavior, plus a visual regression test for the Settings → Models fetch UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
