### PR TITLE
feat(rust): PR3 openai_compat SSE client + fixture matrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,10 +33,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures-core"
@@ -52,14 +162,273 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itoa"
@@ -85,10 +454,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "once_cell"
@@ -107,6 +511,7 @@ dependencies = [
 name = "pawwork-core"
 version = "0.0.0"
 dependencies = [
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -115,10 +520,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -127,6 +547,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -145,10 +621,138 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
@@ -194,10 +798,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -211,13 +861,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -229,6 +949,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -245,10 +975,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -256,10 +1080,25 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -272,6 +1111,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -304,6 +1153,212 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,15 @@ tokio = { version = "1", default-features = false, features = ["sync"] }
 # CancellationToken (cooperative interruption; child tokens are the future
 # subagent shape). Preferred over a hand-rolled watch channel.
 tokio-util = { version = "0.7", default-features = false }
+# The only network dependency: an async HTTP client for the streaming
+# chat/completions call. default-features are off to drop native-tls/OpenSSL in
+# favour of rustls (no system OpenSSL needed on macOS/Windows). The SSE body is
+# driven with Response::chunk(), so the `stream`/`json` features are unnecessary;
+# framing and chunk JSON are hand-parsed in openai_compat. reqwest pulls hyper +
+# tokio rt/net transitively; that is a binary-side build-graph effect and does
+# not widen the core's own direct tokio features (still `sync`).
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+    "http2",
+    "charset",
+] }

--- a/crates/pawwork-core/Cargo.toml
+++ b/crates/pawwork-core/Cargo.toml
@@ -11,6 +11,7 @@ serde_json.workspace = true
 uuid.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+reqwest.workspace = true
 
 [dev-dependencies]
 # Tests drive the async loop and validate the Send discipline on a multi-thread

--- a/crates/pawwork-core/src/agent.rs
+++ b/crates/pawwork-core/src/agent.rs
@@ -66,9 +66,10 @@ const DEFAULT_MAX_MODEL_ROUNDS: usize = 64;
 /// Default cap on tool calls the model may request in a single round. Sibling to
 /// [`DEFAULT_MAX_MODEL_ROUNDS`]: that bounds how many rounds a turn runs, this
 /// bounds one round's batch. A runaway or adversarial model that returns a huge
-/// batch would otherwise have the whole batch written to the ledger and executed
-/// before the next round-budget check; this stops the turn first. Generous enough
-/// that real multi-tool steps are unaffected.
+/// batch would otherwise have the whole batch written to the ledger and history —
+/// and, since it is never executed, replayed on every later request; this stops
+/// the turn before the batch enters the record. Generous enough that real
+/// multi-tool steps are unaffected.
 const DEFAULT_MAX_TOOL_CALLS_PER_TURN: usize = 32;
 
 /// Internal per-call control flow.
@@ -198,6 +199,31 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
                 Some(Ok(turn)) => turn,
             };
 
+            // Batch guard: reject an oversized batch *before* it is recorded or
+            // run. A runaway or adversarial model returning a huge batch would
+            // otherwise have the whole thing written to the ledger and in-memory
+            // history — and, since the batch is never executed, every later request
+            // would replay it and synthesize a cancelled result per call (see
+            // openai_compat::wire, docs §13 P2-1/P2-2), bloating the record and the
+            // context without bound. Record a bounded error and stop before the
+            // batch enters the record.
+            if turn.tool_calls.len() > self.max_tool_calls_per_turn {
+                let reason = format!(
+                    "budget exceeded: max tool calls per turn ({}), got {}",
+                    self.max_tool_calls_per_turn,
+                    turn.tool_calls.len()
+                );
+                emit(
+                    &mut self.store,
+                    tx,
+                    &turn_id,
+                    EventKind::Error {
+                        message: reason.clone(),
+                    },
+                )?;
+                return self.finalize_interrupted(&turn_id, &reason, tx);
+            }
+
             emit(
                 &mut self.store,
                 tx,
@@ -215,28 +241,6 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
             if turn.tool_calls.is_empty() {
                 emit(&mut self.store, tx, &turn_id, EventKind::TurnCompleted)?;
                 return Ok(TurnOutcome::Completed);
-            }
-
-            // Batch guard: a model returning an oversized batch in one round would
-            // otherwise execute the whole thing before the next round-budget check.
-            // Interrupt before executing any of it. The recorded (now unanswered)
-            // tool_calls are sanitized on the next turn's request, not rewritten
-            // here — see openai_compat::wire and docs §13 (P2-1/P2-2).
-            if turn.tool_calls.len() > self.max_tool_calls_per_turn {
-                let reason = format!(
-                    "budget exceeded: max tool calls per turn ({}), got {}",
-                    self.max_tool_calls_per_turn,
-                    turn.tool_calls.len()
-                );
-                emit(
-                    &mut self.store,
-                    tx,
-                    &turn_id,
-                    EventKind::Error {
-                        message: reason.clone(),
-                    },
-                )?;
-                return self.finalize_interrupted(&turn_id, &reason, tx);
             }
 
             let ctx = ToolContext {
@@ -1061,6 +1065,20 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })),
             "an oversized batch must not execute a single call"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ModelMessage { .. })),
