### PR TITLE
feat(rust): PR2 mock LlmClient + tool loop + permissions with interruption

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,3 +34,9 @@ harness:
           - "packages/sdk/**"
           - "packages/core/**"
           - "packages/remote-bridge/**"
+          # Rust agent line (crates/): same agent-engine layer, in Rust. Gives the
+          # Rust-only PRs a routing home so pr-triage's label policy passes.
+          - "crates/**"
+          - "Cargo.toml"
+          - "Cargo.lock"
+          - "rust-toolchain.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +25,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -97,6 +109,8 @@ version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tokio",
+ "tokio-util",
  "uuid",
 ]
 
@@ -194,6 +208,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,11 @@ rust-version = "1.89"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+# tokio is kept minimal on purpose: the core lib only needs `sync` (mpsc for the
+# event stream). The runtime flavor is chosen by the binary's #[tokio::main], not
+# here, so the core stays runtime-agnostic (see docs section 13). macros/rt land
+# in dev-dependencies and the CLI, not the lib.
+tokio = { version = "1", default-features = false, features = ["sync"] }
+# CancellationToken (cooperative interruption; child tokens are the future
+# subagent shape). Preferred over a hand-rolled watch channel.
+tokio-util = { version = "0.7", default-features = false }

--- a/crates/pawwork-core/Cargo.toml
+++ b/crates/pawwork-core/Cargo.toml
@@ -9,3 +9,10 @@ publish = false
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+
+[dev-dependencies]
+# Tests drive the async loop and validate the Send discipline on a multi-thread
+# runtime; the lib build stays on `sync` only (see workspace tokio note).
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/pawwork-core/src/agent.rs
+++ b/crates/pawwork-core/src/agent.rs
@@ -1,0 +1,917 @@
+//! The turn loop.
+//!
+//! [`Agent`] owns the session store, the model client, the tool runtime, and the
+//! permission gate, and drives one user turn to completion or interruption. It is
+//! the single orchestrator: tools and the client never write the ledger, and the
+//! loop never touches stdin. `run_turn` appends every ledger event and mirrors it
+//! onto an [`AgentEvent`] channel — appending first, emitting second, so the
+//! ledger stays the source of truth and the channel is only a live view.
+//!
+//! Interruption is cooperative via a [`CancellationToken`]. It is observed at
+//! four points: at the top of each model round, around the model call, around a
+//! permission wait, and before each tool in a batch. The finalizing
+//! `turn.interrupted` append is itself never cancellable. "Never run a
+//! half-parsed call" needs no code here: the [`LlmClient`] contract only yields
+//! fully-parsed `tool_calls`, and [`crate::tool::Tool::prepare`] rejects a
+//! malformed or out-of-workspace call before any `tool.started`.
+
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::llm::{ChatMessage, LlmClient};
+use crate::permission::{PermissionGate, PermissionRequest};
+use crate::session::event::{EventKind, LedgerEvent, ToolCall};
+use crate::session::store::SessionStore;
+use crate::tool::{ToolContext, ToolRuntime};
+
+/// A wire event, emitted live as the turn runs.
+///
+/// Deliberately distinct from the ledger's [`EventKind`]: the ledger is the
+/// durable projection, while this stream can carry things that are never
+/// persisted. PR2 only mirrors ledger events; a token-level `ModelDelta` variant
+/// (streaming, not persisted) lands with the SSE client, without touching the
+/// on-disk schema.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentEvent {
+    Ledger(LedgerEvent),
+}
+
+/// How a turn ended.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TurnOutcome {
+    Completed,
+    Interrupted { reason: String },
+}
+
+impl TurnOutcome {
+    fn interrupted(reason: impl Into<String>) -> Self {
+        TurnOutcome::Interrupted {
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Internal per-call control flow.
+enum CallFlow {
+    /// Move on to the next tool call (the result, error, or denial was recorded).
+    Continue,
+    /// The turn was cancelled mid-call; the caller must finalize.
+    Interrupted(String),
+}
+
+/// The UI-less agent: one session, one turn at a time.
+pub struct Agent<L: LlmClient, G: PermissionGate> {
+    store: SessionStore,
+    client: L,
+    runtime: ToolRuntime,
+    gate: G,
+    workspace_root: PathBuf,
+    history: Vec<ChatMessage>,
+}
+
+impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
+    /// Wire up an agent over an open session store. `workspace_root` is
+    /// canonicalized once here so the tool fence can compare by component.
+    pub fn new(
+        store: SessionStore,
+        client: L,
+        runtime: ToolRuntime,
+        gate: G,
+        workspace_root: &Path,
+    ) -> io::Result<Self> {
+        let workspace_root = workspace_root.canonicalize()?;
+        Ok(Agent {
+            store,
+            client,
+            runtime,
+            gate,
+            workspace_root,
+            history: Vec::new(),
+        })
+    }
+
+    /// Run one user turn: record the message, then loop model rounds — executing
+    /// any tool calls through the permission gate and feeding results back — until
+    /// the model replies with no tool calls (completed) or the turn is cancelled
+    /// or errors (interrupted).
+    pub async fn run_turn(
+        &mut self,
+        user_text: &str,
+        cancel: &CancellationToken,
+        tx: &mpsc::UnboundedSender<AgentEvent>,
+    ) -> io::Result<TurnOutcome> {
+        // Cancelled before anything is recorded: there is no turn to interrupt.
+        if cancel.is_cancelled() {
+            return Ok(TurnOutcome::interrupted("cancelled before start"));
+        }
+
+        let turn_id = new_id();
+        emit(
+            &mut self.store,
+            tx,
+            &turn_id,
+            EventKind::UserMessage {
+                text: user_text.to_string(),
+            },
+        )?;
+        self.history.push(ChatMessage::User(user_text.to_string()));
+
+        loop {
+            if cancel.is_cancelled() {
+                return self.finalize_interrupted(&turn_id, "cancelled", tx);
+            }
+
+            // Ask the model, cancellable. `None` means the token fired first.
+            let responded = cancel
+                .run_until_cancelled(self.client.respond(&self.history))
+                .await;
+            let turn = match responded {
+                None => return self.finalize_interrupted(&turn_id, "cancelled", tx),
+                Some(Err(err)) => {
+                    emit(
+                        &mut self.store,
+                        tx,
+                        &turn_id,
+                        EventKind::Error {
+                            message: err.message.clone(),
+                        },
+                    )?;
+                    let reason = format!("llm error: {}", err.message);
+                    return self.finalize_interrupted(&turn_id, &reason, tx);
+                }
+                Some(Ok(turn)) => turn,
+            };
+
+            emit(
+                &mut self.store,
+                tx,
+                &turn_id,
+                EventKind::ModelMessage {
+                    text: turn.text.clone(),
+                    tool_calls: turn.tool_calls.clone(),
+                },
+            )?;
+            self.history.push(ChatMessage::Assistant {
+                text: turn.text.clone(),
+                tool_calls: turn.tool_calls.clone(),
+            });
+
+            if turn.tool_calls.is_empty() {
+                emit(&mut self.store, tx, &turn_id, EventKind::TurnCompleted)?;
+                return Ok(TurnOutcome::Completed);
+            }
+
+            let ctx = ToolContext {
+                workspace_root: self.workspace_root.clone(),
+            };
+            for call in &turn.tool_calls {
+                if cancel.is_cancelled() {
+                    return self.finalize_interrupted(&turn_id, "cancelled", tx);
+                }
+                match self.execute_call(call, &ctx, cancel, tx, &turn_id).await? {
+                    CallFlow::Continue => {}
+                    CallFlow::Interrupted(reason) => {
+                        return self.finalize_interrupted(&turn_id, &reason, tx);
+                    }
+                }
+            }
+            // All tool results are in history; loop back for another model round.
+        }
+    }
+
+    /// Run one tool call: reject-before-start on any validation failure, gate on
+    /// confirmation, then execute. Every branch records a `tool.finished` (the
+    /// result fed back to the model), but `tool.started` is recorded only when the
+    /// tool body actually runs — so a lone `tool.finished` marks a call rejected
+    /// or denied before execution.
+    async fn execute_call(
+        &mut self,
+        call: &ToolCall,
+        ctx: &ToolContext,
+        cancel: &CancellationToken,
+        tx: &mpsc::UnboundedSender<AgentEvent>,
+        turn_id: &str,
+    ) -> io::Result<CallFlow> {
+        let call_id = call.call_id.clone();
+
+        let tool = match self.runtime.get(&call.name) {
+            Some(tool) => tool,
+            None => {
+                finish_call(
+                    &mut self.store,
+                    &mut self.history,
+                    tx,
+                    turn_id,
+                    &call_id,
+                    false,
+                    format!("unknown tool '{}'", call.name),
+                )?;
+                return Ok(CallFlow::Continue);
+            }
+        };
+
+        let args: Value = match serde_json::from_str(&call.arguments) {
+            Ok(value) => value,
+            Err(err) => {
+                finish_call(
+                    &mut self.store,
+                    &mut self.history,
+                    tx,
+                    turn_id,
+                    &call_id,
+                    false,
+                    format!("invalid JSON arguments: {err}"),
+                )?;
+                return Ok(CallFlow::Continue);
+            }
+        };
+
+        let prepared = match tool.prepare(ctx, &args) {
+            Ok(prepared) => prepared,
+            Err(reason) => {
+                finish_call(
+                    &mut self.store,
+                    &mut self.history,
+                    tx,
+                    turn_id,
+                    &call_id,
+                    false,
+                    reason,
+                )?;
+                return Ok(CallFlow::Continue);
+            }
+        };
+
+        // Confirmation, only for tools that require it. Auto-allowed tools skip
+        // the gate entirely and record no permission events (avoids two ledger
+        // lines per read).
+        if tool.requires_confirmation() {
+            let summary = tool.summarize(&prepared);
+            emit(
+                &mut self.store,
+                tx,
+                turn_id,
+                EventKind::PermissionRequested {
+                    call_id: call_id.clone(),
+                    action: summary.clone(),
+                },
+            )?;
+            let request = PermissionRequest {
+                tool_name: call.name.clone(),
+                summary,
+            };
+            let allowed = match cancel.run_until_cancelled(self.gate.decide(&request)).await {
+                Some(allowed) => allowed,
+                None => return Ok(CallFlow::Interrupted("cancelled".to_string())),
+            };
+            emit(
+                &mut self.store,
+                tx,
+                turn_id,
+                EventKind::PermissionDecided {
+                    call_id: call_id.clone(),
+                    allowed,
+                },
+            )?;
+            if !allowed {
+                finish_call(
+                    &mut self.store,
+                    &mut self.history,
+                    tx,
+                    turn_id,
+                    &call_id,
+                    false,
+                    "permission denied".to_string(),
+                )?;
+                return Ok(CallFlow::Continue);
+            }
+        }
+
+        emit(
+            &mut self.store,
+            tx,
+            turn_id,
+            EventKind::ToolStarted {
+                call_id: call_id.clone(),
+                name: call.name.clone(),
+            },
+        )?;
+        let (ok, output) = match tool.run(ctx, &prepared).await {
+            Ok(output) => (true, output),
+            Err(err) => (false, err),
+        };
+        finish_call(
+            &mut self.store,
+            &mut self.history,
+            tx,
+            turn_id,
+            &call_id,
+            ok,
+            output,
+        )?;
+        Ok(CallFlow::Continue)
+    }
+
+    /// Record `turn.interrupted` and return. Not cancellable: interruption
+    /// cleanup must always run to completion.
+    fn finalize_interrupted(
+        &mut self,
+        turn_id: &str,
+        reason: &str,
+        tx: &mpsc::UnboundedSender<AgentEvent>,
+    ) -> io::Result<TurnOutcome> {
+        emit(
+            &mut self.store,
+            tx,
+            turn_id,
+            EventKind::TurnInterrupted {
+                reason: reason.to_string(),
+            },
+        )?;
+        Ok(TurnOutcome::interrupted(reason))
+    }
+}
+
+/// Append one ledger event, then mirror it onto the wire stream. Append first so
+/// the ledger is authoritative; a dropped receiver is ignored, not an error.
+fn emit(
+    store: &mut SessionStore,
+    tx: &mpsc::UnboundedSender<AgentEvent>,
+    turn_id: &str,
+    kind: EventKind,
+) -> io::Result<()> {
+    let event = store.append(Some(turn_id.to_string()), kind)?;
+    let _ = tx.send(AgentEvent::Ledger(event));
+    Ok(())
+}
+
+/// Record a `tool.finished` and push its output into history as the tool result
+/// fed back to the model — for a real result, a rejection, or a denial.
+fn finish_call(
+    store: &mut SessionStore,
+    history: &mut Vec<ChatMessage>,
+    tx: &mpsc::UnboundedSender<AgentEvent>,
+    turn_id: &str,
+    call_id: &str,
+    ok: bool,
+    output: String,
+) -> io::Result<()> {
+    let event = store.append(
+        Some(turn_id.to_string()),
+        EventKind::ToolFinished {
+            call_id: call_id.to_string(),
+            ok,
+            output: output.clone(),
+        },
+    )?;
+    let _ = tx.send(AgentEvent::Ledger(event));
+    history.push(ChatMessage::Tool {
+        call_id: call_id.to_string(),
+        content: output,
+    });
+    Ok(())
+}
+
+fn new_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    use crate::llm::{LlmError, MockLlmClient, MockResponse, ModelTurn};
+    use crate::session::store::project;
+    use crate::tool::{BoxFuture, PreparedCall, Tool, ToolResult};
+
+    // --- Fixtures --------------------------------------------------------
+
+    struct TempDirs {
+        base: PathBuf,
+        ledger_root: PathBuf,
+        workspace: PathBuf,
+    }
+
+    impl TempDirs {
+        fn new() -> Self {
+            let base = std::env::temp_dir().join(format!("pawwork-agent-{}", Uuid::new_v4()));
+            let ledger_root = base.join("ledger");
+            let workspace = base.join("workspace");
+            std::fs::create_dir_all(&ledger_root).unwrap();
+            std::fs::create_dir_all(&workspace).unwrap();
+            TempDirs {
+                base,
+                ledger_root,
+                workspace,
+            }
+        }
+
+        fn write(&self, name: &str, contents: &[u8]) {
+            std::fs::write(self.workspace.join(name), contents).unwrap();
+        }
+    }
+
+    impl Drop for TempDirs {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.base).ok();
+        }
+    }
+
+    fn build<L: LlmClient, G: PermissionGate>(
+        client: L,
+        gate: G,
+        runtime: ToolRuntime,
+        dirs: &TempDirs,
+    ) -> (Agent<L, G>, PathBuf) {
+        let store =
+            SessionStore::create(&dirs.ledger_root, dirs.workspace.to_str().unwrap()).unwrap();
+        let session_dir = store.dir().to_path_buf();
+        let agent = Agent::new(store, client, runtime, gate, &dirs.workspace).unwrap();
+        (agent, session_dir)
+    }
+
+    fn call(call_id: &str, name: &str, arguments: &str) -> ToolCall {
+        ToolCall {
+            call_id: call_id.to_string(),
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+        }
+    }
+
+    fn turn_with(calls: Vec<ToolCall>) -> MockResponse {
+        MockResponse::Turn(ModelTurn {
+            text: String::new(),
+            tool_calls: calls,
+        })
+    }
+
+    fn done() -> MockResponse {
+        MockResponse::Turn(ModelTurn {
+            text: "done".to_string(),
+            tool_calls: Vec::new(),
+        })
+    }
+
+    fn channel() -> (
+        mpsc::UnboundedSender<AgentEvent>,
+        mpsc::UnboundedReceiver<AgentEvent>,
+    ) {
+        mpsc::unbounded_channel()
+    }
+
+    fn kinds(events: &[LedgerEvent]) -> Vec<&EventKind> {
+        events.iter().map(|event| &event.kind).collect()
+    }
+
+    // --- Test doubles ----------------------------------------------------
+
+    struct AllowGate;
+    impl PermissionGate for AllowGate {
+        async fn decide(&self, _req: &PermissionRequest) -> bool {
+            true
+        }
+    }
+
+    struct DenyGate;
+    impl PermissionGate for DenyGate {
+        async fn decide(&self, _req: &PermissionRequest) -> bool {
+            false
+        }
+    }
+
+    struct HangGate;
+    impl PermissionGate for HangGate {
+        async fn decide(&self, _req: &PermissionRequest) -> bool {
+            std::future::pending::<bool>().await
+        }
+    }
+
+    /// A tool that requires confirmation, so tests can exercise the gate path
+    /// without a real side-effecting tool (which lands with `edit`/`shell`).
+    struct ConfirmTool;
+    impl Tool for ConfirmTool {
+        fn name(&self) -> &str {
+            "danger"
+        }
+        fn requires_confirmation(&self) -> bool {
+            true
+        }
+        fn prepare(&self, ctx: &ToolContext, _args: &Value) -> Result<PreparedCall, String> {
+            Ok(PreparedCall {
+                path: ctx.workspace_root.clone(),
+            })
+        }
+        fn summarize(&self, _prepared: &PreparedCall) -> String {
+            "do the dangerous thing".to_string()
+        }
+        fn run<'a>(
+            &'a self,
+            _ctx: &'a ToolContext,
+            _prepared: &'a PreparedCall,
+        ) -> BoxFuture<'a, ToolResult> {
+            Box::pin(async { Ok("did the thing".to_string()) })
+        }
+    }
+
+    fn confirm_runtime() -> ToolRuntime {
+        let mut runtime = ToolRuntime::new();
+        runtime.register(Box::new(ConfirmTool));
+        runtime
+    }
+
+    // --- Tests -----------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn plain_text_turn_completes() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::once_text("hi there"),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("hello", &cancel, &tx).await.unwrap();
+        assert_eq!(outcome, TurnOutcome::Completed);
+        let events = project(&session_dir).unwrap();
+        assert!(matches!(
+            kinds(&events).as_slice(),
+            [
+                EventKind::SessionCreated { .. },
+                EventKind::UserMessage { .. },
+                EventKind::ModelMessage { .. },
+                EventKind::TurnCompleted,
+            ]
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn channel_mirrors_appended_events_in_order() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::once_text("hi"),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, mut rx) = channel();
+        agent.run_turn("hello", &cancel, &tx).await.unwrap();
+        drop(tx);
+        let mut streamed = Vec::new();
+        while let Ok(AgentEvent::Ledger(event)) = rx.try_recv() {
+            streamed.push(event);
+        }
+        let ledger = project(&session_dir).unwrap();
+        // Everything after the pre-run session.created is mirrored, in order.
+        assert_eq!(streamed, ledger[1..].to_vec());
+        assert!(matches!(ledger[0].kind, EventKind::SessionCreated { .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_tool_round_trips_result_into_history() {
+        let dirs = TempDirs::new();
+        dirs.write("a.txt", b"hello from file");
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![
+                turn_with(vec![call("c1", "read", r#"{"path":"a.txt"}"#)]),
+                done(),
+            ]),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("read it", &cancel, &tx).await.unwrap();
+        assert_eq!(outcome, TurnOutcome::Completed);
+
+        let events = project(&session_dir).unwrap();
+        // read is auto-allowed: no permission events.
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::PermissionRequested { .. })));
+        let finished = events
+            .iter()
+            .find_map(|e| match &e.kind {
+                EventKind::ToolFinished { ok, output, .. } => Some((*ok, output.clone())),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(finished, (true, "hello from file".to_string()));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })));
+
+        // The second model round saw the tool result in its history.
+        let seen = agent.client.seen_histories();
+        assert_eq!(seen.len(), 2, "two model rounds");
+        assert!(seen[1].iter().any(
+            |m| matches!(m, ChatMessage::Tool { content, .. } if content == "hello from file")
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unknown_tool_is_rejected_without_started() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![turn_with(vec![call("c1", "nope", "{}")]), done()]),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("go", &cancel, &tx).await.unwrap();
+        assert_eq!(
+            outcome,
+            TurnOutcome::Completed,
+            "loop recovers via synthetic error"
+        );
+        let events = project(&session_dir).unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })),
+            "a rejected call must not record tool.started"
+        );
+        let (ok, output) = events
+            .iter()
+            .find_map(|e| match &e.kind {
+                EventKind::ToolFinished { ok, output, .. } => Some((*ok, output.clone())),
+                _ => None,
+            })
+            .unwrap();
+        assert!(!ok);
+        assert!(output.contains("unknown tool"), "got: {output}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn invalid_json_arguments_rejected_without_started() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![
+                turn_with(vec![call("c1", "read", "{not json")]),
+                done(),
+            ]),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        agent.run_turn("go", &cancel, &tx).await.unwrap();
+        let events = project(&session_dir).unwrap();
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })));
+        assert!(events.iter().any(|e| matches!(
+            &e.kind,
+            EventKind::ToolFinished { ok: false, output, .. } if output.contains("invalid JSON")
+        )));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn path_escape_rejected_without_started() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![
+                turn_with(vec![call("c1", "read", r#"{"path":"/etc/hosts"}"#)]),
+                done(),
+            ]),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        agent.run_turn("go", &cancel, &tx).await.unwrap();
+        let events = project(&session_dir).unwrap();
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })));
+        assert!(events.iter().any(|e| matches!(
+            &e.kind,
+            EventKind::ToolFinished { ok: false, output, .. } if output.contains("escapes")
+        )));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn confirmed_tool_records_permission_then_runs() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![turn_with(vec![call("c1", "danger", "{}")]), done()]),
+            AllowGate,
+            confirm_runtime(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("do it", &cancel, &tx).await.unwrap();
+        assert_eq!(outcome, TurnOutcome::Completed);
+        let events = project(&session_dir).unwrap();
+        let seq: Vec<&EventKind> = events
+            .iter()
+            .map(|e| &e.kind)
+            .filter(|k| {
+                matches!(
+                    k,
+                    EventKind::PermissionRequested { .. }
+                        | EventKind::PermissionDecided { .. }
+                        | EventKind::ToolStarted { .. }
+                        | EventKind::ToolFinished { .. }
+                )
+            })
+            .collect();
+        assert!(matches!(
+            seq.as_slice(),
+            [
+                EventKind::PermissionRequested { .. },
+                EventKind::PermissionDecided { allowed: true, .. },
+                EventKind::ToolStarted { .. },
+                EventKind::ToolFinished { ok: true, .. },
+            ]
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn denied_tool_synthesizes_error_and_continues() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![turn_with(vec![call("c1", "danger", "{}")]), done()]),
+            DenyGate,
+            confirm_runtime(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("do it", &cancel, &tx).await.unwrap();
+        assert_eq!(
+            outcome,
+            TurnOutcome::Completed,
+            "denial is not interruption"
+        );
+        let events = project(&session_dir).unwrap();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::PermissionDecided { allowed: false, .. })));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })),
+            "denied before start"
+        );
+        assert!(events.iter().any(|e| matches!(
+            &e.kind,
+            EventKind::ToolFinished { ok: false, output, .. } if output.contains("denied")
+        )));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelled_before_start_records_nothing() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::once_text("hi"),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("hello", &cancel, &tx).await.unwrap();
+        assert!(matches!(outcome, TurnOutcome::Interrupted { .. }));
+        let events = project(&session_dir).unwrap();
+        // Only the pre-run session.created; the turn never began.
+        assert_eq!(
+            kinds(&events),
+            vec![&EventKind::SessionCreated {
+                workspace: dirs.workspace.to_str().unwrap().to_string()
+            }]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancel_during_model_writes_interrupted() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![MockResponse::HangUntilCancel]),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, mut rx) = channel();
+        let canceller = {
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                // Cancel once the user message has been emitted, so the loop is
+                // parked on the (hanging) model call.
+                while let Some(AgentEvent::Ledger(event)) = rx.recv().await {
+                    if matches!(event.kind, EventKind::UserMessage { .. }) {
+                        cancel.cancel();
+                        break;
+                    }
+                }
+            })
+        };
+        let outcome = agent.run_turn("hello", &cancel, &tx).await.unwrap();
+        canceller.await.unwrap();
+        assert!(matches!(outcome, TurnOutcome::Interrupted { .. }));
+        let events = project(&session_dir).unwrap();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::UserMessage { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::TurnInterrupted { .. })));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ModelMessage { .. })),
+            "model never produced a message"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancel_during_permission_wait_writes_interrupted() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![turn_with(vec![call("c1", "danger", "{}")])]),
+            HangGate,
+            confirm_runtime(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, mut rx) = channel();
+        let canceller = {
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                while let Some(AgentEvent::Ledger(event)) = rx.recv().await {
+                    if matches!(event.kind, EventKind::PermissionRequested { .. }) {
+                        cancel.cancel();
+                        break;
+                    }
+                }
+            })
+        };
+        let outcome = agent.run_turn("do it", &cancel, &tx).await.unwrap();
+        canceller.await.unwrap();
+        assert!(matches!(outcome, TurnOutcome::Interrupted { .. }));
+        let events = project(&session_dir).unwrap();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::PermissionRequested { .. })));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::PermissionDecided { .. })),
+            "cancelled before a decision"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })),
+            "cancelled before the tool ran"
+        );
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::TurnInterrupted { .. })));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn llm_error_records_error_then_interrupts() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![MockResponse::Fail(LlmError::new("boom"))]),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("hello", &cancel, &tx).await.unwrap();
+        match outcome {
+            TurnOutcome::Interrupted { reason } => {
+                assert!(reason.contains("boom"), "got: {reason}")
+            }
+            other => panic!("expected interrupted, got {other:?}"),
+        }
+        let events = project(&session_dir).unwrap();
+        assert!(events.iter().any(|e| matches!(
+            &e.kind,
+            EventKind::Error { message } if message == "boom"
+        )));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::TurnInterrupted { .. })));
+    }
+}

