### PR TITLE
feat(desktop): make diagnostics packages agent-readable JSON

### DIFF
--- a/packages/app/src/components/diagnostics-review.test.tsx
+++ b/packages/app/src/components/diagnostics-review.test.tsx
@@ -54,8 +54,8 @@ function makeDialog() {
 const ready: Extract<PrepareReportResult, { status: "ready" }> = {
   status: "ready",
   reportId: "rid_1",
-  fileName: "pawwork-problem-report.md",
-  locationHint: "PawWork app data/.../pawwork-problem-report.md",
+  fileName: "pawwork-problem-report.json",
+  locationHint: "PawWork app data/.../pawwork-problem-report.json",
   hasForm: true,
   contents: { logLines: 2, sessionMessages: null, rendererEvents: 0, rendererError: false },
 }
@@ -172,8 +172,8 @@ const language = { t: (key) => key }
 const ready = {
   status: "ready",
   reportId: "rid_1",
-  fileName: "pawwork-problem-report.md",
-  locationHint: "…/pawwork-problem-report.md",
+  fileName: "pawwork-problem-report.json",
+  locationHint: "…/pawwork-problem-report.json",
   hasForm: true,
   contents: { logLines: 2, sessionMessages: null, rendererEvents: 0, rendererError: false },
 }

--- a/packages/desktop-electron/scripts/report-problem-smoke.mjs
+++ b/packages/desktop-electron/scripts/report-problem-smoke.mjs
@@ -139,7 +139,7 @@ try {
       report.payload?.error?.summary === rendererError.summary &&
       report.payload?.error?.details?.includes('"kind":"manual-smoke"'),
     jsonHasAgentReadableSections:
-      report.payload?.meta?.reportVersion === 1 &&
+      report.payload?.meta?.reportVersion === 2 &&
       report.payload?.environment &&
       Array.isArray(report.payload?.recentErrors) &&
       Array.isArray(report.payload?.logTail),

--- a/packages/desktop-electron/scripts/report-problem-smoke.mjs
+++ b/packages/desktop-electron/scripts/report-problem-smoke.mjs
@@ -43,15 +43,18 @@ function buildSmokeEnv(homeDir) {
   }
 }
 
-function latestMarkdownReport(reportRoot) {
-  if (!existsSync(reportRoot)) return { fileName: undefined, markdown: "" }
+function latestJsonReport(reportRoot) {
+  if (!existsSync(reportRoot)) return { fileName: undefined, json: "", payload: undefined }
   const fileName = readdirSync(reportRoot)
-    .filter((name) => name.endsWith(".md"))
+    .filter((name) => name.endsWith(".json"))
     .sort()
     .at(-1)
+  const json = fileName ? readFileSync(join(reportRoot, fileName), "utf8") : ""
+  const payload = json ? JSON.parse(json) : undefined
   return {
     fileName,
-    markdown: fileName ? readFileSync(join(reportRoot, fileName), "utf8") : "",
+    json,
+    payload,
   }
 }
 
@@ -123,7 +126,8 @@ try {
 
   const userData = await app.evaluate(({ app }) => app.getPath("userData"))
   const reportRoot = join(userData, "problem-reports")
-  const report = latestMarkdownReport(reportRoot)
+  const report = latestJsonReport(reportRoot)
+  const logTail = Array.isArray(report.payload?.logTail) ? report.payload.logTail : []
 
   const summary = {
     homeDir,
@@ -131,11 +135,16 @@ try {
     result,
     staleActions,
     latestReport: report.fileName,
-    markdownHasRendererError:
-      report.markdown.includes(rendererError.summary) && report.markdown.includes('\\"kind\\":\\"manual-smoke\\"'),
-    markdownHasReportPayload: report.markdown.includes("```json"),
-    markdownHasMainLog: report.markdown.includes("== Main process log:"),
-    markdownHasBackendLog: report.markdown.includes("== Backend log:"),
+    jsonHasRendererError:
+      report.payload?.error?.summary === rendererError.summary &&
+      report.payload?.error?.details?.includes('"kind":"manual-smoke"'),
+    jsonHasAgentReadableSections:
+      report.payload?.meta?.reportVersion === 1 &&
+      report.payload?.environment &&
+      Array.isArray(report.payload?.recentErrors) &&
+      Array.isArray(report.payload?.logTail),
+    jsonHasMainLog: logTail.some((line) => line.includes("== Main process log:")),
+    jsonHasBackendLog: logTail.some((line) => line.includes("== Backend log:")),
   }
 
   console.log(JSON.stringify(summary, null, 2))
@@ -152,11 +161,11 @@ try {
     staleActions?.submit?.status === "stale",
     `expected a stale submit through the real bridge; got ${JSON.stringify(staleActions?.submit)}`,
   )
-  assert(report.fileName, "expected a saved markdown problem report")
-  assert(summary.markdownHasRendererError, "expected full report to include renderer error details")
-  assert(summary.markdownHasReportPayload, "expected full report to include the fenced JSON payload")
-  assert(summary.markdownHasMainLog, "expected full report to include main process log tail")
-  assert(summary.markdownHasBackendLog, "expected full report to include backend log tail")
+  assert(report.fileName, "expected a saved JSON problem report")
+  assert(summary.jsonHasRendererError, "expected full report to include renderer error details")
+  assert(summary.jsonHasAgentReadableSections, "expected full report to include agent-readable JSON sections")
+  assert(summary.jsonHasMainLog, "expected full report to include main process log tail")
+  assert(summary.jsonHasBackendLog, "expected full report to include backend log tail")
 } finally {
   await closeApp(app)
   rmSync(homeDir, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 })

--- a/packages/desktop-electron/src/main/feedback.test.ts
+++ b/packages/desktop-electron/src/main/feedback.test.ts
@@ -25,7 +25,7 @@ function setup(overrides: Partial<Parameters<typeof createFeedbackHandler>[0]> =
     showItemCount: 0,
     openedPath: "",
     cleanedUp: "",
-    savedMarkdown: "",
+    savedJson: "",
     errors: [] as unknown[],
     handledErrors: [] as string[],
   }
@@ -46,12 +46,12 @@ function setup(overrides: Partial<Parameters<typeof createFeedbackHandler>[0]> =
       openPath: async (path) => {
         calls.openedPath = path
       },
-      saveReport: async ({ markdown, reportId }) => {
-        calls.savedMarkdown = markdown
+      saveReport: async ({ json, reportId }) => {
+        calls.savedJson = json
         return {
-          path: `/tmp/pawwork/problem-reports/pawwork-problem-report-${reportId}.md`,
-          fileName: `pawwork-problem-report-${reportId}.md`,
-          locationHint: `PawWork app data/.../problem-reports/pawwork-problem-report-${reportId}.md`,
+          path: `/tmp/pawwork/problem-reports/pawwork-problem-report-${reportId}.json`,
+          fileName: `pawwork-problem-report-${reportId}.json`,
+          locationHint: `PawWork app data/.../problem-reports/pawwork-problem-report-${reportId}.json`,
         }
       },
       cleanupReports: async (path) => {
@@ -90,7 +90,8 @@ describe("prepareReport", () => {
     const subject = setup()
     const result = await subject.handler.prepareReport()
 
-    expect(subject.calls.savedMarkdown).toContain("# PawWork Problem Report")
+    expect(subject.calls.savedJson).toContain('"meta"')
+    expect(subject.calls.savedJson).not.toContain("# PawWork Problem Report")
     expect(subject.calls.cleanedUp).toContain("/tmp/pawwork/problem-reports/")
     // Preparation is inert: reveal and form are the user's explicit follow-up choices.
     expect(subject.calls.openExternalCount).toBe(0)
@@ -143,7 +144,7 @@ describe("prepareReport", () => {
       rendererEvents: 2,
       rendererError: true,
     })
-    expect(subject.calls.savedMarkdown).toContain("ChildStoreError: Failed to create persisted cache")
+    expect(subject.calls.savedJson).toContain("ChildStoreError: Failed to create persisted cache")
   })
 
   test("hasForm is false when no feedback URL is configured", async () => {
@@ -152,7 +153,8 @@ describe("prepareReport", () => {
     expect(result.status).toBe("ready")
     if (result.status !== "ready") throw new Error("expected ready")
     expect(result.hasForm).toBe(false)
-    expect(subject.calls.savedMarkdown).toContain("# PawWork Problem Report")
+    expect(subject.calls.savedJson).toContain('"meta"')
+    expect(subject.calls.savedJson).not.toContain("# PawWork Problem Report")
   })
 
   test("session export failure downgrades the package but still prepares it", async () => {
@@ -163,8 +165,8 @@ describe("prepareReport", () => {
     })
     const result = await subject.handler.prepareReport()
     expect(result.status).toBe("ready")
-    expect(subject.calls.savedMarkdown).toContain('"status": "failed"')
-    expect(subject.calls.savedMarkdown).toContain("session unavailable")
+    expect(subject.calls.savedJson).toContain('"status": "failed"')
+    expect(subject.calls.savedJson).toContain("session unavailable")
   })
 
   test("renderer diagnostics failure still prepares the package", async () => {
@@ -176,7 +178,7 @@ describe("prepareReport", () => {
     const result = await subject.handler.prepareReport()
     expect(result.status).toBe("ready")
     expect(subject.calls.handledErrors).toContain("renderer diagnostics slice failed")
-    expect(subject.calls.savedMarkdown).toContain('"status": "write_failed"')
+    expect(subject.calls.savedJson).toContain('"status": "write_failed"')
   })
 
   test("slow renderer diagnostics times out and still prepares the package", async () => {
@@ -187,7 +189,7 @@ describe("prepareReport", () => {
     const result = await subject.handler.prepareReport()
     expect(result.status).toBe("ready")
     expect(subject.calls.handledErrors).toContain("renderer diagnostics slice failed")
-    expect(subject.calls.savedMarkdown).toContain('"status": "write_failed"')
+    expect(subject.calls.savedJson).toContain('"status": "write_failed"')
   })
 
   test("slow session export times out, aborts, and still prepares the package", async () => {
@@ -204,8 +206,8 @@ describe("prepareReport", () => {
     const result = await subject.handler.prepareReport()
     expect(result.status).toBe("ready")
     expect(aborted).toBe(true)
-    expect(subject.calls.savedMarkdown).toContain('"status": "failed"')
-    expect(subject.calls.savedMarkdown).toContain("session export timed out")
+    expect(subject.calls.savedJson).toContain('"status": "failed"')
+    expect(subject.calls.savedJson).toContain("session export timed out")
   })
 
   test("file write failure returns a copyable summary fallback without leaking paths", async () => {

--- a/packages/desktop-electron/src/main/feedback.test.ts
+++ b/packages/desktop-electron/src/main/feedback.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createFeedbackHandler } from "./feedback"
+import { parseProblemReportPayload } from "./problem-report"
 
 const diagnostics = {
   appVersion: "0.2.4",
@@ -145,6 +146,33 @@ describe("prepareReport", () => {
       rendererError: true,
     })
     expect(subject.calls.savedJson).toContain("ChildStoreError: Failed to create persisted cache")
+  })
+
+  test("uses the same recent error selection for the saved JSON and fallback summary", async () => {
+    const subject = setup({
+      logTail: () =>
+        [
+          "plain boot line",
+          "[warn] retry started",
+          "[error] launch failed",
+          "details without keyword",
+          "[exception] renderer crashed",
+        ].join("\n"),
+      openExternal: async () => {
+        throw new Error("browser unavailable")
+      },
+    })
+    const prepared = await subject.handler.prepareReport()
+    expect(prepared.status).toBe("ready")
+    if (prepared.status !== "ready") throw new Error("expected ready")
+
+    const payload = parseProblemReportPayload(subject.calls.savedJson)
+    const submitted = await subject.handler.submitReport(prepared.reportId)
+
+    expect(payload.recentErrors).toEqual(["[warn] retry started", "[error] launch failed", "[exception] renderer crashed"])
+    expect(submitted.status).toBe("form-fallback")
+    if (submitted.status !== "form-fallback") throw new Error("expected form fallback")
+    for (const line of payload.recentErrors) expect(submitted.summary).toContain(`- ${line}`)
   })
 
   test("hasForm is false when no feedback URL is configured", async () => {

--- a/packages/desktop-electron/src/main/feedback.ts
+++ b/packages/desktop-electron/src/main/feedback.ts
@@ -12,6 +12,7 @@ import {
   buildProblemReportSummary,
   DEFAULT_PROBLEM_REPORT_MAX_BYTES,
   defaultReportId,
+  recentKeyErrors,
   type ProblemReportDiagnostics,
   type SessionExport,
 } from "./problem-report"
@@ -116,15 +117,6 @@ function localRedactTerms(): string[] {
     // ignore — no username term
   }
   return terms
-}
-
-function recentKeyErrors(logTail: string) {
-  return logTail
-    .split(/\r?\n/)
-    .filter((line) => /\b(error|warn|warning|failed|exception)\b/i.test(line))
-    .map((line) => line.replace(/\s+/g, " ").trim())
-    .filter(Boolean)
-    .slice(-10)
 }
 
 async function sessionExportWithTimeout(deps: FeedbackDeps, context: unknown) {

--- a/packages/desktop-electron/src/main/feedback.ts
+++ b/packages/desktop-electron/src/main/feedback.ts
@@ -27,7 +27,7 @@ type SavedReport = {
 type SaveReportInput = {
   reportId: string
   generatedAt: string
-  markdown: string
+  json: string
 }
 
 type FeedbackContextOverride = {
@@ -216,7 +216,7 @@ export function createFeedbackHandler(deps: FeedbackDeps): FeedbackHandler {
           { diagnostics, logTail, sessionExport, rendererDiagnostics, rendererError: input.rendererError },
           { reportId: id, generatedAt, maxBytes: DEFAULT_PROBLEM_REPORT_MAX_BYTES, redactTerms },
         )
-        savedReport = await deps.saveReport({ reportId: id, generatedAt, markdown: report.markdown })
+        savedReport = await deps.saveReport({ reportId: id, generatedAt, json: report.json })
       } catch (error) {
         fullReportFailure = safeFailureReason(error)
       }

--- a/packages/desktop-electron/src/main/problem-report-files.test.ts
+++ b/packages/desktop-electron/src/main/problem-report-files.test.ts
@@ -163,4 +163,24 @@ describe("problem report files", () => {
     expect(existsSync(newestArchived)).toBe(true)
     expect(existsSync(oldestArchived)).toBe(false)
   })
+
+  test("cleanup removes legacy Markdown reports without matching ordinary Markdown files", async () => {
+    const root = await tempRoot()
+    const current = await writeProblemReportFile({
+      root,
+      reportId: "pwr_current",
+      generatedAt: "2026-04-23T01:02:03.004Z",
+      json: "current",
+    })
+    const legacyReport = join(root, "pawwork-problem-report-20260423-010203-004-pwr_legacy.md")
+    const ordinaryMarkdown = join(root, "notes.md")
+    await writeFile(legacyReport, "legacy")
+    await writeFile(ordinaryMarkdown, "notes")
+
+    await cleanupProblemReports({ root, keep: 1, currentPath: current.path })
+
+    expect(existsSync(current.path)).toBe(true)
+    expect(existsSync(legacyReport)).toBe(false)
+    expect(existsSync(ordinaryMarkdown)).toBe(true)
+  })
 })

--- a/packages/desktop-electron/src/main/problem-report-files.test.ts
+++ b/packages/desktop-electron/src/main/problem-report-files.test.ts
@@ -24,7 +24,7 @@ afterEach(async () => {
 })
 
 describe("problem report files", () => {
-  test("builds collision-resistant markdown file names in local time", () => {
+  test("builds collision-resistant JSON file names in local time", () => {
     const generatedAt = new Date(2026, 3, 23, 9, 2, 3, 4).toISOString()
     const first = problemReportFileName({
       reportId: "pwr_abc123",
@@ -35,8 +35,8 @@ describe("problem report files", () => {
       generatedAt,
     })
 
-    expect(first).toBe("pawwork-problem-report-20260423-090203-004-pwr_abc123.md")
-    expect(second).toBe("pawwork-problem-report-20260423-090203-004-pwr_def456.md")
+    expect(first).toBe("pawwork-problem-report-20260423-090203-004-pwr_abc123.json")
+    expect(second).toBe("pawwork-problem-report-20260423-090203-004-pwr_def456.json")
   })
 
   test("rejects report ids that cannot be cleaned up safely", () => {
@@ -67,14 +67,14 @@ describe("problem report files", () => {
       root,
       reportId: "pwr_abc123",
       generatedAt: "2026-04-23T01:02:03.004Z",
-      markdown: "first",
+      json: "first",
     })
     await expect(
       writeProblemReportFile({
         root,
         reportId: "pwr_abc123",
         generatedAt: "2026-04-23T01:02:03.004Z",
-        markdown: "second",
+        json: "second",
       }),
     ).rejects.toThrow("Problem report already exists")
 
@@ -88,7 +88,7 @@ describe("problem report files", () => {
       root,
       reportId: "pwr_cleanup_failed",
       generatedAt: "2026-04-23T01:02:03.004Z",
-      markdown: "report",
+      json: "report",
       removeTemp: async () => {
         cleanupAttempted = true
         throw new Error("cleanup failed")
@@ -102,16 +102,16 @@ describe("problem report files", () => {
   test("creates a user-facing location hint without full local paths", () => {
     expect(
       reportLocationHint({
-        fileName: "pawwork-problem-report-20260423-010203-004-pwr_abc123.md",
+        fileName: "pawwork-problem-report-20260423-010203-004-pwr_abc123.json",
         platform: "darwin",
       }),
-    ).toBe("PawWork app data/.../problem-reports/pawwork-problem-report-20260423-010203-004-pwr_abc123.md")
+    ).toBe("PawWork app data/.../problem-reports/pawwork-problem-report-20260423-010203-004-pwr_abc123.json")
     expect(
       reportLocationHint({
-        fileName: "pawwork-problem-report-20260423-010203-004-pwr_abc123.md",
+        fileName: "pawwork-problem-report-20260423-010203-004-pwr_abc123.json",
         platform: "win32",
       }),
-    ).toBe("%APPDATA%/.../problem-reports/pawwork-problem-report-20260423-010203-004-pwr_abc123.md")
+    ).toBe("%APPDATA%/.../problem-reports/pawwork-problem-report-20260423-010203-004-pwr_abc123.json")
   })
 
   test("cleanup keeps current report and skips non-regular or non-matching entries", async () => {
@@ -120,12 +120,12 @@ describe("problem report files", () => {
       root,
       reportId: "pwr_current",
       generatedAt: "2026-04-23T01:02:03.004Z",
-      markdown: "current",
+      json: "current",
     })
-    const old = join(root, "pawwork-problem-report-20260423-010203-004-pwr_old.md")
+    const old = join(root, "pawwork-problem-report-20260423-010203-004-pwr_old.json")
     const other = join(root, "notes.md")
-    const dir = join(root, "pawwork-problem-report-20260423-010203-004-pwr_dir.md")
-    const link = join(root, "pawwork-problem-report-20260423-010203-004-pwr_link.md")
+    const dir = join(root, "pawwork-problem-report-20260423-010203-004-pwr_dir.json")
+    const link = join(root, "pawwork-problem-report-20260423-010203-004-pwr_link.json")
     await writeFile(old, "old")
     await writeFile(other, "other")
     await mkdir(dir)
@@ -146,10 +146,10 @@ describe("problem report files", () => {
       root,
       reportId: "pwr_current",
       generatedAt: "2026-04-23T01:02:03.004Z",
-      markdown: "current",
+      json: "current",
     })
-    const newestArchived = join(root, "pawwork-problem-report-20260423-010203-004-pwr_newest.md")
-    const oldestArchived = join(root, "pawwork-problem-report-20260423-010203-004-pwr_oldest.md")
+    const newestArchived = join(root, "pawwork-problem-report-20260423-010203-004-pwr_newest.json")
+    const oldestArchived = join(root, "pawwork-problem-report-20260423-010203-004-pwr_oldest.json")
     await writeFile(newestArchived, "newest")
     await writeFile(oldestArchived, "oldest")
 

--- a/packages/desktop-electron/src/main/problem-report-files.ts
+++ b/packages/desktop-electron/src/main/problem-report-files.ts
@@ -1,7 +1,7 @@
 import { link, lstat, mkdir, readdir, rm, writeFile } from "node:fs/promises"
 import { basename, join } from "node:path"
 
-const REPORT_FILE_PATTERN = /^pawwork-problem-report-\d{8}-\d{6}-\d{3}-[a-zA-Z0-9_]+\.md$/
+const REPORT_FILE_PATTERN = /^pawwork-problem-report-\d{8}-\d{6}-\d{3}-[a-zA-Z0-9_]+\.json$/
 const REPORT_ID_PATTERN = /^[a-zA-Z0-9_]+$/
 
 function isCanonicalIsoTimestamp(value: string) {
@@ -24,7 +24,7 @@ export function problemReportFileName(input: { reportId: string; generatedAt: st
     "-",
     String(date.getMilliseconds()).padStart(3, "0"),
   ].join("")
-  return `pawwork-problem-report-${stamp}-${input.reportId}.md`
+  return `pawwork-problem-report-${stamp}-${input.reportId}.json`
 }
 
 export function problemReportsRoot(userDataPath: string) {
@@ -40,7 +40,7 @@ export async function writeProblemReportFile(input: {
   root: string
   reportId: string
   generatedAt: string
-  markdown: string
+  json: string
   removeTemp?: (path: string) => Promise<void>
 }) {
   await mkdir(input.root, { recursive: true })
@@ -49,7 +49,7 @@ export async function writeProblemReportFile(input: {
   const tempPath = join(input.root, `.${fileName}.${process.pid}.${Date.now()}.tmp`)
   const removeTemp = input.removeTemp ?? ((path: string) => rm(path, { force: true }))
   try {
-    await writeFile(tempPath, input.markdown, { encoding: "utf8", flag: "wx", mode: 0o600 })
+    await writeFile(tempPath, input.json, { encoding: "utf8", flag: "wx", mode: 0o600 })
     try {
       await link(tempPath, path)
     } catch (error) {

--- a/packages/desktop-electron/src/main/problem-report-files.ts
+++ b/packages/desktop-electron/src/main/problem-report-files.ts
@@ -2,6 +2,7 @@ import { link, lstat, mkdir, readdir, rm, writeFile } from "node:fs/promises"
 import { basename, join } from "node:path"
 
 const REPORT_FILE_PATTERN = /^pawwork-problem-report-\d{8}-\d{6}-\d{3}-[a-zA-Z0-9_]+\.json$/
+const CLEANUP_REPORT_FILE_PATTERN = /^pawwork-problem-report-\d{8}-\d{6}-\d{3}-[a-zA-Z0-9_]+\.(json|md)$/
 const REPORT_ID_PATTERN = /^[a-zA-Z0-9_]+$/
 
 function isCanonicalIsoTimestamp(value: string) {
@@ -73,7 +74,7 @@ export async function cleanupProblemReports(input: { root: string; keep: number;
   try {
     const names = await readdir(input.root)
     for (const name of names) {
-      if (!REPORT_FILE_PATTERN.test(name)) continue
+      if (!CLEANUP_REPORT_FILE_PATTERN.test(name)) continue
       const path = join(input.root, name)
       if (path === input.currentPath) continue
       try {

--- a/packages/desktop-electron/src/main/problem-report-redact.test.ts
+++ b/packages/desktop-electron/src/main/problem-report-redact.test.ts
@@ -642,17 +642,17 @@ describe("buildProblemReport redaction gate", () => {
 
     const samples = [...Object.values(TOKENS), ...Object.values(PATHS), USERNAME, EMAIL]
     for (const sample of samples) {
-      expect(report.markdown, sample).not.toContain(sample)
+      expect(report.json, sample).not.toContain(sample)
     }
     // A bare key body stranded in the log tail (header truncated away) is scrubbed end-to-end.
-    expect(report.markdown).not.toContain(strandedKeyBody)
+    expect(report.json).not.toContain(strandedKeyBody)
     // The rogue rendererError field was dropped, not carried through.
-    expect(report.markdown).not.toContain("extra-field-secret-7f3a")
+    expect(report.json).not.toContain("extra-field-secret-7f3a")
     // The renderer summary (not just events) is scrubbed.
-    expect(report.markdown).not.toContain("sk-ant-statusleak0000000000000000")
+    expect(report.json).not.toContain("sk-ant-statusleak0000000000000000")
     // The report is still a valid, parseable payload after redaction.
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.sessionExport.status).toBe("ok")
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.session.status).toBe("ok")
   })
 
   test("shape-tokens diagnostics directory and logPath even under a non-allowlisted root", () => {
@@ -670,10 +670,10 @@ describe("buildProblemReport redaction gate", () => {
       { reportId: "pwr_custompath", generatedAt: "2026-06-22T01:02:03.004Z" },
     )
 
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.diagnostics.directory).toBe("[path]")
-    expect(payload.diagnostics.logPath).toBe("[path]")
-    expect(report.markdown).not.toContain("customroot")
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.environment.directory).toBe("[path]")
+    expect(payload.environment.logPath).toBe("[path]")
+    expect(report.json).not.toContain("customroot")
   })
 
   test("scrubs a non-string rendererError field arriving from the untyped IPC boundary", () => {
@@ -690,6 +690,6 @@ describe("buildProblemReport redaction gate", () => {
       },
       { reportId: "pwr_nonstring", generatedAt: "2026-06-22T01:02:03.004Z" },
     )
-    expect(report.markdown).not.toContain(TOKENS.anthropic)
+    expect(report.json).not.toContain(TOKENS.anthropic)
   })
 })

--- a/packages/desktop-electron/src/main/problem-report.test.ts
+++ b/packages/desktop-electron/src/main/problem-report.test.ts
@@ -72,25 +72,59 @@ describe("problem report", () => {
       generatedAt: "2026-04-23T01:02:03.004Z",
     })
 
-    const payload = parseProblemReportPayload(report.markdown)
+    const payload = parseProblemReportPayload(report.json)
     expect(report.reportId).toBe("pwr_20260423_abc123")
     expect(report.generatedAt).toBe("2026-04-23T01:02:03.004Z")
-    expect(payload.reportId).toBe("pwr_20260423_abc123")
-    expect(payload.generatedAt).toBe("2026-04-23T01:02:03.004Z")
+    expect(payload.meta.reportId).toBe("pwr_20260423_abc123")
+    expect(payload.meta.generatedAt).toBe("2026-04-23T01:02:03.004Z")
   })
 
-  test("creates markdown with valid fenced JSON", () => {
+  test("creates valid agent-readable JSON", () => {
     const report = buildProblemReport(base)
-    expect(report.markdown).toContain("# PawWork Problem Report")
-    expect(report.markdown).toContain("Upload this markdown file to the feedback form after reviewing it.")
-    expect(report.markdown).not.toContain("Paste this report into the feedback form")
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.reportVersion).toBe(1)
-    expect(payload.reportId).toBe(report.reportId)
-    expect(payload.diagnostics.sessionID).toBe("ses_1")
-    expect(payload.sessionExport.status).toBe("ok")
+    expect(report.json).not.toContain("# PawWork Problem Report")
+    expect(report.json).not.toContain("```json")
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.meta.reportVersion).toBe(1)
+    expect(payload.meta.reportId).toBe(report.reportId)
+    expect(payload.environment.sessionID).toBe("ses_1")
+    expect(payload.session.status).toBe("ok")
     expect(payload.rendererDiagnostics?.status).toBe("ok")
     expect(payload.rendererDiagnostics?.summary.event_count).toBe(1)
+  })
+
+  test("creates agent-readable JSON with stable top-level sections and log lines", () => {
+    const report = buildProblemReport(
+      {
+        ...base,
+        logTail: ["main: boot", "warn: renderer failed"].join("\n"),
+        rendererError: { summary: "Renderer crashed", details: "stack line" },
+      },
+      {
+        reportId: "pwr_agent_readable",
+        generatedAt: "2026-06-24T01:02:03.004Z",
+      },
+    )
+
+    const json = (report as { json?: string }).json
+    expect(json).toBeTruthy()
+    expect(json).not.toContain("```json")
+
+    const payload = parseProblemReportPayload(json ?? "")
+    expect(Object.keys(payload)).toEqual([
+      "meta",
+      "environment",
+      "error",
+      "recentErrors",
+      "session",
+      "rendererDiagnostics",
+      "logTail",
+    ])
+    expect(payload.meta.reportId).toBe("pwr_agent_readable")
+    expect(payload.meta.truncation.omittedLogBytes).toBe(0)
+    expect(payload.environment.sessionID).toBe("ses_1")
+    expect(payload.error?.summary).toBe("Renderer crashed")
+    expect(payload.recentErrors).toEqual(["warn: renderer failed"])
+    expect(payload.logTail.at(-1)).toBe("warn: renderer failed")
   })
 
   test("summarizes renderer diagnostics without exposing event payloads", () => {
@@ -98,8 +132,8 @@ describe("problem report", () => {
       reportId: "pwr_20260423_abc123",
       generatedAt: "2026-04-23T01:02:03.004Z",
       diagnostics: base.diagnostics,
-      reportFileName: "pawwork-problem-report.md",
-      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report.md",
+      reportFileName: "pawwork-problem-report.json",
+      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report.json",
       fullReportStatus: "ready",
       recentErrors: [],
       rendererDiagnostics: base.rendererDiagnostics,
@@ -114,15 +148,15 @@ describe("problem report", () => {
       reportId: "pwr_20260423_abc123",
       generatedAt: "2026-04-23T01:02:03.004Z",
       diagnostics: base.diagnostics,
-      reportFileName: "pawwork-problem-report-20260423-090203-004-abc123.md",
-      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-abc123.md",
+      reportFileName: "pawwork-problem-report-20260423-090203-004-abc123.json",
+      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-abc123.json",
       fullReportStatus: "ready",
       recentErrors: ["[error] launch failed", "[warn] retrying"],
     })
 
     expect(summary).toContain("PawWork Problem Report Summary")
     expect(summary).toContain("Report ID: pwr_20260423_abc123")
-    expect(summary).toContain("Report file: pawwork-problem-report-20260423-090203-004-abc123.md")
+    expect(summary).toContain("Report file: pawwork-problem-report-20260423-090203-004-abc123.json")
     expect(summary).toContain("Full report: ready for manual upload")
     expect(summary).toContain("[error] launch failed")
     expect(summary).not.toContain(base.diagnostics.logPath)
@@ -143,13 +177,13 @@ describe("problem report", () => {
       ].join("\n"),
     }
     const report = buildProblemReport({ ...base, rendererError })
-    const payload = parseProblemReportPayload(report.markdown)
+    const payload = parseProblemReportPayload(report.json)
     const summary = buildProblemReportSummary({
       reportId: report.reportId,
       generatedAt: report.generatedAt,
       diagnostics: base.diagnostics,
-      reportFileName: "pawwork-problem-report.md",
-      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report.md",
+      reportFileName: "pawwork-problem-report.json",
+      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report.json",
       fullReportStatus: "ready",
       recentErrors: [],
       rendererError,
@@ -157,11 +191,11 @@ describe("problem report", () => {
 
     // The full report now redacts the same secret/path shapes as the summary (PR1), so the
     // uploaded file no longer carries raw credentials or local paths in rendererError.
-    expect(payload.rendererError?.summary).toContain("storage=[redacted]")
-    expect(payload.rendererError?.summary).toContain("key=[redacted]")
-    expect(report.markdown).not.toContain("pawwork.workspace.project.abc123.dat")
-    expect(report.markdown).not.toContain("workspace:vcs")
-    expect(report.markdown).not.toContain("/Users/test/project")
+    expect(payload.error?.summary).toContain("storage=[redacted]")
+    expect(payload.error?.summary).toContain("key=[redacted]")
+    expect(report.json).not.toContain("pawwork.workspace.project.abc123.dat")
+    expect(report.json).not.toContain("workspace:vcs")
+    expect(report.json).not.toContain("/Users/test/project")
     expect(summary).toContain("Renderer error: PawWork hit a local state problem.")
     expect(summary).toContain("storage=[redacted]")
     expect(summary).toContain("key=[redacted]")
@@ -192,8 +226,8 @@ describe("problem report", () => {
       reportId: "pwr_20260423_errors",
       generatedAt: "2026-04-23T01:02:03.004Z",
       diagnostics: base.diagnostics,
-      reportFileName: "pawwork-problem-report-20260423-090203-004-errors.md",
-      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-errors.md",
+      reportFileName: "pawwork-problem-report-20260423-090203-004-errors.json",
+      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-errors.json",
       fullReportStatus: "ready",
       recentErrors: Array.from({ length: 20 }, (_, index) => `[error] failure ${index}\nstack line ${index}`),
     })
@@ -210,8 +244,8 @@ describe("problem report", () => {
       reportId: "pwr_long_errors",
       generatedAt: "2026-04-23T01:02:03.004Z",
       diagnostics: base.diagnostics,
-      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_long_errors.md",
-      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_long_errors.md",
+      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_long_errors.json",
+      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_long_errors.json",
       fullReportStatus: "ready",
       recentErrors: [`[error] tool output ${toolOutput}`],
     })
@@ -231,8 +265,8 @@ describe("problem report", () => {
         ...base.diagnostics,
         route: `/session/new?prompt=${encodeURIComponent(prompt)}#${"hash".repeat(200)}`,
       },
-      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_prompt_route.md",
-      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_prompt_route.md",
+      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_prompt_route.json",
+      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_prompt_route.json",
       fullReportStatus: "ready",
       recentErrors: [],
     })
@@ -253,8 +287,8 @@ describe("problem report", () => {
         ...base.diagnostics,
         sessionID: `${longSessionID}/C:\\Users\\name\\secret`,
       },
-      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_long_session.md",
-      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_long_session.md",
+      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_long_session.json",
+      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_long_session.json",
       fullReportStatus: "ready",
       recentErrors: [],
     })
@@ -275,8 +309,8 @@ describe("problem report", () => {
         directory: "C:\\Users\\张 三\\Project Space",
         logPath: "C:\\Users\\张 三\\AppData\\Roaming\\PawWork\\logs\\main.log",
       },
-      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_windows_paths.md",
-      reportLocationHint: "%APPDATA%/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_windows_paths.md",
+      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_windows_paths.json",
+      reportLocationHint: "%APPDATA%/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_windows_paths.json",
       fullReportStatus: "ready",
       recentErrors: ["[error] failed to launch C:\\Users\\张 三\\Project Space\\app.log"],
     })
@@ -299,8 +333,8 @@ describe("problem report", () => {
         directory: "/home/alice/workspace/project",
         logPath: "/home/alice/.config/PawWork/logs/main.log",
       },
-      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_unix_paths.md",
-      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_unix_paths.md",
+      reportFileName: "pawwork-problem-report-20260423-090203-004-pwr_unix_paths.json",
+      reportLocationHint: "PawWork app data/.../problem-reports/pawwork-problem-report-20260423-090203-004-pwr_unix_paths.json",
       fullReportStatus: "ready",
       recentErrors: [
         "[error] failed reading /home/alice/workspace/project/src/index.ts",
@@ -324,7 +358,7 @@ describe("problem report", () => {
       reportId: "pwr_terms",
       generatedAt: "2026-04-23T01:02:03.004Z",
       diagnostics: base.diagnostics,
-      reportFileName: "r.md",
+      reportFileName: "r.json",
       reportLocationHint: "hint",
       fullReportStatus: "ready",
       recentErrors: [
@@ -346,8 +380,8 @@ describe("problem report", () => {
       reportId: "pwr_cjk",
       generatedAt: "2026-04-23T01:02:03.004Z",
       diagnostics: base.diagnostics,
-      reportFileName: "problem.md",
-      reportLocationHint: "/customroot/山田/problem-reports/problem.md",
+      reportFileName: "problem.json",
+      reportLocationHint: "/customroot/山田/problem-reports/problem.json",
       fullReportStatus: "ready",
       recentErrors: ["[error] failed for user 山田"],
       rendererError: { summary: "crash for 山田", details: "" },
@@ -364,8 +398,8 @@ describe("problem report", () => {
       diagnostics: { ...base.diagnostics, sessionID: null },
       sessionExport: { status: "none" },
     })
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.sessionExport).toEqual({ status: "none" })
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.session).toEqual({ status: "none" })
     expect(payload.logTail).toContain("line two")
   })
 
@@ -374,8 +408,8 @@ describe("problem report", () => {
       ...base,
       sessionExport: { status: "failed", error: "session export failed: 500" },
     })
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.sessionExport).toEqual({ status: "failed", error: "session export failed: 500" })
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.session).toEqual({ status: "failed", error: "session export failed: 500" })
   })
 
   test("truncates oversized failed export errors", () => {
@@ -388,11 +422,11 @@ describe("problem report", () => {
       { maxBytes: 8_000 },
     )
 
-    expect(Buffer.byteLength(report.markdown, "utf8")).toBeLessThanOrEqual(8_000)
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.truncation.omittedFailedExportErrorBytes).toBeGreaterThan(0)
-    expect(payload.sessionExport.status).toBe("failed")
-    if (payload.sessionExport.status === "failed") expect(payload.sessionExport.error.length).toBeLessThan(100_000)
+    expect(Buffer.byteLength(report.json, "utf8")).toBeLessThanOrEqual(8_000)
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.meta.truncation.omittedFailedExportErrorBytes).toBeGreaterThan(0)
+    expect(payload.session.status).toBe("failed")
+    if (payload.session.status === "failed") expect(payload.session.error.length).toBeLessThan(100_000)
   })
 
   test("truncates oversized renderer error details to honor max bytes", () => {
@@ -410,12 +444,12 @@ describe("problem report", () => {
       { maxBytes: 8_000 },
     )
 
-    expect(Buffer.byteLength(report.markdown, "utf8")).toBeLessThanOrEqual(8_000)
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.rendererError?.summary).toBe("large renderer error")
-    expect(payload.rendererError?.details.length).toBeLessThan(details.length)
+    expect(Buffer.byteLength(report.json, "utf8")).toBeLessThanOrEqual(8_000)
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.error?.summary).toBe("large renderer error")
+    expect(payload.error?.details.length).toBeLessThan(details.length)
     // The ledger reflects what the overall ladder removed too, not only the component-budget cut.
-    expect(payload.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
+    expect(payload.meta.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
   })
 
   test("truncates renderer diagnostics events to honor max bytes", () => {
@@ -448,12 +482,12 @@ describe("problem report", () => {
       { maxBytes: 5_000 },
     )
 
-    expect(Buffer.byteLength(report.markdown, "utf8")).toBeLessThanOrEqual(5_000)
-    const payload = parseProblemReportPayload(report.markdown)
+    expect(Buffer.byteLength(report.json, "utf8")).toBeLessThanOrEqual(5_000)
+    const payload = parseProblemReportPayload(report.json)
     expect(payload.rendererDiagnostics?.status).toBe("truncated")
     expect(payload.rendererDiagnostics?.truncation).toBeUndefined()
     expect(payload.rendererDiagnostics?.summary.omitted_event_count).toBeGreaterThan(0)
-    expect(payload.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
+    expect(payload.meta.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
   })
 
   test("drains all-protected renderer diagnostics to fit a tight max bytes (no throw)", () => {
@@ -478,11 +512,11 @@ describe("problem report", () => {
 
     // Every event is a protected incident, yet the slice still drains to fit. The old fallback broke on
     // the first protected event, so the report would have exceeded maxBytes (or thrown) here.
-    expect(Buffer.byteLength(report.markdown, "utf8")).toBeLessThanOrEqual(5_000)
-    const payload = parseProblemReportPayload(report.markdown)
+    expect(Buffer.byteLength(report.json, "utf8")).toBeLessThanOrEqual(5_000)
+    const payload = parseProblemReportPayload(report.json)
     expect(payload.rendererDiagnostics?.status).toBe("truncated")
     expect(payload.rendererDiagnostics?.summary.omitted_event_count).toBeGreaterThan(0)
-    expect(payload.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
+    expect(payload.meta.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
   })
 
   test("re-bounds oversized renderer diagnostics to the component budget below the overall limit", () => {
@@ -501,8 +535,8 @@ describe("problem report", () => {
       },
     })
 
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.meta.truncation.omittedRendererDiagnosticsBytes).toBeGreaterThan(0)
     expect(payload.rendererDiagnostics?.summary.omitted_event_count).toBeGreaterThan(0)
     expect(Buffer.byteLength(JSON.stringify(payload.rendererDiagnostics?.events ?? []), "utf8")).toBeLessThanOrEqual(
       1024 * 1024,
@@ -523,16 +557,16 @@ describe("problem report", () => {
       },
     })
 
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.sessionExport.status).toBe("ok")
-    if (payload.sessionExport.status === "ok") {
-      expect(payload.sessionExport.info).toEqual({
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.session.status).toBe("ok")
+    if (payload.session.status === "ok") {
+      expect(payload.session.info).toEqual({
         id: "ses_1",
         executionContext: { activeDirectory: "[path]" },
       })
       // A non-{info,parts} message shape is reported, not passed through, so it cannot smuggle
       // raw content into the report (PR1 structure-aware allowlist).
-      const message = payload.sessionExport.messages[0] as { unrecognized?: boolean; bytes?: number }
+      const message = payload.session.messages[0] as { unrecognized?: boolean; bytes?: number }
       expect(message.unrecognized).toBe(true)
       expect(message.bytes).toBeGreaterThan(0)
     }
@@ -555,9 +589,9 @@ describe("problem report", () => {
       { maxBytes: 10_000 },
     )
 
-    expect(Buffer.byteLength(report.markdown, "utf8")).toBeLessThanOrEqual(10_000)
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.truncation.omittedMessages).toBeGreaterThan(0)
+    expect(Buffer.byteLength(report.json, "utf8")).toBeLessThanOrEqual(10_000)
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.meta.truncation.omittedMessages).toBeGreaterThan(0)
   })
 
   test("omits oversized session info to honor max bytes", () => {
@@ -576,11 +610,11 @@ describe("problem report", () => {
       { maxBytes: 3_000 },
     )
 
-    expect(Buffer.byteLength(report.markdown, "utf8")).toBeLessThanOrEqual(5_000)
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(payload.truncation.omittedSessionInfoBytes).toBeGreaterThan(0)
-    expect(payload.sessionExport.status).toBe("ok")
-    if (payload.sessionExport.status === "ok") expect(payload.sessionExport.info).toBeNull()
+    expect(Buffer.byteLength(report.json, "utf8")).toBeLessThanOrEqual(5_000)
+    const payload = parseProblemReportPayload(report.json)
+    expect(payload.meta.truncation.omittedSessionInfoBytes).toBeGreaterThan(0)
+    expect(payload.session.status).toBe("ok")
+    if (payload.session.status === "ok") expect(payload.session.info).toBeNull()
   })
 
   test("rejects invalid max byte limits", () => {
@@ -602,146 +636,37 @@ describe("problem report", () => {
     )
   })
 
-  test("parses only the first JSON fence", () => {
-    const report = [
-      "```json",
-      JSON.stringify({
-        reportVersion: 1,
-        reportId: "pwr_fixture",
-        generatedAt: new Date().toISOString(),
-        diagnostics: base.diagnostics,
-        logTail: "",
-        sessionExport: { status: "none" },
-        truncation: {
-          omittedMessages: 0,
-          omittedMessagePartsBytes: 0,
-          omittedLogBytes: 0,
-          omittedSessionInfoBytes: 0,
-          omittedFailedExportErrorBytes: 0,
-          omittedRendererErrorBytes: 0,
-          omittedRendererDiagnosticsBytes: 0,
-          omittedDiagnosticsBytes: 0,
-        },
-      }),
-      "```",
-      "",
-      "```",
-      "extra",
-      "```",
-    ].join("\n")
+  test("parses pure JSON payloads", () => {
+    const report = buildProblemReport({ ...base, sessionExport: { status: "none" } }).json
 
-    expect(parseProblemReportPayload(report).sessionExport.status).toBe("none")
+    expect(parseProblemReportPayload(report).session.status).toBe("none")
   })
 
-  test("parses CRLF fenced JSON", () => {
-    const report = [
-      "```json",
-      JSON.stringify({
-        reportVersion: 1,
-        reportId: "pwr_fixture",
-        generatedAt: new Date().toISOString(),
-        diagnostics: base.diagnostics,
-        logTail: "",
-        sessionExport: { status: "none" },
-        truncation: {
-          omittedMessages: 0,
-          omittedMessagePartsBytes: 0,
-          omittedLogBytes: 0,
-          omittedSessionInfoBytes: 0,
-          omittedFailedExportErrorBytes: 0,
-          omittedRendererErrorBytes: 0,
-          omittedRendererDiagnosticsBytes: 0,
-          omittedDiagnosticsBytes: 0,
-        },
-      }),
-      "```",
-    ].join("\r\n")
+  test("rejects legacy markdown fenced JSON reports", () => {
+    const report = ["# PawWork Problem Report", "", "```json", buildProblemReport(base).json, "```"].join("\n")
 
-    expect(parseProblemReportPayload(report).sessionExport.status).toBe("none")
-  })
-
-  test("skips invalid fenced JSON before a valid report", () => {
-    const report = [
-      "```json",
-      "{ invalid",
-      "```",
-      "```json",
-      JSON.stringify({
-        reportVersion: 1,
-        reportId: "pwr_fixture",
-        generatedAt: new Date().toISOString(),
-        diagnostics: base.diagnostics,
-        logTail: "",
-        sessionExport: { status: "none" },
-        truncation: {
-          omittedMessages: 0,
-          omittedMessagePartsBytes: 0,
-          omittedLogBytes: 0,
-          omittedSessionInfoBytes: 0,
-          omittedFailedExportErrorBytes: 0,
-          omittedRendererErrorBytes: 0,
-          omittedRendererDiagnosticsBytes: 0,
-          omittedDiagnosticsBytes: 0,
-        },
-      }),
-      "```",
-    ].join("\n")
-
-    expect(parseProblemReportPayload(report).sessionExport.status).toBe("none")
+    expect(() => parseProblemReportPayload(report)).toThrow("Problem report JSON payload not found")
   })
 
   test("rejects malformed renderer error details", () => {
-    const report = [
-      "```json",
-      JSON.stringify({
-        reportVersion: 1,
-        reportId: "pwr_fixture",
-        generatedAt: new Date().toISOString(),
-        diagnostics: base.diagnostics,
-        logTail: "",
-        rendererError: { summary: "missing details" },
-        sessionExport: { status: "none" },
-        truncation: {
-          omittedMessages: 0,
-          omittedMessagePartsBytes: 0,
-          omittedLogBytes: 0,
-          omittedSessionInfoBytes: 0,
-          omittedFailedExportErrorBytes: 0,
-          omittedRendererErrorBytes: 0,
-          omittedRendererDiagnosticsBytes: 0,
-          omittedDiagnosticsBytes: 0,
-        },
-      }),
-      "```",
-    ].join("\n")
+    const payload = parseProblemReportPayload(buildProblemReport({ ...base, sessionExport: { status: "none" } }).json)
+    const report = JSON.stringify({ ...payload, error: { summary: "missing details" } })
 
-    expect(() => parseProblemReportPayload(report)).toThrow("Problem report JSON block not found")
+    expect(() => parseProblemReportPayload(report)).toThrow("Problem report JSON payload not found")
   })
 
-  test("rejects fenced JSON that is not a valid problem report payload", () => {
-    const report = [
-      "```json",
-      JSON.stringify({
-        reportVersion: 1,
-        reportId: "pwr_invalid",
-        diagnostics: base.diagnostics,
-        logTail: "",
-        sessionExport: { status: "none" },
-        truncation: {
-          omittedMessages: 0,
-          omittedMessagePartsBytes: 0,
-          omittedLogBytes: 0,
-          omittedSessionInfoBytes: 0,
-          omittedFailedExportErrorBytes: 0,
-          omittedRendererErrorBytes: 0,
-          omittedRendererDiagnosticsBytes: 0,
-          omittedDiagnosticsBytes: 0,
-        },
-      }),
-      "```",
-    ].join("\n")
+  test("rejects JSON that is not a valid problem report payload", () => {
+    const report = JSON.stringify({
+      meta: { reportVersion: 1, reportId: "pwr_invalid" },
+      environment: base.diagnostics,
+      error: null,
+      recentErrors: [],
+      session: { status: "none" },
+      rendererDiagnostics: null,
+      logTail: [],
+    })
 
-    expect(() => parseProblemReportPayload(report)).toThrow("Problem report JSON block not found")
+    expect(() => parseProblemReportPayload(report)).toThrow("Problem report JSON payload not found")
   })
 })
 
@@ -828,9 +753,9 @@ describe("component budgets — pure helpers", () => {
 describe("component budgets — wired into buildProblemReport", () => {
   test("caps the log tail to the default budget, keeping the most recent lines", () => {
     const lines = ["OLDEST_LINE", ...Array.from({ length: 150_000 }, () => "log line"), "NEWEST_LINE"]
-    const payload = parseProblemReportPayload(buildProblemReport({ ...base, logTail: lines.join("\n") }).markdown)
-    expect(Buffer.byteLength(payload.logTail, "utf8")).toBeLessThanOrEqual(1024 * 1024)
-    expect(payload.truncation.omittedLogBytes).toBeGreaterThan(0)
+    const payload = parseProblemReportPayload(buildProblemReport({ ...base, logTail: lines.join("\n") }).json)
+    expect(Buffer.byteLength(payload.logTail.join("\n"), "utf8")).toBeLessThanOrEqual(1024 * 1024)
+    expect(payload.meta.truncation.omittedLogBytes).toBeGreaterThan(0)
     expect(payload.logTail).toContain("NEWEST_LINE")
     expect(payload.logTail).not.toContain("OLDEST_LINE")
   })
@@ -839,9 +764,9 @@ describe("component budgets — wired into buildProblemReport", () => {
     const parts = Array.from({ length: 200 }, (_, i) => ({ id: `p_${i}`, type: "text", text: `part ${i} ${"x".repeat(2_000)}` }))
     const messages = [{ info: { id: "msg_big", sessionID: "ses_1", role: "assistant", time: { created: 1 } }, parts }]
     const payload = parseProblemReportPayload(
-      buildProblemReport({ ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } }).markdown,
+      buildProblemReport({ ...base, sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages } }).json,
     )
-    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
+    const kept = payload.session.status === "ok" ? payload.session.messages : []
     expect(kept.length).toBe(1)
     const message = kept[0] as { omittedParts?: number }
     expect(message.omittedParts).toBeGreaterThan(0)
@@ -849,7 +774,7 @@ describe("component budgets — wired into buildProblemReport", () => {
     // The latest parts (nearest the failure) survive; the start of the turn is trimmed.
     expect(JSON.stringify(message)).toContain("part 199 ")
     expect(JSON.stringify(message)).not.toContain("part 0 ")
-    expect(payload.truncation.omittedMessagePartsBytes).toBeGreaterThan(0)
+    expect(payload.meta.truncation.omittedMessagePartsBytes).toBeGreaterThan(0)
   })
 
   test("byte-caps the stub identity so an oversized id can't escape under default budgets", () => {
@@ -861,8 +786,8 @@ describe("component budgets — wired into buildProblemReport", () => {
       sessionExport: { status: "ok", info: { id: "ses_1", title: "t" }, messages },
     })
 
-    const payload = parseProblemReportPayload(report.markdown)
-    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
+    const payload = parseProblemReportPayload(report.json)
+    const kept = payload.session.status === "ok" ? payload.session.messages : []
     // Even the stub's id is byte-capped, so the whole session stays well under the default budget.
     expect(Buffer.byteLength(JSON.stringify(kept), "utf8")).toBeLessThanOrEqual(4_096)
     expect((kept[0] as { oversized?: boolean }).oversized).toBe(true)
@@ -875,13 +800,13 @@ describe("component budgets — wired into buildProblemReport", () => {
       rendererError: { summary: `boom ${"S".repeat(100_000)}`, details: "stack frame\n".repeat(20_000) },
     })
 
-    const payload = parseProblemReportPayload(report.markdown)
-    expect(Buffer.byteLength(payload.rendererError?.summary ?? "", "utf8")).toBeLessThanOrEqual(64 * 1024)
-    expect(Buffer.byteLength(payload.rendererError?.details ?? "", "utf8")).toBeLessThanOrEqual(64 * 1024)
+    const payload = parseProblemReportPayload(report.json)
+    expect(Buffer.byteLength(payload.error?.summary ?? "", "utf8")).toBeLessThanOrEqual(64 * 1024)
+    expect(Buffer.byteLength(payload.error?.details ?? "", "utf8")).toBeLessThanOrEqual(64 * 1024)
     // Both keep the head (the error message + top of the stack), the useful part of an error.
-    expect(payload.rendererError?.summary.startsWith("boom ")).toBe(true)
-    expect(payload.rendererError?.details.startsWith("stack frame")).toBe(true)
-    expect(payload.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
+    expect(payload.error?.summary.startsWith("boom ")).toBe(true)
+    expect(payload.error?.details.startsWith("stack frame")).toBe(true)
+    expect(payload.meta.truncation.omittedRendererErrorBytes).toBeGreaterThan(0)
   })
 
   test("does not count part-trim bytes for a message the overall ladder later drops whole", () => {
@@ -903,19 +828,19 @@ describe("component budgets — wired into buildProblemReport", () => {
       { maxBytes: 10_000 },
     )
 
-    const payload = parseProblemReportPayload(report.markdown)
-    const kept = payload.sessionExport.status === "ok" ? payload.sessionExport.messages : []
+    const payload = parseProblemReportPayload(report.json)
+    const kept = payload.session.status === "ok" ? payload.session.messages : []
     expect(JSON.stringify(kept)).toContain("msg_new")
     expect(JSON.stringify(kept)).not.toContain("msg_old")
-    expect(payload.truncation.omittedMessages).toBeGreaterThan(0)
+    expect(payload.meta.truncation.omittedMessages).toBeGreaterThan(0)
     // The dropped message's part-trim is not double-counted; the surviving message had no trim.
-    expect(payload.truncation.omittedMessagePartsBytes).toBe(0)
+    expect(payload.meta.truncation.omittedMessagePartsBytes).toBe(0)
   })
 
   test("leaves a small report untouched under default budgets", () => {
-    const payload = parseProblemReportPayload(buildProblemReport(base).markdown)
-    expect(payload.truncation.omittedLogBytes).toBe(0)
-    expect(payload.truncation.omittedMessages).toBe(0)
-    expect(payload.truncation.omittedRendererErrorBytes).toBe(0)
+    const payload = parseProblemReportPayload(buildProblemReport(base).json)
+    expect(payload.meta.truncation.omittedLogBytes).toBe(0)
+    expect(payload.meta.truncation.omittedMessages).toBe(0)
+    expect(payload.meta.truncation.omittedRendererErrorBytes).toBe(0)
   })
 })

--- a/packages/desktop-electron/src/main/problem-report.test.ts
+++ b/packages/desktop-electron/src/main/problem-report.test.ts
@@ -84,7 +84,7 @@ describe("problem report", () => {
     expect(report.json).not.toContain("# PawWork Problem Report")
     expect(report.json).not.toContain("```json")
     const payload = parseProblemReportPayload(report.json)
-    expect(payload.meta.reportVersion).toBe(1)
+    expect(payload.meta.reportVersion).toBe(2)
     expect(payload.meta.reportId).toBe(report.reportId)
     expect(payload.environment.sessionID).toBe("ses_1")
     expect(payload.session.status).toBe("ok")
@@ -657,7 +657,7 @@ describe("problem report", () => {
 
   test("rejects JSON that is not a valid problem report payload", () => {
     const report = JSON.stringify({
-      meta: { reportVersion: 1, reportId: "pwr_invalid" },
+      meta: { reportVersion: 2, reportId: "pwr_invalid" },
       environment: base.diagnostics,
       error: null,
       recentErrors: [],

--- a/packages/desktop-electron/src/main/problem-report.ts
+++ b/packages/desktop-electron/src/main/problem-report.ts
@@ -14,6 +14,7 @@ import {
 } from "./problem-report-redact"
 
 export const DEFAULT_PROBLEM_REPORT_MAX_BYTES = 5 * 1024 * 1024
+const PROBLEM_REPORT_VERSION = 2
 
 // Per-component byte budgets. Each source is bounded independently so one component (a giant log, a
 // long session, a huge renderer stack) can't fill the whole report and crowd out the rest. They sum
@@ -87,7 +88,7 @@ type Options = {
 
 type Payload = {
   meta: {
-    reportVersion: 1
+    reportVersion: typeof PROBLEM_REPORT_VERSION
     reportId: string
     generatedAt: string
     truncation: {
@@ -250,7 +251,7 @@ function logLines(value: string) {
   return value.length > 0 ? value.split(/\r?\n/) : []
 }
 
-function recentKeyErrors(value: string) {
+export function recentKeyErrors(value: string) {
   return logLines(value)
     .filter((line) => /\b(error|warn|warning|failed|exception)\b/i.test(line))
     .map((line) => line.replace(/\s+/g, " ").trim())
@@ -471,7 +472,7 @@ export function buildProblemReport(input: Input, options: Options = {}) {
 
   const makePayload = (): Payload => ({
     meta: {
-      reportVersion: 1,
+      reportVersion: PROBLEM_REPORT_VERSION,
       reportId,
       generatedAt,
       truncation: {
@@ -779,7 +780,7 @@ function isProblemReportPayload(value: unknown): value is Payload {
   if (!isRecord(value)) return false
   return (
     isRecord(value.meta) &&
-    value.meta.reportVersion === 1 &&
+    value.meta.reportVersion === PROBLEM_REPORT_VERSION &&
     typeof value.meta.reportId === "string" &&
     value.meta.reportId.length > 0 &&
     typeof value.meta.generatedAt === "string" &&

--- a/packages/desktop-electron/src/main/problem-report.ts
+++ b/packages/desktop-electron/src/main/problem-report.ts
@@ -86,24 +86,27 @@ type Options = {
 }
 
 type Payload = {
-  reportVersion: 1
-  reportId: string
-  generatedAt: string
-  diagnostics: ProblemReportDiagnostics
-  logTail: string
-  rendererError?: RendererErrorDetails
-  rendererDiagnostics?: RendererDiagnosticsSlice
-  sessionExport: SafeSessionExport
-  truncation: {
-    omittedMessages: number
-    omittedMessagePartsBytes: number
-    omittedLogBytes: number
-    omittedSessionInfoBytes: number
-    omittedFailedExportErrorBytes: number
-    omittedRendererErrorBytes: number
-    omittedRendererDiagnosticsBytes: number
-    omittedDiagnosticsBytes: number
+  meta: {
+    reportVersion: 1
+    reportId: string
+    generatedAt: string
+    truncation: {
+      omittedMessages: number
+      omittedMessagePartsBytes: number
+      omittedLogBytes: number
+      omittedSessionInfoBytes: number
+      omittedFailedExportErrorBytes: number
+      omittedRendererErrorBytes: number
+      omittedRendererDiagnosticsBytes: number
+      omittedDiagnosticsBytes: number
+    }
   }
+  environment: ProblemReportDiagnostics
+  error: RendererErrorDetails | null
+  recentErrors: string[]
+  session: SafeSessionExport
+  rendererDiagnostics: RendererDiagnosticsSlice | null
+  logTail: string[]
 }
 
 function bytes(value: string) {
@@ -239,17 +242,20 @@ export function capSessionMessagesBytes(
   }
 }
 
-function markdown(payload: Payload) {
-  return [
-    "# PawWork Problem Report",
-    "",
-    "Upload this markdown file to the feedback form after reviewing it.",
-    "",
-    "```json",
-    JSON.stringify(payload, null, 2),
-    "```",
-    "",
-  ].join("\n")
+function jsonReport(payload: Payload) {
+  return JSON.stringify(payload, null, 2)
+}
+
+function logLines(value: string) {
+  return value.length > 0 ? value.split(/\r?\n/) : []
+}
+
+function recentKeyErrors(value: string) {
+  return logLines(value)
+    .filter((line) => /\b(error|warn|warning|failed|exception)\b/i.test(line))
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .filter(Boolean)
+    .slice(-10)
 }
 
 function sessionMessages(sessionExport: SafeSessionExport): JsonValue[] {
@@ -464,35 +470,38 @@ export function buildProblemReport(input: Input, options: Options = {}) {
   if (redactedRendererDiagnostics) capRendererDiagnostics(budgets.rendererDiagnosticsBytes)
 
   const makePayload = (): Payload => ({
-    reportVersion: 1,
-    reportId,
-    generatedAt,
-    diagnostics,
-    logTail,
-    ...(rendererError ? { rendererError } : {}),
-    ...(rendererDiagnostics ? { rendererDiagnostics } : {}),
-    sessionExport: withFailedExportError(
+    meta: {
+      reportVersion: 1,
+      reportId,
+      generatedAt,
+      truncation: {
+        omittedMessages,
+        omittedMessagePartsBytes,
+        omittedLogBytes,
+        omittedSessionInfoBytes,
+        omittedFailedExportErrorBytes,
+        // Derived: whatever the renderer-error text (summary + details) lost across every truncation
+        // stage, including full removal.
+        omittedRendererErrorBytes: Math.max(
+          0,
+          rendererErrorBaseline - (rendererError ? bytes(rendererError.summary) + bytes(rendererError.details) : 0),
+        ),
+        omittedRendererDiagnosticsBytes,
+        omittedDiagnosticsBytes,
+      },
+    },
+    environment: diagnostics,
+    error: rendererError ?? null,
+    recentErrors: recentKeyErrors(logTail),
+    session: withFailedExportError(
       withMessages(withSessionInfo(sessionExport, sessionInfo ?? null), messages),
       failedExportError,
     ),
-    truncation: {
-      omittedMessages,
-      omittedMessagePartsBytes,
-      omittedLogBytes,
-      omittedSessionInfoBytes,
-      omittedFailedExportErrorBytes,
-      // Derived: whatever the renderer-error text (summary + details) lost across every truncation
-      // stage, including full removal.
-      omittedRendererErrorBytes: Math.max(
-        0,
-        rendererErrorBaseline - (rendererError ? bytes(rendererError.summary) + bytes(rendererError.details) : 0),
-      ),
-      omittedRendererDiagnosticsBytes,
-      omittedDiagnosticsBytes,
-    },
+    rendererDiagnostics: rendererDiagnostics ?? null,
+    logTail: logLines(logTail),
   })
 
-  let output = markdown(makePayload())
+  let output = jsonReport(makePayload())
 
   // Drop older entries first so the report keeps the most recent context around the failure.
   while (bytes(output) > maxBytes && messages.length > 0) {
@@ -502,20 +511,20 @@ export function buildProblemReport(input: Input, options: Options = {}) {
     // Keep the part-trim ledger consistent: the dropped messages are no longer in the report.
     survivorPartTrimBytes = survivorPartTrimBytes.slice(remove)
     omittedMessagePartsBytes = sumPartTrim()
-    output = markdown(makePayload())
+    output = jsonReport(makePayload())
   }
 
   while (bytes(output) > maxBytes && logTail.length > 0) {
     const remove = Math.max(1, Math.ceil(logTail.length / 2))
     omittedLogBytes += bytes(logTail.slice(0, remove))
     logTail = logTail.slice(remove)
-    output = markdown(makePayload())
+    output = jsonReport(makePayload())
   }
 
   if (bytes(output) > maxBytes && sessionExport.status === "ok" && sessionInfo != null) {
     omittedSessionInfoBytes += jsonBytes(sessionInfo)
     sessionInfo = null
-    output = markdown(makePayload())
+    output = jsonReport(makePayload())
   }
 
   if (bytes(output) > maxBytes && failedExportError !== undefined) {
@@ -524,7 +533,7 @@ export function buildProblemReport(input: Input, options: Options = {}) {
     while (bytes(output) > maxBytes && errorLimit >= 0) {
       failedExportError = truncateString(originalError, errorLimit)
       omittedFailedExportErrorBytes = Math.max(0, bytes(originalError) - bytes(failedExportError))
-      output = markdown(makePayload())
+      output = jsonReport(makePayload())
       if (errorLimit === 0) break
       errorLimit = Math.floor(errorLimit / 2)
     }
@@ -538,7 +547,7 @@ export function buildProblemReport(input: Input, options: Options = {}) {
         ...rendererError,
         details: truncateString(originalDetails, detailsLimit),
       }
-      output = markdown(makePayload())
+      output = jsonReport(makePayload())
       if (detailsLimit === 0) break
       detailsLimit = Math.floor(detailsLimit / 2)
     }
@@ -546,7 +555,7 @@ export function buildProblemReport(input: Input, options: Options = {}) {
 
   if (bytes(output) > maxBytes && rendererError) {
     rendererError = undefined
-    output = markdown(makePayload())
+    output = jsonReport(makePayload())
   }
 
   // Final backstop: halve the renderer-diagnostics event budget until the report fits. Uses the same
@@ -556,7 +565,7 @@ export function buildProblemReport(input: Input, options: Options = {}) {
     let limit = Math.max(0, Math.floor(jsonBytes(rendererDiagnostics.events) / 2))
     while (bytes(output) > maxBytes && limit >= 0) {
       capRendererDiagnostics(limit)
-      output = markdown(makePayload())
+      output = jsonReport(makePayload())
       if (limit === 0) break
       limit = Math.floor(limit / 2)
     }
@@ -566,7 +575,7 @@ export function buildProblemReport(input: Input, options: Options = {}) {
   while (bytes(output) > maxBytes && diagnosticStringLimit >= 0) {
     diagnostics = truncateDiagnostics(redactedDiagnostics, diagnosticStringLimit)
     omittedDiagnosticsBytes = Math.max(0, jsonBytes(redactedDiagnostics) - jsonBytes(diagnostics))
-    output = markdown(makePayload())
+    output = jsonReport(makePayload())
     if (diagnosticStringLimit === 0) break
     diagnosticStringLimit = Math.floor(diagnosticStringLimit / 2)
   }
@@ -575,7 +584,7 @@ export function buildProblemReport(input: Input, options: Options = {}) {
     throw new Error("Problem report exceeds maxBytes after truncation")
   }
 
-  return { markdown: output, reportId, generatedAt }
+  return { json: output, reportId, generatedAt }
 }
 
 type ProblemReportSummaryInput = {
@@ -748,7 +757,11 @@ function isRendererDiagnosticsSlice(value: unknown): value is RendererDiagnostic
   )
 }
 
-function isTruncation(value: unknown): value is Payload["truncation"] {
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}
+
+function isTruncation(value: unknown): value is Payload["meta"]["truncation"] {
   if (!isRecord(value)) return false
   return (
     isFiniteNumber(value.omittedMessages) &&
@@ -765,34 +778,29 @@ function isTruncation(value: unknown): value is Payload["truncation"] {
 function isProblemReportPayload(value: unknown): value is Payload {
   if (!isRecord(value)) return false
   return (
-    value.reportVersion === 1 &&
-    typeof value.reportId === "string" &&
-    value.reportId.length > 0 &&
-    typeof value.generatedAt === "string" &&
-    !Number.isNaN(Date.parse(value.generatedAt)) &&
-    isDiagnostics(value.diagnostics) &&
-    typeof value.logTail === "string" &&
-    (value.rendererError === undefined || isRendererErrorDetails(value.rendererError)) &&
-    (value.rendererDiagnostics === undefined || isRendererDiagnosticsSlice(value.rendererDiagnostics)) &&
-    isSessionExport(value.sessionExport) &&
-    isTruncation(value.truncation)
+    isRecord(value.meta) &&
+    value.meta.reportVersion === 1 &&
+    typeof value.meta.reportId === "string" &&
+    value.meta.reportId.length > 0 &&
+    typeof value.meta.generatedAt === "string" &&
+    !Number.isNaN(Date.parse(value.meta.generatedAt)) &&
+    isTruncation(value.meta.truncation) &&
+    isDiagnostics(value.environment) &&
+    (value.error === null || isRendererErrorDetails(value.error)) &&
+    isStringArray(value.recentErrors) &&
+    isSessionExport(value.session) &&
+    (value.rendererDiagnostics === null || isRendererDiagnosticsSlice(value.rendererDiagnostics)) &&
+    isStringArray(value.logTail)
   )
 }
 
 export function parseProblemReportPayload(input: string): Payload {
-  const lines = input.split(/\r?\n/)
-  for (let start = 0; start < lines.length; start++) {
-    if (lines[start] !== "```json") continue
-    for (let end = start + 1; end < lines.length; end++) {
-      if (lines[end] !== "```") continue
-      try {
-        const parsed = JSON.parse(lines.slice(start + 1, end).join("\n")) as unknown
-        if (isProblemReportPayload(parsed)) return parsed
-      } catch {
-        continue
-      }
-    }
+  try {
+    const parsed = JSON.parse(input) as unknown
+    if (isProblemReportPayload(parsed)) return parsed
+  } catch {
+    // fall through to the shared error below
   }
 
-  throw new Error("Problem report JSON block not found")
+  throw new Error("Problem report JSON payload not found")
 }


### PR DESCRIPTION
## Summary

Replaces the saved diagnostics package body with pure, pretty JSON instead of a Markdown wrapper. The JSON now uses stable top-level sections for `meta`, `environment`, `error`, `recentErrors`, `session`, `rendererDiagnostics`, and `logTail`, with `logTail` saved as an array of lines.

Also switches newly saved report files from `.md` to `.json`, bumps the report contract to `meta.reportVersion: 2`, updates cleanup/file-writing expectations, and moves the smoke test assertions from Markdown-string checks to JSON payload checks.

## Why

Part of PR4 for the diagnostics package rebuild: make the package easier for agents and support tooling to read directly, without first stripping prose or fenced code blocks.

## Related Issue

Part of #1465.

## Human Review Status

Pending

## Review Focus

Please focus on the JSON contract shape, especially the stable top-level keys, `meta.reportVersion: 2`, `meta.truncation`, `error: null | object`, and `logTail: string[]`.

Also worth checking: this intentionally drops legacy Markdown parser compatibility for full reports, following the product decision for PR4. Legacy `.md` report files are only kept in the cleanup matcher so old local diagnostics packages still age out.

## Risk Notes

Legacy `.md` diagnostics reports are no longer parsed by the local parser and new reports are always generated as `.json`. Cleanup still recognizes legacy `pawwork-problem-report-*.md` files so existing local support packages do not fall out of retention. Saved reports are local support artifacts, so there is no data migration.

Visible UI checklist left unticked: no layout or user-facing copy changed. The generated filename extension shown in the review flow changes from `.md` to `.json` and is covered by focused tests and smoke.

## How To Verify

```text
bun test src/main/problem-report-redact.test.ts src/main/problem-report-files.test.ts src/main/feedback.test.ts src/main/problem-report.test.ts: 123 passed
bun test src/components/diagnostics-review.test.tsx: 6 passed
bun run build: passed, with existing Vite/eval warnings only
bun run smoke:report: passed; saved pawwork-problem-report-*.json and JSON assertions were true
GOMAXPROCS=2 bun run typecheck: passed
git diff --check: passed
```

## Screenshots or Recordings

Not applicable. No visual UI layout change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