+            "an oversized batch must not be recorded to the ledger"
+        );
+        assert!(
+            !agent.history.iter().any(|m| matches!(
+                m,
+                ChatMessage::Assistant { tool_calls, .. } if !tool_calls.is_empty()
+            )),
+            "an oversized batch must not poison the in-memory history (it would be \
+             replayed on every later request)"
         );
         assert!(events.iter().any(|e| matches!(
             &e.kind,

--- a/crates/pawwork-core/src/agent.rs
+++ b/crates/pawwork-core/src/agent.rs
@@ -63,6 +63,14 @@ impl TurnOutcome {
 /// of model requests. Generous enough that real multi-step tasks are unaffected.
 const DEFAULT_MAX_MODEL_ROUNDS: usize = 64;
 
+/// Default cap on tool calls the model may request in a single round. Sibling to
+/// [`DEFAULT_MAX_MODEL_ROUNDS`]: that bounds how many rounds a turn runs, this
+/// bounds one round's batch. A runaway or adversarial model that returns a huge
+/// batch would otherwise have the whole batch written to the ledger and executed
+/// before the next round-budget check; this stops the turn first. Generous enough
+/// that real multi-tool steps are unaffected.
+const DEFAULT_MAX_TOOL_CALLS_PER_TURN: usize = 32;
+
 /// Internal per-call control flow.
 enum CallFlow {
     /// Move on to the next tool call (the result, error, or denial was recorded).
@@ -80,6 +88,7 @@ pub struct Agent<L: LlmClient, G: PermissionGate> {
     workspace_root: PathBuf,
     history: Vec<ChatMessage>,
     max_model_rounds: usize,
+    max_tool_calls_per_turn: usize,
 }
 
 impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
@@ -101,12 +110,19 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
             workspace_root,
             history: Vec::new(),
             max_model_rounds: DEFAULT_MAX_MODEL_ROUNDS,
+            max_tool_calls_per_turn: DEFAULT_MAX_TOOL_CALLS_PER_TURN,
         })
     }
 
     /// Override the per-turn model-round budget (see [`DEFAULT_MAX_MODEL_ROUNDS`]).
     pub fn with_max_model_rounds(mut self, max_model_rounds: usize) -> Self {
         self.max_model_rounds = max_model_rounds;
+        self
+    }
+
+    /// Override the per-round tool-call cap (see [`DEFAULT_MAX_TOOL_CALLS_PER_TURN`]).
+    pub fn with_max_tool_calls_per_turn(mut self, max_tool_calls_per_turn: usize) -> Self {
+        self.max_tool_calls_per_turn = max_tool_calls_per_turn;
         self
     }
 
@@ -199,6 +215,28 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
             if turn.tool_calls.is_empty() {
                 emit(&mut self.store, tx, &turn_id, EventKind::TurnCompleted)?;
                 return Ok(TurnOutcome::Completed);
+            }
+
+            // Batch guard: a model returning an oversized batch in one round would
+            // otherwise execute the whole thing before the next round-budget check.
+            // Interrupt before executing any of it. The recorded (now unanswered)
+            // tool_calls are sanitized on the next turn's request, not rewritten
+            // here — see openai_compat::wire and docs §13 (P2-1/P2-2).
+            if turn.tool_calls.len() > self.max_tool_calls_per_turn {
+                let reason = format!(
+                    "budget exceeded: max tool calls per turn ({}), got {}",
+                    self.max_tool_calls_per_turn,
+                    turn.tool_calls.len()
+                );
+                emit(
+                    &mut self.store,
+                    tx,
+                    &turn_id,
+                    EventKind::Error {
+                        message: reason.clone(),
+                    },
+                )?;
+                return self.finalize_interrupted(&turn_id, &reason, tx);
             }
 
             let ctx = ToolContext {
@@ -990,5 +1028,134 @@ mod tests {
         assert!(events
             .iter()
             .any(|e| matches!(e.kind, EventKind::TurnInterrupted { .. })));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn oversized_tool_batch_interrupts_before_executing() {
+        let dirs = TempDirs::new();
+        dirs.write("a.txt", b"x");
+        // One round returning more calls than the cap allows.
+        let (agent, session_dir) = build(
+            MockLlmClient::new(vec![turn_with(vec![
+                call("c1", "read", r#"{"path":"a.txt"}"#),
+                call("c2", "read", r#"{"path":"a.txt"}"#),
+                call("c3", "read", r#"{"path":"a.txt"}"#),
+            ])]),
+            AllowGate,
+            ToolRuntime::with_read_only(),
+            &dirs,
+        );
+        let mut agent = agent.with_max_tool_calls_per_turn(2);
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("go", &cancel, &tx).await.unwrap();
+        match outcome {
+            TurnOutcome::Interrupted { reason } => {
+                assert!(reason.contains("tool calls"), "got: {reason}")
+            }
+            other => panic!("expected batch-cap interruption, got {other:?}"),
+        }
+        let events = project(&session_dir).unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })),
+            "an oversized batch must not execute a single call"
+        );
+        assert!(events.iter().any(|e| matches!(
+            &e.kind,
+            EventKind::Error { message } if message.contains("tool calls")
+        )));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::TurnInterrupted { .. })));
+    }
+
+    /// Every assistant `tool_call` in the outbound body is paired with a `tool`
+    /// message — the property a real provider enforces with a 400.
+    fn no_dangling_tool_call(body: &Value) -> bool {
+        let messages = body["messages"].as_array().unwrap();
+        let answered: std::collections::HashSet<&str> = messages
+            .iter()
+            .filter(|m| m["role"] == serde_json::json!("tool"))
+            .filter_map(|m| m["tool_call_id"].as_str())
+            .collect();
+        messages
+            .iter()
+            .filter(|m| m["role"] == serde_json::json!("assistant"))
+            .filter_map(|m| m["tool_calls"].as_array())
+            .flatten()
+            .filter_map(|call| call["id"].as_str())
+            .all(|id| answered.contains(id))
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelled_batch_leaves_dangling_call_sanitized_on_next_request() {
+        use crate::openai_compat::{build_request_body, RequestConfig};
+
+        let dirs = TempDirs::new();
+        // Turn 1: a confirm-required tool whose permission wait hangs, then is
+        // cancelled — leaving an assistant tool_call with no tool result.
+        let (mut agent, _session_dir) = build(
+            MockLlmClient::new(vec![turn_with(vec![call("c1", "danger", "{}")])]),
+            HangGate,
+            confirm_runtime(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, mut rx) = channel();
+        let canceller = {
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                while let Some(AgentEvent::Ledger(event)) = rx.recv().await {
+                    if matches!(event.kind, EventKind::PermissionRequested { .. }) {
+                        cancel.cancel();
+                        break;
+                    }
+                }
+            })
+        };
+        let outcome = agent.run_turn("do it", &cancel, &tx).await.unwrap();
+        canceller.await.unwrap();
+        assert!(matches!(outcome, TurnOutcome::Interrupted { .. }));
+
+        // The loop's history carries a dangling tool_call (the regression).
+        assert!(matches!(
+            agent.history.last(),
+            Some(ChatMessage::Assistant { tool_calls, .. }) if !tool_calls.is_empty()
+        ));
+        assert!(
+            !agent
+                .history
+                .iter()
+                .any(|m| matches!(m, ChatMessage::Tool { .. })),
+            "no tool result was recorded for the cancelled call"
+        );
+
+        // Turn 2: the user continues. What matters is the history the model sees.
+        let cancel2 = CancellationToken::new();
+        let (tx2, _rx2) = channel();
+        agent.run_turn("continue", &cancel2, &tx2).await.unwrap();
+
+        let seen = agent.client.seen_histories();
+        let next_request_history = seen.last().expect("turn 2 called the model");
+        // History is unchanged: the dangling call is still present (not rewritten).
+        assert!(next_request_history.iter().any(|m| matches!(
+            m,
+            ChatMessage::Assistant { tool_calls, .. } if !tool_calls.is_empty()
+        )));
+
+        // The outbound request, however, pairs it with a synthesized cancelled
+        // result — no dangling tool_call reaches the provider.
+        let config = RequestConfig {
+            model: "m".to_string(),
+            tools: Vec::new(),
+            system_prompt: None,
+        };
+        let body = build_request_body(&config, next_request_history);
+        assert!(
+            no_dangling_tool_call(&body),
+            "the sanitized request body must have no unpaired tool_call"
+        );
     }
 }

--- a/crates/pawwork-core/src/lib.rs
+++ b/crates/pawwork-core/src/lib.rs
@@ -3,6 +3,8 @@
 //! Layers (see `docs/architecture/2026-07-09-rust-agent-v0.md`, section 13):
 //! - [`session`] — JSONL ledger, the single source of truth (PR1).
 //! - [`llm`] — the [`llm::LlmClient`] boundary plus a scripted mock.
+//! - [`openai_compat`] — a hand-written streaming client that implements
+//!   [`llm::LlmClient`] against any OpenAI-compatible chat/completions endpoint.
 //! - [`tool`] — the [`tool::Tool`] boundary, a runtime registry, and the
 //!   read-only `read`/`list` tools with their workspace path fence.
 //! - [`permission`] — the [`permission::PermissionGate`] callback boundary.
@@ -14,6 +16,7 @@
 
 pub mod agent;
 pub mod llm;
+pub mod openai_compat;
 pub mod permission;
 pub mod session;
 pub mod tool;

--- a/crates/pawwork-core/src/openai_compat/mod.rs
+++ b/crates/pawwork-core/src/openai_compat/mod.rs
@@ -92,7 +92,7 @@ impl LlmClient for OpenAiClient {
                 .map_err(|err| LlmError::new(format!("request failed: {err}")))?;
             let status = response.status();
             if !status.is_success() {
-                let body = response.text().await.unwrap_or_default();
+                let body = read_capped_error_body(&mut response).await;
                 return Err(status_error(status.as_u16(), api_key_env.as_deref(), &body));
             }
 
@@ -123,6 +123,28 @@ impl LlmClient for OpenAiClient {
             accumulator.finish()
         }
     }
