### PR TITLE
fix(ui): replace remaining product-UI middle-dot separators with gap

### DIFF
--- a/packages/app/src/components/prompt-input/context-items.test.ts
+++ b/packages/app/src/components/prompt-input/context-items.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
 import { isExternalChip } from "./path-canonical"
 
 // isExternalChip is the pure helper that backs the external-chip guard in
@@ -8,6 +9,21 @@ import { isExternalChip } from "./path-canonical"
 // scaffolding; the logic tested here covers the decision boundary completely.
 // (aria-disabled was dropped from the chip wrapper — its inner remove button
 // stays operable, so advertising the container as disabled was misleading.)
+
+const contextItemsSrc = readFileSync(new URL("./context-items.tsx", import.meta.url), "utf8")
+
+describe("PromptContextItems: no-dot tooltip", () => {
+  test("external-file tooltip uses gap, not a middle-dot separator (DESIGN.md no-dot rule)", () => {
+    // Label + path used to join with a middle-dot glyph; now gap + mono path.
+    // Source pin keeps the glyph from creeping back without a Solid harness.
+    expect(contextItemsSrc).not.toMatch(/\}\s*·\s*\{/)
+    expect(contextItemsSrc).not.toMatch(/externalFile"\)\}\s*·/)
+    // Parent of the label uses gap-2; path token is mono for sans-vs-mono contrast.
+    expect(contextItemsSrc).toMatch(/inline-flex items-baseline gap-2/)
+    expect(contextItemsSrc).toContain('props.t("prompt.context.externalFile")')
+    expect(contextItemsSrc).toMatch(/font-family["']?\s*:\s*["']?var\(--font-family-mono\)/)
+  })
+})
 
 describe("isExternalChip", () => {
   test("relative path returns false (never external)", () => {

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -40,8 +40,15 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                 value={
                   <span class="flex flex-col gap-0.5 max-w-[300px]">
                     <Show when={external}>
-                      <span class="opacity-80 text-xs">
-                        {props.t("prompt.context.externalFile")} · {item.path}
+                      {/* No middle-dot (DESIGN.md no-`·` rule): gap + mono path. */}
+                      <span class="inline-flex items-baseline gap-2 opacity-80 text-xs max-w-full">
+                        <span class="shrink-0">{props.t("prompt.context.externalFile")}</span>
+                        <span
+                          class="min-w-0 break-all [unicode-bidi:plaintext]"
+                          style={{ "font-family": "var(--font-family-mono)" }}
+                        >
+                          {item.path}
+                        </span>
                       </span>
                     </Show>
                     <Show when={!external}>

--- a/packages/ui/src/components/rate-limit-card.css
+++ b/packages/ui/src/components/rate-limit-card.css
@@ -3,20 +3,17 @@
      This variant drops CardTitle, so the gap is set explicitly here. */
   gap: var(--space-md);
 
-  /* Headline: title · reset, folded onto one line.
-     Color inherits from the card root, set by the Card primitive in card.css;
-     only the weight is bumped so the title reads as emphasis. */
+  /* Headline: title + reset, folded onto one line.
+     No middle-dot separator (DESIGN.md no-`·` rule): gap divides the tokens;
+     title weight vs reset weak color provides the contrast. Color inherits
+     from the card root (Card primitive in card.css); only the weight is
+     bumped so the title reads as emphasis. */
   .rate-limit-card__head {
     font-weight: var(--font-weight-emphasis);
     display: flex;
     align-items: baseline;
     flex-wrap: wrap;
-  }
-
-  .rate-limit-card__sep {
-    color: var(--fg-weak);
-    font-weight: var(--font-weight-body);
-    margin: 0 var(--space-sm);
+    gap: var(--space-md);
   }
 
   .rate-limit-card__reset {

--- a/packages/ui/src/components/rate-limit-card.test.tsx
+++ b/packages/ui/src/components/rate-limit-card.test.tsx
@@ -164,6 +164,16 @@ describe("RateLimitCard: CSS token contract", () => {
     // font-size, but legitimately via --font-size-kbd.
     expect(css).not.toMatch(/\.rate-limit-card__note\s*\{[^}]*font-size:/)
   })
+
+  test("headline uses gap, not a middle-dot separator (DESIGN.md no-dot rule)", () => {
+    // Title + reset fold onto one line via flex gap; weight/color contrast
+    // replaces the former `__sep` glyph. Pin the absence of a rendered glyph
+    // (and of the dead class) plus the presence of the gap token.
+    expect(src).not.toMatch(/>\s*·\s*</)
+    expect(src).not.toContain("rate-limit-card__sep")
+    expect(css).not.toContain("rate-limit-card__sep")
+    expect(css).toMatch(/\.rate-limit-card__head[\s\S]*?gap:\s*var\(--space-/)
+  })
 })
 
 // ── Note rows for each recommendation ─────────────────────────────────────

--- a/packages/ui/src/components/rate-limit-card.tsx
+++ b/packages/ui/src/components/rate-limit-card.tsx
@@ -71,19 +71,17 @@ export function RateLimitCard(props: RateLimitCardProps) {
   // The warning triangle that CardTitle would inject is redundant with the
   // 2px orange rule on the card's left edge — both encode the same warning
   // semantic. We drop CardTitle/CardDescription entirely and render a single
-  // headline that folds title + reset onto one line via a middle-dot, then
-  // hand the action ledger a grid of `[primary link, prerequisite note]`
-  // rows so the two recommendations sit on aligned columns. The user picks by
-  // matching their situation to the right-column prerequisite before clicking
-  // the left-column brand link — the prerequisite is read first, not as a
+  // headline that folds title + reset onto one line via gap (DESIGN.md no-`·`
+  // rule; title emphasis vs reset weak provides the contrast), then hand the
+  // action ledger a grid of `[primary link, prerequisite note]` rows so the
+  // two recommendations sit on aligned columns. The user picks by matching
+  // their situation to the right-column prerequisite before clicking the
+  // left-column brand link — the prerequisite is read first, not as a
   // skippable footnote.
   return (
     <Card variant="warning" data-slot="rate-limit-card" data-kind="rate-limit-card">
       <div class="rate-limit-card__head" data-slot="rate-limit-card-head">
         <span class="rate-limit-card__title">{i18n.t("ui.rateLimitCard.title")}</span>
-        <span class="rate-limit-card__sep" aria-hidden="true">
-          ·
-        </span>
         <span class="rate-limit-card__reset">{resetSubtitle()}</span>
       </div>
       <CardActions>


### PR DESCRIPTION
<!-- Checklist policy: the Checklist section below is policy. Do not edit, add, or remove items. Tick boxes only by replacing [ ] with [x]. -->

## Summary

Finish #1197 by clearing the last two product-UI middle-dot (`·`) separators left after #1211:

1. **Rate-limit card headline** — drop `__sep` / `·` between title and reset subtitle; use flex `gap: var(--space-md)` on `__head`. Title keeps emphasis weight; reset stays `fg-weak` (weight/color contrast).
2. **Prompt context external-file tooltip** — label and absolute path no longer join with ` · `; use `inline-flex` + `gap-2`, with the path in mono for sans-vs-mono contrast.

No DESIGN.md exceptions registered — both sites read clearly with gap.

## Why

DESIGN.md Do's and Don'ts forbids middle-dot as a separator or decoration in product UI. Timeline footers were fixed in #1211; these two call sites remained.

## Related Issue

Closes #1197

## Human Review Status

Pending

## Review Focus

- Rate-limit card headline spacing (title vs reset) still reads as one line without a glyph.
- External-file tooltip: label + mono path layout, especially long absolute paths (`break-all`).

## Risk Notes

- Low: pure presentational spacing change; no i18n key or behavior change.
- Context-items tooltip has no dedicated snap target; only rate-limit-card was snapped. External-file tooltip path covered by source-pin unit test.
- Platform/packaging surfaces untouched.

## How To Verify

```text
packages/ui: bun test src/components/rate-limit-card.test.tsx
  → 37 pass (incl. new no-dot headline contract)

packages/app: bun test src/components/prompt-input/context-items.test.ts
  → 11 pass (incl. new no-dot tooltip contract)

bun run snap rate-limit-card
  → 1 passed; grid at docs/design/preview/screenshots/rate-limit-card.png
  → headline reads "今天的免费额度用完了 稍后重试" with gap, no middle-dot

grep audit (product render paths under packages/app|ui src):
  → no remaining · in .tsx/.css product UI (comments / stories / tests / tokens only)
```

## Screenshots or Recordings

`bun run snap rate-limit-card` (zh card + page). Title and reset subtitle separated by gap only; no middle-dot. (Screenshot is local-only under `docs/` and not committed.)

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.