--- a/crates/pawwork-core/src/agent.rs
+++ b/crates/pawwork-core/src/agent.rs
@@ -57,6 +57,12 @@ impl TurnOutcome {
     }
 }
 
+/// Default cap on model rounds within a single turn. A runaway or adversarial
+/// model that keeps returning tool calls would otherwise loop forever, growing
+/// the ledger and context without end; this bounds one turn to a finite number
+/// of model requests. Generous enough that real multi-step tasks are unaffected.
+const DEFAULT_MAX_MODEL_ROUNDS: usize = 64;
+
 /// Internal per-call control flow.
 enum CallFlow {
     /// Move on to the next tool call (the result, error, or denial was recorded).
@@ -73,6 +79,7 @@ pub struct Agent<L: LlmClient, G: PermissionGate> {
     gate: G,
     workspace_root: PathBuf,
     history: Vec<ChatMessage>,
+    max_model_rounds: usize,
 }
 
 impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
@@ -93,7 +100,14 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
             gate,
             workspace_root,
             history: Vec::new(),
+            max_model_rounds: DEFAULT_MAX_MODEL_ROUNDS,
         })
+    }
+
+    /// Override the per-turn model-round budget (see [`DEFAULT_MAX_MODEL_ROUNDS`]).
+    pub fn with_max_model_rounds(mut self, max_model_rounds: usize) -> Self {
+        self.max_model_rounds = max_model_rounds;
+        self
     }
 
     /// Run one user turn: record the message, then loop model rounds — executing