+}
+
+/// Cap on how much of a non-2xx response body the client reads. We only ever echo
+/// a short truncated summary, so a pathological endpoint — a wrong base_url, or a
+/// proxy returning a huge HTML error page — must not make the client buffer an
+/// unbounded body just to drop nearly all of it.
+const ERROR_BODY_CAP: usize = 8 * 1024;
+
+/// Read at most [`ERROR_BODY_CAP`] bytes of an error response, then stop draining.
+/// Reuses the same chunked read as the success stream, so a giant error body is
+/// bounded the same way a giant stream would be. A read error mid-body just ends
+/// the read early — a truncated detail is still better than none.
+async fn read_capped_error_body(response: &mut reqwest::Response) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    while buf.len() < ERROR_BODY_CAP {
+        match response.chunk().await {
+            Ok(Some(bytes)) => buf.extend_from_slice(&bytes),
+            Ok(None) | Err(_) => break,
+        }
+    }
+    buf.truncate(ERROR_BODY_CAP);
+    String::from_utf8_lossy(&buf).into_owned()
 }
 
 /// Turn a non-2xx status into an [`LlmError`], naming the key env var on 401 so a

--- a/crates/pawwork-core/src/openai_compat/mod.rs
+++ b/crates/pawwork-core/src/openai_compat/mod.rs
@@ -25,7 +25,12 @@ use crate::llm::{ChatMessage, LlmClient, LlmError, ModelTurn};
 use stream::{SseDecoder, TurnAccumulator};
 
 /// Everything needed to reach one provider endpoint.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is hand-written, not derived: `api_key` is a plaintext secret, and a
+/// derived `Debug` would print it verbatim the moment this config lands in a log
+/// line or error context (provider/endpoint/401 troubleshooting is exactly when
+/// that happens). The impl redacts it.
+#[derive(Clone)]
 pub struct OpenAiConfig {
     /// Base URL without a trailing `/chat/completions` (e.g. `https://api.deepseek.com`).
     pub base_url: String,
@@ -37,6 +42,26 @@ pub struct OpenAiConfig {
     /// Pre-built tool JSON schemas the model may call; empty omits `tools`.
     pub tools: Vec<Value>,
     pub system_prompt: Option<String>,
+}
+
+impl std::fmt::Debug for OpenAiConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render the key itself; show only whether one is set, so debugging
+        // a missing/empty credential stays possible without leaking the secret.
+        let api_key = if self.api_key.is_empty() {
+            "<unset>"
+        } else {
+            "<redacted>"
+        };
+        f.debug_struct("OpenAiConfig")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("api_key", &api_key)
+            .field("api_key_env", &self.api_key_env)
+            .field("tools", &self.tools)
+            .field("system_prompt", &self.system_prompt)
+            .finish()
+    }
 }
 
 /// A streaming OpenAI-compatible model client.
@@ -133,17 +158,26 @@ const ERROR_BODY_CAP: usize = 8 * 1024;
 
 /// Read at most [`ERROR_BODY_CAP`] bytes of an error response, then stop draining.
 /// Reuses the same chunked read as the success stream, so a giant error body is
-/// bounded the same way a giant stream would be. A read error mid-body just ends
-/// the read early — a truncated detail is still better than none.
+/// bounded the same way a giant stream would be. Only the remaining capacity of a
+/// chunk is copied — a single huge chunk cannot push the buffer past the cap — so
+/// the "at most 8 KiB" bound holds even at the chunk boundary. A read error
+/// mid-body just ends the read early: a truncated detail beats none.
 async fn read_capped_error_body(response: &mut reqwest::Response) -> String {
     let mut buf: Vec<u8> = Vec::new();
     while buf.len() < ERROR_BODY_CAP {
         match response.chunk().await {
-            Ok(Some(bytes)) => buf.extend_from_slice(&bytes),
+            Ok(Some(bytes)) => {
+                let remaining = ERROR_BODY_CAP - buf.len();
+                if bytes.len() <= remaining {
+                    buf.extend_from_slice(&bytes);
+                } else {
+                    buf.extend_from_slice(&bytes[..remaining]);
+                    break;
+                }
+            }
             Ok(None) | Err(_) => break,
         }
     }
-    buf.truncate(ERROR_BODY_CAP);
     String::from_utf8_lossy(&buf).into_owned()
 }
 
@@ -159,4 +193,42 @@ fn status_error(status: u16, api_key_env: Option<&str>, body: &str) -> LlmError 
     // Bound the echoed body so a huge HTML error page cannot flood the message.
     let detail: String = body.trim().chars().take(500).collect();
     LlmError::new(format!("HTTP {status}: {detail}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_the_api_key() {
+        let config = OpenAiConfig {
+            base_url: "https://api.example.com".to_string(),
+            model: "m".to_string(),
+            api_key: "sk-super-secret-value".to_string(),
+            api_key_env: Some("EXAMPLE_API_KEY".to_string()),
+            tools: Vec::new(),
+            system_prompt: None,
+        };
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains("sk-super-secret-value"),
+            "the secret must never appear in Debug output: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"));
+        // The non-secret env var name stays visible, so config is still debuggable.
+        assert!(rendered.contains("EXAMPLE_API_KEY"));
+    }
+
+    #[test]
+    fn debug_marks_an_unset_key() {
+        let config = OpenAiConfig {
+            base_url: "https://api.example.com".to_string(),
+            model: "m".to_string(),
+            api_key: String::new(),
+            api_key_env: None,
+            tools: Vec::new(),
+            system_prompt: None,
+        };
+        assert!(format!("{config:?}").contains("<unset>"));
+    }
 }

