### PR TITLE
chore(release): bump desktop version to 2026.6.13

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.6.12",
+      "version": "2026.6.13",
       "dependencies": {
         "@opencode-ai/remote-bridge": "workspace:*",
         "@opencode-ai/util": "workspace:*",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.6.12",
+  "version": "2026.6.13",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the desktop release metadata to `2026.6.13` so the two user-facing fixes
already merged to `dev` ship in a stable release:

- `#1481` — sidebar drag now has a movement threshold, so clicks are no longer eaten by hand jitter.
- `#1482` — the Skills surface gets an **Open skills folder** action.

## Change boundary

- `packages/desktop-electron/package.json`: `2026.6.12` → `2026.6.13`.
- `bun.lock`: sync the matching workspace package version (only the version line changes).

## Verification

- `bun install --frozen-lockfile` completed in the release worktree.
- `bun install --lockfile-only` updated the lockfile; `git diff` is exactly the two version lines.
- `git diff --check` passed.

Release build (submit/finalize/Windows), publish, R2 mirror, and post-release
verification follow `.github/RELEASE_CHECKLIST.md` after this merges.
