### PR TITLE
fix(remote-bridge): percent-encode x-opencode-directory header

### DIFF
--- a/packages/remote-bridge/src/pawwork-client-http.test.ts
+++ b/packages/remote-bridge/src/pawwork-client-http.test.ts
@@ -5,8 +5,20 @@ interface Captured {
   method: string
   path: string
   directory: string | null
+  directoryRaw: string | null
   auth: string | null
   body: any
+}
+
+// Mirror the server middleware: it decodeURIComponent()s the header, so `directory`
+// holds the decoded path while `directoryRaw` keeps the exact bytes sent on the wire.
+function decodeDir(raw: string | null): string | null {
+  if (raw === null) return null
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return raw
+  }
 }
 
 function mockServer(routes: (req: { method: string; path: string; body: any }) => Response | undefined) {
@@ -17,10 +29,12 @@ function mockServer(routes: (req: { method: string; path: string; body: any }) =
       const url = new URL(req.url)
       const text = await req.text()
       const body = text === "" ? undefined : JSON.parse(text)
+      const directoryRaw = req.headers.get("x-opencode-directory")
       seen.push({
         method: req.method,
         path: url.pathname + url.search,
-        directory: req.headers.get("x-opencode-directory"),
+        directory: decodeDir(directoryRaw),
+        directoryRaw,
         auth: req.headers.get("authorization"),
         body,
       })
@@ -99,7 +113,7 @@ test("listPermissions skips a directory on a transient 5xx and surfaces the rest
     port: 0,
     fetch(req) {
       const url = new URL(req.url)
-      const dir = req.headers.get("x-opencode-directory")
+      const dir = decodeDir(req.headers.get("x-opencode-directory"))
       if (url.pathname === "/experimental/session") return json([{ id: "ses_x", directory: "/repo/b" }])
       if (url.pathname === "/permission") {
         if (dir === "/repo/a") return new Response("boom", { status: 500 })
@@ -115,5 +129,27 @@ test("listPermissions skips a directory on a transient 5xx and surfaces the rest
     expect(perms).toEqual([{ id: "perm_9", sessionID: "ses_x", permission: "edit", patterns: ["x"], directory: "/repo/b" }])
   } finally {
     server.stop(true)
+  }
+})
+
+test("percent-encodes a non-ASCII directory so fetch does not reject the header (issue #1488)", async () => {
+  // A Windows profile path with Cyrillic — the raw path has code points > 255, which
+  // fetch cannot put in a header value. Without encoding this throws a ByteString error
+  // ("Cannot convert argument to a ByteString") before the request ever leaves the client.
+  const cyrillicDir = "C:\\Users\\Андрей\\proj"
+  const server = mockServer(({ method, path }) => {
+    if (method === "POST" && path === "/session") return json({ id: "ses_1", directory: cyrillicDir })
+    return undefined
+  })
+  try {
+    const client = new PawWorkClient({ baseURL: server.url, directory: cyrillicDir })
+    const id = await client.createSession()
+    expect(id).toBe("ses_1")
+    const create = server.seen.find((r) => r.path === "/session")
+    // On the wire the header is percent-encoded; decoded server-side it is the original path.
+    expect(create?.directoryRaw).toBe(encodeURIComponent(cyrillicDir))
+    expect(create?.directory).toBe(cyrillicDir)
+  } finally {
+    server.stop()
   }
 })

--- a/packages/remote-bridge/src/pawwork-client-hydration.test.ts
+++ b/packages/remote-bridge/src/pawwork-client-hydration.test.ts
@@ -8,6 +8,18 @@ import { SessionPointers } from "./session-pointers.ts"
 
 const json = (value: unknown) => new Response(JSON.stringify(value), { headers: { "content-type": "application/json" } })
 
+// Mirror the server middleware: the client percent-encodes x-opencode-directory,
+// so decode it here to recover the logical path the assertions below expect.
+function capturedDir(req: Request): string | null {
+  const raw = req.headers.get("x-opencode-directory")
+  if (raw === null) return null
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return raw
+  }
+}
+
 function recorder() {
   const texts: { sessionID: string; text: string }[] = []
   const handler: EventHandler = {
@@ -33,12 +45,12 @@ test("replyPermission and submitQuestion post the expected bodies and directory"
       const url = new URL(req.url)
       const body = await req.json().catch(() => undefined)
       if (url.pathname === "/permission/perm_1/reply") {
-        seen.permissionDirectory = req.headers.get("x-opencode-directory")
+        seen.permissionDirectory = capturedDir(req)
         seen.permissionBody = body
         return json(true)
       }
       if (url.pathname === "/session/ses_1/tool/respond") {
-        seen.questionDirectory = req.headers.get("x-opencode-directory")
+        seen.questionDirectory = capturedDir(req)
         seen.questionBody = body
         return json({ status: "ok" })
       }
@@ -77,11 +89,11 @@ test("listPermissions and listQuestions map fields and reuse the session directo
       const url = new URL(req.url)
       if (url.pathname === "/experimental/session") return json([{ id: "ses_1", directory: "/repo/a" }])
       if (url.pathname === "/permission") {
-        permissionDirectories.push(req.headers.get("x-opencode-directory"))
+        permissionDirectories.push(capturedDir(req))
         return json([{ id: "perm_1", sessionID: "ses_1", permission: "edit", patterns: ["/repo/app.ts"] }])
       }
       if (url.pathname === "/external-result") {
-        questionDirectories.push(req.headers.get("x-opencode-directory"))
+        questionDirectories.push(capturedDir(req))
         return json([
           {
             part: {

--- a/packages/remote-bridge/src/pawwork-client.ts
+++ b/packages/remote-bridge/src/pawwork-client.ts
@@ -224,7 +224,11 @@ export class PawWorkClient implements Sidecar {
       body = JSON.stringify(input)
       headers["content-type"] = "application/json"
     }
-    if (directory !== "") headers["x-opencode-directory"] = directory
+    // Percent-encode the path: a directory containing non-ASCII characters (e.g. a
+    // Windows profile like C:\Users\Андрей) cannot be a header value — fetch rejects
+    // any code point > 255 with a ByteString error. The SDK encodes this same header
+    // and the server decodeURIComponent()s it, so this keeps us on that contract.
+    if (directory !== "") headers["x-opencode-directory"] = encodeURIComponent(directory)
     this.authorize(headers)
     const res = await fetch(this.baseURL + path, { method, headers, body, signal })
     if (res.status < 200 || res.status >= 300) {


### PR DESCRIPTION
## Summary

`doJSON()` in the remote-bridge client wrote the raw directory path straight into the `x-opencode-directory` header value. `fetch` requires header values to be Latin-1 (ByteString); any code point > 255 throws `Cannot convert argument to a ByteString` before the request leaves the client. This PR percent-encodes the value with `encodeURIComponent`, and updates the mock servers in two test files to decode the header like the real server middleware, plus a Cyrillic regression test.

## Why

Issue #1488: Telegram/WeChat requests failed on any machine whose project path contains non-ASCII characters — the reproducer is a Windows profile like `C:\Users\Андрей`:

```
Cannot convert argument to a ByteString because the character at index 9 has a value of 1040 which is greater than 255
```

The root cause is **not** the request body (the issue's first guess). It is the unencoded header. That explains why it reproduced regardless of message language, why the failing index was fixed at 9 (right after the ASCII `C:\Users\` prefix), and why editing the body encoding never helped. The SDK already encodes this same header (`packages/sdk/js/src/client.ts:48`) and every server read site already `decodeURIComponent()`s it (`production-httpapi.ts:142`, `instance/middleware.ts:42`, `routes/instance/middleware.ts:14`); remote-bridge was the one send site missing the encoding. The `listSessions` query string in this same file already encoded the directory.

## Related Issue

Closes #1488

## Human Review Status

`Pending`

## Review Focus

- The one-line contract change in `pawwork-client.ts` `doJSON()`: encode on send, server decodes on receive. Confirm no other remote-bridge send site puts a raw non-ASCII value into a header.
- The test mock servers now `decodeURIComponent` the header to mirror real middleware, so existing assertions keep checking the logical path. The Cyrillic test additionally asserts the raw wire value is percent-encoded.

## Risk Notes

Low risk, isolated to remote-bridge request headers. No behavior change for ASCII paths (`encodeURIComponent("/repo/a")` round-trips through the server decode to `/repo/a`). No API, dependency, or schema change.

Unticked conditional checklist items:
- Visible UI / copy: none changed (backend request path only).
- Docs / release notes / dependencies / credentials: none touched.

## How To Verify

```text
Root cause proof: reverting the fix makes the new Cyrillic test fail with the exact ByteString error ("Header 'x-opencode-directory' has invalid value: 'C:\Users\Андрей\proj'"); restoring it passes.
Full remote-bridge suite (matches CI unit-remote-bridge): bun test ./src -> 182 pass, 0 fail
Typecheck: bun run typecheck (tsgo --noEmit) -> clean
CI: unit-remote-bridge -> pass
```

## Screenshots or Recordings

N/A — no visible UI change.

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.