--- a/crates/pawwork-core/src/openai_compat/mod.rs
+++ b/crates/pawwork-core/src/openai_compat/mod.rs
@@ -1,0 +1,140 @@
+//! A hand-written OpenAI-compatible streaming client for [`LlmClient`].
+//!
+//! No SDK: one `POST /chat/completions` with `stream: true`, parsed with our own
+//! SSE decoder ([`stream`]) and folded into a [`ModelTurn`] ([`stream::TurnAccumulator`]).
+//! Request shaping — including cancelled-call sanitation — lives in [`wire`]. The
+//! same base_url/model/api_key seam serves any provider that speaks the OpenAI
+//! wire (DeepSeek, national compatible endpoints); provider quirks that need more
+//! than config land later.
+//!
+//! Scope note: retry/backoff on 429/5xx and idle-stall watchdogs
+//! (`docs/architecture/2026-07-09-rust-agent-v0.md`, §5) are deliberately not
+//! here yet — this PR proves incremental parsing and pairing against offline
+//! fixtures. A dropped stream currently surfaces as one `Err`, not a reconnect.
+
+mod stream;
+pub mod wire;
+
+pub use wire::{build_request_body, RequestConfig};
+
+use std::future::Future;
+
+use serde_json::Value;
+
+use crate::llm::{ChatMessage, LlmClient, LlmError, ModelTurn};
+use stream::{SseDecoder, TurnAccumulator};
+
+/// Everything needed to reach one provider endpoint.
+#[derive(Debug, Clone)]
+pub struct OpenAiConfig {
+    /// Base URL without a trailing `/chat/completions` (e.g. `https://api.deepseek.com`).
+    pub base_url: String,
+    pub model: String,
+    /// The resolved secret. The client never reads the environment itself.
+    pub api_key: String,
+    /// The env var the key came from, used only to make a 401 message actionable.
+    pub api_key_env: Option<String>,
+    /// Pre-built tool JSON schemas the model may call; empty omits `tools`.
+    pub tools: Vec<Value>,
+    pub system_prompt: Option<String>,
+}
+
+/// A streaming OpenAI-compatible model client.
+pub struct OpenAiClient {
+    http: reqwest::Client,
+    request: RequestConfig,
+    /// `base_url` with any trailing slash trimmed.
+    base_url: String,
+    api_key: String,
+    api_key_env: Option<String>,
+}
+
+impl OpenAiClient {
+    pub fn new(config: OpenAiConfig) -> Result<Self, LlmError> {
+        let http = reqwest::Client::builder()
+            .build()
+            .map_err(|err| LlmError::new(format!("failed to build HTTP client: {err}")))?;
+        Ok(OpenAiClient {
+            http,
+            request: RequestConfig {
+                model: config.model,
+                tools: config.tools,
+                system_prompt: config.system_prompt,
+            },
+            base_url: config.base_url.trim_end_matches('/').to_string(),
+            api_key: config.api_key,
+            api_key_env: config.api_key_env,
+        })
+    }
+}
+
+impl LlmClient for OpenAiClient {
+    fn respond(
+        &self,
+        history: &[ChatMessage],
+    ) -> impl Future<Output = Result<ModelTurn, LlmError>> + Send {
+        // Build the request synchronously so nothing borrows `self` or `history`
+        // across the await.
+        let body = build_request_body(&self.request, history);
+        let pending = self
+            .http
+            .post(format!("{}/chat/completions", self.base_url))
+            .bearer_auth(&self.api_key)
+            .header("content-type", "application/json")
+            .header("accept", "text/event-stream")
+            .body(body.to_string())
+            .send();
+        let api_key_env = self.api_key_env.clone();
+
+        async move {
+            let mut response = pending
+                .await
+                .map_err(|err| LlmError::new(format!("request failed: {err}")))?;
+            let status = response.status();
+            if !status.is_success() {
+                let body = response.text().await.unwrap_or_default();
+                return Err(status_error(status.as_u16(), api_key_env.as_deref(), &body));
+            }
+
+            let mut decoder = SseDecoder::new();
+            let mut accumulator = TurnAccumulator::new();
+            let mut frames = Vec::new();
+            loop {
+                let chunk = response
+                    .chunk()
+                    .await
+                    .map_err(|err| LlmError::new(format!("stream read error: {err}")))?;
+                match chunk {
+                    Some(bytes) => {
+                        decoder.push(&bytes, &mut frames);
+                        for frame in frames.drain(..) {
+                            accumulator.ingest(frame);
+                        }
+                    }
+                    None => {
+                        decoder.finish(&mut frames);
+                        for frame in frames.drain(..) {
+                            accumulator.ingest(frame);
+                        }
+                        break;
+                    }
+                }
+            }
+            accumulator.finish()
+        }
+    }
+}
+
+/// Turn a non-2xx status into an [`LlmError`], naming the key env var on 401 so a
+/// misconfigured credential is self-diagnosing.
+fn status_error(status: u16, api_key_env: Option<&str>, body: &str) -> LlmError {
+    if status == 401 {
+        let hint = api_key_env
+            .map(|env| format!(" (check that {env} holds a valid key)"))
+            .unwrap_or_default();
+        return LlmError::new(format!("HTTP 401 unauthorized{hint}"));
+    }
+    // Bound the echoed body so a huge HTML error page cannot flood the message.
+    let detail: String = body.trim().chars().take(500).collect();
+    LlmError::new(format!("HTTP {status}: {detail}"))
+}