@@ -122,9 +136,29 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
         )?;
         self.history.push(ChatMessage::User(user_text.to_string()));
 
+        let mut round = 0usize;
         loop {
             if cancel.is_cancelled() {
                 return self.finalize_interrupted(&turn_id, "cancelled", tx);
+            }
+
+            // Runaway guard: a model that keeps returning tool calls must not loop
+            // forever. Record an error and interrupt once the round budget is spent.
+            round += 1;
+            if round > self.max_model_rounds {
+                let reason = format!(
+                    "budget exceeded: max model rounds ({})",
+                    self.max_model_rounds
+                );
+                emit(
+                    &mut self.store,
+                    tx,
+                    &turn_id,
+                    EventKind::Error {
+                        message: reason.clone(),
+                    },
+                )?;
+                return self.finalize_interrupted(&turn_id, &reason, tx);
             }
 
             // Ask the model, cancellable. `None` means the token fired first.
@@ -909,6 +943,49 @@ mod tests {
         assert!(events.iter().any(|e| matches!(
             &e.kind,
             EventKind::Error { message } if message == "boom"
+        )));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::TurnInterrupted { .. })));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn model_round_budget_interrupts_a_runaway_loop() {
+        let dirs = TempDirs::new();
+        dirs.write("a.txt", b"x");
+        // A model that keeps asking for a tool every round would loop forever.
+        let (agent, session_dir) = build(
+            MockLlmClient::new(vec![
+                turn_with(vec![call("c1", "read", r#"{"path":"a.txt"}"#)]),
+                turn_with(vec![call("c2", "read", r#"{"path":"a.txt"}"#)]),
+                turn_with(vec![call("c3", "read", r#"{"path":"a.txt"}"#)]),
+            ]),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let mut agent = agent.with_max_model_rounds(2);
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("loop forever", &cancel, &tx).await.unwrap();
+        match outcome {
+            TurnOutcome::Interrupted { reason } => {
+                assert!(reason.contains("budget"), "got: {reason}")
+            }
+            other => panic!("expected budget interruption, got {other:?}"),
+        }
+        let events = project(&session_dir).unwrap();
+        let rounds = events
+            .iter()
+            .filter(|e| matches!(e.kind, EventKind::ModelMessage { .. }))
+            .count();
+        assert_eq!(
+            rounds, 2,
+            "budget stops after exactly max_model_rounds calls"
+        );
+        assert!(events.iter().any(|e| matches!(
+            &e.kind,
+            EventKind::Error { message } if message.contains("budget")
         )));
         assert!(events
             .iter()

--- a/crates/pawwork-core/src/lib.rs
+++ b/crates/pawwork-core/src/lib.rs
@@ -1,5 +1,19 @@
 //! pawwork-core: UI-less agent core (ledger, tools, llm) for the Rust line.
 //!
-//! M0 scope is the session ledger; see `docs/architecture/2026-07-09-rust-agent-v0.md`.
+//! Layers (see `docs/architecture/2026-07-09-rust-agent-v0.md`, section 13):
+//! - [`session`] — JSONL ledger, the single source of truth (PR1).
+//! - [`llm`] — the [`llm::LlmClient`] boundary plus a scripted mock.
+//! - [`tool`] — the [`tool::Tool`] boundary, a runtime registry, and the
+//!   read-only `read`/`list` tools with their workspace path fence.
+//! - [`permission`] — the [`permission::PermissionGate`] callback boundary.
+//! - [`agent`] — the turn loop that wires them together, appends ledger events,
+//!   and mirrors them onto a wire event stream.
+//!
+//! The core never touches stdin or builds a runtime; adapters (CLI, later Tauri)
+//! own the runtime flavor and the interactive surface.
 
+pub mod agent;
+pub mod llm;
+pub mod permission;
 pub mod session;
+pub mod tool;

--- a/crates/pawwork-core/src/llm.rs
+++ b/crates/pawwork-core/src/llm.rs
@@ -1,0 +1,144 @@
+//! The model boundary.
+//!
+//! [`LlmClient`] is the seam between the turn loop and whatever produces model
+//! turns — a scripted [`MockLlmClient`] here, a real OpenAI-compatible SSE client
+//! in a later PR. The trait is generic (never `dyn`): the loop holds exactly one
+//! client, so a concrete type parameter is simpler than a boxed future and keeps
+//! the `Send` bound legible at the definition rather than at a distant use site.
+//!
+//! Half-parsed tool calls are unrepresentable by contract: a client only ever
+//! returns a [`ModelTurn`] whose `tool_calls` are fully parsed. A stream that
+//! dies or is cancelled mid-flight resolves to `Err`/never resolves — the torn
+//! buffer dies inside the client, so the loop has no "is this a half call?" branch
+//! to get wrong.
+
+use std::future::Future;
+
+use crate::session::event::ToolCall;
+
+/// One message in the in-memory chat history the loop feeds back to the model.
+///
+/// This is the wire/model view, distinct from the ledger's [`crate::session::event::EventKind`].
+/// PR2 builds it live during a turn; reconstructing it from the ledger for
+/// cross-session resume is deferred to the resume/CLI PR.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChatMessage {
+    User(String),
+    Assistant {
+        text: String,
+        tool_calls: Vec<ToolCall>,
+    },
+    /// The result fed back for one tool call — a real output, or a synthesized
+    /// error when the call was rejected, denied, or cancelled before execution.
+    Tool {
+        call_id: String,
+        content: String,
+    },
+}
+
+/// A completed model turn: assistant text plus fully-parsed tool calls.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelTurn {
+    pub text: String,
+    pub tool_calls: Vec<ToolCall>,
+}
+
+/// An unrecoverable model/transport error. Minimal in PR2 (mock only); the real
+/// client will carry status/kind for backoff decisions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LlmError {
+    pub message: String,
+}
+
+impl LlmError {
+    pub fn new(message: impl Into<String>) -> Self {
+        LlmError {
+            message: message.into(),
+        }
+    }
+}
+
+/// The model boundary. One turn in, one turn out.
+///
+/// `respond`'s future is `Send` so the loop can run on a multi-thread runtime;
+/// this is stated here rather than inferred at a spawn site far away.
+pub trait LlmClient: Send + Sync {
+    fn respond(
+        &self,
+        history: &[ChatMessage],
+    ) -> impl Future<Output = Result<ModelTurn, LlmError>> + Send;
+}
+
+/// A scripted model for tests and CLI bring-up: pops one [`MockResponse`] per
+/// call, in order, and records the history it was handed so tests can assert the
+/// loop reconstructs the conversation correctly.
+#[derive(Debug)]
+pub struct MockLlmClient {
+    script: std::sync::Mutex<std::collections::VecDeque<MockResponse>>,
+    seen: std::sync::Mutex<Vec<Vec<ChatMessage>>>,
+}
+
+/// One scripted step.
+#[derive(Debug, Clone)]
+pub enum MockResponse {
+    /// Return this turn (empty `tool_calls` ends the loop).
+    Turn(ModelTurn),
+    /// Return an error, exercising the loop's error path.
+    Fail(LlmError),
+    /// Never resolve, so the loop parks on the model await until cancelled — the
+    /// only way to test mid-model interruption.
+    HangUntilCancel,
+}
+
+impl MockLlmClient {
+    pub fn new(script: Vec<MockResponse>) -> Self {
+        MockLlmClient {
+            script: std::sync::Mutex::new(script.into()),
+            seen: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Convenience: a one-shot text reply with no tool calls.
+    pub fn once_text(text: impl Into<String>) -> Self {
+        MockLlmClient::new(vec![MockResponse::Turn(ModelTurn {
+            text: text.into(),
+            tool_calls: Vec::new(),
+        })])
+    }
+
+    /// The histories handed to `respond`, in call order — one entry per model
+    /// round.
+    pub fn seen_histories(&self) -> Vec<Vec<ChatMessage>> {
+        self.seen.lock().expect("mock seen lock").clone()
+    }
+}
+
+impl LlmClient for MockLlmClient {
+    fn respond(
+        &self,
+        history: &[ChatMessage],
+    ) -> impl Future<Output = Result<ModelTurn, LlmError>> + Send {
+        // Record and pop synchronously; do not hold either lock across the await.
+        self.seen
+            .lock()
+            .expect("mock seen lock")
+            .push(history.to_vec());
+        let next = self.script.lock().expect("mock script lock").pop_front();
+        async move {
+            match next {
+                Some(MockResponse::Turn(turn)) => Ok(turn),
+                Some(MockResponse::Fail(err)) => Err(err),
+                Some(MockResponse::HangUntilCancel) => {
+                    std::future::pending::<Result<ModelTurn, LlmError>>().await
+                }
+                // Exhausted script: end the turn with an empty reply rather than
+                // hang, so a test that under-scripts fails loudly on assertions
+                // instead of deadlocking.
+                None => Ok(ModelTurn {
+                    text: String::new(),
+                    tool_calls: Vec::new(),
+                }),
+            }
+        }
+    }
+}

--- a/crates/pawwork-core/src/permission.rs
+++ b/crates/pawwork-core/src/permission.rs
@@ -1,0 +1,31 @@
+//! The permission boundary.
+//!
+//! The core never prompts: when a tool needs confirmation the loop calls a
+//! [`PermissionGate`], which an adapter (CLI, later Tauri) implements against its
+//! own UI. Like [`crate::llm::LlmClient`] the gate is generic, not `dyn` — the
+//! loop holds one.
+//!
+//! The request is structured, not a raw JSON blob for the user to eyeball: PR2
+//! carries the tool name and a rendered human summary. A richer typed action
+//! enum (read-path / write-file / shell-command) lands with `edit`/`shell`, its
+//! first real producers; introducing those variants now would be speculative
+//! dead code, since PR2's only tools (`read`/`list`) are auto-allowed and never
+//! reach the gate.
+
+use std::future::Future;
+
+/// What the user is being asked to approve.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PermissionRequest {
+    pub tool_name: String,
+    /// A rendered, human-readable description of the concrete action. This is
+    /// also what the ledger's `permission.requested` records as its `action`.
+    pub summary: String,
+}
+
+/// The interactive approval boundary, consulted only for tools that require
+/// confirmation. `decide` returns `true` to allow, `false` to deny; the future
+/// is `Send` for the same multi-thread reason as [`crate::llm::LlmClient`].
+pub trait PermissionGate: Send + Sync {
+    fn decide(&self, request: &PermissionRequest) -> impl Future<Output = bool> + Send;
+}

--- a/crates/pawwork-core/src/tool/fence.rs
+++ b/crates/pawwork-core/src/tool/fence.rs
@@ -1,0 +1,140 @@
+//! Workspace path fence.
+//!
+//! This is an advisory fence, not a sandbox: it keeps a cooperating model from
+//! reading outside the workspace by mistake. It does not defend against TOCTOU
+//! races (a path can change between the check and the open) and is not an OS-level
+//! confinement boundary — that is deferred (seatbelt et al.). The fence anchors
+//! only the file tools; `shell`'s boundary is confirmation, not this.
+//!
+//! Resolution canonicalizes both the workspace root (once, by the caller) and the
+//! requested target, then requires the target to be *under* the root by path
+//! component (`Path::starts_with`), never by string prefix — so `/ws-evil` cannot
+//! masquerade as being inside `/ws`. Canonicalization resolves symlinks, so a
+//! symlink pointing outside the root is rejected, and it requires the target to
+//! exist, which is exactly right for the read-only `read`/`list` tools.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve `requested` against an already-canonicalized `root`, returning the
+/// canonical target iff it stays inside the workspace.
+///
+/// `requested` may be relative (joined onto `root`) or absolute (which replaces
+/// `root` in the join, then must still canonicalize back inside it).
+pub fn resolve_in_workspace(root: &Path, requested: &str) -> Result<PathBuf, String> {
+    if requested.trim().is_empty() {
+        return Err("empty path".to_string());
+    }
+    let candidate = root.join(requested);
+    let canonical = candidate
+        .canonicalize()
+        .map_err(|err| format!("cannot resolve '{requested}': {err}"))?;
+    if !canonical.starts_with(root) {
+        return Err(format!("path '{requested}' escapes the workspace"));
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use uuid::Uuid;
+
+    struct TempWorkspace {
+        root: PathBuf,
+    }
+
+    impl TempWorkspace {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!("pawwork-fence-{}", Uuid::new_v4()));
+            fs::create_dir_all(&root).unwrap();
+            // Canonicalize the root the way the agent does at startup (temp dirs
+            // are often symlinked, e.g. /var -> /private/var on macOS).
+            let root = root.canonicalize().unwrap();
+            TempWorkspace { root }
+        }
+    }
+
+    impl Drop for TempWorkspace {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.root).ok();
+        }
+    }
+
+    #[test]
+    fn accepts_path_inside_workspace() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("note.txt"), b"hi").unwrap();
+        let resolved = resolve_in_workspace(&ws.root, "note.txt").unwrap();
+        assert_eq!(resolved, ws.root.join("note.txt"));
+    }
+
+    #[test]
+    fn accepts_the_root_itself() {
+        let ws = TempWorkspace::new();
+        let resolved = resolve_in_workspace(&ws.root, ".").unwrap();
+        assert_eq!(resolved, ws.root);
+    }
+
+    #[test]
+    fn rejects_absolute_path_outside() {
+        let ws = TempWorkspace::new();
+        let err = resolve_in_workspace(&ws.root, "/etc/hosts").unwrap_err();
+        assert!(err.contains("escapes"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_dotdot_escape() {
+        let ws = TempWorkspace::new();
+        let err = resolve_in_workspace(&ws.root, "../../etc/hosts").unwrap_err();
+        // Either it escapes, or the traversed path does not exist — both are a
+        // refusal, never a success.
+        assert!(
+            err.contains("escapes") || err.contains("cannot resolve"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_symlink_pointing_outside() {
+        let ws = TempWorkspace::new();
+        let outside = std::env::temp_dir().join(format!("pawwork-outside-{}", Uuid::new_v4()));
+        fs::write(&outside, b"secret").unwrap();
+        let link = ws.root.join("escape");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&outside, &link).unwrap();
+        let err = resolve_in_workspace(&ws.root, "escape").unwrap_err();
+        assert!(
+            err.contains("escapes"),
+            "symlink out must be rejected, got: {err}"
+        );
+        fs::remove_file(&outside).ok();
+    }
+
+    #[test]
+    fn rejects_missing_path() {
+        let ws = TempWorkspace::new();
+        let err = resolve_in_workspace(&ws.root, "nope.txt").unwrap_err();
+        assert!(err.contains("cannot resolve"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_sibling_with_shared_prefix() {
+        // A component-wise check must not treat `/tmp/ws-evil` as inside `/tmp/ws`.
+        let base = std::env::temp_dir().join(format!("pawwork-prefix-{}", Uuid::new_v4()));
+        let root = base.join("ws");
+        let sibling = base.join("ws-evil");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&sibling).unwrap();
+        let root = root.canonicalize().unwrap();
+        fs::write(sibling.join("f.txt"), b"x").unwrap();
+        let err = resolve_in_workspace(&root, "../ws-evil/f.txt").unwrap_err();
+        assert!(
+            err.contains("escapes"),
+            "sibling prefix must be rejected, got: {err}"
+        );
+        fs::remove_dir_all(&base).ok();
+    }
+}

--- a/crates/pawwork-core/src/tool/fs.rs
+++ b/crates/pawwork-core/src/tool/fs.rs
@@ -1,0 +1,221 @@
+//! Built-in read-only tools: `read` and `list`.
+//!
+//! Both are auto-allowed (no confirmation) and fenced to the workspace. Their
+//! filesystem work is synchronous inside the returned future: the reads are small
+//! and the outputs are capped, so for M0 an inline `std::fs` call is simpler than
+//! a `spawn_blocking` hop (which would also force the core to pull a runtime
+//! feature it otherwise avoids). Moving to `spawn_blocking` is a later concern if
+//! a tool reads large files.
+
+use serde_json::Value;
+
+use super::fence::resolve_in_workspace;
+use super::{BoxFuture, PreparedCall, Tool, ToolContext, ToolResult};
+
+/// Cap on bytes returned by `read`, so a huge file cannot flood the context.
+const MAX_READ_BYTES: usize = 64 * 1024;
+/// Cap on entries returned by `list`.
+const MAX_LIST_ENTRIES: usize = 1000;
+
+/// Pull the required `path` string argument out of a tool call's JSON.
+fn path_arg(args: &Value) -> Result<&str, String> {
+    args.get("path")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "missing required string argument 'path'".to_string())
+}
+
+/// `read`: return the (capped) UTF-8 contents of a file inside the workspace.
+pub struct ReadTool;
+
+impl Tool for ReadTool {
+    fn name(&self) -> &str {
+        "read"
+    }
+
+    fn requires_confirmation(&self) -> bool {
+        false
+    }
+
+    fn prepare(&self, ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String> {
+        let requested = path_arg(args)?;
+        let path = resolve_in_workspace(&ctx.workspace_root, requested)?;
+        if !path.is_file() {
+            return Err(format!("'{requested}' is not a file"));
+        }
+        Ok(PreparedCall { path })
+    }
+
+    fn summarize(&self, prepared: &PreparedCall) -> String {
+        format!("read {}", prepared.path.display())
+    }
+
+    fn run<'a>(
+        &'a self,
+        _ctx: &'a ToolContext,
+        prepared: &'a PreparedCall,
+    ) -> BoxFuture<'a, ToolResult> {
+        Box::pin(async move {
+            let bytes =
+                std::fs::read(&prepared.path).map_err(|err| format!("read failed: {err}"))?;
+            let truncated = bytes.len() > MAX_READ_BYTES;
+            let slice = &bytes[..bytes.len().min(MAX_READ_BYTES)];
+            let mut text = String::from_utf8_lossy(slice).into_owned();
+            if truncated {
+                text.push_str("\n… [truncated]");
+            }
+            Ok(text)
+        })
+    }
+}
+
+/// `list`: return the (capped, sorted) entry names of a directory inside the
+/// workspace.
+pub struct ListTool;
+
+impl Tool for ListTool {
+    fn name(&self) -> &str {
+        "list"
+    }
+
+    fn requires_confirmation(&self) -> bool {
+        false
+    }
+
+    fn prepare(&self, ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String> {
+        let requested = path_arg(args)?;
+        let path = resolve_in_workspace(&ctx.workspace_root, requested)?;
+        if !path.is_dir() {
+            return Err(format!("'{requested}' is not a directory"));
+        }
+        Ok(PreparedCall { path })
+    }
+
+    fn summarize(&self, prepared: &PreparedCall) -> String {
+        format!("list {}", prepared.path.display())
+    }
+
+    fn run<'a>(
+        &'a self,
+        _ctx: &'a ToolContext,
+        prepared: &'a PreparedCall,
+    ) -> BoxFuture<'a, ToolResult> {
+        Box::pin(async move {
+            let entries =
+                std::fs::read_dir(&prepared.path).map_err(|err| format!("list failed: {err}"))?;
+            let mut names = Vec::new();
+            for entry in entries {
+                let entry = entry.map_err(|err| format!("list failed: {err}"))?;
+                names.push(entry.file_name().to_string_lossy().into_owned());
+            }
+            names.sort();
+            let truncated = names.len() > MAX_LIST_ENTRIES;
+            names.truncate(MAX_LIST_ENTRIES);
+            let mut out = names.join("\n");
+            if truncated {
+                out.push_str("\n… [truncated]");
+            }
+            Ok(out)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    struct TempWorkspace {
+        root: PathBuf,
+    }
+
+    impl TempWorkspace {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!("pawwork-fs-{}", Uuid::new_v4()));
+            fs::create_dir_all(&root).unwrap();
+            let root = root.canonicalize().unwrap();
+            TempWorkspace { root }
+        }
+
+        fn ctx(&self) -> ToolContext {
+            ToolContext {
+                workspace_root: self.root.clone(),
+            }
+        }
+    }
+
+    impl Drop for TempWorkspace {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.root).ok();
+        }
+    }
+
+    #[tokio::test]
+    async fn read_returns_file_contents() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("a.txt"), b"hello").unwrap();
+        let ctx = ws.ctx();
+        let prepared = ReadTool.prepare(&ctx, &json!({ "path": "a.txt" })).unwrap();
+        let out = ReadTool.run(&ctx, &prepared).await.unwrap();
+        assert_eq!(out, "hello");
+    }
+
+    #[tokio::test]
+    async fn read_caps_large_files() {
+        let ws = TempWorkspace::new();
+        let big = vec![b'x'; MAX_READ_BYTES + 500];
+        fs::write(ws.root.join("big.txt"), &big).unwrap();
+        let ctx = ws.ctx();
+        let prepared = ReadTool
+            .prepare(&ctx, &json!({ "path": "big.txt" }))
+            .unwrap();
+        let out = ReadTool.run(&ctx, &prepared).await.unwrap();
+        assert!(out.ends_with("[truncated]"), "large read must be capped");
+        assert!(
+            out.len() < big.len(),
+            "output must be smaller than the file"
+        );
+    }
+
+    #[test]
+    fn read_rejects_directory_at_prepare() {
+        let ws = TempWorkspace::new();
+        fs::create_dir(ws.root.join("sub")).unwrap();
+        let err = ReadTool
+            .prepare(&ws.ctx(), &json!({ "path": "sub" }))
+            .unwrap_err();
+        assert!(err.contains("not a file"), "got: {err}");
+    }
+
+    #[test]
+    fn read_rejects_missing_path_argument() {
+        let ws = TempWorkspace::new();
+        let err = ReadTool.prepare(&ws.ctx(), &json!({})).unwrap_err();
+        assert!(err.contains("path"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn list_returns_sorted_names() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("b.txt"), b"").unwrap();
+        fs::write(ws.root.join("a.txt"), b"").unwrap();
+        fs::create_dir(ws.root.join("c")).unwrap();
+        let ctx = ws.ctx();
+        let prepared = ListTool.prepare(&ctx, &json!({ "path": "." })).unwrap();
+        let out = ListTool.run(&ctx, &prepared).await.unwrap();
+        assert_eq!(out, "a.txt\nb.txt\nc");
+    }
+
+    #[test]
+    fn list_rejects_file_at_prepare() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("f.txt"), b"").unwrap();
+        let err = ListTool
+            .prepare(&ws.ctx(), &json!({ "path": "f.txt" }))
+            .unwrap_err();
+        assert!(err.contains("not a directory"), "got: {err}");
+    }
+}

--- a/crates/pawwork-core/src/tool/fs.rs
+++ b/crates/pawwork-core/src/tool/fs.rs
@@ -1,11 +1,18 @@
 //! Built-in read-only tools: `read` and `list`.
 //!
 //! Both are auto-allowed (no confirmation) and fenced to the workspace. Their
-//! filesystem work is synchronous inside the returned future: the reads are small
-//! and the outputs are capped, so for M0 an inline `std::fs` call is simpler than
-//! a `spawn_blocking` hop (which would also force the core to pull a runtime
-//! feature it otherwise avoids). Moving to `spawn_blocking` is a later concern if
-//! a tool reads large files.
+//! filesystem work is synchronous inside the returned future: the reads are
+//! bounded (see the caps below), so for M0 an inline `std::fs` call is simpler
+//! than a `spawn_blocking` hop (which would also force the core to pull a runtime
+//! feature it otherwise avoids). Moving to `spawn_blocking` is a later concern.
+//!
+//! The caps bound *work*, not just output: `read` reads at most one byte past the
+//! limit instead of slurping a whole file then truncating, and `list` stops
+//! scanning at a ceiling instead of collecting an unbounded directory. A model
+//! pointing at a huge file or directory therefore cannot stall the turn or blow
+//! memory.
+
+use std::io::Read;
 
 use serde_json::Value;
 
@@ -16,6 +23,10 @@ use super::{BoxFuture, PreparedCall, Tool, ToolContext, ToolResult};
 const MAX_READ_BYTES: usize = 64 * 1024;
 /// Cap on entries returned by `list`.
 const MAX_LIST_ENTRIES: usize = 1000;
+/// Ceiling on directory entries `list` will scan into memory before it stops and
+/// marks the result truncated. Well above [`MAX_LIST_ENTRIES`] so a normal
+/// directory still sorts correctly, but bounded so a pathological one cannot OOM.
+const MAX_LIST_SCAN: usize = 10_000;
 
 /// Pull the required `path` string argument out of a tool call's JSON.
 fn path_arg(args: &Value) -> Result<&str, String> {
@@ -56,11 +67,17 @@ impl Tool for ReadTool {
         prepared: &'a PreparedCall,
     ) -> BoxFuture<'a, ToolResult> {
         Box::pin(async move {
-            let bytes =
-                std::fs::read(&prepared.path).map_err(|err| format!("read failed: {err}"))?;
+            // Read at most one byte past the cap: enough to know the file was
+            // longer, without pulling a multi-gigabyte file into memory.
+            let file =
+                std::fs::File::open(&prepared.path).map_err(|err| format!("read failed: {err}"))?;
+            let mut bytes = Vec::new();
+            file.take((MAX_READ_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)
+                .map_err(|err| format!("read failed: {err}"))?;
             let truncated = bytes.len() > MAX_READ_BYTES;
-            let slice = &bytes[..bytes.len().min(MAX_READ_BYTES)];
-            let mut text = String::from_utf8_lossy(slice).into_owned();
+            bytes.truncate(MAX_READ_BYTES);
+            let mut text = String::from_utf8_lossy(&bytes).into_owned();
             if truncated {
                 text.push_str("\n… [truncated]");
             }
@@ -104,12 +121,19 @@ impl Tool for ListTool {
             let entries =
                 std::fs::read_dir(&prepared.path).map_err(|err| format!("list failed: {err}"))?;
             let mut names = Vec::new();
+            let mut overflowed = false;
             for entry in entries {
+                if names.len() >= MAX_LIST_SCAN {
+                    // Stop scanning a pathological directory; the result is marked
+                    // truncated below.
+                    overflowed = true;
+                    break;
+                }
                 let entry = entry.map_err(|err| format!("list failed: {err}"))?;
                 names.push(entry.file_name().to_string_lossy().into_owned());
             }
             names.sort();
-            let truncated = names.len() > MAX_LIST_ENTRIES;
+            let truncated = overflowed || names.len() > MAX_LIST_ENTRIES;
             names.truncate(MAX_LIST_ENTRIES);
             let mut out = names.join("\n");
             if truncated {

--- a/crates/pawwork-core/src/tool/mod.rs
+++ b/crates/pawwork-core/src/tool/mod.rs
@@ -1,0 +1,105 @@
+//! The tool boundary and runtime.
+//!
+//! Unlike the single-instance [`crate::llm::LlmClient`] / [`crate::permission::PermissionGate`]
+//! seams, tools are a heterogeneous set, so [`Tool`] is used behind `dyn`. Native
+//! `async fn` in traits is not `dyn`-compatible, so `run` returns a hand-boxed
+//! [`BoxFuture`] — one type alias, no `async-trait` dependency.
+//!
+//! Execution is split into `prepare` then `run` so that "never execute a
+//! malformed call" is a type-level guarantee, not a comment: `prepare` does all
+//! validation and path fencing with no side effects and yields a [`PreparedCall`],
+//! and only a successful `PreparedCall` can reach `run`. Invalid JSON, an unknown
+//! tool, a missing field, or a path that escapes the workspace all fail at
+//! `prepare`, before any `tool.started` is recorded and before `run` is called.
+
+pub mod fence;
+pub mod fs;
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+
+use serde_json::Value;
+
+/// A boxed, `Send` future — the object-safe return shape for [`Tool::run`].
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// The output of running a tool: `Ok` text, or an `Err` message that is fed back
+/// to the model as a tool error so it can recover.
+pub type ToolResult = Result<String, String>;
+
+/// Shared, read-only context handed to every tool invocation.
+///
+/// PR2 carries only the canonicalized workspace root (the fence anchor). A
+/// cancellation handle for long-running tools (`shell`) is deferred until a tool
+/// that can actually block on it exists.
+#[derive(Debug, Clone)]
+pub struct ToolContext {
+    pub workspace_root: PathBuf,
+}
+
+/// A validated, ready-to-run invocation. Only [`Tool::prepare`] can mint one, so
+/// its existence certifies that arguments parsed and the path is inside the
+/// workspace. PR2's tools all resolve to a single fenced path; this grows fields
+/// (content, argv) when `edit`/`shell` arrive.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PreparedCall {
+    pub path: PathBuf,
+}
+
+/// One tool the agent can call.
+pub trait Tool: Send + Sync {
+    fn name(&self) -> &str;
+
+    /// Whether an invocation must clear the [`PermissionGate`](crate::permission::PermissionGate)
+    /// before running. Read-only tools return `false` (auto-allowed); `edit`/`shell`
+    /// will return `true`. Centralizing the policy here keeps the loop free of
+    /// per-tool-name conditionals.
+    fn requires_confirmation(&self) -> bool;
+
+    /// Validate arguments and fence paths with no side effects. `Err` rejects the
+    /// call before it starts.
+    fn prepare(&self, ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String>;
+
+    /// A human summary of the prepared action, shown to the user and recorded as
+    /// the ledger's `permission.requested` action. Only reached for tools that
+    /// require confirmation.
+    fn summarize(&self, prepared: &PreparedCall) -> String;
+
+    /// Execute a prepared call. Reached only after `prepare` succeeded and (if
+    /// required) permission was granted.
+    fn run<'a>(
+        &'a self,
+        ctx: &'a ToolContext,
+        prepared: &'a PreparedCall,
+    ) -> BoxFuture<'a, ToolResult>;
+}
+
+/// The set of tools available to a session, keyed by name.
+#[derive(Default)]
+pub struct ToolRuntime {
+    tools: HashMap<String, Box<dyn Tool>>,
+}
+
+impl ToolRuntime {
+    pub fn new() -> Self {
+        ToolRuntime::default()
+    }
+
+    /// A runtime with the built-in read-only tools (`read`, `list`).
+    pub fn with_read_only() -> Self {
+        let mut runtime = ToolRuntime::new();
+        runtime.register(Box::new(fs::ReadTool));
+        runtime.register(Box::new(fs::ListTool));
+        runtime
+    }
+
+    pub fn register(&mut self, tool: Box<dyn Tool>) {
+        self.tools.insert(tool.name().to_string(), tool);
+    }
+
+    pub fn get(&self, name: &str) -> Option<&dyn Tool> {
+        self.tools.get(name).map(|boxed| boxed.as_ref())
+    }
+}


### PR DESCRIPTION
## Summary

Add the `pawwork-core` turn loop (M0, experimental Rust line): a generic `Agent` that drives one user turn over an `LlmClient`, a tool runtime, and a permission gate, appending every step to the JSONL ledger and mirroring it onto a wire event stream. Core only — no CLI interaction (that is a later PR). Zero compile dependency on `packages/*`; does not ship in the desktop product.

- **llm** — `LlmClient` async trait (generic, RPITIT + `Send`) + a scripted `MockLlmClient` with a hang-until-cancel step. Half-parsed tool calls are unrepresentable by contract, so the loop has no "is this half a call?" branch.
- **tool** — `Tool` trait (`dyn` via a hand-boxed `Send` future, no `async-trait`) + `ToolRuntime`. A `prepare`/`run` split rejects a malformed, unknown, or out-of-workspace call *before* any `tool.started` and before `run()`. Read-only `read`/`list` with a workspace path fence (`canonicalize` + component-wise `Path::starts_with`; advisory, not a sandbox) and output caps.
- **permission** — `PermissionGate` async trait (generic) + a structured `PermissionRequest` (tool name + rendered summary). The typed action enum lands with `edit`/`shell`, its first real producers.
- **agent** — `run_turn`. Appends ledger events and emits `AgentEvent::Ledger` after each durable append (ledger is the source of truth; the channel is a live mirror). Interruption via `CancellationToken` at four checkpoints (model-round top, model call, permission wait, between tools); the `turn.interrupted` finalize is itself uninterruptible. Permission denial synthesizes a tool error and continues — it is not an interruption.
- **ci** — second commit `ci(labeler)`: routes the Rust `crates/` line (plus root `Cargo.toml`/`Cargo.lock`, `rust-toolchain.toml`) to the existing `harness` routing label in `.github/labeler.yml`. Rust-only PRs previously matched no routing glob, so pr-triage's label policy failed for every one of them; PR1 only passed by incidentally touching `.github/**`.

## Why

Step 2 of the Rust agent v0 plan (after PR1 #1497 scaffold + ledger). This lands the runnable loop skeleton against a mock model, so the OpenAI-compatible SSE client (PR3) and the interactive CLI (PR4) can slot into fixed `LlmClient` / `PermissionGate` / event-stream seams without reshaping the loop.

Key decisions, from a Fable + codex architecture review (recorded in the local design doc, section 13):
- **Runtime**: async on tokio, **multi-thread default flavor** — chosen to force `Send` discipline now for future subagents, not because `select!` needs it. Core stays runtime-agnostic (tokio `sync` feature only; the flavor is the binary's `#[tokio::main]`, deferred to the CLI PR).
- Auto-allowed read-only tools record **no** permission events; only real user decisions do.
- Chat history is built in-memory this turn; ledger→messages replay for cross-session resume is deferred to the resume/CLI PR.

## Related Issue

No dedicated issue — continues the experimental Rust line started in #1497.

## Human Review Status

Pending

## Review Focus

- The path fence (`tool/fence.rs`): component-wise containment, symlink and sibling-prefix escapes. This is the one security-relevant surface.
- Interruption correctness in `agent.rs`: the four checkpoints, and that the `turn.interrupted` finalize is not itself cancellable.
- The reject-before-start contract: unknown tool / invalid JSON / path escape must produce a `tool.finished(ok=false)` with **no** `tool.started`.

## Risk Notes

Experimental line; rust-ci is not a required check during M0 and the crates do not ship in the product. Two commits by concern: the core loop (Rust) and a `.github/labeler.yml` routing fix (CI config only, no behavior change). No macOS/Windows packaging surface touched (pure library + tests; the fence's symlink test is cfg-split for both). New dependencies: `tokio` (`sync` only in the lib) and `tokio-util` (CancellationToken) — both mainstream, justified inline. No visible UI or copy.

## How To Verify

```text
cargo test --workspace --locked: 41 passed (16 ledger + 25 new)
  - loop: plain text turn, channel mirrors ledger in order, read tool round-trips result into history
  - reject-before-start: unknown tool / invalid JSON / path escape -> tool.finished(false), no tool.started
  - permission: confirm allow (requested->decided->started->finished), deny (synthesized error, continues)
  - interruption: cancel before start (records nothing), mid-model, mid-permission-wait
  - llm error: records error then turn.interrupted
  - fence matrix: inside/root/absolute-out/dotdot/symlink-out/missing/sibling-prefix
cargo fmt --check: clean
cargo clippy --workspace --all-targets -- -D warnings: clean
CI: rust SUCCESS, pr-triage SUCCESS
```

## Screenshots or Recordings

N/A — no visible UI.