### PR TITLE
chore(release): bump desktop version to 2026.7.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.6.13",
+      "version": "2026.7.1",
       "dependencies": {
         "@opencode-ai/remote-bridge": "workspace:*",
         "@opencode-ai/util": "workspace:*",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.6.13",
+  "version": "2026.7.1",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the desktop app release version from `2026.6.13` to `2026.7.1` in `packages/desktop-electron/package.json` and `bun.lock`.

No related issue; this is the release train version bump for the next July release.

## Why

The latest published release is `v2026.6.13`. Per the release version format, the first July 2026 release should use `v2026.7.1`.

## Related Issue

None.

## Human Review Status

Not required: automated release version bump only.

## Review Focus

Confirm that the diff only updates the desktop version metadata and that the lockfile mirrors the same workspace version.

## Risk Notes

Low risk. No runtime behavior changes. No visible UI changed, so the visible UI checklist item is intentionally left unticked.

## How To Verify

```text
Desktop version: node -p "require('./packages/desktop-electron/package.json').version" -> 2026.7.1
Lockfile consistency: bun install --frozen-lockfile -> checked 1398 installs across 1589 packages, no changes
Diff check: git diff --check -> no whitespace errors
Diff review: only packages/desktop-electron/package.json and bun.lock changed, each from 2026.6.13 to 2026.7.1
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