--- a/crates/pawwork-core/src/openai_compat/stream.rs
+++ b/crates/pawwork-core/src/openai_compat/stream.rs
@@ -238,15 +238,19 @@ impl TurnAccumulator {
 
     /// Resolve the accumulated stream into a turn, or an error.
     ///
-    /// A mid-stream error object, or a stream that ended without a terminal
-    /// `finish_reason`, or a `length`/`content_filter` stop all yield `Err` — the
-    /// last two because a truncated turn must not be handed back as if complete.
+    /// Only `stop`/`tool_calls` yield `Ok`. A mid-stream error object, a stream
+    /// that ended without a terminal `finish_reason`, or any other reason
+    /// (`length`, `content_filter`, or the legacy `function_call`) yields `Err` —
+    /// a truncated turn must not be handed back as if complete. `function_call`
+    /// specifically is refused rather than accepted: this client parses only the
+    /// modern `delta.tool_calls`, not the deprecated `delta.function_call`, so a
+    /// `function_call` stop would otherwise silently drop the call the model made.
     pub fn finish(self) -> Result<ModelTurn, LlmError> {
         if let Some(message) = self.error {
             return Err(LlmError::new(message));
         }
         match self.finish_reason.as_deref() {
-            Some("stop") | Some("tool_calls") | Some("function_call") => {
+            Some("stop") | Some("tool_calls") => {
                 let TurnAccumulator {
                     text,
                     mut calls,
@@ -435,6 +439,24 @@ mod tests {
         );
         let turn = accumulate(raw.as_bytes()).unwrap();
         assert_eq!(turn.text, "ok");
+    }
+
+    #[test]
+    fn legacy_function_call_finish_is_an_error() {
+        // finish_reason "function_call" with the deprecated delta.function_call
+        // field (which this client does not parse). Accepting it would return an
+        // empty turn and silently drop the call; it must error instead.
+        let raw = concat!(
+            "data: {\"choices\":[{\"delta\":{\"function_call\":{\"name\":\"read\",\"arguments\":\"{}\"}},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"function_call\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let err = accumulate(raw.as_bytes()).unwrap_err();
+        assert!(
+            err.message.contains("function_call"),
+            "got: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/crates/pawwork-core/src/openai_compat/stream.rs
+++ b/crates/pawwork-core/src/openai_compat/stream.rs
@@ -1,0 +1,450 @@
+//! Inbound SSE parsing: raw bytes → one [`ModelTurn`].
+//!
+//! Two sans-io pieces the real client and the offline fixtures share. [`SseDecoder`]
+//! is a push parser: bytes in, complete SSE frames out, buffering any partial
+//! trailing line — so a chunked HTTP body split at arbitrary byte boundaries
+//! yields the same frames as one contiguous buffer. [`TurnAccumulator`] folds
+//! those frames' chunk deltas into text plus tool calls, keyed by index.
+//!
+//! Half-parsed tool calls die here, satisfying the [`crate::llm::LlmClient`]
+//! contract. A turn is only [`TurnAccumulator::finish`]ed into `Ok(ModelTurn)`
+//! when a terminal `finish_reason` of `stop`/`tool_calls` was seen; a stream that
+//! ends without one (a dropped connection mid-arguments) resolves to `Err`, so a
+//! torn arguments buffer never escapes as a runnable call.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::llm::{LlmError, ModelTurn};
+use crate::session::event::ToolCall;
+
+/// One dispatched SSE event: a `data:` payload, or the `[DONE]` sentinel.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SseFrame {
+    Data(String),
+    Done,
+}
+
+/// A push parser for the `text/event-stream` framing.
+///
+/// Splits on line boundaries (`\n`, tolerating `\r\n`), joins multi-line `data:`
+/// fields with `\n`, ignores `:` comment/keepalive lines and non-`data` fields,
+/// and dispatches one frame per blank-line-terminated event.
+#[derive(Default)]
+pub struct SseDecoder {
+    /// Bytes not yet forming a complete line. Splitting on the `\n` byte is
+    /// UTF-8 safe (a newline never appears inside a multi-byte sequence), so a
+    /// partial line held here may hold an incomplete char without harm.
+    buf: Vec<u8>,
+    /// `data:` field values accumulated for the event currently being parsed.
+    data: Vec<String>,
+}
+
+impl SseDecoder {
+    pub fn new() -> Self {
+        SseDecoder::default()
+    }
+
+    /// Feed a chunk of bytes, appending any newly completed frames to `out`.
+    pub fn push(&mut self, chunk: &[u8], out: &mut Vec<SseFrame>) {
+        self.buf.extend_from_slice(chunk);
+        while let Some(newline) = self.buf.iter().position(|&byte| byte == b'\n') {
+            let mut line: Vec<u8> = self.buf.drain(..=newline).collect();
+            line.pop(); // drop '\n'
+            if line.last() == Some(&b'\r') {
+                line.pop(); // drop '\r' of a CRLF terminator
+            }
+            self.line(&line, out);
+        }
+    }
+
+    /// Flush a final event that arrived without a terminating blank line (some
+    /// servers send the last chunk then close the connection).
+    pub fn finish(&mut self, out: &mut Vec<SseFrame>) {
+        self.dispatch(out);
+    }
+
+    fn line(&mut self, line: &[u8], out: &mut Vec<SseFrame>) {
+        if line.is_empty() {
+            self.dispatch(out);
+            return;
+        }
+        if line[0] == b':' {
+            return; // comment / keepalive
+        }
+        let (field, value) = match line.iter().position(|&byte| byte == b':') {
+            Some(colon) => {
+                let value = &line[colon + 1..];
+                // A single leading space after the colon is part of the framing.
+                let value = value.strip_prefix(b" ").unwrap_or(value);
+                (&line[..colon], value)
+            }
+            None => (line, &b""[..]),
+        };
+        if field == b"data" {
+            self.data.push(String::from_utf8_lossy(value).into_owned());
+        }
+        // event:/id:/retry: carry no meaning for chat completions; ignore them.
+    }
+
+    fn dispatch(&mut self, out: &mut Vec<SseFrame>) {
+        if self.data.is_empty() {
+            return; // a blank line with no pending data is just a separator
+        }
+        let payload = std::mem::take(&mut self.data).join("\n");
+        if payload == "[DONE]" {
+            out.push(SseFrame::Done);
+        } else {
+            out.push(SseFrame::Data(payload));
+        }
+    }
+}
+
+// --- Chunk wire shape (a subset; unknown fields are ignored) ---------------
+
+#[derive(Deserialize)]
+struct Chunk {
+    #[serde(default)]
+    choices: Vec<Choice>,
+    #[serde(default)]
+    error: Option<ApiError>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    #[serde(default)]
+    delta: Delta,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct Delta {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<ToolCallDelta>,
+}
+
+#[derive(Deserialize)]
+struct ToolCallDelta {
+    #[serde(default)]
+    index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<FunctionDelta>,
+}
+
+#[derive(Deserialize)]
+struct FunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ApiError {
+    message: String,
+}
+
+/// One tool call being assembled across deltas.
+struct PartialCall {
+    id: Option<String>,
+    name: String,
+    arguments: String,
+}
+
+/// Folds SSE frames into a single [`ModelTurn`].
+#[derive(Default)]
+pub struct TurnAccumulator {
+    text: String,
+    /// Calls keyed by their streamed `index`, plus the order indices first
+    /// appeared so the finished list is deterministic.
+    calls: HashMap<usize, PartialCall>,
+    order: Vec<usize>,
+    finish_reason: Option<String>,
+    /// An error object seen mid-stream; wins over any accumulated content.
+    error: Option<String>,
+}
+
+impl TurnAccumulator {
+    pub fn new() -> Self {
+        TurnAccumulator::default()
+    }
+
+    /// Fold one frame in. A malformed `data:` payload is recorded as an error so
+    /// [`finish`](Self::finish) fails loudly rather than dropping content silently.
+    pub fn ingest(&mut self, frame: SseFrame) {
+        let payload = match frame {
+            SseFrame::Done => return, // stream terminator; finish_reason is the real signal
+            SseFrame::Data(payload) => payload,
+        };
+        let chunk: Chunk = match serde_json::from_str(&payload) {
+            Ok(chunk) => chunk,
+            Err(err) => {
+                self.error
+                    .get_or_insert_with(|| format!("malformed stream chunk: {err}"));
+                return;
+            }
+        };
+        if let Some(api_error) = chunk.error {
+            self.error.get_or_insert(api_error.message);
+            return;
+        }
+        for choice in chunk.choices {
+            if let Some(content) = choice.delta.content {
+                self.text.push_str(&content);
+            }
+            for delta in choice.delta.tool_calls {
+                self.merge_call(delta);
+            }
+            if let Some(reason) = choice.finish_reason {
+                self.finish_reason = Some(reason);
+            }
+        }
+    }
+
+    fn merge_call(&mut self, delta: ToolCallDelta) {
+        use std::collections::hash_map::Entry;
+        let index = delta.index;
+        // Record first-seen order the moment we mint a new call, so the finished
+        // list is deterministic without capturing `self.order` in an entry closure.
+        if let Entry::Vacant(slot) = self.calls.entry(index) {
+            slot.insert(PartialCall {
+                id: None,
+                name: String::new(),
+                arguments: String::new(),
+            });
+            self.order.push(index);
+        }
+        let call = self.calls.get_mut(&index).expect("just inserted");
+        if let Some(id) = delta.id {
+            if !id.is_empty() {
+                call.id = Some(id);
+            }
+        }
+        if let Some(function) = delta.function {
+            if let Some(name) = function.name {
+                call.name.push_str(&name);
+            }
+            if let Some(arguments) = function.arguments {
+                call.arguments.push_str(&arguments);
+            }
+        }
+    }
+
+    /// Resolve the accumulated stream into a turn, or an error.
+    ///
+    /// A mid-stream error object, or a stream that ended without a terminal
+    /// `finish_reason`, or a `length`/`content_filter` stop all yield `Err` — the
+    /// last two because a truncated turn must not be handed back as if complete.
+    pub fn finish(self) -> Result<ModelTurn, LlmError> {
+        if let Some(message) = self.error {
+            return Err(LlmError::new(message));
+        }
+        match self.finish_reason.as_deref() {
+            Some("stop") | Some("tool_calls") | Some("function_call") => {
+                let TurnAccumulator {
+                    text,
+                    mut calls,
+                    order,
+                    ..
+                } = self;
+                let tool_calls = order
+                    .into_iter()
+                    .filter_map(|index| calls.remove(&index).map(|call| (index, call)))
+                    .map(|(index, call)| ToolCall {
+                        // Missing id (some compatible providers omit it) → call_N.
+                        call_id: call.id.unwrap_or_else(|| format!("call_{index}")),
+                        name: call.name,
+                        arguments: call.arguments,
+                    })
+                    .collect();
+                Ok(ModelTurn { text, tool_calls })
+            }
+            Some(other) => Err(LlmError::new(format!(
+                "model stopped early (finish_reason={other})"
+            ))),
+            None => Err(LlmError::new("stream ended before completion")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive a whole fixture through decoder + accumulator in one shot.
+    fn accumulate(raw: &[u8]) -> Result<ModelTurn, LlmError> {
+        let mut decoder = SseDecoder::new();
+        let mut accumulator = TurnAccumulator::new();
+        let mut frames = Vec::new();
+        decoder.push(raw, &mut frames);
+        decoder.finish(&mut frames);
+        for frame in frames {
+            accumulator.ingest(frame);
+        }
+        accumulator.finish()
+    }
+
+    /// Same, but fed `size` bytes at a time to prove incremental framing.
+    fn accumulate_chunked(raw: &[u8], size: usize) -> Result<ModelTurn, LlmError> {
+        let mut decoder = SseDecoder::new();
+        let mut accumulator = TurnAccumulator::new();
+        for piece in raw.chunks(size) {
+            let mut frames = Vec::new();
+            decoder.push(piece, &mut frames);
+            for frame in frames {
+                accumulator.ingest(frame);
+            }
+        }
+        let mut frames = Vec::new();
+        decoder.finish(&mut frames);
+        for frame in frames {
+            accumulator.ingest(frame);
+        }
+        accumulator.finish()
+    }
+
+    const PURE_TEXT: &str = concat!(
+        "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\", world\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+
+    const SINGLE_TOOL: &str = concat!(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_abc\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"a.txt\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+
+    const MULTI_TOOL: &str = concat!(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_2\",\"function\":{\"name\":\"list\",\"arguments\":\"{}\"}}]},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+
+    const MID_STREAM_ERROR: &str = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"error\":{\"message\":\"rate limit exceeded\",\"type\":\"rate_limit\"}}\n\n",
+    );
+
+    // Content, then a tool call cut off mid-arguments — no finish_reason, no [DONE].
+    const BROKEN_STREAM: &str = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"thinking\"},\"finish_reason\":null}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_x\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"pa\"}}]},\"finish_reason\":null}]}",
+    );
+
+    #[test]
+    fn pure_text_turn() {
+        let turn = accumulate(PURE_TEXT.as_bytes()).unwrap();
+        assert_eq!(turn.text, "Hello, world");
+        assert!(turn.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn single_tool_call_reassembles_arguments() {
+        let turn = accumulate(SINGLE_TOOL.as_bytes()).unwrap();
+        assert!(turn.text.is_empty());
+        assert_eq!(turn.tool_calls.len(), 1);
+        let call = &turn.tool_calls[0];
+        assert_eq!(call.call_id, "call_abc");
+        assert_eq!(call.name, "read");
+        assert_eq!(call.arguments, r#"{"path":"a.txt"}"#);
+    }
+
+    #[test]
+    fn multiple_tool_calls_kept_in_index_order() {
+        let turn = accumulate(MULTI_TOOL.as_bytes()).unwrap();
+        let names: Vec<&str> = turn.tool_calls.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["read", "list"]);
+        let ids: Vec<&str> = turn.tool_calls.iter().map(|c| c.call_id.as_str()).collect();
+        assert_eq!(ids, vec!["call_1", "call_2"]);
+    }
+
+    #[test]
+    fn mid_stream_error_becomes_err() {
+        let err = accumulate(MID_STREAM_ERROR.as_bytes()).unwrap_err();
+        assert!(err.message.contains("rate limit"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn broken_stream_never_yields_a_half_call() {
+        // No finish_reason arrived, so the torn `{"pa` arguments must not surface
+        // as a runnable call — the turn fails instead.
+        let err = accumulate(BROKEN_STREAM.as_bytes()).unwrap_err();
+        assert!(err.message.contains("stream ended"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn chunked_delivery_matches_whole_buffer() {
+        // Byte-at-a-time framing must reassemble identically to one buffer.
+        let one_shot = accumulate(SINGLE_TOOL.as_bytes()).unwrap();
+        let byte_by_byte = accumulate_chunked(SINGLE_TOOL.as_bytes(), 1).unwrap();
+        assert_eq!(one_shot, byte_by_byte);
+    }
+
+    #[test]
+    fn crlf_terminators_and_keepalive_comments_are_tolerated() {
+        let with_crlf = PURE_TEXT.replace('\n', "\r\n");
+        let with_keepalive = format!(": ping\r\n\r\n{with_crlf}");
+        let turn = accumulate(with_keepalive.as_bytes()).unwrap();
+        assert_eq!(turn.text, "Hello, world");
+    }
+
+    #[test]
+    fn multiline_data_field_is_joined() {
+        // One JSON object split across two data: lines (joined with '\n', which is
+        // insignificant whitespace to a JSON parser). Missing id → call_0.
+        let raw = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\n",
+            "data: \"function\":{\"name\":\"read\",\"arguments\":\"{}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let turn = accumulate(raw.as_bytes()).unwrap();
+        assert_eq!(turn.tool_calls.len(), 1);
+        assert_eq!(turn.tool_calls[0].call_id, "call_0");
+        assert_eq!(turn.tool_calls[0].name, "read");
+    }
+
+    #[test]
+    fn usage_only_chunk_and_empty_choices_are_ignored() {
+        let raw = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1}}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let turn = accumulate(raw.as_bytes()).unwrap();
+        assert_eq!(turn.text, "hi");
+    }
+
+    #[test]
+    fn finish_without_done_sentinel_still_completes() {
+        // finish_reason, but the connection closes before a data: [DONE].
+        let raw = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        );
+        let turn = accumulate(raw.as_bytes()).unwrap();
+        assert_eq!(turn.text, "ok");
+    }
+
+    #[test]
+    fn length_finish_reason_is_an_error() {
+        let raw = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"cut\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let err = accumulate(raw.as_bytes()).unwrap_err();
+        assert!(err.message.contains("length"), "got: {}", err.message);
+    }
+}

--- a/crates/pawwork-core/src/openai_compat/wire.rs
+++ b/crates/pawwork-core/src/openai_compat/wire.rs
@@ -1,0 +1,279 @@
+//! Outbound request construction for the OpenAI-compatible chat/completions API.
+//!
+//! The only non-mechanical part here is pairing sanitation. A real provider
+//! rejects a request (HTTP 400) when an assistant message carries a `tool_calls`
+//! entry that never receives a matching `tool` result — the exact state the turn
+//! loop leaves in its in-memory history when a batch is cancelled mid-permission
+//! or mid-execution (see `docs/architecture/2026-07-09-rust-agent-v0.md`, §13,
+//! P2-2). The fix lives *here*, at request construction: any unpaired `tool_call`
+//! is answered with a synthesized "cancelled" tool result in the outbound body.
+//! The ledger and the loop's history are never mutated — sanitation is a
+//! projection onto the wire, not a rewrite of the record.
+
+use serde_json::{json, Value};
+
+use crate::llm::ChatMessage;
+
+/// The fed-back result for a `tool_call` that was never executed, synthesized
+/// only into the outbound request so the provider sees a paired call.
+const CANCELLED_TOOL_RESULT: &str = "Tool call was cancelled before execution.";
+
+/// Provider-shaped bits of a request that live on the client, not in the
+/// per-turn history: the model id, the tool schemas the model may call, and an
+/// optional system prompt. Deliberately holds pre-built tool JSON rather than the
+/// [`crate::tool::ToolRuntime`] — turning tools into schemas is a wiring concern
+/// for the CLI PR, and keeping it out here leaves the tool trait untouched.
+#[derive(Debug, Clone)]
+pub struct RequestConfig {
+    pub model: String,
+    pub tools: Vec<Value>,
+    pub system_prompt: Option<String>,
+}
+
+/// Build the JSON body for a streaming chat/completions request from the running
+/// history, sanitizing any unpaired `tool_call` (see the module note).
+pub fn build_request_body(config: &RequestConfig, history: &[ChatMessage]) -> Value {
+    let mut body = json!({
+        "model": config.model,
+        "messages": messages(config.system_prompt.as_deref(), history),
+        "stream": true,
+    });
+    if !config.tools.is_empty() {
+        body["tools"] = Value::Array(config.tools.clone());
+    }
+    body
+}
+
+/// Convert the history into OpenAI messages, appending a synthesized `tool`
+/// result for every `tool_call` that has no real result later in the history.
+fn messages(system_prompt: Option<&str>, history: &[ChatMessage]) -> Vec<Value> {
+    // A call is "answered" if some Tool message anywhere carries its id. Ids are
+    // unique per call, so a single pass over the whole history is enough.
+    let answered: std::collections::HashSet<&str> = history
+        .iter()
+        .filter_map(|message| match message {
+            ChatMessage::Tool { call_id, .. } => Some(call_id.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    let mut out = Vec::new();
+    if let Some(prompt) = system_prompt {
+        out.push(json!({ "role": "system", "content": prompt }));
+    }
+    for message in history {
+        match message {
+            ChatMessage::User(text) => {
+                out.push(json!({ "role": "user", "content": text }));
+            }
+            ChatMessage::Assistant { text, tool_calls } if tool_calls.is_empty() => {
+                out.push(json!({ "role": "assistant", "content": text }));
+            }
+            ChatMessage::Assistant { text, tool_calls } => {
+                let calls: Vec<Value> = tool_calls
+                    .iter()
+                    .map(|call| {
+                        json!({
+                            "id": call.call_id,
+                            "type": "function",
+                            "function": { "name": call.name, "arguments": call.arguments },
+                        })
+                    })
+                    .collect();
+                // Content is null (not "") when the assistant only made tool calls,
+                // matching the shape providers emit and expect back.
+                let content = if text.is_empty() {
+                    Value::Null
+                } else {
+                    json!(text)
+                };
+                out.push(json!({
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": calls,
+                }));
+                // Sanitize: answer every unpaired call so the batch is complete on
+                // the wire even though the loop never ran (or finished) it.
+                for call in tool_calls {
+                    if !answered.contains(call.call_id.as_str()) {
+                        out.push(json!({
+                            "role": "tool",
+                            "tool_call_id": call.call_id,
+                            "content": CANCELLED_TOOL_RESULT,
+                        }));
+                    }
+                }
+            }
+            ChatMessage::Tool { call_id, content } => {
+                out.push(json!({
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": content,
+                }));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::event::ToolCall;
+
+    fn config() -> RequestConfig {
+        RequestConfig {
+            model: "test-model".to_string(),
+            tools: Vec::new(),
+            system_prompt: None,
+        }
+    }
+
+    fn tool_call(call_id: &str, name: &str, arguments: &str) -> ToolCall {
+        ToolCall {
+            call_id: call_id.to_string(),
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+        }
+    }
+
+    /// Every assistant `tool_call` id that has no matching `tool` message is a
+    /// dangling call — the exact thing a provider rejects with a 400.
+    fn dangling_call_ids(body: &Value) -> Vec<String> {
+        let messages = body["messages"].as_array().unwrap();
+        let answered: std::collections::HashSet<&str> = messages
+            .iter()
+            .filter(|m| m["role"] == json!("tool"))
+            .filter_map(|m| m["tool_call_id"].as_str())
+            .collect();
+        messages
+            .iter()
+            .filter(|m| m["role"] == json!("assistant"))
+            .filter_map(|m| m["tool_calls"].as_array())
+            .flatten()
+            .filter_map(|call| call["id"].as_str())
+            .filter(|id| !answered.contains(id))
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn plain_conversation_roundtrips_roles() {
+        let history = vec![
+            ChatMessage::User("hi".to_string()),
+            ChatMessage::Assistant {
+                text: "hello".to_string(),
+                tool_calls: Vec::new(),
+            },
+        ];
+        let body = build_request_body(&config(), &history);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0], json!({ "role": "user", "content": "hi" }));
+        assert_eq!(
+            messages[1],
+            json!({ "role": "assistant", "content": "hello" })
+        );
+        assert_eq!(body["stream"], json!(true));
+        assert_eq!(body["model"], json!("test-model"));
+        assert!(body.get("tools").is_none(), "no tools => omit the field");
+    }
+
+    #[test]
+    fn paired_tool_call_is_left_untouched() {
+        let history = vec![
+            ChatMessage::Assistant {
+                text: String::new(),
+                tool_calls: vec![tool_call("c1", "read", r#"{"path":"a.txt"}"#)],
+            },
+            ChatMessage::Tool {
+                call_id: "c1".to_string(),
+                content: "file body".to_string(),
+            },
+        ];
+        let body = build_request_body(&config(), &history);
+        assert!(dangling_call_ids(&body).is_empty());
+        let tool_messages: Vec<_> = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|m| m["role"] == json!("tool"))
+            .collect();
+        assert_eq!(tool_messages.len(), 1, "no synthesized duplicate result");
+        assert_eq!(tool_messages[0]["content"], json!("file body"));
+    }
+
+    #[test]
+    fn unpaired_tool_call_gets_synthesized_result() {
+        // Assistant asked for a call; the loop was cancelled before answering it.
+        let history = vec![ChatMessage::Assistant {
+            text: String::new(),
+            tool_calls: vec![tool_call("c1", "danger", "{}")],
+        }];
+        let body = build_request_body(&config(), &history);
+        assert!(
+            dangling_call_ids(&body).is_empty(),
+            "the unpaired call must be answered on the wire"
+        );
+        let tool_message = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["role"] == json!("tool"))
+            .expect("a synthesized tool result");
+        assert_eq!(tool_message["tool_call_id"], json!("c1"));
+        assert_eq!(tool_message["content"], json!(CANCELLED_TOOL_RESULT));
+    }
+
+    #[test]
+    fn partially_answered_batch_only_synthesizes_the_gap() {
+        // Two calls, only the first executed before cancellation.
+        let history = vec![
+            ChatMessage::Assistant {
+                text: String::new(),
+                tool_calls: vec![tool_call("c1", "read", "{}"), tool_call("c2", "read", "{}")],
+            },
+            ChatMessage::Tool {
+                call_id: "c1".to_string(),
+                content: "done".to_string(),
+            },
+        ];
+        let body = build_request_body(&config(), &history);
+        assert!(dangling_call_ids(&body).is_empty());
+        let answered: Vec<&str> = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|m| m["role"] == json!("tool"))
+            .map(|m| m["tool_call_id"].as_str().unwrap())
+            .collect();
+        assert!(answered.contains(&"c1") && answered.contains(&"c2"));
+    }
+
+    #[test]
+    fn assistant_with_tool_calls_has_null_content() {
+        let history = vec![ChatMessage::Assistant {
+            text: String::new(),
+            tool_calls: vec![tool_call("c1", "read", "{}")],
+        }];
+        let body = build_request_body(&config(), &history);
+        let assistant = &body["messages"].as_array().unwrap()[0];
+        assert_eq!(assistant["content"], Value::Null);
+    }
+
+    #[test]
+    fn system_prompt_and_tools_are_emitted_when_set() {
+        let config = RequestConfig {
+            model: "m".to_string(),
+            tools: vec![json!({ "type": "function", "function": { "name": "read" } })],
+            system_prompt: Some("be terse".to_string()),
+        };
+        let body = build_request_body(&config, &[ChatMessage::User("hi".to_string())]);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(
+            messages[0],
+            json!({ "role": "system", "content": "be terse" })
+        );
+        assert_eq!(body["tools"].as_array().unwrap().len(), 1);
+    }
+}

--- a/crates/pawwork-core/src/openai_compat/wire.rs
+++ b/crates/pawwork-core/src/openai_compat/wire.rs
@@ -45,23 +45,13 @@ pub fn build_request_body(config: &RequestConfig, history: &[ChatMessage]) -> Va
 }
 
 /// Convert the history into OpenAI messages, appending a synthesized `tool`
-/// result for every `tool_call` that has no real result later in the history.
+/// result for every `tool_call` that has no real result following it.
 fn messages(system_prompt: Option<&str>, history: &[ChatMessage]) -> Vec<Value> {
-    // A call is "answered" if some Tool message anywhere carries its id. Ids are
-    // unique per call, so a single pass over the whole history is enough.
-    let answered: std::collections::HashSet<&str> = history
-        .iter()
-        .filter_map(|message| match message {
-            ChatMessage::Tool { call_id, .. } => Some(call_id.as_str()),
-            _ => None,
-        })
-        .collect();
-
     let mut out = Vec::new();
     if let Some(prompt) = system_prompt {
         out.push(json!({ "role": "system", "content": prompt }));
     }
-    for message in history {
+    for (position, message) in history.iter().enumerate() {
         match message {
             ChatMessage::User(text) => {
                 out.push(json!({ "role": "user", "content": text }));
@@ -93,7 +83,20 @@ fn messages(system_prompt: Option<&str>, history: &[ChatMessage]) -> Vec<Value> 
                     "tool_calls": calls,
                 }));
                 // Sanitize: answer every unpaired call so the batch is complete on
-                // the wire even though the loop never ran (or finished) it.
+                // the wire even though the loop never ran (or finished) it. Pair
+                // positionally — a call is answered only by a Tool result in the
+                // run of Tool messages that immediately follows this assistant (how
+                // the loop records them). A whole-history id set would be wrong
+                // when ids collide across rounds: a provider that omits ids makes
+                // every first call fall back to `call_0`, so an executed `call_0`
+                // in an earlier round must not mask a cancelled `call_0` here.
+                let answered: std::collections::HashSet<&str> = history[position + 1..]
+                    .iter()
+                    .map_while(|following| match following {
+                        ChatMessage::Tool { call_id, .. } => Some(call_id.as_str()),
+                        _ => None,
+                    })
+                    .collect();
                 for call in tool_calls {
                     if !answered.contains(call.call_id.as_str()) {
                         out.push(json!({
@@ -248,6 +251,44 @@ mod tests {
             .map(|m| m["tool_call_id"].as_str().unwrap())
             .collect();
         assert!(answered.contains(&"c1") && answered.contains(&"c2"));
+    }
+
+    #[test]
+    fn colliding_fallback_ids_across_rounds_are_paired_positionally() {
+        // A provider that omits tool_call ids makes every first call fall back to
+        // "call_0". Round 1 executed; round 2 cancelled. A whole-history id set
+        // would see round 1's result and wrongly treat round 2's call_0 as
+        // answered, leaking a dangling call; positional pairing must not.
+        let history = vec![
+            ChatMessage::Assistant {
+                text: String::new(),
+                tool_calls: vec![tool_call("call_0", "read", "{}")],
+            },
+            ChatMessage::Tool {
+                call_id: "call_0".to_string(),
+                content: "round 1 result".to_string(),
+            },
+            ChatMessage::Assistant {
+                text: String::new(),
+                tool_calls: vec![tool_call("call_0", "read", "{}")],
+            },
+            // No tool result for round 2: cancelled before execution.
+        ];
+        let body = build_request_body(&config(), &history);
+        let tool_messages: Vec<&Value> = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|m| m["role"] == json!("tool"))
+            .collect();
+        // Two results: round 1's real one and round 2's synthesized cancellation.
+        assert_eq!(tool_messages.len(), 2);
+        assert!(tool_messages
+            .iter()
+            .any(|m| m["content"] == json!("round 1 result")));
+        assert!(tool_messages
+            .iter()
+            .any(|m| m["content"] == json!(CANCELLED_TOOL_RESULT)));
     }
 
     #[test]


### PR DESCRIPTION
## What

PR3 of the Rust agent v0 line: a hand-written OpenAI-compatible streaming client that implements the frozen `LlmClient` trait, plus the two P2s ChatGPT flagged after the PR2 merge (both no-ops under the mock, provable only now that a real wire body exists). Contract untouched — `LlmClient` / `ModelTurn` / `ChatMessage` unchanged, and no half-parse logic leaks into `agent.rs`.

## Deliverable 1 — openai_compat SSE client

New `crates/pawwork-core/src/openai_compat/`, core stays runtime-agnostic:

- **`stream.rs`** — a sans-io `SseDecoder` (push parser: bytes in, frames out, buffering partial lines so a chunked HTTP body split at any byte boundary reassembles identically) and a `TurnAccumulator` that folds chunk deltas into one `ModelTurn`, accumulating `tool_calls` by index (missing id → `call_N`). A turn only finishes into `Ok` when a terminal `finish_reason` (`stop`/`tool_calls`) arrives; a stream that ends without one yields `Err`, so **a torn mid-arguments buffer never escapes as a runnable call** — the trait's half-parse guarantee, enforced inside the client.
- **`wire.rs`** — builds the chat/completions request body from history (also home of the P2-2 fix).
- **`mod.rs`** — `OpenAiClient` over `reqwest`, `POST` + `Response::chunk()` driving the decoder. 401 names its key env var. No retry/backoff or idle-stall watchdog yet (deferred; a dropped stream surfaces as one `Err`).

**Fixture matrix (offline, no network):** pure text · single tool_call · multi tool_call · mid-stream error object · broken stream · CRLF · `:` keepalive · multi-line `data:` · usage-only / empty `choices` · finish without `[DONE]` · missing id → `call_N` · byte-at-a-time delivery.

## Deliverable 2 — P2-2: dangling `tool_call` → provider 400

A batch cancelled mid-permission (or mid-execution) leaves an assistant `tool_call` with no `tool` result in the loop's history; a real provider rejects that with a 400. **Fixed at request construction only** (`wire.rs`): every unpaired call is answered with a synthesized "cancelled before execution" tool result on the wire. History and ledger are never rewritten. Proven two ways: unit tests on the body, and an agent test that cancels mid-permission then asserts the next turn's request body has no unpaired call **while the history still carries it**.

## Deliverable 3 — P2-1: unbounded tool-call batch

Add `max_tool_calls_per_turn` (sibling to `max_model_rounds`). An oversized batch records an `Error` and interrupts before executing any call; the now-unpaired calls are sanitized on the next request. Mock test proves no `tool.started` is recorded.

## New dependency

`reqwest 0.12` — features `rustls-tls`, `http2`, `charset`, default features off (no native-tls / OpenSSL). The only network dependency; SSE framing and chunk JSON are hand-parsed. It pulls `hyper` + `tokio` rt/net transitively — a binary-side build-graph effect; the core's own direct `tokio` features stay `sync`.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --locked` — 61 pass (17 in `openai_compat`)

The real HTTP path (reqwest send/stream) is covered by the endpoint smoke step, not this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming chat/completions with OpenAI-compatible providers.
  * Expanded agent configuration to let you set a maximum number of tool calls per turn.

* **Bug Fixes**
  * Prevents oversized tool-call batches from being processed, avoiding broken conversation state.
  * Improves handling of streamed responses, including partial chunks, tool-call reconstruction, and end-of-stream completion.
  * Better error reporting for failed requests and authentication issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->