### PR TITLE
fix(sidebar): give drag a movement threshold so clicks are not eaten by hand jitter

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-drag-pointer.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-drag-pointer.spec.ts
@@ -21,7 +21,7 @@ import { pawworkSidebarSelector } from "../selectors"
  * locales).
  */
 
-const SORTABLE_DRAG_THRESHOLD_PX = 8 // SortableJS internal default before fallback considers a drag started
+const SORTABLE_DRAG_THRESHOLD_PX = 8 // comfortably above the configured fallbackTolerance (5px in pawwork-sidebar-drag.ts) so the nudge reliably starts a drag
 
 async function startDragFrom(
   page: Page,

--- a/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
@@ -214,6 +214,46 @@ test("sidebar session press does not dim the row before drag starts", async ({ p
   }
 })
 
+test("sidebar session click with slight jitter still navigates instead of starting a drag", async ({ page, slug, sdk, gotoSession }) => {
+  const stamp = Date.now()
+  const source = await sdk.session.create({ title: `e2e sidebar jitter source ${stamp}` }).then((r) => r.data)
+  const target = await sdk.session.create({ title: `e2e sidebar jitter target ${stamp}` }).then((r) => r.data)
+
+  if (!source?.id) throw new Error("Source session create did not return an id")
+  if (!target?.id) throw new Error("Target session create did not return an id")
+
+  try {
+    await gotoSession(source.id)
+    await openSidebar(page)
+
+    const targetRow = page.locator(`[data-session-id="${target.id}"][data-component="pawwork-session-row"]`).first()
+    await expect(targetRow).toBeVisible()
+    const targetBox = await targetRow.boundingBox()
+    if (!targetBox) throw new Error("Target session row did not expose a bounding box")
+
+    // Press, drift a few px (inside the 5px fallbackTolerance dead zone), release.
+    // This is the hand-jitter case a 0-tolerance config misread as a drag, which
+    // swallowed the click so navigation never fired and the row felt unresponsive.
+    const startX = targetBox.x + targetBox.width / 3
+    const startY = targetBox.y + targetBox.height / 2
+    await page.mouse.move(startX, startY)
+    await nextFrame(page)
+    await page.mouse.down()
+    await page.mouse.move(startX + 3, startY + 3, { steps: 3 })
+    await nextFrame(page)
+    await page.mouse.up()
+
+    const selectedSessionUrl = new RegExp(`/${slug}/session/${target.id}(?:\\?|#|$)`)
+    await expect(page).toHaveURL(selectedSessionUrl)
+    await expect(page.locator(`[data-session-id="${target.id}"] a`).first()).toHaveClass(/\bactive\b/)
+    // The row did not get dragged anywhere: still exactly one instance in the sidebar.
+    await expect(page.locator(`[data-session-id="${target.id}"][data-component="pawwork-session-row"]`)).toHaveCount(1)
+  } finally {
+    await cleanupSession({ sdk, sessionID: source.id })
+    await cleanupSession({ sdk, sessionID: target.id })
+  }
+})
+
 test("sidebar session links can switch workspaces without opening the error boundary", async ({ page, backend, project }) => {
   const stamp = Date.now()
   const other = await createTestProject({ serverUrl: backend.url })

--- a/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
@@ -214,7 +214,7 @@ test("sidebar session press does not dim the row before drag starts", async ({ p
   }
 })
 
-test("sidebar session click with slight jitter still navigates instead of starting a drag", async ({ page, slug, sdk, gotoSession }) => {
+test("@smoke sidebar session click with slight jitter still navigates instead of starting a drag", async ({ page, slug, sdk, gotoSession }) => {
   const stamp = Date.now()
   const source = await sdk.session.create({ title: `e2e sidebar jitter source ${stamp}` }).then((r) => r.data)
   const target = await sdk.session.create({ title: `e2e sidebar jitter target ${stamp}` }).then((r) => r.data)

--- a/packages/app/src/pages/layout/pawwork-sidebar-drag.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-drag.ts
@@ -18,6 +18,9 @@ import { onCleanup } from "solid-js"
  * 5. `sort: kind === "pinned"` — only the pinned list owns positional state.
  *    Recent and project-group lists are derived; intra-list reorder there
  *    would visibly shuffle then snap back, which is misleading.
+ * 6. `fallbackTolerance: 5` — a movement dead zone so an ordinary click with a
+ *    little hand jitter is not mistaken for a drag (default is 0, which eats
+ *    the click and makes the row feel unresponsive).
  *
  * Project mode: project groups also accept drag, but ONLY for drops from
  * pinned (a session's project is derived from its directory and is read-only;
@@ -71,6 +74,14 @@ export function createSortableAttacher(deps: SortableAttacherDeps) {
       animation: 150,
       forceFallback: true,
       fallbackOnBody: true,
+      // Click and drag share one mousedown on the same row. Default
+      // fallbackTolerance is 0, so any ~1px hand jitter during a click is read
+      // as a drag — that swallows the click, navigation never fires, and the
+      // row feels slow/unresponsive (issue: clicking the sidebar title). A
+      // small movement dead zone keeps still clicks as clicks; only deliberate
+      // movement starts a drag.
+      fallbackTolerance: 5,
+      touchStartThreshold: 5,
       scroll: true,
       bubbleScroll: true,
       emptyInsertThreshold: 32,

--- a/packages/app/src/pages/layout/pawwork-sidebar-drag.ts
+++ b/packages/app/src/pages/layout/pawwork-sidebar-drag.ts
@@ -79,9 +79,11 @@ export function createSortableAttacher(deps: SortableAttacherDeps) {
       // as a drag — that swallows the click, navigation never fires, and the
       // row feels slow/unresponsive (issue: clicking the sidebar title). A
       // small movement dead zone keeps still clicks as clicks; only deliberate
-      // movement starts a drag.
+      // movement starts a drag. forceFallback routes touch through the same
+      // fallback path, so this one threshold covers mouse and touch (the
+      // touchStartThreshold option is inert here — it only applies while `delay`
+      // is counting down, which we don't use).
       fallbackTolerance: 5,
-      touchStartThreshold: 5,
       scroll: true,
       bubbleScroll: true,
       emptyInsertThreshold: 32,

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -38,6 +38,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/settings/settings.spec.ts:@smoke new installs start with the PawWork theme",
   "packages/app/e2e/settings/settings.spec.ts:@smoke settings dialog opens, switches tabs, closes",
   "packages/app/e2e/sidebar/sidebar-drag-pointer.spec.ts:@smoke real drag (pointer) round-trips Pinned ↔ All without duplicating rows",
+  "packages/app/e2e/sidebar/sidebar-session-links.spec.ts:@smoke sidebar session click with slight jitter still navigates instead of starting a drag",
   "packages/app/e2e/sidebar/sidebar.spec.ts:@smoke sidebar can be collapsed and expanded",
   "packages/app/e2e/terminal/terminal-init.spec.ts:@smoke terminal mounts and can create a second tab",
 ]


### PR DESCRIPTION
## Summary

Add a small movement dead zone to the sidebar session-row drag so an ordinary click is no longer mistaken for a drag.

- `pawwork-sidebar-drag.ts`: set `fallbackTolerance: 5` on the SortableJS instance (previously defaulted to `0`). Under `forceFallback`, this dead zone covers both mouse and touch.
- New regression test: a click with a few px of jitter still navigates instead of starting a drag.
- Reworded a stale comment in `sidebar-drag-pointer.spec.ts` (the `8` constant was wrongly described as the "SortableJS internal default"; the configured tolerance is `5`).

## Why

Clicking a sidebar session title often felt slow or unresponsive, and repeated clicking would misfire into the rename dialog.

Root cause: session rows are SortableJS draggables, and click + drag share one `mousedown` on the same row. With `fallbackTolerance` unset (default `0`), any ~1px of natural hand jitter during a click was read as a drag start. SortableJS then captured the pointer and suppressed the synthetic `click`, so navigation never fired — the row felt dead. Users clicked again, and the rapid second click landed as a `dblclick`, which opens rename. So both reported symptoms (unresponsive click, accidental rename) trace to the missing drag threshold.

A distance threshold fixes this without adding any latency: a still click stays a click, only deliberate movement starts a drag. Double-click-to-rename behavior is intentionally unchanged.

## Related Issue

No tracked issue; maintainer-reported UX friction.

## Human Review Status

Pending

## Review Focus

- The threshold value (`5px`). It must be large enough to absorb hand jitter but small enough that a deliberate drag still feels immediate.
- That double-click rename and keyboard reorder (`Alt+Arrow`) are untouched.

## Risk Notes

- Low risk: one SortableJS option pair, scoped to the sidebar drag wiring; fully reversible.
- No visual/appearance or copy change — this is interaction behavior only — so the "visible UI" checklist item is left unticked; verified via user-path E2E instead of a snapshot.
- The pre-existing `@smoke` drag round-trip test (`sidebar-drag-pointer.spec.ts`) fails locally on the drag-back-in step. It fails identically on baseline with the threshold reverted, so it is an environment timing flake unrelated to this change; CI runs it with retries.
- Review follow-up (CodeRabbit): an initial `touchStartThreshold: 5` was dropped — in SortableJS 1.15.7 that option is only read during a `delay` countdown (which we don't use), so it was inert; `fallbackTolerance` already covers touch under `forceFallback`. Verified against `node_modules/sortablejs/Sortable.js`.
- Review follow-up (Codex): the click-jitter regression test was tagged `@smoke` so it runs in PR CI — `e2e-artifacts.yml` runs only `--grep @smoke` on `pull_request`, so an untagged test would never guard PRs.

## How To Verify

```text
packages/app typecheck (tsgo -b): pass
eslint packages/app/src/pages/layout/pawwork-sidebar-drag.ts: pass (exit 0)
E2E (local harness, chromium) sidebar/sidebar-session-links.spec.ts: 7 passed
  incl. new "@smoke sidebar session click with slight jitter still navigates instead of starting a drag"
E2E smoke selection (--grep @smoke) picks up the new regression test: 1 passed
Attribution check: drag-pointer @smoke failure reproduces on baseline (threshold reverted) -> not caused by this change
```

## Screenshots or Recordings

No visual change; sidebar click/drag is interaction behavior, verified via user-path E2E (see How To Verify).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [ ] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [ ] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>`.
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
