### PR TITLE
feat(rust): PR4 write-side tools edit/write/shell, fold list into read

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -32,7 +32,15 @@ permissions:
 
 jobs:
   rust:
-    runs-on: ubuntu-latest
+    # Both targets the Rust line supports: linux (primary) and windows. The windows
+    # leg is load-bearing — the shell tool's `cmd`/`taskkill` path and the
+    # `ReplaceFileW` atomic replace are `cfg(windows)`, so only a windows runner
+    # compiles, lints, and tests them.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -528,6 +528,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "uuid",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1217,6 +1218,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +521,7 @@ dependencies = [
 name = "pawwork-core"
 version = "0.0.0"
 dependencies = [
+ "libc",
  "reqwest",
  "serde",
  "serde_json",
@@ -816,6 +827,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +956,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,17 @@ rust-version = "1.89"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
-# tokio is kept minimal on purpose: the core lib only needs `sync` (mpsc for the
-# event stream). The runtime flavor is chosen by the binary's #[tokio::main], not
-# here, so the core stays runtime-agnostic (see docs section 13). macros/rt land
-# in dev-dependencies and the CLI, not the lib.
+# tokio's workspace default is kept minimal on purpose: only `sync` (mpsc for the
+# event stream). The `shell` tool needs more (process/time/io-util/macros), but
+# that widening lives in pawwork-core's own [dependencies], not here, so the
+# default stays lean for any other member. The runtime flavor is still chosen by
+# the binary's #[tokio::main], not here, so the core stays runtime-agnostic (see
+# docs section 13). rt-multi-thread lands in dev-dependencies and the CLI, not the
+# lib.
 tokio = { version = "1", default-features = false, features = ["sync"] }
+# Process-group kill for the shell tool (kill(2) with a negative pgid). Pulled in
+# only on unix, via pawwork-core's [target.'cfg(unix)'.dependencies].
+libc = "0.2"
 # CancellationToken (cooperative interruption; child tokens are the future
 # subagent shape). Preferred over a hand-rolled watch channel.
 tokio-util = { version = "0.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ libc = "0.2"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
+    "Win32_Globalization",
 ] }
 # CancellationToken (cooperative interruption; child tokens are the future
 # subagent shape). Preferred over a hand-rolled watch channel.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ libc = "0.2"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
-    "Win32_Globalization",
 ] }
 # CancellationToken (cooperative interruption; child tokens are the future
 # subagent shape). Preferred over a hand-rolled watch channel.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ libc = "0.2"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
+    "Win32_Globalization",
+    "Win32_System_Console",
 ] }
 # CancellationToken (cooperative interruption; child tokens are the future
 # subagent shape). Preferred over a hand-rolled watch channel.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,14 @@ tokio = { version = "1", default-features = false, features = ["sync"] }
 # Process-group kill for the shell tool (kill(2) with a negative pgid). Pulled in
 # only on unix, via pawwork-core's [target.'cfg(unix)'.dependencies].
 libc = "0.2"
+# Windows-only FFI: `ReplaceFileW` (atomic replace that preserves the target's ACL
+# and attributes, which `rename`/`MoveFileEx` drops). Pulled in only on windows,
+# via pawwork-core's [target.'cfg(windows)'.dependencies]. Feature-gated to the two
+# modules we touch so the build graph stays minimal.
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+] }
 # CancellationToken (cooperative interruption; child tokens are the future
 # subagent shape). Preferred over a hand-rolled watch channel.
 tokio-util = { version = "0.7", default-features = false }

--- a/crates/pawwork-core/Cargo.toml
+++ b/crates/pawwork-core/Cargo.toml
@@ -30,6 +30,12 @@ reqwest.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+# `edit`/`write` replace a file atomically. On windows `rename` (MoveFileEx) drops
+# the target's ACL; `ReplaceFileW` keeps it. std does not expose that call, so the
+# windows-sys shim is pulled in only here, on windows.
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
+
 [dev-dependencies]
 # Tests drive the async loop and the shell tool on a multi-thread runtime and
 # validate the Send discipline. `rt-multi-thread` is dev-only; the lib itself

--- a/crates/pawwork-core/Cargo.toml
+++ b/crates/pawwork-core/Cargo.toml
@@ -9,11 +9,29 @@ publish = false
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
-tokio.workspace = true
+# The core lib takes the workspace `sync` baseline and widens it here (not at the
+# workspace root) for the `shell` tool: `process` to spawn a child, `time` for its
+# timeout, `io-util` to drain its pipes, and `macros` for `select!`. Keeping the
+# widening local leaves the workspace default minimal for any other member. The
+# runtime flavor is still chosen by the binary's #[tokio::main]; the core builds
+# no runtime and its futures stay Send.
+tokio = { workspace = true, features = [
+    "process",
+    "time",
+    "io-util",
+    "macros",
+] }
 tokio-util.workspace = true
 reqwest.workspace = true
 
+# `shell` kills the child's process group on timeout/cancel via `kill(2)` with a
+# negative pgid, which std does not expose; libc is the minimal way in, and only
+# on unix (elsewhere the tool falls back to `child.kill()`).
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
-# Tests drive the async loop and validate the Send discipline on a multi-thread
-# runtime; the lib build stays on `sync` only (see workspace tokio note).
+# Tests drive the async loop and the shell tool on a multi-thread runtime and
+# validate the Send discipline. `rt-multi-thread` is dev-only; the lib itself
+# never constructs a runtime.
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/pawwork-core/src/agent.rs
+++ b/crates/pawwork-core/src/agent.rs
@@ -245,6 +245,9 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
 
             let ctx = ToolContext {
                 workspace_root: self.workspace_root.clone(),
+                // Hand tools a clone of the turn's token so a long-running one
+                // (`shell`) can abort promptly when the turn is interrupted.
+                cancel: cancel.clone(),
             };
             for call in &turn.tool_calls {
                 if cancel.is_cancelled() {
@@ -340,6 +343,7 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
             )?;
             let request = PermissionRequest {
                 tool_name: call.name.clone(),
+                action: prepared.clone(),
                 summary,
             };
             let allowed = match cancel.run_until_cancelled(self.gate.decide(&request)).await {
@@ -576,12 +580,18 @@ mod tests {
         fn name(&self) -> &str {
             "danger"
         }
+        fn description(&self) -> &str {
+            "a dangerous test tool"
+        }
+        fn parameters(&self) -> Value {
+            serde_json::json!({ "type": "object", "properties": {} })
+        }
         fn requires_confirmation(&self) -> bool {
             true
         }
-        fn prepare(&self, ctx: &ToolContext, _args: &Value) -> Result<PreparedCall, String> {
-            Ok(PreparedCall {
-                path: ctx.workspace_root.clone(),
+        fn prepare(&self, _ctx: &ToolContext, _args: &Value) -> Result<PreparedCall, String> {
+            Ok(PreparedCall::Shell {
+                command: "noop".to_string(),
             })
         }
         fn summarize(&self, _prepared: &PreparedCall) -> String {
@@ -610,7 +620,7 @@ mod tests {
         let (mut agent, session_dir) = build(
             MockLlmClient::once_text("hi there"),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -635,7 +645,7 @@ mod tests {
         let (mut agent, session_dir) = build(
             MockLlmClient::once_text("hi"),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -662,7 +672,7 @@ mod tests {
                 done(),
             ]),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -701,7 +711,7 @@ mod tests {
         let (mut agent, session_dir) = build(
             MockLlmClient::new(vec![turn_with(vec![call("c1", "nope", "{}")]), done()]),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -739,7 +749,7 @@ mod tests {
                 done(),
             ]),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -764,7 +774,7 @@ mod tests {
                 done(),
             ]),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -857,7 +867,7 @@ mod tests {
         let (mut agent, session_dir) = build(
             MockLlmClient::once_text("hi"),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -881,7 +891,7 @@ mod tests {
         let (mut agent, session_dir) = build(
             MockLlmClient::new(vec![MockResponse::HangUntilCancel]),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -969,7 +979,7 @@ mod tests {
         let (mut agent, session_dir) = build(
             MockLlmClient::new(vec![MockResponse::Fail(LlmError::new("boom"))]),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let cancel = CancellationToken::new();
@@ -1003,7 +1013,7 @@ mod tests {
                 turn_with(vec![call("c3", "read", r#"{"path":"a.txt"}"#)]),
             ]),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let mut agent = agent.with_max_model_rounds(2);
@@ -1046,7 +1056,7 @@ mod tests {
                 call("c3", "read", r#"{"path":"a.txt"}"#),
             ])]),
             AllowGate,
-            ToolRuntime::with_read_only(),
+            ToolRuntime::with_builtins(),
             &dirs,
         );
         let mut agent = agent.with_max_tool_calls_per_turn(2);
@@ -1175,5 +1185,108 @@ mod tests {
             no_dangling_tool_call(&body),
             "the sanitized request body must have no unpaired tool_call"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_tool_denied_does_not_create_the_file() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![
+                turn_with(vec![call(
+                    "c1",
+                    "write",
+                    r#"{"path":"out.txt","content":"hello"}"#,
+                )]),
+                done(),
+            ]),
+            DenyGate,
+            ToolRuntime::with_builtins(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("write it", &cancel, &tx).await.unwrap();
+        // Denial is not interruption: the loop recovers and completes.
+        assert_eq!(outcome, TurnOutcome::Completed);
+        assert!(
+            !dirs.workspace.join("out.txt").exists(),
+            "a denied write must not touch the disk"
+        );
+        let events = project(&session_dir).unwrap();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::PermissionRequested { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::PermissionDecided { allowed: false, .. })));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })),
+            "denied before the tool ran"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_tool_allowed_creates_the_file() {
+        let dirs = TempDirs::new();
+        let (mut agent, session_dir) = build(
+            MockLlmClient::new(vec![
+                turn_with(vec![call(
+                    "c1",
+                    "write",
+                    r#"{"path":"out.txt","content":"hello"}"#,
+                )]),
+                done(),
+            ]),
+            AllowGate,
+            ToolRuntime::with_builtins(),
+            &dirs,
+        );
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = channel();
+        let outcome = agent.run_turn("write it", &cancel, &tx).await.unwrap();
+        assert_eq!(outcome, TurnOutcome::Completed);
+        assert_eq!(
+            std::fs::read_to_string(dirs.workspace.join("out.txt")).unwrap(),
+            "hello",
+            "an allowed write must land the exact content"
+        );
+        let events = project(&session_dir).unwrap();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(&e.kind, EventKind::ToolFinished { ok: true, .. })));
+    }
+
+    #[test]
+    fn builtin_schemas_describe_the_four_tools() {
+        let runtime = ToolRuntime::with_builtins();
+        let schemas = runtime.schemas();
+        assert_eq!(schemas.len(), 4, "read, edit, write, shell");
+        // Sorted by name for a deterministic request body.
+        let names: Vec<&str> = schemas
+            .iter()
+            .map(|schema| schema["function"]["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["edit", "read", "shell", "write"]);
+        for schema in &schemas {
+            assert_eq!(schema["type"], serde_json::json!("function"));
+            let function = &schema["function"];
+            assert!(function["name"].is_string());
+            assert!(
+                function["description"]
+                    .as_str()
+                    .is_some_and(|d| !d.is_empty()),
+                "each tool needs a description"
+            );
+            assert_eq!(
+                function["parameters"]["type"],
+                serde_json::json!("object"),
+                "parameters is a JSON Schema object"
+            );
+        }
     }
 }

--- a/crates/pawwork-core/src/agent.rs
+++ b/crates/pawwork-core/src/agent.rs
@@ -373,6 +373,16 @@ impl<L: LlmClient, G: PermissionGate> Agent<L, G> {
             }
         }
 
+        // Recheck cancellation before starting a side-effecting tool. The
+        // confirmation future and the cancel token can become ready together, and
+        // `run_until_cancelled` picks a winner nondeterministically — so a Ctrl-C
+        // that raced (or preceded) approval could otherwise let `edit`/`write`
+        // mutate a file or `shell` spawn a process after the interrupt. This also
+        // covers auto-allowed tools, which skip the gate entirely.
+        if cancel.is_cancelled() {
+            return Ok(CallFlow::Interrupted("cancelled".to_string()));
+        }
+
         emit(
             &mut self.store,
             tx,

--- a/crates/pawwork-core/src/agent.rs
+++ b/crates/pawwork-core/src/agent.rs
@@ -794,9 +794,14 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| matches!(e.kind, EventKind::ToolStarted { .. })));
+        // The refusal message differs by platform: unix resolves `/etc/hosts` and
+        // rejects it as escaping the workspace; windows maps it to a non-existent
+        // `\etc\hosts` on the current drive, so the resolver rejects it as
+        // unresolvable first. Either is a refusal with no `ToolStarted`.
         assert!(events.iter().any(|e| matches!(
             &e.kind,
-            EventKind::ToolFinished { ok: false, output, .. } if output.contains("escapes")
+            EventKind::ToolFinished { ok: false, output, .. }
+                if output.contains("escapes") || output.contains("cannot resolve")
         )));
     }
 

--- a/crates/pawwork-core/src/lib.rs
+++ b/crates/pawwork-core/src/lib.rs
@@ -5,8 +5,8 @@
 //! - [`llm`] — the [`llm::LlmClient`] boundary plus a scripted mock.
 //! - [`openai_compat`] — a hand-written streaming client that implements
 //!   [`llm::LlmClient`] against any OpenAI-compatible chat/completions endpoint.
-//! - [`tool`] — the [`tool::Tool`] boundary, a runtime registry, and the
-//!   read-only `read`/`list` tools with their workspace path fence.
+//! - [`tool`] — the [`tool::Tool`] boundary, a runtime registry, and the built-in
+//!   tools (`read`, `edit`, `write`, `shell`) with their workspace path fence.
 //! - [`permission`] — the [`permission::PermissionGate`] callback boundary.
 //! - [`agent`] — the turn loop that wires them together, appends ledger events,
 //!   and mirrors them onto a wire event stream.

--- a/crates/pawwork-core/src/permission.rs
+++ b/crates/pawwork-core/src/permission.rs
@@ -5,21 +5,29 @@
 //! own UI. Like [`crate::llm::LlmClient`] the gate is generic, not `dyn` — the
 //! loop holds one.
 //!
-//! The request is structured, not a raw JSON blob for the user to eyeball: PR2
-//! carries the tool name and a rendered human summary. A richer typed action
-//! enum (read-path / write-file / shell-command) lands with `edit`/`shell`, its
-//! first real producers; introducing those variants now would be speculative
-//! dead code, since PR2's only tools (`read`/`list`) are auto-allowed and never
-//! reach the gate.
+//! The request carries a structured action, not a raw JSON blob for the user to
+//! eyeball: the tool name, the validated [`PreparedCall`] (the concrete "what will
+//! run" — the fenced path, the replacement strings, the command line), and a
+//! rendered `summary` for display. [`PreparedCall`] is reused as the typed action
+//! rather than a parallel enum: it is already the loop's certified plan, so an
+//! adapter can render, diff, or policy-check the exact bytes that will execute,
+//! not a lossy string. The ledger's `permission.requested` still records only the
+//! `summary` string, so this richer action does not touch the on-disk schema.
 
 use std::future::Future;
+
+use crate::tool::PreparedCall;
 
 /// What the user is being asked to approve.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PermissionRequest {
     pub tool_name: String,
-    /// A rendered, human-readable description of the concrete action. This is
-    /// also what the ledger's `permission.requested` records as its `action`.
+    /// The validated action that will run if approved — the same [`PreparedCall`]
+    /// the loop will hand to the tool. An adapter can inspect it directly (path,
+    /// content, command) instead of parsing the rendered summary.
+    pub action: PreparedCall,
+    /// A rendered, human-readable description of the concrete action. This is also
+    /// what the ledger's `permission.requested` records as its `action`.
     pub summary: String,
 }
 

--- a/crates/pawwork-core/src/tool/edit.rs
+++ b/crates/pawwork-core/src/tool/edit.rs
@@ -1,0 +1,460 @@
+//! The write-side file tools: `edit` and `write`.
+//!
+//! Both mutate a workspace file, so both require confirmation and both land their
+//! change through one [`atomic_write`] helper (write a sibling temp file, then
+//! rename over the target) so a reader never sees a half-written file. Grouping
+//! them here keeps the "changes a file on disk" surface in one place, next to the
+//! atomicity guarantee they share.
+//!
+//! `edit` is an **exact** substring replacement, deliberately not the fuzzy
+//! replacer cascade the TypeScript tool grew: exactly one occurrence of
+//! `old_string` must match or the edit fails. Exact matching is predictable and
+//! reviewable; a fuzzy match that silently edits the wrong line is the failure
+//! mode a confirmation gate cannot catch. `write` replaces (or creates) a whole
+//! file.
+
+use std::io::Read;
+use std::path::Path;
+
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use super::fence::{resolve_in_workspace, resolve_new_in_workspace};
+use super::{BoxFuture, PreparedCall, Tool, ToolContext, ToolResult, MISMATCHED_CALL};
+
+/// Cap on the size of a file `edit` will load. Same work-bounding philosophy as
+/// `read`'s cap: exact string matching over a multi-gigabyte file would stall the
+/// turn and blow memory, and an edit target that large is not a real edit.
+const MAX_EDIT_BYTES: usize = 8 * 1024 * 1024;
+
+/// Pull a required string argument. Unlike [`super::fs`]'s `path_arg`, this does
+/// not reject an empty value — `write`'s `content` may legitimately be `""`.
+fn string_arg<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("missing required string argument '{key}'"))
+}
+
+/// Write `content` to `path` atomically: stage it in a uniquely-named sibling temp
+/// file in the same directory, then `rename` over the target. `rename` within one
+/// directory is atomic on the platforms we target, so a concurrent reader sees
+/// either the old file or the new one, never a partial write. No `fsync`:
+/// durability across a crash is an explicitly deferred concern. The temp file is
+/// removed on any failure so a stray partial write is never left behind.
+fn atomic_write(path: &Path, content: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "target has no parent directory".to_string())?;
+    let temp = parent.join(format!(".pawwork-tmp-{}", Uuid::new_v4()));
+    if let Err(err) = std::fs::write(&temp, content) {
+        std::fs::remove_file(&temp).ok();
+        return Err(format!("write failed: {err}"));
+    }
+    if let Err(err) = std::fs::rename(&temp, path) {
+        std::fs::remove_file(&temp).ok();
+        return Err(format!("write failed: {err}"));
+    }
+    Ok(())
+}
+
+/// `edit`: replace the single occurrence of `old_string` with `new_string` in a
+/// file inside the workspace.
+pub struct EditTool;
+
+impl Tool for EditTool {
+    fn name(&self) -> &str {
+        "edit"
+    }
+
+    fn description(&self) -> &str {
+        "Replace an exact substring in an existing workspace file. old_string must \
+         match exactly once; if it is missing or appears more than once the edit \
+         fails, so include enough surrounding context to make it unique. Preserve \
+         exact whitespace. Use write to create a new file or replace one wholesale."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to edit, relative to the workspace root."
+                },
+                "old_string": {
+                    "type": "string",
+                    "description": "The exact text to replace. Must occur exactly once."
+                },
+                "new_string": {
+                    "type": "string",
+                    "description": "The text to replace it with."
+                }
+            },
+            "required": ["path", "old_string", "new_string"],
+            "additionalProperties": false
+        })
+    }
+
+    fn requires_confirmation(&self) -> bool {
+        true
+    }
+
+    fn prepare(&self, ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String> {
+        let requested = string_arg(args, "path")?;
+        let old = string_arg(args, "old_string")?;
+        let new = string_arg(args, "new_string")?;
+        if old.is_empty() {
+            return Err("old_string must not be empty".to_string());
+        }
+        if old == new {
+            return Err("old_string and new_string are identical; nothing to change".to_string());
+        }
+        let path = resolve_in_workspace(&ctx.workspace_root, requested)?;
+        if !path.is_file() {
+            return Err(format!("'{requested}' is not a file"));
+        }
+        Ok(PreparedCall::Edit {
+            path,
+            old: old.to_string(),
+            new: new.to_string(),
+        })
+    }
+
+    fn summarize(&self, prepared: &PreparedCall) -> String {
+        match prepared {
+            PreparedCall::Edit { path, .. } => format!("edit {}", path.display()),
+            _ => "edit".to_string(),
+        }
+    }
+
+    fn run<'a>(
+        &'a self,
+        _ctx: &'a ToolContext,
+        prepared: &'a PreparedCall,
+    ) -> BoxFuture<'a, ToolResult> {
+        let PreparedCall::Edit { path, old, new } = prepared else {
+            return Box::pin(async { Err(MISMATCHED_CALL.to_string()) });
+        };
+        Box::pin(async move {
+            // Read at most one byte past the cap so an oversized file is rejected
+            // without loading it whole.
+            let file = std::fs::File::open(path).map_err(|err| format!("read failed: {err}"))?;
+            let mut bytes = Vec::new();
+            file.take((MAX_EDIT_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)
+                .map_err(|err| format!("read failed: {err}"))?;
+            if bytes.len() > MAX_EDIT_BYTES {
+                return Err(format!(
+                    "file is too large to edit (over {MAX_EDIT_BYTES} bytes)"
+                ));
+            }
+            // Exact matching on a lossy conversion would corrupt the file on
+            // write-back, so a non-UTF-8 file is refused, not mangled.
+            let text = String::from_utf8(bytes).map_err(|_| {
+                "file is not valid UTF-8; edit requires exact text matching".to_string()
+            })?;
+            let occurrences = text.matches(old.as_str()).count();
+            match occurrences {
+                0 => return Err("no match: old_string was not found in the file".to_string()),
+                1 => {}
+                many => {
+                    return Err(format!(
+                        "ambiguous edit: old_string appears {many} times; include more \
+                         surrounding context so it matches exactly once"
+                    ))
+                }
+            }
+            let updated = text.replacen(old.as_str(), new.as_str(), 1);
+            atomic_write(path, updated.as_bytes())?;
+            Ok(format!("edited {}", path.display()))
+        })
+    }
+}
+
+/// `write`: create a new file, or overwrite an existing one, inside the workspace.
+pub struct WriteTool;
+
+impl Tool for WriteTool {
+    fn name(&self) -> &str {
+        "write"
+    }
+
+    fn description(&self) -> &str {
+        "Write content to a workspace file, creating it or overwriting it whole. \
+         The parent directory must already exist. Prefer edit for a small change to \
+         an existing file."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to write, relative to the workspace root."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The full contents to write. May be empty."
+                }
+            },
+            "required": ["path", "content"],
+            "additionalProperties": false
+        })
+    }
+
+    fn requires_confirmation(&self) -> bool {
+        true
+    }
+
+    fn prepare(&self, ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String> {
+        let requested = string_arg(args, "path")?;
+        let content = string_arg(args, "content")?;
+        let path = resolve_new_in_workspace(&ctx.workspace_root, requested)?;
+        Ok(PreparedCall::Write {
+            path,
+            content: content.to_string(),
+        })
+    }
+
+    fn summarize(&self, prepared: &PreparedCall) -> String {
+        match prepared {
+            PreparedCall::Write { path, content } => {
+                format!("write {} ({} bytes)", path.display(), content.len())
+            }
+            _ => "write".to_string(),
+        }
+    }
+
+    fn run<'a>(
+        &'a self,
+        _ctx: &'a ToolContext,
+        prepared: &'a PreparedCall,
+    ) -> BoxFuture<'a, ToolResult> {
+        let PreparedCall::Write { path, content } = prepared else {
+            return Box::pin(async { Err(MISMATCHED_CALL.to_string()) });
+        };
+        Box::pin(async move {
+            atomic_write(path, content.as_bytes())?;
+            Ok(format!(
+                "wrote {} ({} bytes)",
+                path.display(),
+                content.len()
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    struct TempWorkspace {
+        root: PathBuf,
+    }
+
+    impl TempWorkspace {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!("pawwork-edit-{}", Uuid::new_v4()));
+            fs::create_dir_all(&root).unwrap();
+            let root = root.canonicalize().unwrap();
+            TempWorkspace { root }
+        }
+
+        fn ctx(&self) -> ToolContext {
+            ToolContext {
+                workspace_root: self.root.clone(),
+                cancel: CancellationToken::new(),
+            }
+        }
+    }
+
+    impl Drop for TempWorkspace {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.root).ok();
+        }
+    }
+
+    // --- edit ------------------------------------------------------------
+
+    #[tokio::test]
+    async fn edit_replaces_the_single_match_exactly() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("a.txt"), b"hello world\n").unwrap();
+        let ctx = ws.ctx();
+        let prepared = EditTool
+            .prepare(
+                &ctx,
+                &json!({ "path": "a.txt", "old_string": "world", "new_string": "there" }),
+            )
+            .unwrap();
+        EditTool.run(&ctx, &prepared).await.unwrap();
+        let after = fs::read_to_string(ws.root.join("a.txt")).unwrap();
+        assert_eq!(after, "hello there\n", "content must be exactly replaced");
+    }
+
+    #[tokio::test]
+    async fn edit_with_no_match_errors() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("a.txt"), b"hello").unwrap();
+        let ctx = ws.ctx();
+        let prepared = EditTool
+            .prepare(
+                &ctx,
+                &json!({ "path": "a.txt", "old_string": "absent", "new_string": "x" }),
+            )
+            .unwrap();
+        let err = EditTool.run(&ctx, &prepared).await.unwrap_err();
+        assert!(err.contains("no match"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn edit_with_multiple_matches_reports_ambiguity() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("a.txt"), b"a a a").unwrap();
+        let ctx = ws.ctx();
+        let prepared = EditTool
+            .prepare(
+                &ctx,
+                &json!({ "path": "a.txt", "old_string": "a", "new_string": "b" }),
+            )
+            .unwrap();
+        let err = EditTool.run(&ctx, &prepared).await.unwrap_err();
+        assert!(err.contains("ambiguous"), "got: {err}");
+        assert!(err.contains('3'), "count must be named, got: {err}");
+    }
+
+    #[test]
+    fn edit_rejects_identical_old_and_new_at_prepare() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("a.txt"), b"x").unwrap();
+        let err = EditTool
+            .prepare(
+                &ws.ctx(),
+                &json!({ "path": "a.txt", "old_string": "x", "new_string": "x" }),
+            )
+            .unwrap_err();
+        assert!(err.contains("identical"), "got: {err}");
+    }
+
+    #[test]
+    fn edit_rejects_empty_old_string_at_prepare() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("a.txt"), b"x").unwrap();
+        let err = EditTool
+            .prepare(
+                &ws.ctx(),
+                &json!({ "path": "a.txt", "old_string": "", "new_string": "y" }),
+            )
+            .unwrap_err();
+        assert!(err.contains("empty"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn edit_rejects_non_utf8_file() {
+        let ws = TempWorkspace::new();
+        // An invalid UTF-8 byte sequence.
+        fs::write(ws.root.join("bin.dat"), [0xff, 0xfe, 0x00]).unwrap();
+        let ctx = ws.ctx();
+        let prepared = EditTool
+            .prepare(
+                &ctx,
+                &json!({ "path": "bin.dat", "old_string": "x", "new_string": "y" }),
+            )
+            .unwrap();
+        let err = EditTool.run(&ctx, &prepared).await.unwrap_err();
+        assert!(err.contains("UTF-8"), "got: {err}");
+    }
+
+    #[test]
+    fn edit_rejects_escape_at_prepare() {
+        let ws = TempWorkspace::new();
+        let err = EditTool
+            .prepare(
+                &ws.ctx(),
+                &json!({ "path": "/etc/hosts", "old_string": "a", "new_string": "b" }),
+            )
+            .unwrap_err();
+        assert!(err.contains("escapes"), "got: {err}");
+    }
+
+    #[test]
+    fn edit_rejects_missing_file_at_prepare() {
+        let ws = TempWorkspace::new();
+        let err = EditTool
+            .prepare(
+                &ws.ctx(),
+                &json!({ "path": "nope.txt", "old_string": "a", "new_string": "b" }),
+            )
+            .unwrap_err();
+        assert!(err.contains("cannot resolve"), "got: {err}");
+    }
+
+    // --- write -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn write_creates_a_new_file() {
+        let ws = TempWorkspace::new();
+        let ctx = ws.ctx();
+        let prepared = WriteTool
+            .prepare(&ctx, &json!({ "path": "new.txt", "content": "fresh" }))
+            .unwrap();
+        WriteTool.run(&ctx, &prepared).await.unwrap();
+        assert_eq!(
+            fs::read_to_string(ws.root.join("new.txt")).unwrap(),
+            "fresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_overwrites_an_existing_file() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("f.txt"), b"old contents").unwrap();
+        let ctx = ws.ctx();
+        let prepared = WriteTool
+            .prepare(&ctx, &json!({ "path": "f.txt", "content": "new" }))
+            .unwrap();
+        WriteTool.run(&ctx, &prepared).await.unwrap();
+        assert_eq!(fs::read_to_string(ws.root.join("f.txt")).unwrap(), "new");
+    }
+
+    #[tokio::test]
+    async fn write_allows_empty_content() {
+        let ws = TempWorkspace::new();
+        let ctx = ws.ctx();
+        let prepared = WriteTool
+            .prepare(&ctx, &json!({ "path": "empty.txt", "content": "" }))
+            .unwrap();
+        WriteTool.run(&ctx, &prepared).await.unwrap();
+        assert_eq!(fs::read_to_string(ws.root.join("empty.txt")).unwrap(), "");
+    }
+
+    #[test]
+    fn write_rejects_missing_parent_at_prepare() {
+        let ws = TempWorkspace::new();
+        let err = WriteTool
+            .prepare(&ws.ctx(), &json!({ "path": "nodir/f.txt", "content": "x" }))
+            .unwrap_err();
+        assert!(err.contains("cannot resolve parent"), "got: {err}");
+    }
+
+    #[test]
+    fn write_rejects_escape_at_prepare() {
+        let ws = TempWorkspace::new();
+        let err = WriteTool
+            .prepare(
+                &ws.ctx(),
+                &json!({ "path": "/etc/pawwork-x.txt", "content": "x" }),
+            )
+            .unwrap_err();
+        assert!(
+            err.contains("escapes") || err.contains("cannot resolve parent"),
+            "got: {err}"
+        );
+    }
+}

--- a/crates/pawwork-core/src/tool/edit.rs
+++ b/crates/pawwork-core/src/tool/edit.rs
@@ -46,23 +46,46 @@ fn atomic_write(path: &Path, content: &[u8]) -> Result<(), String> {
         .parent()
         .ok_or_else(|| "target has no parent directory".to_string())?;
     let temp = parent.join(format!(".pawwork-tmp-{}", Uuid::new_v4()));
-    if let Err(err) = std::fs::write(&temp, content) {
+    let existing = std::fs::metadata(path).ok();
+    if let Err(err) = write_temp(&temp, content, existing.as_ref()) {
         std::fs::remove_file(&temp).ok();
         return Err(format!("write failed: {err}"));
-    }
-    // The rename installs the temp's inode, so the target's permissions would
-    // otherwise be replaced by the temp's umask default — turning a 0755 script
-    // non-executable or widening a 0600 file. Carry the target's mode over first;
-    // a missing target means a create, where the default mode is right.
-    if let Ok(existing) = std::fs::metadata(path) {
-        if let Err(err) = std::fs::set_permissions(&temp, existing.permissions()) {
-            std::fs::remove_file(&temp).ok();
-            return Err(format!("write failed: {err}"));
-        }
     }
     if let Err(err) = std::fs::rename(&temp, path) {
         std::fs::remove_file(&temp).ok();
         return Err(format!("write failed: {err}"));
+    }
+    Ok(())
+}
+
+/// Stage the temp file without ever being more readable than the final target.
+///
+/// The rename installs the temp's inode, so the target's permissions must be
+/// carried onto the temp or a 0755 script turns non-executable and a 0600 file
+/// widens to the umask default. Order matters for secrecy too: when replacing an
+/// existing file the temp is *created* 0600 (unix) before any content is written,
+/// then tightened/relaxed to the target's exact mode — so there is no window (or
+/// crash residue) in which private content sits in a default-mode temp. A missing
+/// target is a create, where the default umask mode matches the final state.
+fn write_temp(
+    temp: &Path,
+    content: &[u8],
+    existing: Option<&std::fs::Metadata>,
+) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    if existing.is_some() {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(temp)?;
+    file.write_all(content)?;
+    drop(file);
+    if let Some(metadata) = existing {
+        std::fs::set_permissions(temp, metadata.permissions())?;
     }
     Ok(())
 }
@@ -509,6 +532,24 @@ mod tests {
             .unwrap();
         WriteTool.run(&ctx, &prepared).await.unwrap();
         assert_eq!(fs::read_to_string(ws.root.join("empty.txt")).unwrap(), "");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_preserves_a_private_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let ws = TempWorkspace::new();
+        let secret = ws.root.join("secret.txt");
+        fs::write(&secret, b"old").unwrap();
+        fs::set_permissions(&secret, fs::Permissions::from_mode(0o600)).unwrap();
+        let ctx = ws.ctx();
+        let prepared = WriteTool
+            .prepare(&ctx, &json!({ "path": "secret.txt", "content": "new" }))
+            .unwrap();
+        WriteTool.run(&ctx, &prepared).await.unwrap();
+        let mode = fs::metadata(&secret).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "overwriting must not widen a private file");
+        assert_eq!(fs::read_to_string(&secret).unwrap(), "new");
     }
 
     #[test]

--- a/crates/pawwork-core/src/tool/edit.rs
+++ b/crates/pawwork-core/src/tool/edit.rs
@@ -35,6 +35,23 @@ fn string_arg<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
         .ok_or_else(|| format!("missing required string argument '{key}'"))
 }
 
+/// Render a fenced target for a tool *result* as a workspace-relative path. The
+/// fence canonicalizes to an absolute path (e.g. `/Users/<name>/proj/src/x.rs`),
+/// and that result string is appended to the conversation and sent to the model
+/// provider on the next turn — echoing the absolute form leaks the local username
+/// and directory layout the model never named (it submitted a relative path). Strip
+/// the workspace root; fall back to the file name if the path is somehow not under
+/// it (it always is post-fence), never the raw absolute path.
+fn display_in_workspace(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .ok()
+        .filter(|rel| !rel.as_os_str().is_empty())
+        .or_else(|| path.file_name().map(Path::new))
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
 /// Write `content` to `path` atomically: stage it in a uniquely-named sibling temp
 /// file in the same directory, then swap it over the target. The swap within one
 /// directory is atomic on the platforms we target, so a concurrent reader sees
@@ -61,7 +78,17 @@ fn atomic_write(path: &Path, content: &[u8]) -> Result<(), String> {
         .parent()
         .ok_or_else(|| "target has no parent directory".to_string())?;
     let temp = parent.join(format!(".pawwork-tmp-{}", Uuid::new_v4()));
-    let existing = std::fs::metadata(path).ok();
+    // Only a genuine `NotFound` means "fresh create". A `metadata` failure from an
+    // ACL denial, a sharing violation, or transient I/O must NOT be misread as
+    // absence: doing so skips the permission-preserving path (unix mode copy /
+    // windows `ReplaceFileW`) and falls back to a plain create/rename, so an
+    // overwrite that still succeeds via the parent silently drops the target's
+    // original permissions. Propagate every non-`NotFound` error instead.
+    let existing = match std::fs::metadata(path) {
+        Ok(meta) => Some(meta),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => return Err(format!("write failed: cannot stat target: {err}")),
+    };
     if let Err(err) = write_temp(&temp, content, existing.as_ref()) {
         std::fs::remove_file(&temp).ok();
         return Err(format!("write failed: {err}"));
@@ -269,7 +296,7 @@ impl Tool for EditTool {
 
     fn run<'a>(
         &'a self,
-        _ctx: &'a ToolContext,
+        ctx: &'a ToolContext,
         prepared: &'a PreparedCall,
     ) -> BoxFuture<'a, ToolResult> {
         let PreparedCall::Edit { path, old, new } = prepared else {
@@ -306,7 +333,10 @@ impl Tool for EditTool {
             }
             let updated = text.replacen(old.as_str(), new.as_str(), 1);
             atomic_write(path, updated.as_bytes())?;
-            Ok(format!("edited {}", path.display()))
+            Ok(format!(
+                "edited {}",
+                display_in_workspace(path, &ctx.workspace_root)
+            ))
         })
     }
 }
@@ -368,7 +398,7 @@ impl Tool for WriteTool {
 
     fn run<'a>(
         &'a self,
-        _ctx: &'a ToolContext,
+        ctx: &'a ToolContext,
         prepared: &'a PreparedCall,
     ) -> BoxFuture<'a, ToolResult> {
         let PreparedCall::Write { path, content } = prepared else {
@@ -378,7 +408,7 @@ impl Tool for WriteTool {
             atomic_write(path, content.as_bytes())?;
             Ok(format!(
                 "wrote {} ({} bytes)",
-                path.display(),
+                display_in_workspace(path, &ctx.workspace_root),
                 content.len()
             ))
         })
@@ -584,6 +614,48 @@ mod tests {
     }
 
     // --- write -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn write_result_reports_a_relative_path_not_the_absolute_one() {
+        // The result string is fed back to the model provider next turn, so it must
+        // not leak the absolute path (username + local layout). It should echo the
+        // workspace-relative path the model submitted.
+        let ws = TempWorkspace::new();
+        let ctx = ws.ctx();
+        // The parent must exist for a create.
+        fs::create_dir(ws.root.join("sub")).unwrap();
+        let prepared = WriteTool
+            .prepare(&ctx, &json!({ "path": "sub/note.txt", "content": "hi" }))
+            .unwrap();
+        let msg = WriteTool.run(&ctx, &prepared).await.unwrap();
+        assert!(
+            !msg.contains(ws.root.to_str().unwrap()),
+            "result must not leak the absolute workspace root: {msg}"
+        );
+        assert!(
+            msg.contains("sub") && msg.contains("note.txt"),
+            "result should name the relative path: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_result_reports_a_relative_path_not_the_absolute_one() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("a.txt"), b"hello world\n").unwrap();
+        let ctx = ws.ctx();
+        let prepared = EditTool
+            .prepare(
+                &ctx,
+                &json!({ "path": "a.txt", "old_string": "world", "new_string": "there" }),
+            )
+            .unwrap();
+        let msg = EditTool.run(&ctx, &prepared).await.unwrap();
+        assert!(
+            !msg.contains(ws.root.to_str().unwrap()),
+            "result must not leak the absolute workspace root: {msg}"
+        );
+        assert!(msg.contains("a.txt"), "result should name the file: {msg}");
+    }
 
     #[tokio::test]
     async fn write_creates_a_new_file() {

--- a/crates/pawwork-core/src/tool/edit.rs
+++ b/crates/pawwork-core/src/tool/edit.rs
@@ -544,7 +544,11 @@ mod tests {
                 &json!({ "path": "/etc/hosts", "old_string": "a", "new_string": "b" }),
             )
             .unwrap_err();
-        assert!(err.contains("escapes"), "got: {err}");
+        // unix rejects the escape; windows rejects `\etc\hosts` as unresolvable.
+        assert!(
+            err.contains("escapes") || err.contains("cannot resolve"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/pawwork-core/src/tool/edit.rs
+++ b/crates/pawwork-core/src/tool/edit.rs
@@ -50,11 +50,44 @@ fn atomic_write(path: &Path, content: &[u8]) -> Result<(), String> {
         std::fs::remove_file(&temp).ok();
         return Err(format!("write failed: {err}"));
     }
+    // The rename installs the temp's inode, so the target's permissions would
+    // otherwise be replaced by the temp's umask default — turning a 0755 script
+    // non-executable or widening a 0600 file. Carry the target's mode over first;
+    // a missing target means a create, where the default mode is right.
+    if let Ok(existing) = std::fs::metadata(path) {
+        if let Err(err) = std::fs::set_permissions(&temp, existing.permissions()) {
+            std::fs::remove_file(&temp).ok();
+            return Err(format!("write failed: {err}"));
+        }
+    }
     if let Err(err) = std::fs::rename(&temp, path) {
         std::fs::remove_file(&temp).ok();
         return Err(format!("write failed: {err}"));
     }
     Ok(())
+}
+
+/// Count occurrences of `needle` in `haystack`, **including overlapping ones**,
+/// stopping at 2 (the caller only distinguishes zero / one / many). `str::matches`
+/// counts non-overlapping occurrences only, which would let `aa` in `aaa` pass as
+/// unique when two valid match positions exist — an ambiguous edit slipping the
+/// exactly-once contract. The early stop also bounds the scan: a pathological
+/// self-overlapping needle over an 8 MiB file cannot go quadratic.
+fn count_matches_capped(haystack: &str, needle: &str) -> usize {
+    debug_assert!(!needle.is_empty(), "prepare rejects an empty old_string");
+    let mut count = 0;
+    let mut from = 0;
+    while let Some(found) = haystack[from..].find(needle) {
+        count += 1;
+        if count >= 2 {
+            break;
+        }
+        // Advance by one full character (not one byte) past the match start so
+        // overlapping candidates are seen and the slice stays on a char boundary.
+        let first_char = needle.chars().next().map_or(1, char::len_utf8);
+        from += found + first_char;
+    }
+    count
 }
 
 /// `edit`: replace the single occurrence of `old_string` with `new_string` in a
@@ -153,15 +186,15 @@ impl Tool for EditTool {
             let text = String::from_utf8(bytes).map_err(|_| {
                 "file is not valid UTF-8; edit requires exact text matching".to_string()
             })?;
-            let occurrences = text.matches(old.as_str()).count();
-            match occurrences {
+            match count_matches_capped(&text, old) {
                 0 => return Err("no match: old_string was not found in the file".to_string()),
                 1 => {}
-                many => {
-                    return Err(format!(
-                        "ambiguous edit: old_string appears {many} times; include more \
+                _ => {
+                    return Err(
+                        "ambiguous edit: old_string appears more than once; include more \
                          surrounding context so it matches exactly once"
-                    ))
+                            .to_string(),
+                    )
                 }
             }
             let updated = text.replacen(old.as_str(), new.as_str(), 1);
@@ -326,7 +359,51 @@ mod tests {
             .unwrap();
         let err = EditTool.run(&ctx, &prepared).await.unwrap_err();
         assert!(err.contains("ambiguous"), "got: {err}");
-        assert!(err.contains('3'), "count must be named, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn edit_detects_overlapping_matches_as_ambiguous() {
+        // `str::matches` would count only one non-overlapping `aa` in `aaa`, but
+        // two valid match positions exist — the edit is ambiguous and must fail.
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("a.txt"), b"aaa").unwrap();
+        let ctx = ws.ctx();
+        let prepared = EditTool
+            .prepare(
+                &ctx,
+                &json!({ "path": "a.txt", "old_string": "aa", "new_string": "b" }),
+            )
+            .unwrap();
+        let err = EditTool.run(&ctx, &prepared).await.unwrap_err();
+        assert!(err.contains("ambiguous"), "got: {err}");
+        assert_eq!(
+            fs::read_to_string(ws.root.join("a.txt")).unwrap(),
+            "aaa",
+            "an ambiguous edit must not touch the file"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn edit_preserves_the_target_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let ws = TempWorkspace::new();
+        let script = ws.root.join("run.sh");
+        fs::write(&script, b"echo old").unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+        let ctx = ws.ctx();
+        let prepared = EditTool
+            .prepare(
+                &ctx,
+                &json!({ "path": "run.sh", "old_string": "old", "new_string": "new" }),
+            )
+            .unwrap();
+        EditTool.run(&ctx, &prepared).await.unwrap();
+        let mode = fs::metadata(&script).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o755,
+            "the atomic replacement must keep the target executable"
+        );
     }
 
     #[test]

--- a/crates/pawwork-core/src/tool/edit.rs
+++ b/crates/pawwork-core/src/tool/edit.rs
@@ -36,7 +36,7 @@ fn string_arg<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
 }
 
 /// Write `content` to `path` atomically: stage it in a uniquely-named sibling temp
-/// file in the same directory, then `rename` over the target. `rename` within one
+/// file in the same directory, then swap it over the target. The swap within one
 /// directory is atomic on the platforms we target, so a concurrent reader sees
 /// either the old file or the new one, never a partial write. No `fsync`:
 /// durability across a crash is an explicitly deferred concern. The temp file is
@@ -51,22 +51,83 @@ fn atomic_write(path: &Path, content: &[u8]) -> Result<(), String> {
         std::fs::remove_file(&temp).ok();
         return Err(format!("write failed: {err}"));
     }
-    if let Err(err) = std::fs::rename(&temp, path) {
+    if let Err(err) = commit_replace(&temp, path, existing.is_some()) {
         std::fs::remove_file(&temp).ok();
         return Err(format!("write failed: {err}"));
     }
     Ok(())
 }
 
+/// Swap the staged temp file over the target.
+///
+/// A create (no prior target) has no security descriptor to keep, so a plain
+/// `rename` is correct on every platform. Replacing an *existing* file is where
+/// the platforms diverge: on unix `rename` keeps the inode's permissions the temp
+/// already carries (see [`write_temp`]); on windows `rename` (MoveFileEx) installs
+/// the *temp's* ACL and drops the target's, silently widening access when the
+/// target was more restricted than its parent. `ReplaceFileW` is the call that
+/// preserves the replaced file's ACL and attributes, so windows routes a replace
+/// through it.
+fn commit_replace(temp: &Path, target: &Path, target_existed: bool) -> std::io::Result<()> {
+    #[cfg(windows)]
+    if target_existed {
+        return replace_file_win(temp, target);
+    }
+    #[cfg(not(windows))]
+    let _ = target_existed;
+    std::fs::rename(temp, target)
+}
+
+/// Windows replace that keeps the target's ACL and attributes (`ReplaceFileW`),
+/// unlike `rename`. Only reached when the target already exists.
+#[cfg(windows)]
+fn replace_file_win(temp: &Path, target: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_IGNORE_MERGE_ERRORS};
+
+    fn wide(path: &Path) -> Vec<u16> {
+        path.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+    let replaced = wide(target);
+    let replacement = wide(temp);
+    // Safety: both pointers are valid, null-terminated UTF-16 buffers that live for
+    // the duration of the call; the backup/exclude/reserved params are null per the
+    // API contract. IGNORE_MERGE_ERRORS keeps the replace from failing on a
+    // best-effort metadata merge while still applying the target's security.
+    let ok = unsafe {
+        ReplaceFileW(
+            replaced.as_ptr(),
+            replacement.as_ptr(),
+            std::ptr::null(),
+            REPLACEFILE_IGNORE_MERGE_ERRORS,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
 /// Stage the temp file without ever being more readable than the final target.
 ///
-/// The rename installs the temp's inode, so the target's permissions must be
-/// carried onto the temp or a 0755 script turns non-executable and a 0600 file
-/// widens to the umask default. Order matters for secrecy too: when replacing an
-/// existing file the temp is *created* 0600 (unix) before any content is written,
-/// then tightened/relaxed to the target's exact mode — so there is no window (or
-/// crash residue) in which private content sits in a default-mode temp. A missing
-/// target is a create, where the default umask mode matches the final state.
+/// On unix the swap ([`commit_replace`]) is a `rename` that installs the temp's
+/// inode, so the target's permissions must be carried onto the temp or a 0755
+/// script turns non-executable and a 0600 file widens to the umask default. Order
+/// matters for secrecy too: when replacing an existing file the temp is *created*
+/// 0600 before any content is written, then tightened/relaxed to the target's exact
+/// mode — so there is no window (or crash residue) in which private content sits in
+/// a default-mode temp. A missing target is a create, where the default umask mode
+/// matches the final state.
+///
+/// On windows the temp's permissions are left alone here: the swap goes through
+/// `ReplaceFileW`, which applies the *target's* ACL and attributes to the result,
+/// so copying anything onto the temp would be redundant (and would risk a read-only
+/// temp that the replace could choke on).
 fn write_temp(
     temp: &Path,
     content: &[u8],
@@ -84,9 +145,12 @@ fn write_temp(
     let mut file = options.open(temp)?;
     file.write_all(content)?;
     drop(file);
+    #[cfg(unix)]
     if let Some(metadata) = existing {
         std::fs::set_permissions(temp, metadata.permissions())?;
     }
+    #[cfg(not(unix))]
+    let _ = existing;
     Ok(())
 }
 

--- a/crates/pawwork-core/src/tool/edit.rs
+++ b/crates/pawwork-core/src/tool/edit.rs
@@ -41,6 +41,21 @@ fn string_arg<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
 /// either the old file or the new one, never a partial write. No `fsync`:
 /// durability across a crash is an explicitly deferred concern. The temp file is
 /// removed on any failure so a stray partial write is never left behind.
+///
+/// Known metadata-preservation limits of the stage-then-swap pattern (both marginal
+/// in the M0 single-user, local workspace threat model; fully closing either needs
+/// security-descriptor FFI CI cannot verify on a single-user runner, so they are
+/// tracked, not yet done):
+/// - unix: the classic mode bits (rwx, incl. the executable and 0600 bits) are
+///   carried across, but POSIX *extended* ACLs (`setfacl`) and owner/group identity
+///   are not — the temp is a fresh inode owned by the current user. Editing a file
+///   with an extended ACL, or one owned by another user via group-write, can change
+///   who may read/execute it.
+/// - windows: the *final* file gets the target's ACL (`ReplaceFileW`, fail-closed),
+///   but the staging temp briefly holds the parent directory's inherited ACL while
+///   `write_all` runs. On a multi-user machine another user with directory access
+///   could read that temp mid-write, or find it after a hard crash. Closing this
+///   needs creating the temp with a restrictive/target DACL up front.
 fn atomic_write(path: &Path, content: &[u8]) -> Result<(), String> {
     let parent = path
         .parent()
@@ -83,7 +98,7 @@ fn commit_replace(temp: &Path, target: &Path, target_existed: bool) -> std::io::
 #[cfg(windows)]
 fn replace_file_win(temp: &Path, target: &Path) -> std::io::Result<()> {
     use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_IGNORE_MERGE_ERRORS};
+    use windows_sys::Win32::Storage::FileSystem::ReplaceFileW;
 
     fn wide(path: &Path) -> Vec<u16> {
         path.as_os_str()
@@ -93,16 +108,21 @@ fn replace_file_win(temp: &Path, target: &Path) -> std::io::Result<()> {
     }
     let replaced = wide(target);
     let replacement = wide(temp);
+    // Fail closed: pass zero flags so that if `ReplaceFileW` cannot carry the
+    // target's ACL/attributes onto the result it returns an error instead of
+    // silently keeping the temp's (parent-inherited, possibly broader) ACL. A
+    // failed replace surfaces as "write failed" and the temp is cleaned up — better
+    // than an approved edit quietly widening who can read the file.
+    //
     // Safety: both pointers are valid, null-terminated UTF-16 buffers that live for
     // the duration of the call; the backup/exclude/reserved params are null per the
-    // API contract. IGNORE_MERGE_ERRORS keeps the replace from failing on a
-    // best-effort metadata merge while still applying the target's security.
+    // API contract.
     let ok = unsafe {
         ReplaceFileW(
             replaced.as_ptr(),
             replacement.as_ptr(),
             std::ptr::null(),
-            REPLACEFILE_IGNORE_MERGE_ERRORS,
+            0,
             std::ptr::null(),
             std::ptr::null(),
         )

--- a/crates/pawwork-core/src/tool/fence.rs
+++ b/crates/pawwork-core/src/tool/fence.rs
@@ -58,6 +58,19 @@ pub fn resolve_new_in_workspace(root: &Path, requested: &str) -> Result<PathBuf,
     if requested.trim().is_empty() {
         return Err("empty path".to_string());
     }
+    // A trailing separator (or `/.`) asserts "this is a directory". For a regular
+    // file `exists()` is then false (ENOTDIR), which would fall into the create
+    // branch below — where `file_name()` silently strips the trailing syntax and
+    // collapses `existing.txt/` onto `existing.txt`, overwriting a file the
+    // caller never named. Refuse the syntax outright instead.
+    let trimmed = requested.trim_end();
+    if trimmed.ends_with('/')
+        || trimmed.ends_with('\\')
+        || trimmed.ends_with("/.")
+        || trimmed.ends_with("\\.")
+    {
+        return Err(format!("path '{requested}' does not name a file"));
+    }
     let candidate = root.join(requested);
 
     if candidate.exists() {
@@ -247,6 +260,25 @@ mod tests {
         assert!(
             err.contains("directory") || err.contains("does not name a file"),
             "got: {err}"
+        );
+    }
+
+    #[test]
+    fn trailing_separator_on_a_file_is_rejected() {
+        // `exists.txt/` claims directory semantics; `file_name()` would strip the
+        // slash and collapse onto the real file. It must be refused, not written.
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("exists.txt"), b"keep").unwrap();
+        for requested in ["exists.txt/", "exists.txt/.", "exists.txt\\"] {
+            let err = resolve_new_in_workspace(&ws.root, requested).unwrap_err();
+            assert!(
+                err.contains("does not name a file"),
+                "'{requested}' must be rejected, got: {err}"
+            );
+        }
+        assert_eq!(
+            fs::read_to_string(ws.root.join("exists.txt")).unwrap(),
+            "keep"
         );
     }
 

--- a/crates/pawwork-core/src/tool/fence.rs
+++ b/crates/pawwork-core/src/tool/fence.rs
@@ -165,7 +165,13 @@ mod tests {
     fn rejects_absolute_path_outside() {
         let ws = TempWorkspace::new();
         let err = resolve_in_workspace(&ws.root, "/etc/hosts").unwrap_err();
-        assert!(err.contains("escapes"), "got: {err}");
+        // unix resolves `/etc/hosts` and rejects the escape; windows maps it to a
+        // non-existent `\etc\hosts` on the current drive and rejects it as
+        // unresolvable. Both are refusals, never a success.
+        assert!(
+            err.contains("escapes") || err.contains("cannot resolve"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/pawwork-core/src/tool/fence.rs
+++ b/crates/pawwork-core/src/tool/fence.rs
@@ -98,6 +98,22 @@ pub fn resolve_new_in_workspace(root: &Path, requested: &str) -> Result<PathBuf,
         return Ok(canonical);
     }
 
+    // A dangling symlink (one whose target does not exist) makes `exists()` false
+    // above, so without this guard it would fall through to the create branch and
+    // `atomic_write` would silently `rename` a regular file over the link — deleting
+    // it — while a *live* symlink is instead canonicalized and followed by the branch
+    // above. Detect the link via `symlink_metadata` (which does not follow it) and
+    // reject it, so the two cases stay consistent and this fails closed rather than
+    // clobbering a link the caller never named a file.
+    if candidate
+        .symlink_metadata()
+        .is_ok_and(|meta| meta.file_type().is_symlink())
+    {
+        return Err(format!(
+            "path '{requested}' is a dangling symlink, not a file"
+        ));
+    }
+
     // The create case. `file_name` returns `None` for a path ending in `.` or
     // `..` (and for the root), so a final component that is not a real filename is
     // rejected before we touch the filesystem.
@@ -348,5 +364,25 @@ mod tests {
             "a symlinked parent escaping the root must be rejected, got: {err}"
         );
         fs::remove_dir_all(&outside).ok();
+    }
+
+    #[test]
+    fn dangling_symlink_target_is_rejected() {
+        let ws = TempWorkspace::new();
+        // A symlink inside the workspace whose target does not exist: `exists()` is
+        // false, so without the guard this would be treated as a fresh create and the
+        // subsequent atomic rename would silently clobber the link. It must be
+        // rejected instead.
+        let missing = ws.root.join("nonexistent-target");
+        let link = ws.root.join("dangling.txt");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&missing, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&missing, &link).unwrap();
+        let err = resolve_new_in_workspace(&ws.root, "dangling.txt").unwrap_err();
+        assert!(
+            err.contains("dangling symlink"),
+            "a dangling symlink target must be rejected, got: {err}"
+        );
     }
 }

--- a/crates/pawwork-core/src/tool/fence.rs
+++ b/crates/pawwork-core/src/tool/fence.rs
@@ -41,6 +41,21 @@ pub fn resolve_in_workspace(root: &Path, requested: &str) -> Result<PathBuf, Str
     Ok(canonical)
 }
 
+/// Whether `requested` uses trailing directory syntax — a path separator, or a
+/// final `.` component — that `Path` normalizes away, so `file_name()` would
+/// silently collapse a write target onto its parent. Separators are platform-aware
+/// via `std::path::is_separator` (`/` everywhere, `\` only on Windows), so on the
+/// unix target ordinary filenames ending in a backslash or a dot-space are
+/// preserved rather than wrongly rejected by a blunt string match.
+fn names_a_directory(requested: &str) -> bool {
+    if requested.ends_with(std::path::is_separator) {
+        return true;
+    }
+    // A final `.` that stands as its own component: '.' preceded by a separator.
+    let mut chars = requested.chars();
+    chars.next_back() == Some('.') && chars.next_back().is_some_and(std::path::is_separator)
+}
+
 /// Resolve a `write` target that may not yet exist, returning the canonical path
 /// to write to iff it stays inside the workspace.
 ///
@@ -58,17 +73,14 @@ pub fn resolve_new_in_workspace(root: &Path, requested: &str) -> Result<PathBuf,
     if requested.trim().is_empty() {
         return Err("empty path".to_string());
     }
-    // A trailing separator (or `/.`) asserts "this is a directory". For a regular
-    // file `exists()` is then false (ENOTDIR), which would fall into the create
-    // branch below — where `file_name()` silently strips the trailing syntax and
-    // collapses `existing.txt/` onto `existing.txt`, overwriting a file the
-    // caller never named. Refuse the syntax outright instead.
-    let trimmed = requested.trim_end();
-    if trimmed.ends_with('/')
-        || trimmed.ends_with('\\')
-        || trimmed.ends_with("/.")
-        || trimmed.ends_with("\\.")
-    {
+    // A trailing separator ("existing.txt/") or a trailing "/." both assert "this
+    // is a directory". For a regular file `exists()` is then false (ENOTDIR), so it
+    // falls into the create branch below — where `Path` has already normalized the
+    // trailing syntax away (`components()` drops a final `.`, and a trailing
+    // separator leaves no component of its own), so `file_name()` collapses it back
+    // onto `existing.txt`, overwriting a file the caller never named. Refuse both
+    // forms outright.
+    if names_a_directory(requested) {
         return Err(format!("path '{requested}' does not name a file"));
     }
     let candidate = root.join(requested);
@@ -266,10 +278,13 @@ mod tests {
     #[test]
     fn trailing_separator_on_a_file_is_rejected() {
         // `exists.txt/` claims directory semantics; `file_name()` would strip the
-        // slash and collapse onto the real file. It must be refused, not written.
+        // slash and collapse onto the real file. `exists.txt/.` is caught in the
+        // create branch (`file_name()` returns `None`). Both must be refused, not
+        // written. A trailing backslash is *not* tested here — on unix it is an
+        // ordinary filename byte (see `backslash_is_an_ordinary_filename_byte`).
         let ws = TempWorkspace::new();
         fs::write(ws.root.join("exists.txt"), b"keep").unwrap();
-        for requested in ["exists.txt/", "exists.txt/.", "exists.txt\\"] {
+        for requested in ["exists.txt/", "exists.txt/."] {
             let err = resolve_new_in_workspace(&ws.root, requested).unwrap_err();
             assert!(
                 err.contains("does not name a file"),
@@ -280,6 +295,17 @@ mod tests {
             fs::read_to_string(ws.root.join("exists.txt")).unwrap(),
             "keep"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn backslash_is_an_ordinary_filename_byte() {
+        // On unix `\` is not a path separator, so `report\` names a real (if odd)
+        // new file. It must resolve as a create target, not be rejected as
+        // directory syntax and not collapse onto any existing file.
+        let ws = TempWorkspace::new();
+        let resolved = resolve_new_in_workspace(&ws.root, "report\\").unwrap();
+        assert_eq!(resolved, ws.root.join("report\\"));
     }
 
     #[test]

--- a/crates/pawwork-core/src/tool/fence.rs
+++ b/crates/pawwork-core/src/tool/fence.rs
@@ -11,7 +11,14 @@
 //! component (`Path::starts_with`), never by string prefix — so `/ws-evil` cannot
 //! masquerade as being inside `/ws`. Canonicalization resolves symlinks, so a
 //! symlink pointing outside the root is rejected, and it requires the target to
-//! exist, which is exactly right for the read-only `read`/`list` tools.
+//! exist, which is exactly right for the read-only `read` tool.
+//!
+//! `write` cannot use that resolver: canonicalizing a not-yet-created file fails
+//! (there is nothing to resolve), so [`resolve_new_in_workspace`] fences the
+//! *parent* directory instead and re-attaches a plain filename. Fencing the parent
+//! still resolves a symlinked directory that escapes the workspace, so the safety
+//! property is preserved; only the "target must already exist" precondition is
+//! dropped.
 
 use std::path::{Path, PathBuf};
 
@@ -32,6 +39,59 @@ pub fn resolve_in_workspace(root: &Path, requested: &str) -> Result<PathBuf, Str
         return Err(format!("path '{requested}' escapes the workspace"));
     }
     Ok(canonical)
+}
+
+/// Resolve a `write` target that may not yet exist, returning the canonical path
+/// to write to iff it stays inside the workspace.
+///
+/// Two cases:
+/// - The target **already exists**: canonicalize and fence it like a read, but
+///   require it to be a plain file. Overwriting a file is fine; a directory target
+///   is an error, not a silent no-op.
+/// - The target **does not exist** (the create case): its parent must exist —
+///   intermediate directories are never created here (the model can `mkdir` via
+///   `shell` under confirmation). Canonicalize and fence the *parent*, which
+///   rejects a symlinked parent escaping the workspace, then re-attach the final
+///   component. That component must be a plain filename: empty, `.`, `..`, or a
+///   value carrying a path separator is rejected.
+pub fn resolve_new_in_workspace(root: &Path, requested: &str) -> Result<PathBuf, String> {
+    if requested.trim().is_empty() {
+        return Err("empty path".to_string());
+    }
+    let candidate = root.join(requested);
+
+    if candidate.exists() {
+        let canonical = candidate
+            .canonicalize()
+            .map_err(|err| format!("cannot resolve '{requested}': {err}"))?;
+        if !canonical.starts_with(root) {
+            return Err(format!("path '{requested}' escapes the workspace"));
+        }
+        if !canonical.is_file() {
+            return Err(format!("'{requested}' is a directory, not a file"));
+        }
+        return Ok(canonical);
+    }
+
+    // The create case. `file_name` returns `None` for a path ending in `.` or
+    // `..` (and for the root), so a final component that is not a real filename is
+    // rejected before we touch the filesystem.
+    let file_name = candidate
+        .file_name()
+        .ok_or_else(|| format!("path '{requested}' does not name a file"))?;
+    let parent = candidate
+        .parent()
+        .ok_or_else(|| format!("path '{requested}' has no parent directory"))?;
+    let canonical_parent = parent
+        .canonicalize()
+        .map_err(|err| format!("cannot resolve parent of '{requested}': {err}"))?;
+    if !canonical_parent.starts_with(root) {
+        return Err(format!("path '{requested}' escapes the workspace"));
+    }
+    if !canonical_parent.is_dir() {
+        return Err(format!("parent of '{requested}' is not a directory"));
+    }
+    Ok(canonical_parent.join(file_name))
 }
 
 #[cfg(test)]
@@ -136,5 +196,93 @@ mod tests {
             "sibling prefix must be rejected, got: {err}"
         );
         fs::remove_dir_all(&base).ok();
+    }
+
+    // --- resolve_new_in_workspace (write targets) ------------------------
+
+    #[test]
+    fn new_file_in_root_is_accepted() {
+        let ws = TempWorkspace::new();
+        let resolved = resolve_new_in_workspace(&ws.root, "new.txt").unwrap();
+        assert_eq!(resolved, ws.root.join("new.txt"));
+    }
+
+    #[test]
+    fn new_file_in_existing_subdir_is_accepted() {
+        let ws = TempWorkspace::new();
+        fs::create_dir(ws.root.join("sub")).unwrap();
+        let resolved = resolve_new_in_workspace(&ws.root, "sub/new.txt").unwrap();
+        assert_eq!(resolved, ws.root.join("sub").join("new.txt"));
+    }
+
+    #[test]
+    fn new_file_with_missing_parent_is_rejected() {
+        let ws = TempWorkspace::new();
+        // The resolver must not create intermediate directories.
+        let err = resolve_new_in_workspace(&ws.root, "nodir/new.txt").unwrap_err();
+        assert!(err.contains("cannot resolve parent"), "got: {err}");
+        assert!(
+            !ws.root.join("nodir").exists(),
+            "must not have created a dir"
+        );
+    }
+
+    #[test]
+    fn new_file_with_parent_outside_root_is_rejected() {
+        let ws = TempWorkspace::new();
+        let err = resolve_new_in_workspace(&ws.root, "/etc/pawwork-new-xyz.txt").unwrap_err();
+        assert!(
+            err.contains("escapes") || err.contains("cannot resolve parent"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn new_file_with_dotdot_final_component_is_rejected() {
+        let ws = TempWorkspace::new();
+        fs::create_dir(ws.root.join("sub")).unwrap();
+        // `sub/..` resolves to the (existing) root directory: a directory target,
+        // never a writable file.
+        let err = resolve_new_in_workspace(&ws.root, "sub/..").unwrap_err();
+        assert!(
+            err.contains("directory") || err.contains("does not name a file"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn overwrite_existing_file_is_accepted() {
+        let ws = TempWorkspace::new();
+        fs::write(ws.root.join("exists.txt"), b"old").unwrap();
+        let resolved = resolve_new_in_workspace(&ws.root, "exists.txt").unwrap();
+        assert_eq!(resolved, ws.root.join("exists.txt"));
+    }
+
+    #[test]
+    fn existing_directory_target_is_rejected() {
+        let ws = TempWorkspace::new();
+        fs::create_dir(ws.root.join("adir")).unwrap();
+        let err = resolve_new_in_workspace(&ws.root, "adir").unwrap_err();
+        assert!(err.contains("directory"), "got: {err}");
+    }
+
+    #[test]
+    fn symlinked_parent_escaping_is_rejected() {
+        let ws = TempWorkspace::new();
+        // A directory outside the workspace, reached via a symlink inside it. The
+        // fence must resolve the symlink and reject the escape.
+        let outside = std::env::temp_dir().join(format!("pawwork-outdir-{}", Uuid::new_v4()));
+        fs::create_dir_all(&outside).unwrap();
+        let link = ws.root.join("linkdir");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&outside, &link).unwrap();
+        let err = resolve_new_in_workspace(&ws.root, "linkdir/new.txt").unwrap_err();
+        assert!(
+            err.contains("escapes"),
+            "a symlinked parent escaping the root must be rejected, got: {err}"
+        );
+        fs::remove_dir_all(&outside).ok();
     }
 }

--- a/crates/pawwork-core/src/tool/fs.rs
+++ b/crates/pawwork-core/src/tool/fs.rs
@@ -75,9 +75,14 @@ impl Tool for ReadTool {
     fn prepare(&self, ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String> {
         let requested = path_arg(args)?;
         // `resolve_in_workspace` requires the target to exist, so a genuinely
-        // missing path is rejected here. A file or a directory is accepted; `run`
-        // branches on which.
+        // missing path is rejected here. A regular file or a directory is
+        // accepted; `run` branches on which. Anything else (FIFO, socket, device)
+        // is refused: `read` is auto-allowed and its open is synchronous, so a
+        // FIFO with no writer would block the turn forever.
         let path = resolve_in_workspace(&ctx.workspace_root, requested)?;
+        if !path.is_file() && !path.is_dir() {
+            return Err(format!("'{requested}' is not a regular file or directory"));
+        }
         Ok(PreparedCall::Read { path })
     }
 
@@ -240,5 +245,26 @@ mod tests {
         let ws = TempWorkspace::new();
         let err = ReadTool.prepare(&ws.ctx(), &json!({})).unwrap_err();
         assert!(err.contains("path"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_rejects_a_fifo_at_prepare() {
+        // A FIFO canonicalizes fine, but opening it blocks until a writer shows
+        // up — and `read` is auto-allowed, so that would pin the turn with no
+        // confirmation ever shown. It must be refused before `run`.
+        let ws = TempWorkspace::new();
+        let status = std::process::Command::new("mkfifo")
+            .arg(ws.root.join("pipe"))
+            .status()
+            .expect("mkfifo runs");
+        assert!(status.success(), "mkfifo must succeed");
+        let err = ReadTool
+            .prepare(&ws.ctx(), &json!({ "path": "pipe" }))
+            .unwrap_err();
+        assert!(
+            err.contains("not a regular file or directory"),
+            "got: {err}"
+        );
     }
 }

--- a/crates/pawwork-core/src/tool/fs.rs
+++ b/crates/pawwork-core/src/tool/fs.rs
@@ -1,29 +1,32 @@
-//! Built-in read-only tools: `read` and `list`.
+//! The built-in read tool.
 //!
-//! Both are auto-allowed (no confirmation) and fenced to the workspace. Their
-//! filesystem work is synchronous inside the returned future: the reads are
+//! `read` is auto-allowed (no confirmation) and fenced to the workspace. It reads
+//! a file *or* a directory: pointed at a file it returns the (capped) contents,
+//! pointed at a directory it returns the (capped, sorted) entry names. Folding the
+//! two into one tool matches how the model thinks ("show me this path") and keeps
+//! the surface small; the branch is a cheap `is_dir` check in `run`.
+//!
+//! The filesystem work is synchronous inside the returned future: the reads are
 //! bounded (see the caps below), so for M0 an inline `std::fs` call is simpler
-//! than a `spawn_blocking` hop (which would also force the core to pull a runtime
-//! feature it otherwise avoids). Moving to `spawn_blocking` is a later concern.
+//! than a `spawn_blocking` hop. Moving to `spawn_blocking` is a later concern.
 //!
-//! The caps bound *work*, not just output: `read` reads at most one byte past the
-//! limit instead of slurping a whole file then truncating, and `list` stops
-//! scanning at a ceiling instead of collecting an unbounded directory. A model
-//! pointing at a huge file or directory therefore cannot stall the turn or blow
-//! memory.
+//! The caps bound *work*, not just output: a file read stops one byte past the
+//! limit instead of slurping a whole file then truncating, and a directory scan
+//! stops at a ceiling instead of collecting an unbounded listing. A model pointing
+//! at a huge file or directory therefore cannot stall the turn or blow memory.
 
 use std::io::Read;
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::fence::resolve_in_workspace;
-use super::{BoxFuture, PreparedCall, Tool, ToolContext, ToolResult};
+use super::{BoxFuture, PreparedCall, Tool, ToolContext, ToolResult, MISMATCHED_CALL};
 
-/// Cap on bytes returned by `read`, so a huge file cannot flood the context.
+/// Cap on bytes returned by a file read, so a huge file cannot flood the context.
 const MAX_READ_BYTES: usize = 64 * 1024;
-/// Cap on entries returned by `list`.
+/// Cap on entries returned by a directory read.
 const MAX_LIST_ENTRIES: usize = 1000;
-/// Ceiling on directory entries `list` will scan into memory before it stops and
+/// Ceiling on directory entries a read will scan into memory before it stops and
 /// marks the result truncated. Well above [`MAX_LIST_ENTRIES`] so a normal
 /// directory still sorts correctly, but bounded so a pathological one cannot OOM.
 const MAX_LIST_SCAN: usize = 10_000;
@@ -36,7 +39,8 @@ fn path_arg(args: &Value) -> Result<&str, String> {
         .ok_or_else(|| "missing required string argument 'path'".to_string())
 }
 
-/// `read`: return the (capped) UTF-8 contents of a file inside the workspace.
+/// `read`: return the (capped) contents of a file, or the (capped, sorted) entry
+/// names of a directory, inside the workspace.
 pub struct ReadTool;
 
 impl Tool for ReadTool {
@@ -44,21 +48,44 @@ impl Tool for ReadTool {
         "read"
     }
 
+    fn description(&self) -> &str {
+        "Read a path inside the workspace. Given a file, returns its contents (long \
+         files are truncated). Given a directory, returns its entry names, one per \
+         line, sorted. Errors if the path does not exist."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to a file or directory, relative to the workspace root."
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
     fn requires_confirmation(&self) -> bool {
         false
     }
 
     fn prepare(&self, ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String> {
         let requested = path_arg(args)?;
+        // `resolve_in_workspace` requires the target to exist, so a genuinely
+        // missing path is rejected here. A file or a directory is accepted; `run`
+        // branches on which.
         let path = resolve_in_workspace(&ctx.workspace_root, requested)?;
-        if !path.is_file() {
-            return Err(format!("'{requested}' is not a file"));
-        }
-        Ok(PreparedCall { path })
+        Ok(PreparedCall::Read { path })
     }
 
     fn summarize(&self, prepared: &PreparedCall) -> String {
-        format!("read {}", prepared.path.display())
+        match prepared {
+            PreparedCall::Read { path } => format!("read {}", path.display()),
+            _ => "read".to_string(),
+        }
     }
 
     fn run<'a>(
@@ -66,82 +93,60 @@ impl Tool for ReadTool {
         _ctx: &'a ToolContext,
         prepared: &'a PreparedCall,
     ) -> BoxFuture<'a, ToolResult> {
+        let PreparedCall::Read { path } = prepared else {
+            return Box::pin(async { Err(MISMATCHED_CALL.to_string()) });
+        };
         Box::pin(async move {
-            // Read at most one byte past the cap: enough to know the file was
-            // longer, without pulling a multi-gigabyte file into memory.
-            let file =
-                std::fs::File::open(&prepared.path).map_err(|err| format!("read failed: {err}"))?;
-            let mut bytes = Vec::new();
-            file.take((MAX_READ_BYTES + 1) as u64)
-                .read_to_end(&mut bytes)
-                .map_err(|err| format!("read failed: {err}"))?;
-            let truncated = bytes.len() > MAX_READ_BYTES;
-            bytes.truncate(MAX_READ_BYTES);
-            let mut text = String::from_utf8_lossy(&bytes).into_owned();
-            if truncated {
-                text.push_str("\n… [truncated]");
+            if path.is_dir() {
+                read_directory(path)
+            } else {
+                read_file(path)
             }
-            Ok(text)
         })
     }
 }
 
-/// `list`: return the (capped, sorted) entry names of a directory inside the
-/// workspace.
-pub struct ListTool;
-
-impl Tool for ListTool {
-    fn name(&self) -> &str {
-        "list"
+/// Read at most one byte past the cap: enough to know the file was longer, without
+/// pulling a multi-gigabyte file into memory.
+fn read_file(path: &std::path::Path) -> ToolResult {
+    let file = std::fs::File::open(path).map_err(|err| format!("read failed: {err}"))?;
+    let mut bytes = Vec::new();
+    file.take((MAX_READ_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|err| format!("read failed: {err}"))?;
+    let truncated = bytes.len() > MAX_READ_BYTES;
+    bytes.truncate(MAX_READ_BYTES);
+    let mut text = String::from_utf8_lossy(&bytes).into_owned();
+    if truncated {
+        text.push_str("\n… [truncated]");
     }
+    Ok(text)
+}
 
-    fn requires_confirmation(&self) -> bool {
-        false
-    }
-
-    fn prepare(&self, ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String> {
-        let requested = path_arg(args)?;
-        let path = resolve_in_workspace(&ctx.workspace_root, requested)?;
-        if !path.is_dir() {
-            return Err(format!("'{requested}' is not a directory"));
+/// Scan at most [`MAX_LIST_SCAN`] entries, sort, and return the first
+/// [`MAX_LIST_ENTRIES`], marking the result truncated if either bound was hit.
+fn read_directory(path: &std::path::Path) -> ToolResult {
+    let entries = std::fs::read_dir(path).map_err(|err| format!("read failed: {err}"))?;
+    let mut names = Vec::new();
+    let mut overflowed = false;
+    for entry in entries {
+        if names.len() >= MAX_LIST_SCAN {
+            // Stop scanning a pathological directory; the result is marked
+            // truncated below.
+            overflowed = true;
+            break;
         }
-        Ok(PreparedCall { path })
+        let entry = entry.map_err(|err| format!("read failed: {err}"))?;
+        names.push(entry.file_name().to_string_lossy().into_owned());
     }
-
-    fn summarize(&self, prepared: &PreparedCall) -> String {
-        format!("list {}", prepared.path.display())
+    names.sort();
+    let truncated = overflowed || names.len() > MAX_LIST_ENTRIES;
+    names.truncate(MAX_LIST_ENTRIES);
+    let mut out = names.join("\n");
+    if truncated {
+        out.push_str("\n… [truncated]");
     }
-
-    fn run<'a>(
-        &'a self,
-        _ctx: &'a ToolContext,
-        prepared: &'a PreparedCall,
-    ) -> BoxFuture<'a, ToolResult> {
-        Box::pin(async move {
-            let entries =
-                std::fs::read_dir(&prepared.path).map_err(|err| format!("list failed: {err}"))?;
-            let mut names = Vec::new();
-            let mut overflowed = false;
-            for entry in entries {
-                if names.len() >= MAX_LIST_SCAN {
-                    // Stop scanning a pathological directory; the result is marked
-                    // truncated below.
-                    overflowed = true;
-                    break;
-                }
-                let entry = entry.map_err(|err| format!("list failed: {err}"))?;
-                names.push(entry.file_name().to_string_lossy().into_owned());
-            }
-            names.sort();
-            let truncated = overflowed || names.len() > MAX_LIST_ENTRIES;
-            names.truncate(MAX_LIST_ENTRIES);
-            let mut out = names.join("\n");
-            if truncated {
-                out.push_str("\n… [truncated]");
-            }
-            Ok(out)
-        })
-    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -150,6 +155,7 @@ mod tests {
     use serde_json::json;
     use std::fs;
     use std::path::PathBuf;
+    use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
     struct TempWorkspace {
@@ -167,6 +173,7 @@ mod tests {
         fn ctx(&self) -> ToolContext {
             ToolContext {
                 workspace_root: self.root.clone(),
+                cancel: CancellationToken::new(),
             }
         }
     }
@@ -204,14 +211,28 @@ mod tests {
         );
     }
 
-    #[test]
-    fn read_rejects_directory_at_prepare() {
+    #[tokio::test]
+    async fn read_lists_directory_entries_sorted() {
         let ws = TempWorkspace::new();
-        fs::create_dir(ws.root.join("sub")).unwrap();
+        fs::write(ws.root.join("b.txt"), b"").unwrap();
+        fs::write(ws.root.join("a.txt"), b"").unwrap();
+        fs::create_dir(ws.root.join("c")).unwrap();
+        let ctx = ws.ctx();
+        // read now accepts a directory: it returns the sorted entry names.
+        let prepared = ReadTool.prepare(&ctx, &json!({ "path": "." })).unwrap();
+        let out = ReadTool.run(&ctx, &prepared).await.unwrap();
+        assert_eq!(out, "a.txt\nb.txt\nc");
+    }
+
+    #[test]
+    fn read_rejects_missing_path_target() {
+        let ws = TempWorkspace::new();
+        // A genuinely missing target is still rejected (the resolver requires the
+        // path to exist); only the file-vs-directory distinction was relaxed.
         let err = ReadTool
-            .prepare(&ws.ctx(), &json!({ "path": "sub" }))
+            .prepare(&ws.ctx(), &json!({ "path": "nope.txt" }))
             .unwrap_err();
-        assert!(err.contains("not a file"), "got: {err}");
+        assert!(err.contains("cannot resolve"), "got: {err}");
     }
 
     #[test]
@@ -219,27 +240,5 @@ mod tests {
         let ws = TempWorkspace::new();
         let err = ReadTool.prepare(&ws.ctx(), &json!({})).unwrap_err();
         assert!(err.contains("path"), "got: {err}");
-    }
-
-    #[tokio::test]
-    async fn list_returns_sorted_names() {
-        let ws = TempWorkspace::new();
-        fs::write(ws.root.join("b.txt"), b"").unwrap();
-        fs::write(ws.root.join("a.txt"), b"").unwrap();
-        fs::create_dir(ws.root.join("c")).unwrap();
-        let ctx = ws.ctx();
-        let prepared = ListTool.prepare(&ctx, &json!({ "path": "." })).unwrap();
-        let out = ListTool.run(&ctx, &prepared).await.unwrap();
-        assert_eq!(out, "a.txt\nb.txt\nc");
-    }
-
-    #[test]
-    fn list_rejects_file_at_prepare() {
-        let ws = TempWorkspace::new();
-        fs::write(ws.root.join("f.txt"), b"").unwrap();
-        let err = ListTool
-            .prepare(&ws.ctx(), &json!({ "path": "f.txt" }))
-            .unwrap_err();
-        assert!(err.contains("not a directory"), "got: {err}");
     }
 }

--- a/crates/pawwork-core/src/tool/mod.rs
+++ b/crates/pawwork-core/src/tool/mod.rs
@@ -11,16 +11,26 @@
 //! and only a successful `PreparedCall` can reach `run`. Invalid JSON, an unknown
 //! tool, a missing field, or a path that escapes the workspace all fail at
 //! `prepare`, before any `tool.started` is recorded and before `run` is called.
+//!
+//! [`PreparedCall`] is an enum, one variant per built-in action. The variant *is*
+//! the validated plan: it carries exactly the data `run` needs (a fenced path,
+//! the replacement strings, the command line) and nothing else, so `run` cannot
+//! re-derive a path or re-parse an argument. Only `prepare` mints a variant, and a
+//! tool's `run` handles just its own; a variant it did not mint is an internal
+//! bug, reported as an `Err`, never a panic (the core must not abort a turn).
 
+pub mod edit;
 pub mod fence;
 pub mod fs;
+pub mod shell;
 
 use std::collections::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 
-use serde_json::Value;
+use serde_json::{json, Value};
+use tokio_util::sync::CancellationToken;
 
 /// A boxed, `Send` future — the object-safe return shape for [`Tool::run`].
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -29,33 +39,64 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// to the model as a tool error so it can recover.
 pub type ToolResult = Result<String, String>;
 
+/// The `Err` a tool returns when it is handed a [`PreparedCall`] variant it did
+/// not mint. Unreachable if the runtime is wired correctly (each tool's `prepare`
+/// only produces its own variant), so this is a defensive internal-error string,
+/// never a panic — the loop must survive it and keep the turn alive.
+const MISMATCHED_CALL: &str = "internal: mismatched prepared call";
+
 /// Shared, read-only context handed to every tool invocation.
 ///
-/// PR2 carries only the canonicalized workspace root (the fence anchor). A
-/// cancellation handle for long-running tools (`shell`) is deferred until a tool
-/// that can actually block on it exists.
+/// Carries the canonicalized workspace root (the fence anchor) and a cancellation
+/// handle. The token lets a long-running tool (`shell`) abort promptly when the
+/// turn is interrupted; path-only tools ignore it.
 #[derive(Debug, Clone)]
 pub struct ToolContext {
     pub workspace_root: PathBuf,
+    /// Fired when the turn is cancelled. `shell` selects on it to kill its process
+    /// tree; the fast file tools finish before it could ever matter.
+    pub cancel: CancellationToken,
 }
 
 /// A validated, ready-to-run invocation. Only [`Tool::prepare`] can mint one, so
-/// its existence certifies that arguments parsed and the path is inside the
-/// workspace. PR2's tools all resolve to a single fenced path; this grows fields
-/// (content, argv) when `edit`/`shell` arrive.
+/// its existence certifies that arguments parsed and (for the file tools) the path
+/// is inside the workspace. One variant per built-in action; each carries exactly
+/// what its `run` consumes.
 #[derive(Debug, Clone, PartialEq)]
-pub struct PreparedCall {
-    pub path: PathBuf,
+pub enum PreparedCall {
+    /// `read`: a fenced, existing file or directory to read/list.
+    Read { path: PathBuf },
+    /// `edit`: a fenced, existing file plus the exact substring to replace.
+    Edit {
+        path: PathBuf,
+        old: String,
+        new: String,
+    },
+    /// `write`: a fenced target (new or overwrite) and the bytes to write.
+    Write { path: PathBuf, content: String },
+    /// `shell`: a command line to run under `/bin/sh -c`. Not path-fenced — a
+    /// shell's reach is unbounded, so its boundary is the permission gate.
+    Shell { command: String },
 }
 
 /// One tool the agent can call.
 pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
 
+    /// A one-line, model-facing description of what the tool does, adapted from the
+    /// vendored prompt copy. Fed into the provider's function schema via
+    /// [`ToolRuntime::schemas`].
+    fn description(&self) -> &str;
+
+    /// The JSON Schema for the tool's arguments object (the `parameters` field of
+    /// an OpenAI function definition). An object schema with typed properties and
+    /// a `required` list.
+    fn parameters(&self) -> Value;
+
     /// Whether an invocation must clear the [`PermissionGate`](crate::permission::PermissionGate)
-    /// before running. Read-only tools return `false` (auto-allowed); `edit`/`shell`
-    /// will return `true`. Centralizing the policy here keeps the loop free of
-    /// per-tool-name conditionals.
+    /// before running. Read-only tools return `false` (auto-allowed); the
+    /// write-side tools (`edit`/`write`/`shell`) return `true`. Centralizing the
+    /// policy here keeps the loop free of per-tool-name conditionals.
     fn requires_confirmation(&self) -> bool;
 
     /// Validate arguments and fence paths with no side effects. `Err` rejects the
@@ -87,11 +128,16 @@ impl ToolRuntime {
         ToolRuntime::default()
     }
 
-    /// A runtime with the built-in read-only tools (`read`, `list`).
-    pub fn with_read_only() -> Self {
+    /// A runtime with all built-in tools: the read-only `read` and the write-side
+    /// `edit`, `write`, and `shell`. `shell` runs on the default timeout.
+    pub fn with_builtins() -> Self {
         let mut runtime = ToolRuntime::new();
         runtime.register(Box::new(fs::ReadTool));
-        runtime.register(Box::new(fs::ListTool));
+        runtime.register(Box::new(edit::EditTool));
+        runtime.register(Box::new(edit::WriteTool));
+        runtime.register(Box::new(shell::ShellTool::new(
+            shell::DEFAULT_SHELL_TIMEOUT,
+        )));
         runtime
     }
 
@@ -101,5 +147,31 @@ impl ToolRuntime {
 
     pub fn get(&self, name: &str) -> Option<&dyn Tool> {
         self.tools.get(name).map(|boxed| boxed.as_ref())
+    }
+
+    /// The registered tools as OpenAI function schemas, sorted by name for a
+    /// deterministic request body. This is what the CLI feeds into
+    /// [`crate::openai_compat::RequestConfig::tools`].
+    pub fn schemas(&self) -> Vec<Value> {
+        let mut schemas: Vec<Value> = self
+            .tools
+            .values()
+            .map(|tool| {
+                json!({
+                    "type": "function",
+                    "function": {
+                        "name": tool.name(),
+                        "description": tool.description(),
+                        "parameters": tool.parameters(),
+                    },
+                })
+            })
+            .collect();
+        schemas.sort_by(|left, right| {
+            left["function"]["name"]
+                .as_str()
+                .cmp(&right["function"]["name"].as_str())
+        });
+        schemas
     }
 }

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -209,8 +209,8 @@ async fn run_command(
         }
     };
 
-    let stdout = join_captured(stdout_task, stdout_slot).await;
-    let stderr = join_captured(stderr_task, stderr_slot).await;
+    let (stdout, stderr) =
+        join_captured_pair(stdout_task, stdout_slot, stderr_task, stderr_slot, &cancel).await;
     let stdout_text = render(stdout);
     let stderr_text = render(stderr);
 
@@ -271,19 +271,53 @@ async fn drain_capped<R: AsyncRead + Unpin>(mut reader: R, slot: CaptureSlot) {
     }
 }
 
-/// Await a drain task for at most [`DRAIN_GRACE`], then take the slot's capture.
-/// The child has already exited here, so a drain that is still blocked can only
-/// be waiting on an orphan that inherited the pipe — abandon it (marking the
-/// capture truncated) rather than pin the turn on a process we chose not to kill.
-async fn join_captured(mut task: tokio::task::JoinHandle<()>, slot: CaptureSlot) -> Captured {
-    if tokio::time::timeout(DRAIN_GRACE, &mut task).await.is_err() {
-        task.abort();
-        lock_slot(&slot).truncated = true;
+/// Await both drain tasks concurrently under a single [`DRAIN_GRACE`] budget that
+/// also observes cancellation. The child has already exited here, so a drain still
+/// blocked can only be waiting on an orphan that inherited the pipe — abandon both
+/// (marking each abandoned capture truncated) rather than pin the turn on a process
+/// we chose not to kill, and still honor a Ctrl-C that lands during the wait.
+///
+/// Sharing one budget matters: awaiting the two serially would double the worst
+/// case (each its own grace) and, once `child.wait()` had already won, would stop
+/// observing cancellation entirely.
+async fn join_captured_pair(
+    mut stdout_task: tokio::task::JoinHandle<()>,
+    stdout_slot: CaptureSlot,
+    mut stderr_task: tokio::task::JoinHandle<()>,
+    stderr_slot: CaptureSlot,
+    cancel: &CancellationToken,
+) -> (Captured, Captured) {
+    let both = async {
+        let _ = tokio::join!(&mut stdout_task, &mut stderr_task);
+    };
+    tokio::select! {
+        _ = both => {}
+        _ = tokio::time::sleep(DRAIN_GRACE) => {}
+        _ = cancel.cancelled() => {}
     }
-    let captured = lock_slot(&slot);
+    // A drain that has not finished is abandoned on an orphan pipe; abort it and
+    // mark only that stream truncated, so a clean stream keeps an accurate result.
+    let stdout_abandoned = !stdout_task.is_finished();
+    let stderr_abandoned = !stderr_task.is_finished();
+    if stdout_abandoned {
+        stdout_task.abort();
+    }
+    if stderr_abandoned {
+        stderr_task.abort();
+    }
+    (
+        take_capture(&stdout_slot, stdout_abandoned),
+        take_capture(&stderr_slot, stderr_abandoned),
+    )
+}
+
+/// Clone a slot's capture, OR-ing in an `abandoned` flag from the joiner on top of
+/// any cap-truncation the drain already recorded.
+fn take_capture(slot: &CaptureSlot, abandoned: bool) -> Captured {
+    let captured = lock_slot(slot);
     Captured {
         bytes: captured.bytes.clone(),
-        truncated: captured.truncated,
+        truncated: captured.truncated || abandoned,
     }
 }
 

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -88,13 +88,12 @@ impl Tool for ShellTool {
         #[cfg(windows)]
         {
             "Run one shell command via cmd.exe (cmd /C) in the workspace directory, \
-             using Windows cmd syntax (not POSIX). The console output code page is set \
-             to UTF-8 (chcp 65001) before the command runs. stdin is closed and \
-             stdout/stderr are captured (truncated if large) and returned. Use it for \
-             terminal operations like git, build, and test commands, not for reading, \
-             writing, or listing files (use read/write/edit). A non-zero exit is \
-             returned as an error including the captured output; the command runs to a \
-             timeout and requires confirmation."
+             using Windows cmd syntax (not POSIX). stdin is closed and stdout/stderr \
+             are captured (truncated if large) and returned. Use it for terminal \
+             operations like git, build, and test commands, not for reading, writing, \
+             or listing files (use read/write/edit). A non-zero exit is returned as \
+             an error including the captured output; the command runs to a timeout \
+             and requires confirmation."
         }
     }
 
@@ -212,7 +211,7 @@ async fn run_command(
         );
     }
     // Pick the platform shell: unix runs `/bin/sh -c <command>`, windows runs
-    // `cmd /D /S /C "chcp 65001>nul & <command>"` (see the windows branch below).
+    // `cmd /D /S /C "<command>"` (verbatim, see the windows branch below).
     #[cfg(unix)]
     let mut builder = {
         let mut builder = Command::new("/bin/sh");
@@ -230,21 +229,18 @@ async fn run_command(
         // *different* command than the approved `PreparedCall` (e.g. a
         // `git commit -m "msg"`). `raw_arg` appends without escaping; `/S` makes cmd
         // strip exactly the outer quotes and run the remainder literally, so the
-        // approved command line is what actually executes. `/D` disables execution
-        // of the `Command Processor\AutoRun` registry value, which `cmd` would
-        // otherwise run *before* the approved command — a side effect absent from the
-        // `PreparedCall` the user approved, defeating the exact-command guarantee.
+        // approved command line — and nothing else — is what actually executes. `/D`
+        // disables execution of the `Command Processor\AutoRun` registry value, which
+        // `cmd` would otherwise run *before* the approved command — a side effect
+        // absent from the `PreparedCall` the user approved, defeating the exact-command
+        // guarantee.
         //
-        // `chcp 65001>nul &` normalizes the *output* encoding to UTF-8 up front. One
-        // redirected pipe otherwise carries two encodings with no in-band marker —
-        // cmd built-ins emit the OEM code page (e.g. GBK), modern tools emit UTF-8 —
-        // and no decode-side heuristic can tell them apart (GBK `一` is bytes D2 BB,
-        // which is *also* valid UTF-8). Forcing the console output code page to 65001
-        // makes every writer emit UTF-8, so the capture decodes unambiguously. The
-        // `>nul` swallows chcp's own "Active code page" line; `&` (not `&&`) still runs
-        // the command even on the rare host where chcp fails. This is a deterministic,
-        // disclosed prefix (see `description`), not a hidden extra action.
-        builder.raw_arg(format!("/D /S /C \"chcp 65001>nul & {command}\""));
+        // No encoding-normalization prefix (e.g. `chcp 65001`) is injected here: it
+        // would run a command the permission gate never approved *and* persistently
+        // mutate the shared console's code page. Output is instead decoded lossily as
+        // UTF-8 (see `render`); the residual mojibake for non-ASCII output under a
+        // legacy console code page is a documented limitation.
+        builder.raw_arg(format!("/D /S /C \"{command}\""));
         builder
     };
     builder
@@ -409,10 +405,14 @@ fn take_capture(slot: &CaptureSlot, abandoned: bool) -> Captured {
 }
 
 fn render(stream: Captured) -> String {
-    // Output is UTF-8 on every target: unix by convention, and windows because the
-    // shell is launched with `chcp 65001` forcing the console output code page to
-    // UTF-8 (see the windows builder branch). A lossy decode degrades a stray invalid
-    // byte to U+FFFD rather than dropping the whole result.
+    // Decode as UTF-8, lossily. On unix output is UTF-8 by convention. On windows a
+    // console using a legacy code page (e.g. GBK) emits non-UTF-8 bytes for non-ASCII
+    // cmd built-in output, which degrade to U+FFFD here — a documented limitation:
+    // the fully-correct fix (a UTF-8 pseudo-console / ConPTY) is deferred, since the
+    // lighter alternatives are worse (a decode-side heuristic cannot disambiguate
+    // GBK from UTF-8, and injecting `chcp` both escapes the approved action and
+    // persistently mutates the user's console code page). ASCII — the overwhelmingly
+    // common case for command output — is unaffected either way.
     let mut text = String::from_utf8_lossy(&stream.bytes).into_owned();
     if stream.truncated {
         text.push_str("\n… [truncated]");

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -184,7 +184,7 @@ async fn run_command(
     timeout: Duration,
 ) -> ToolResult {
     // Pick the platform shell: unix runs `/bin/sh -c <command>`, windows runs
-    // `cmd /S /C "<command>"` (verbatim, see the windows branch below).
+    // `cmd /D /S /C "<command>"` (verbatim, see the windows branch below).
     #[cfg(unix)]
     let mut builder = {
         let mut builder = Command::new("/bin/sh");
@@ -202,8 +202,11 @@ async fn run_command(
         // *different* command than the approved `PreparedCall` (e.g. a
         // `git commit -m "msg"`). `raw_arg` appends without escaping; `/S` makes cmd
         // strip exactly the outer quotes and run the remainder literally, so the
-        // approved command line is what actually executes.
-        builder.raw_arg(format!("/S /C \"{command}\""));
+        // approved command line is what actually executes. `/D` disables execution
+        // of the `Command Processor\AutoRun` registry value, which `cmd` would
+        // otherwise run *before* the approved command — a side effect absent from the
+        // `PreparedCall` the user approved, defeating the exact-command guarantee.
+        builder.raw_arg(format!("/D /S /C \"{command}\""));
         builder
     };
     builder

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -177,12 +177,36 @@ fn lock_slot(slot: &CaptureSlot) -> std::sync::MutexGuard<'_, Captured> {
     slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Whether `path` is a UNC path (`\\server\share\...` or its verbatim form).
+/// `cmd.exe` cannot use a UNC path as its working directory.
+#[cfg(windows)]
+fn is_unc_path(path: &std::path::Path) -> bool {
+    use std::path::{Component, Prefix};
+    matches!(
+        path.components().next(),
+        Some(Component::Prefix(p)) if matches!(p.kind(), Prefix::UNC(..) | Prefix::VerbatimUNC(..))
+    )
+}
+
 async fn run_command(
     command: String,
     workspace_root: std::path::PathBuf,
     cancel: CancellationToken,
     timeout: Duration,
 ) -> ToolResult {
+    // `cmd.exe` cannot use a UNC path as its current directory: handed one it prints
+    // a warning and silently falls back to the Windows directory, so a `current_dir`
+    // set to a UNC workspace is ignored and an approved relative-path command would
+    // execute *outside* the workspace, defeating the fence. Refuse to spawn rather
+    // than run in the wrong place.
+    #[cfg(windows)]
+    if is_unc_path(&workspace_root) {
+        return Err(format!(
+            "cannot run shell command: workspace root '{}' is a UNC path, which cmd.exe \
+             cannot use as a working directory",
+            workspace_root.display()
+        ));
+    }
     // Pick the platform shell: unix runs `/bin/sh -c <command>`, windows runs
     // `cmd /D /S /C "<command>"` (verbatim, see the windows branch below).
     #[cfg(unix)]

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -193,7 +193,8 @@ async fn run_command(
     };
     #[cfg(windows)]
     let mut builder = {
-        use std::os::windows::process::CommandExt;
+        // `raw_arg` is inherent on tokio's `Command` (no std `CommandExt` import
+        // needed): append the command line verbatim, bypassing the default escaping.
         let mut builder = Command::new("cmd");
         // Hand the command line to cmd verbatim. Rust's normal `.arg()` escaping
         // targets CommandLineToArgvW, but `cmd /C` parses by different rules, so

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -88,12 +88,13 @@ impl Tool for ShellTool {
         #[cfg(windows)]
         {
             "Run one shell command via cmd.exe (cmd /C) in the workspace directory, \
-             using Windows cmd syntax (not POSIX). stdin is closed and stdout/stderr \
-             are captured (truncated if large) and returned. Use it for terminal \
-             operations like git, build, and test commands, not for reading, writing, \
-             or listing files (use read/write/edit). A non-zero exit is returned as \
-             an error including the captured output; the command runs to a timeout \
-             and requires confirmation."
+             using Windows cmd syntax (not POSIX). The console output code page is set \
+             to UTF-8 (chcp 65001) before the command runs. stdin is closed and \
+             stdout/stderr are captured (truncated if large) and returned. Use it for \
+             terminal operations like git, build, and test commands, not for reading, \
+             writing, or listing files (use read/write/edit). A non-zero exit is \
+             returned as an error including the captured output; the command runs to a \
+             timeout and requires confirmation."
         }
     }
 
@@ -201,14 +202,17 @@ async fn run_command(
     // than run in the wrong place.
     #[cfg(windows)]
     if is_unc_path(&workspace_root) {
-        return Err(format!(
-            "cannot run shell command: workspace root '{}' is a UNC path, which cmd.exe \
-             cannot use as a working directory",
-            workspace_root.display()
-        ));
+        // Path-free on purpose: this error is fed back to the model as a tool result
+        // and sent to the provider next turn, so echoing the canonical UNC root would
+        // leak the server/share layout (same reason edit/write return relative paths).
+        return Err(
+            "cannot run shell command: the workspace root is a UNC path, which cmd.exe \
+             cannot use as a working directory"
+                .to_string(),
+        );
     }
     // Pick the platform shell: unix runs `/bin/sh -c <command>`, windows runs
-    // `cmd /D /S /C "<command>"` (verbatim, see the windows branch below).
+    // `cmd /D /S /C "chcp 65001>nul & <command>"` (see the windows branch below).
     #[cfg(unix)]
     let mut builder = {
         let mut builder = Command::new("/bin/sh");
@@ -230,7 +234,17 @@ async fn run_command(
         // of the `Command Processor\AutoRun` registry value, which `cmd` would
         // otherwise run *before* the approved command — a side effect absent from the
         // `PreparedCall` the user approved, defeating the exact-command guarantee.
-        builder.raw_arg(format!("/D /S /C \"{command}\""));
+        //
+        // `chcp 65001>nul &` normalizes the *output* encoding to UTF-8 up front. One
+        // redirected pipe otherwise carries two encodings with no in-band marker —
+        // cmd built-ins emit the OEM code page (e.g. GBK), modern tools emit UTF-8 —
+        // and no decode-side heuristic can tell them apart (GBK `一` is bytes D2 BB,
+        // which is *also* valid UTF-8). Forcing the console output code page to 65001
+        // makes every writer emit UTF-8, so the capture decodes unambiguously. The
+        // `>nul` swallows chcp's own "Active code page" line; `&` (not `&&`) still runs
+        // the command even on the rare host where chcp fails. This is a deterministic,
+        // disclosed prefix (see `description`), not a hidden extra action.
+        builder.raw_arg(format!("/D /S /C \"chcp 65001>nul & {command}\""));
         builder
     };
     builder
@@ -365,16 +379,19 @@ async fn join_captured_pair(
         _ = tokio::time::sleep(DRAIN_GRACE) => {}
         _ = cancel.cancelled() => {}
     }
-    // A drain that has not finished is abandoned on an orphan pipe; abort it and
-    // mark only that stream truncated, so a clean stream keeps an accurate result.
+    // A drain that has not finished is still blocked reading a pipe a background
+    // survivor (the child exited but left a descendant holding the write end) keeps
+    // open. Mark that stream truncated so a clean stream keeps an accurate result —
+    // but do NOT abort the drain: aborting drops the read end, and the next time the
+    // survivor writes to stdout/stderr it takes `EPIPE`/`SIGPIPE` and can die, killing
+    // the very background job this normal-exit path means to leave running. Instead
+    // detach the drain (drop its handle without awaiting): it keeps consuming and
+    // discarding the pipe until the survivor finally closes it, so it neither pins the
+    // turn nor severs the pipe. The capture snapshot is already taken below.
     let stdout_abandoned = !stdout_task.is_finished();
     let stderr_abandoned = !stderr_task.is_finished();
-    if stdout_abandoned {
-        stdout_task.abort();
-    }
-    if stderr_abandoned {
-        stderr_task.abort();
-    }
+    drop(stdout_task);
+    drop(stderr_task);
     (
         take_capture(&stdout_slot, stdout_abandoned),
         take_capture(&stderr_slot, stderr_abandoned),
@@ -392,82 +409,15 @@ fn take_capture(slot: &CaptureSlot, abandoned: bool) -> Captured {
 }
 
 fn render(stream: Captured) -> String {
-    let mut text = decode_output(&stream.bytes);
+    // Output is UTF-8 on every target: unix by convention, and windows because the
+    // shell is launched with `chcp 65001` forcing the console output code page to
+    // UTF-8 (see the windows builder branch). A lossy decode degrades a stray invalid
+    // byte to U+FFFD rather than dropping the whole result.
+    let mut text = String::from_utf8_lossy(&stream.bytes).into_owned();
     if stream.truncated {
         text.push_str("\n… [truncated]");
     }
     text
-}
-
-/// Decode captured child output to text. Unix streams are UTF-8 by convention, so a
-/// lossy decode is exactly right.
-#[cfg(not(windows))]
-fn decode_output(bytes: &[u8]) -> String {
-    String::from_utf8_lossy(bytes).into_owned()
-}
-
-/// Decode captured child output on Windows, where one pipe can carry two encodings
-/// with no in-band marker: `cmd` built-ins (`echo`, `dir`) emit the OEM console code
-/// page (e.g. 936/932/437), while modern tools (`git`, `node`) emit UTF-8.
-///
-/// Auto-detect by trying UTF-8 first — it is self-validating, so a legacy-code-page
-/// run of non-ASCII bytes almost never forms a valid multi-byte UTF-8 sequence.
-/// Bytes that are valid UTF-8 (or valid except for an incomplete final char left by
-/// the output cap) are taken as UTF-8; anything with a genuine mid-stream invalid
-/// byte is decoded via the OEM code page. Pure ASCII is identical under both, so the
-/// common case is lossless regardless of which branch runs.
-#[cfg(windows)]
-fn decode_output(bytes: &[u8]) -> String {
-    match std::str::from_utf8(bytes) {
-        Ok(text) => text.to_string(),
-        // `error_len() == None` means the only fault is an incomplete multi-byte char
-        // at the very end — i.e. UTF-8 truncated at the byte cap. The prefix is valid
-        // UTF-8, so keep decoding it as such rather than misfiring the OEM path.
-        Err(err) if err.error_len().is_none() => String::from_utf8_lossy(bytes).into_owned(),
-        Err(_) => decode_oem_codepage(bytes),
-    }
-}
-
-/// Decode bytes using the system OEM code page (`GetOEMCP` + `MultiByteToWideChar`),
-/// the encoding `cmd`'s built-in commands write to a redirected pipe. Falls back to
-/// UTF-8 lossy if the conversion is unavailable, so output is never dropped.
-#[cfg(windows)]
-fn decode_oem_codepage(bytes: &[u8]) -> String {
-    use windows_sys::Win32::Globalization::{GetOEMCP, MultiByteToWideChar};
-
-    if bytes.is_empty() {
-        return String::new();
-    }
-    // The API is `i32`-bounded; the output cap keeps `bytes` far below `i32::MAX`, but
-    // clamp defensively so a hypothetical oversized buffer can never wrap negative.
-    let len = bytes.len().min(i32::MAX as usize) as i32;
-    // Safety: `GetOEMCP` takes no arguments and returns the active OEM code page id.
-    let code_page = unsafe { GetOEMCP() };
-    // Safety: first call with a null output buffer and zero length asks only for the
-    // required wide-char count; `bytes`/`len` describe a valid readable range.
-    let wide_len =
-        unsafe { MultiByteToWideChar(code_page, 0, bytes.as_ptr(), len, std::ptr::null_mut(), 0) };
-    if wide_len <= 0 {
-        return String::from_utf8_lossy(bytes).into_owned();
-    }
-    let mut wide = vec![0u16; wide_len as usize];
-    // Safety: `wide` has exactly `wide_len` slots, matching the length passed here;
-    // the input range is the same one measured above.
-    let written = unsafe {
-        MultiByteToWideChar(
-            code_page,
-            0,
-            bytes.as_ptr(),
-            len,
-            wide.as_mut_ptr(),
-            wide_len,
-        )
-    };
-    if written <= 0 {
-        return String::from_utf8_lossy(bytes).into_owned();
-    }
-    wide.truncate(written as usize);
-    String::from_utf16_lossy(&wide)
 }
 
 /// Best-effort kill of the whole process tree. On unix, `SIGKILL` the negative
@@ -685,24 +635,54 @@ mod tests {
         );
     }
 
-    #[test]
-    fn decode_output_passes_through_valid_utf8() {
-        // The UTF-8 branch must be taken for valid UTF-8 on every platform (git/node
-        // output on Windows, all output on unix), leaving multi-byte text intact.
-        let bytes = "café — 日本語".as_bytes();
-        assert_eq!(decode_output(bytes), "café — 日本語");
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn background_writer_survives_the_turn_ending() {
+        // A survivor that writes to stdout *after* the foreground command returns must
+        // not be killed by the drain being torn down. If the drain were aborted, that
+        // write would hit a closed pipe (EPIPE/SIGPIPE) and the subshell would die
+        // before the sentinel; detaching the drain keeps the pipe consumed so the
+        // write succeeds. The existing `sleep`-based survivor test never writes, so it
+        // cannot catch this. DRAIN_GRACE is 2s, so the survivor sleeps past it (3s) to
+        // guarantee it still holds the pipe when the drain is abandoned.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let sentinel = std::env::temp_dir().join(format!("pawwork-shell-survivor-{nanos}"));
+        std::fs::remove_file(&sentinel).ok();
+        let script = format!(
+            "( sleep 3; echo late-output; echo ok > '{}' ) & echo fg",
+            sentinel.display()
+        );
+        let tool = ShellTool::new(Duration::from_secs(30));
+        let out = tool.run(&ctx(), &prepared(&script)).await.unwrap();
+        assert!(out.contains("fg"), "foreground output expected, got: {out}");
+        // The survivor wakes at ~3s and writes the sentinel; poll generously past that.
+        let mut found = false;
+        for _ in 0..40 {
+            if sentinel.exists() {
+                found = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+        std::fs::remove_file(&sentinel).ok();
+        assert!(
+            found,
+            "a background writer must survive writing to stdout after the turn ends"
+        );
     }
 
-    #[cfg(windows)]
     #[test]
-    fn decode_output_recovers_non_utf8_via_oem_codepage() {
-        // A genuine mid-stream invalid-UTF-8 byte routes through the OEM code page
-        // instead of being lost to U+FFFD. The exact glyph depends on the runner's
-        // code page, so assert only that it does not panic and yields non-empty text.
-        let decoded = decode_output(&[0x48, 0x69, 0x81, 0x40]); // "Hi" + a high-byte pair
-        assert!(
-            !decoded.is_empty(),
-            "OEM decode must not drop the stream: {decoded:?}"
-        );
+    fn render_decodes_utf8_output() {
+        // Output is UTF-8 on every target (unix by convention; windows via the
+        // chcp-65001 normalization), so multi-byte text must survive intact.
+        let captured = Captured {
+            bytes: "café — 日本語".as_bytes().to_vec(),
+            truncated: false,
+        };
+        assert_eq!(render(captured), "café — 日本語");
     }
 }

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -26,6 +26,7 @@
 //!   the pid tree, and both then also call `child.kill()` as a fallback; on other
 //!   platforms only `child.kill()` is available.
 
+use std::collections::VecDeque;
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -45,6 +46,14 @@ pub const DEFAULT_SHELL_TIMEOUT: Duration = Duration::from_secs(120);
 /// Per-stream capture cap. Enough context for the model to act on, bounded so a
 /// flood of output cannot blow memory or the model's context window.
 const MAX_SHELL_CAPTURE: usize = 32 * 1024;
+
+/// When output exceeds [`MAX_SHELL_CAPTURE`], keep this much of the head and the rest
+/// as a rolling tail, so both the command's opening context *and* its final, usually
+/// most actionable output (a test runner's last failure) survive — instead of keeping
+/// only the head and discarding the ending. `CAPTURE_HEAD + CAPTURE_TAIL` equals the
+/// cap, so the retained bytes never exceed it.
+const CAPTURE_HEAD: usize = 24 * 1024;
+const CAPTURE_TAIL: usize = MAX_SHELL_CAPTURE - CAPTURE_HEAD;
 
 /// How long after the child exits the drain may keep waiting for pipe EOF.
 /// Normally EOF is immediate; the grace only elapses when a backgrounded
@@ -153,11 +162,15 @@ impl Tool for ShellTool {
     }
 }
 
-/// What a single output stream captured, and whether it was cut off (at the cap,
-/// or by abandoning a drain whose pipe an orphan kept open).
+/// What a single output stream captured. When output exceeds the cap the `head` holds
+/// the first [`CAPTURE_HEAD`] bytes and `tail` the last [`CAPTURE_TAIL`], with
+/// `dropped` counting the bytes discarded between them. `abandoned` marks a drain cut
+/// off because an orphan kept the pipe open past the grace.
 struct Captured {
-    bytes: Vec<u8>,
-    truncated: bool,
+    head: Vec<u8>,
+    tail: VecDeque<u8>,
+    dropped: usize,
+    abandoned: bool,
 }
 
 /// A capture buffer shared between the drain task and the joiner, so an abandoned
@@ -166,8 +179,10 @@ type CaptureSlot = Arc<Mutex<Captured>>;
 
 fn capture_slot() -> CaptureSlot {
     Arc::new(Mutex::new(Captured {
-        bytes: Vec::new(),
-        truncated: false,
+        head: Vec::new(),
+        tail: VecDeque::new(),
+        dropped: 0,
+        abandoned: false,
     }))
 }
 
@@ -253,6 +268,14 @@ async fn run_command(
     // there goes through `taskkill /T` by pid (see `kill_tree`), so nothing to set.
     #[cfg(unix)]
     builder.process_group(0);
+    // On windows, cmd (and CreateProcess) search the *current directory* for an
+    // executable before `PATH` by default. Since the current directory is the
+    // workspace, a repo that plants `git.exe`/`git.cmd` there would run on an approved
+    // `git status` — repository-controlled code from a benign-looking command. Setting
+    // this environment variable disables the implicit current-directory lookup while
+    // still honoring an explicit `.\tool.exe`.
+    #[cfg(windows)]
+    builder.env("NoDefaultCurrentDirectoryInExePath", "1");
 
     let mut child = builder
         .spawn()
@@ -283,9 +306,17 @@ async fn run_command(
         }
         _ = tokio::time::sleep(timeout) => {
             kill_tree(&mut child, pid).await;
+            // A timeout is a recoverable tool error: include whatever the command
+            // emitted before it stalled, which often shows *why* it hung. Snapshot the
+            // captures before aborting the drains.
+            let stdout = take_capture(&stdout_slot, !stdout_task.is_finished());
+            let stderr = take_capture(&stderr_slot, !stderr_task.is_finished());
             stdout_task.abort();
             stderr_task.abort();
-            return Err(format!("command timed out after {}s", timeout.as_secs()));
+            let mut out = format!("command timed out after {}s", timeout.as_secs());
+            push_stream(&mut out, "stdout", &render(stdout));
+            push_stream(&mut out, "stderr", &render(stderr));
+            return Err(out);
         }
     };
 
@@ -298,10 +329,7 @@ async fn run_command(
         // Exit 0: return stdout, appending a labelled stderr only if the command
         // wrote to it (warnings, progress).
         let mut out = stdout_text;
-        if !stderr_text.is_empty() {
-            out.push_str("\n[stderr]\n");
-            out.push_str(&stderr_text);
-        }
+        push_stream(&mut out, "stderr", &stderr_text);
         Ok(out)
     } else {
         // Non-zero exit is a recoverable tool error: the model sees the code and
@@ -311,22 +339,27 @@ async fn run_command(
             .map(|code| code.to_string())
             .unwrap_or_else(|| "terminated by signal".to_string());
         let mut out = format!("command exited with status {code}");
-        if !stdout_text.is_empty() {
-            out.push_str("\n[stdout]\n");
-            out.push_str(&stdout_text);
-        }
-        if !stderr_text.is_empty() {
-            out.push_str("\n[stderr]\n");
-            out.push_str(&stderr_text);
-        }
+        push_stream(&mut out, "stdout", &stdout_text);
+        push_stream(&mut out, "stderr", &stderr_text);
         Err(out)
     }
 }
 
-/// Read a stream to EOF into the shared slot, keeping at most
-/// [`MAX_SHELL_CAPTURE`] bytes but always draining the rest (so the child never
-/// blocks on a full pipe). Writes into the slot incrementally so an abandoned
-/// drain still leaves its capture behind.
+/// Append a labelled, non-empty stream section (`\n[label]\n<text>`) to a result or
+/// error message. No-op for an empty stream, so a silent stream adds no noise.
+fn push_stream(out: &mut String, label: &str, text: &str) {
+    if !text.is_empty() {
+        out.push_str("\n[");
+        out.push_str(label);
+        out.push_str("]\n");
+        out.push_str(text);
+    }
+}
+
+/// Read a stream to EOF into the shared slot, keeping the first [`CAPTURE_HEAD`]
+/// bytes and the last [`CAPTURE_TAIL`] (a rolling window), but always draining the
+/// rest (so the child never blocks on a full pipe). Writes into the slot
+/// incrementally so an abandoned drain still leaves its capture behind.
 async fn drain_capped<R: AsyncRead + Unpin>(mut reader: R, slot: CaptureSlot) {
     let mut buf = [0u8; 8192];
     loop {
@@ -334,16 +367,21 @@ async fn drain_capped<R: AsyncRead + Unpin>(mut reader: R, slot: CaptureSlot) {
             Ok(0) => break,
             Ok(read) => {
                 let mut captured = lock_slot(&slot);
-                if captured.bytes.len() < MAX_SHELL_CAPTURE {
-                    let room = MAX_SHELL_CAPTURE - captured.bytes.len();
-                    let take = room.min(read);
-                    captured.bytes.extend_from_slice(&buf[..take]);
-                    if take < read {
-                        captured.truncated = true;
+                let mut data = &buf[..read];
+                // Fill the head first.
+                if captured.head.len() < CAPTURE_HEAD {
+                    let take = (CAPTURE_HEAD - captured.head.len()).min(data.len());
+                    captured.head.extend_from_slice(&data[..take]);
+                    data = &data[take..];
+                }
+                // Everything past the head rolls through the bounded tail window; a
+                // byte pushed out of it is counted as dropped from the middle.
+                for &byte in data {
+                    if captured.tail.len() == CAPTURE_TAIL {
+                        captured.tail.pop_front();
+                        captured.dropped += 1;
                     }
-                } else {
-                    // Past the cap: discard, but keep reading to drain the pipe.
-                    captured.truncated = true;
+                    captured.tail.push_back(byte);
                 }
             }
             Err(_) => break,
@@ -395,29 +433,110 @@ async fn join_captured_pair(
 }
 
 /// Clone a slot's capture, OR-ing in an `abandoned` flag from the joiner on top of
-/// any cap-truncation the drain already recorded.
+/// whatever the drain already recorded.
 fn take_capture(slot: &CaptureSlot, abandoned: bool) -> Captured {
     let captured = lock_slot(slot);
     Captured {
-        bytes: captured.bytes.clone(),
-        truncated: captured.truncated || abandoned,
+        head: captured.head.clone(),
+        tail: captured.tail.clone(),
+        dropped: captured.dropped,
+        abandoned: captured.abandoned || abandoned,
     }
 }
 
 fn render(stream: Captured) -> String {
-    // Decode as UTF-8, lossily. On unix output is UTF-8 by convention. On windows a
-    // console using a legacy code page (e.g. GBK) emits non-UTF-8 bytes for non-ASCII
-    // cmd built-in output, which degrade to U+FFFD here — a documented limitation:
-    // the fully-correct fix (a UTF-8 pseudo-console / ConPTY) is deferred, since the
-    // lighter alternatives are worse (a decode-side heuristic cannot disambiguate
-    // GBK from UTF-8, and injecting `chcp` both escapes the approved action and
-    // persistently mutates the user's console code page). ASCII — the overwhelmingly
-    // common case for command output — is unaffected either way.
-    let mut text = String::from_utf8_lossy(&stream.bytes).into_owned();
-    if stream.truncated {
+    let tail: Vec<u8> = stream.tail.into_iter().collect();
+    let mut text = if stream.dropped == 0 {
+        // Nothing dropped: head and tail are contiguous, so decode them as one buffer
+        // (a multi-byte char spanning the boundary is not split).
+        let mut all = stream.head;
+        all.extend_from_slice(&tail);
+        decode_output(&all)
+    } else {
+        // Head … omitted-middle marker … tail, so the actionable end survives.
+        let mut out = decode_output(&stream.head);
+        out.push_str(&format!("\n… [{} bytes omitted] …\n", stream.dropped));
+        out.push_str(&decode_output(&tail));
+        out
+    };
+    if stream.abandoned {
         text.push_str("\n… [truncated]");
     }
     text
+}
+
+/// Decode captured child output to text. Unix streams are UTF-8 by convention, so a
+/// lossy decode is exactly right.
+#[cfg(not(windows))]
+fn decode_output(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+/// Decode captured child output on Windows using the code page the shell actually
+/// wrote it in, rather than blindly assuming UTF-8.
+///
+/// `cmd`'s built-in commands (`echo`, `dir`) encode their output in the console
+/// *output* code page — the value `GetConsoleOutputCP` reports — which on a legacy
+/// system is an OEM page like 936 (GBK) or 932 (Shift-JIS), not UTF-8. Decoding those
+/// bytes as UTF-8 turns every non-ASCII character into U+FFFD. This asks the system
+/// which code page the child used and decodes with it, so the common case (a CLI's
+/// console at its real code page) is correct.
+///
+/// This is not a guess: it reads the authoritative code page the writer used, unlike
+/// the discarded "assume UTF-8, fall back on invalid bytes" heuristic (which a short
+/// GBK run like `一` = `D2 BB` defeats, since those bytes are *also* valid UTF-8).
+/// The one residual: a program that emits UTF-8 regardless of the console (rare — e.g.
+/// `git` with `core.quotepath=false`; `git` defaults to ASCII-escaping) is misread on
+/// a non-UTF-8 console. Fully removing even that needs a UTF-8 pseudo-console (ConPTY)
+/// and is deferred; this stays side-effect-free and never touches the approved command.
+#[cfg(windows)]
+fn decode_output(bytes: &[u8]) -> String {
+    use windows_sys::Win32::Globalization::{GetOEMCP, MultiByteToWideChar, CP_UTF8};
+    use windows_sys::Win32::System::Console::GetConsoleOutputCP;
+
+    if bytes.is_empty() {
+        return String::new();
+    }
+    // The child (`cmd`) inherits this process's console, so its output code page is our
+    // `GetConsoleOutputCP`. With no console attached (e.g. a GUI/Tauri host) that
+    // returns 0; the child then spins up its own console at the system OEM page, so
+    // fall back to `GetOEMCP`.
+    // Safety: both calls take no arguments and only read process/console state.
+    let code_page = match unsafe { GetConsoleOutputCP() } {
+        0 => unsafe { GetOEMCP() },
+        cp => cp,
+    };
+    if code_page == CP_UTF8 {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    // The API is `i32`-bounded; the capture cap keeps `bytes` far below `i32::MAX`, but
+    // clamp defensively so a hypothetical oversized buffer can never wrap negative.
+    let len = bytes.len().min(i32::MAX as usize) as i32;
+    // Safety: first call measures the required wide length; `bytes`/`len` describe a
+    // valid readable range and the output pointer is null with zero length.
+    let wide_len =
+        unsafe { MultiByteToWideChar(code_page, 0, bytes.as_ptr(), len, std::ptr::null_mut(), 0) };
+    if wide_len <= 0 {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    let mut wide = vec![0u16; wide_len as usize];
+    // Safety: `wide` has exactly `wide_len` slots, matching the count passed here; the
+    // input range is the one measured above.
+    let written = unsafe {
+        MultiByteToWideChar(
+            code_page,
+            0,
+            bytes.as_ptr(),
+            len,
+            wide.as_mut_ptr(),
+            wide_len,
+        )
+    };
+    if written <= 0 {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    wide.truncate(written as usize);
+    String::from_utf16_lossy(&wide)
 }
 
 /// Best-effort kill of the whole process tree. On unix, `SIGKILL` the negative
@@ -554,17 +673,38 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn large_output_is_truncated_but_command_completes() {
         // ~100 KiB of output, well past the 32 KiB cap: the drain keeps reading so
-        // the command can finish, and the result is marked truncated.
+        // the command can finish, and the result keeps a head + tail with an
+        // omitted-middle marker rather than dropping the ending.
         let tool = ShellTool::new(Duration::from_secs(10));
         let out = tool
             .run(&ctx(), &prepared("yes | head -c 100000"))
             .await
             .unwrap();
-        assert!(out.ends_with("[truncated]"), "must be truncated");
         assert!(
-            out.len() < 100000,
-            "captured output must be capped, got {} bytes",
+            out.contains("bytes omitted"),
+            "over-cap output must carry the omitted-middle marker, got end: {:?}",
+            &out[out.len().saturating_sub(80)..]
+        );
+        assert!(
+            out.len() < MAX_SHELL_CAPTURE + 100,
+            "captured output must stay near the cap, got {} bytes",
             out.len()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(unix)]
+    async fn truncation_keeps_the_actionable_tail() {
+        // The failure a test runner prints last must survive truncation: emit a head
+        // marker, a large filler past the cap, then a distinctive tail.
+        let tool = ShellTool::new(Duration::from_secs(10));
+        let script = "printf 'HEAD-MARKER '; yes | head -c 100000; printf ' TAIL-FAILURE'";
+        let out = tool.run(&ctx(), &prepared(script)).await.unwrap();
+        assert!(out.contains("HEAD-MARKER"), "head must survive: {out:.60}");
+        assert!(
+            out.trim_end().ends_with("TAIL-FAILURE"),
+            "the actionable tail must survive truncation, got end: {:?}",
+            &out[out.len().saturating_sub(60)..]
         );
     }
 
@@ -680,8 +820,10 @@ mod tests {
         // Output is UTF-8 on every target (unix by convention; windows via the
         // chcp-65001 normalization), so multi-byte text must survive intact.
         let captured = Captured {
-            bytes: "café — 日本語".as_bytes().to_vec(),
-            truncated: false,
+            head: "café — 日本語".as_bytes().to_vec(),
+            tail: VecDeque::new(),
+            dropped: 0,
+            abandoned: false,
         };
         assert_eq!(render(captured), "café — 日本語");
     }

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -1,0 +1,442 @@
+//! The `shell` tool: run one command in the workspace under confirmation.
+//!
+//! Unlike the file tools, `shell` is **not** path-fenced. A shell command's reach
+//! is unbounded by nature (it can invoke any program, touch any path), so a path
+//! fence would be security theatre. Its real boundary is the permission gate:
+//! `requires_confirmation` is always `true` — the default, most-cautious tier —
+//! and the user approves the exact command line before it runs.
+//!
+//! Runtime discipline:
+//! - Each call spawns `/bin/sh -c <command>` with `current_dir` set to the
+//!   workspace root, stdin closed (`Stdio::null`, so a command that reads stdin —
+//!   `cat` — sees EOF and terminates instead of hanging the turn), and stdout /
+//!   stderr piped.
+//! - stdout and stderr are drained concurrently, each capped at
+//!   [`MAX_SHELL_CAPTURE`]. The drain *keeps reading and discarding* past the cap,
+//!   so a chatty child never blocks on a full pipe (which would deadlock against
+//!   our own `wait`). After the child exits, the drain gets [`DRAIN_GRACE`] to
+//!   reach EOF: a command that backgrounds a survivor (`server &`) leaves the
+//!   pipe open indefinitely, and the turn must not be pinned on that orphan —
+//!   the capture so far is returned, marked truncated, and the orphan keeps
+//!   running (killing it would defeat deliberately backgrounded work).
+//! - A [`ShellTool::timeout`] and the turn's [`CancellationToken`] both race the
+//!   process; either one kills the whole process tree and returns `Err`. Tree kill
+//!   is best-effort: on unix we `SIGKILL` the negative process-group id (the child
+//!   leads its own group via `process_group(0)`), then also call `child.kill()` as
+//!   a fallback; on other platforms only `child.kill()` is available.
+
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::{Child, Command};
+use tokio_util::sync::CancellationToken;
+
+use super::{BoxFuture, PreparedCall, Tool, ToolContext, ToolResult, MISMATCHED_CALL};
+
+/// Default wall-clock budget for one command. Long enough for a real build or test
+/// run, bounded so a hung command cannot pin the turn forever. Overridable per
+/// tool so tests can use a tiny value.
+pub const DEFAULT_SHELL_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Per-stream capture cap. Enough context for the model to act on, bounded so a
+/// flood of output cannot blow memory or the model's context window.
+const MAX_SHELL_CAPTURE: usize = 32 * 1024;
+
+/// How long after the child exits the drain may keep waiting for pipe EOF.
+/// Normally EOF is immediate; the grace only elapses when a backgrounded
+/// survivor still holds the write end, in which case the drain is abandoned
+/// with whatever was captured.
+const DRAIN_GRACE: Duration = Duration::from_secs(2);
+
+/// `shell`: run one command via `/bin/sh -c` in the workspace.
+pub struct ShellTool {
+    timeout: Duration,
+}
+
+impl ShellTool {
+    /// Construct with an explicit timeout. Built-ins pass
+    /// [`DEFAULT_SHELL_TIMEOUT`]; tests pass a tiny value to exercise the
+    /// timeout path quickly.
+    pub fn new(timeout: Duration) -> Self {
+        ShellTool { timeout }
+    }
+}
+
+impl Tool for ShellTool {
+    fn name(&self) -> &str {
+        "shell"
+    }
+
+    fn description(&self) -> &str {
+        "Run one shell command via /bin/sh -c in the workspace directory. stdin is \
+         closed and stdout/stderr are captured (truncated if large) and returned. \
+         Use it for terminal operations like git, build, and test commands, not for \
+         reading, writing, or listing files (use read/write/edit). A non-zero exit \
+         is returned as an error including the captured output; the command runs to \
+         a timeout and requires confirmation."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The command line to run, as a single /bin/sh -c string."
+                }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+        })
+    }
+
+    fn requires_confirmation(&self) -> bool {
+        true
+    }
+
+    fn prepare(&self, _ctx: &ToolContext, args: &Value) -> Result<PreparedCall, String> {
+        let command = args
+            .get("command")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| "missing required string argument 'command'".to_string())?;
+        Ok(PreparedCall::Shell {
+            command: command.to_string(),
+        })
+    }
+
+    fn summarize(&self, prepared: &PreparedCall) -> String {
+        match prepared {
+            PreparedCall::Shell { command } => format!("run `{command}`"),
+            _ => "run shell".to_string(),
+        }
+    }
+
+    fn run<'a>(
+        &'a self,
+        ctx: &'a ToolContext,
+        prepared: &'a PreparedCall,
+    ) -> BoxFuture<'a, ToolResult> {
+        let PreparedCall::Shell { command } = prepared else {
+            return Box::pin(async { Err(MISMATCHED_CALL.to_string()) });
+        };
+        let command = command.clone();
+        let workspace_root = ctx.workspace_root.clone();
+        let cancel = ctx.cancel.clone();
+        let timeout = self.timeout;
+        Box::pin(async move { run_command(command, workspace_root, cancel, timeout).await })
+    }
+}
+
+/// What a single output stream captured, and whether it was cut off (at the cap,
+/// or by abandoning a drain whose pipe an orphan kept open).
+struct Captured {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+/// A capture buffer shared between the drain task and the joiner, so an abandoned
+/// drain still surrenders the bytes it captured before the grace elapsed.
+type CaptureSlot = Arc<Mutex<Captured>>;
+
+fn capture_slot() -> CaptureSlot {
+    Arc::new(Mutex::new(Captured {
+        bytes: Vec::new(),
+        truncated: false,
+    }))
+}
+
+/// Lock a slot, recovering from poisoning: a panicked drain task must not take
+/// the whole tool result down with it.
+fn lock_slot(slot: &CaptureSlot) -> std::sync::MutexGuard<'_, Captured> {
+    slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+async fn run_command(
+    command: String,
+    workspace_root: std::path::PathBuf,
+    cancel: CancellationToken,
+    timeout: Duration,
+) -> ToolResult {
+    let mut builder = Command::new("/bin/sh");
+    builder
+        .arg("-c")
+        .arg(&command)
+        .current_dir(&workspace_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Put the child in its own process group so a timeout / cancel can kill the
+    // whole tree, not just the leader.
+    #[cfg(unix)]
+    builder.process_group(0);
+
+    let mut child = builder
+        .spawn()
+        .map_err(|err| format!("failed to start shell: {err}"))?;
+    // Captured before any `wait`, which would drop the id.
+    let pid = child.id();
+
+    // Drain both pipes concurrently so a full pipe cannot block `wait`.
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let stderr = child.stderr.take().expect("stderr was piped");
+    let stdout_slot = capture_slot();
+    let stderr_slot = capture_slot();
+    let stdout_task = tokio::spawn(drain_capped(stdout, stdout_slot.clone()));
+    let stderr_task = tokio::spawn(drain_capped(stderr, stderr_slot.clone()));
+
+    let status = tokio::select! {
+        waited = child.wait() => {
+            waited.map_err(|err| format!("failed to wait for shell: {err}"))?
+        }
+        _ = cancel.cancelled() => {
+            kill_tree(&mut child, pid).await;
+            return Err("cancelled".to_string());
+        }
+        _ = tokio::time::sleep(timeout) => {
+            kill_tree(&mut child, pid).await;
+            return Err(format!("command timed out after {}s", timeout.as_secs()));
+        }
+    };
+
+    let stdout = join_captured(stdout_task, stdout_slot).await;
+    let stderr = join_captured(stderr_task, stderr_slot).await;
+    let stdout_text = render(stdout);
+    let stderr_text = render(stderr);
+
+    if status.success() {
+        // Exit 0: return stdout, appending a labelled stderr only if the command
+        // wrote to it (warnings, progress).
+        let mut out = stdout_text;
+        if !stderr_text.is_empty() {
+            out.push_str("\n[stderr]\n");
+            out.push_str(&stderr_text);
+        }
+        Ok(out)
+    } else {
+        // Non-zero exit is a recoverable tool error: the model sees the code and
+        // the output so it can react.
+        let code = status
+            .code()
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "terminated by signal".to_string());
+        let mut out = format!("command exited with status {code}");
+        if !stdout_text.is_empty() {
+            out.push_str("\n[stdout]\n");
+            out.push_str(&stdout_text);
+        }
+        if !stderr_text.is_empty() {
+            out.push_str("\n[stderr]\n");
+            out.push_str(&stderr_text);
+        }
+        Err(out)
+    }
+}
+
+/// Read a stream to EOF into the shared slot, keeping at most
+/// [`MAX_SHELL_CAPTURE`] bytes but always draining the rest (so the child never
+/// blocks on a full pipe). Writes into the slot incrementally so an abandoned
+/// drain still leaves its capture behind.
+async fn drain_capped<R: AsyncRead + Unpin>(mut reader: R, slot: CaptureSlot) {
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(read) => {
+                let mut captured = lock_slot(&slot);
+                if captured.bytes.len() < MAX_SHELL_CAPTURE {
+                    let room = MAX_SHELL_CAPTURE - captured.bytes.len();
+                    let take = room.min(read);
+                    captured.bytes.extend_from_slice(&buf[..take]);
+                    if take < read {
+                        captured.truncated = true;
+                    }
+                } else {
+                    // Past the cap: discard, but keep reading to drain the pipe.
+                    captured.truncated = true;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Await a drain task for at most [`DRAIN_GRACE`], then take the slot's capture.
+/// The child has already exited here, so a drain that is still blocked can only
+/// be waiting on an orphan that inherited the pipe — abandon it (marking the
+/// capture truncated) rather than pin the turn on a process we chose not to kill.
+async fn join_captured(mut task: tokio::task::JoinHandle<()>, slot: CaptureSlot) -> Captured {
+    if tokio::time::timeout(DRAIN_GRACE, &mut task).await.is_err() {
+        task.abort();
+        lock_slot(&slot).truncated = true;
+    }
+    let captured = lock_slot(&slot);
+    Captured {
+        bytes: captured.bytes.clone(),
+        truncated: captured.truncated,
+    }
+}
+
+fn render(stream: Captured) -> String {
+    let mut text = String::from_utf8_lossy(&stream.bytes).into_owned();
+    if stream.truncated {
+        text.push_str("\n… [truncated]");
+    }
+    text
+}
+
+/// Best-effort kill of the whole process tree. On unix, `SIGKILL` the negative
+/// process-group id (set up via `process_group(0)`), then also `child.kill()` as a
+/// fallback; elsewhere only `child.kill()` is available.
+async fn kill_tree(child: &mut Child, pid: Option<u32>) {
+    #[cfg(unix)]
+    if let Some(pid) = pid {
+        // Safety: `kill(2)` with a negative pid signals the process group. A stale
+        // pid at worst signals nothing; it cannot corrupt our address space.
+        unsafe {
+            libc::kill(-(pid as i32), libc::SIGKILL);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = pid;
+    let _ = child.kill().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            workspace_root: std::env::temp_dir(),
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    fn prepared(command: &str) -> PreparedCall {
+        PreparedCall::Shell {
+            command: command.to_string(),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn echo_returns_stdout() {
+        let tool = ShellTool::new(DEFAULT_SHELL_TIMEOUT);
+        let out = tool.run(&ctx(), &prepared("echo hello")).await.unwrap();
+        assert_eq!(out.trim(), "hello");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stderr_is_captured_and_labelled() {
+        let tool = ShellTool::new(DEFAULT_SHELL_TIMEOUT);
+        let out = tool
+            .run(&ctx(), &prepared("echo out; echo err 1>&2"))
+            .await
+            .unwrap();
+        assert!(out.contains("out"), "stdout present, got: {out}");
+        assert!(out.contains("[stderr]"), "stderr labelled, got: {out}");
+        assert!(out.contains("err"), "stderr captured, got: {out}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn non_zero_exit_is_error_with_code() {
+        let tool = ShellTool::new(DEFAULT_SHELL_TIMEOUT);
+        let err = tool
+            .run(&ctx(), &prepared("exit 3"))
+            .await
+            .expect_err("non-zero exit must be an error");
+        assert!(err.contains('3'), "exit code named, got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn command_reading_stdin_terminates() {
+        // stdin is closed, so `cat` sees EOF and exits instead of hanging.
+        let tool = ShellTool::new(Duration::from_secs(5));
+        let out = tool.run(&ctx(), &prepared("cat")).await.unwrap();
+        assert_eq!(out, "", "cat on empty stdin yields no output");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn large_output_is_truncated_but_command_completes() {
+        // ~100 KiB of output, well past the 32 KiB cap: the drain keeps reading so
+        // the command can finish, and the result is marked truncated.
+        let tool = ShellTool::new(Duration::from_secs(10));
+        let out = tool
+            .run(&ctx(), &prepared("yes | head -c 100000"))
+            .await
+            .unwrap();
+        assert!(out.ends_with("[truncated]"), "must be truncated");
+        assert!(
+            out.len() < 100000,
+            "captured output must be capped, got {} bytes",
+            out.len()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn background_survivor_does_not_pin_the_turn() {
+        // The command exits immediately but backgrounds a `sleep` that inherits
+        // the stdout pipe, so the pipe never reaches EOF. The drain must be
+        // abandoned after the grace period, keeping the output that did arrive.
+        let tool = ShellTool::new(Duration::from_secs(30));
+        let started = Instant::now();
+        let out = tool
+            .run(&ctx(), &prepared("echo hi; sleep 30 &"))
+            .await
+            .unwrap();
+        assert!(out.contains("hi"), "pre-orphan output kept, got: {out}");
+        assert!(
+            out.contains("[truncated]"),
+            "an abandoned drain must be marked, got: {out}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the orphan must not pin the turn, took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn timeout_kills_a_long_command_promptly() {
+        let tool = ShellTool::new(Duration::from_millis(200));
+        let started = Instant::now();
+        let err = tool
+            .run(&ctx(), &prepared("sleep 30"))
+            .await
+            .expect_err("a timed-out command must be an error");
+        assert!(err.contains("timed out"), "got: {err}");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "timeout must fire promptly, took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancellation_returns_error_promptly() {
+        let context = ctx();
+        let cancel = context.cancel.clone();
+        let tool = ShellTool::new(Duration::from_secs(30));
+        let call = prepared("sleep 30");
+        let started = Instant::now();
+        let canceller = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            cancel.cancel();
+        });
+        let err = tool
+            .run(&context, &call)
+            .await
+            .expect_err("a cancelled command must be an error");
+        canceller.await.unwrap();
+        assert!(err.contains("cancelled"), "got: {err}");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "cancel must fire promptly, took {:?}",
+            started.elapsed()
+        );
+    }
+}

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -72,21 +72,42 @@ impl Tool for ShellTool {
     }
 
     fn description(&self) -> &str {
-        "Run one shell command via /bin/sh -c in the workspace directory. stdin is \
-         closed and stdout/stderr are captured (truncated if large) and returned. \
-         Use it for terminal operations like git, build, and test commands, not for \
-         reading, writing, or listing files (use read/write/edit). A non-zero exit \
-         is returned as an error including the captured output; the command runs to \
-         a timeout and requires confirmation."
+        // Name the actual platform shell so the model writes syntax that runs: POSIX
+        // for `/bin/sh` on unix, cmd.exe syntax on windows (`dir`, no single quotes,
+        // `nul` not `/dev/null`).
+        #[cfg(not(windows))]
+        {
+            "Run one shell command via /bin/sh -c in the workspace directory, using \
+             POSIX shell syntax. stdin is closed and stdout/stderr are captured \
+             (truncated if large) and returned. Use it for terminal operations like \
+             git, build, and test commands, not for reading, writing, or listing \
+             files (use read/write/edit). A non-zero exit is returned as an error \
+             including the captured output; the command runs to a timeout and \
+             requires confirmation."
+        }
+        #[cfg(windows)]
+        {
+            "Run one shell command via cmd.exe (cmd /C) in the workspace directory, \
+             using Windows cmd syntax (not POSIX). stdin is closed and stdout/stderr \
+             are captured (truncated if large) and returned. Use it for terminal \
+             operations like git, build, and test commands, not for reading, writing, \
+             or listing files (use read/write/edit). A non-zero exit is returned as \
+             an error including the captured output; the command runs to a timeout \
+             and requires confirmation."
+        }
     }
 
     fn parameters(&self) -> Value {
+        #[cfg(not(windows))]
+        let command_desc = "The command line to run, as a single /bin/sh -c string.";
+        #[cfg(windows)]
+        let command_desc = "The command line to run, as a single cmd /C string.";
         json!({
             "type": "object",
             "properties": {
                 "command": {
                     "type": "string",
-                    "description": "The command line to run, as a single /bin/sh -c string."
+                    "description": command_desc
                 }
             },
             "required": ["command"],
@@ -163,7 +184,7 @@ async fn run_command(
     timeout: Duration,
 ) -> ToolResult {
     // Pick the platform shell: unix runs `/bin/sh -c <command>`, windows runs
-    // `cmd /C <command>`. Both take the whole command line as one argument.
+    // `cmd /S /C "<command>"` (verbatim, see the windows branch below).
     #[cfg(unix)]
     let mut builder = {
         let mut builder = Command::new("/bin/sh");
@@ -172,8 +193,16 @@ async fn run_command(
     };
     #[cfg(windows)]
     let mut builder = {
+        use std::os::windows::process::CommandExt;
         let mut builder = Command::new("cmd");
-        builder.arg("/C").arg(&command);
+        // Hand the command line to cmd verbatim. Rust's normal `.arg()` escaping
+        // targets CommandLineToArgvW, but `cmd /C` parses by different rules, so
+        // `.arg(&command)` would rewrite embedded quotes/metacharacters into a
+        // *different* command than the approved `PreparedCall` (e.g. a
+        // `git commit -m "msg"`). `raw_arg` appends without escaping; `/S` makes cmd
+        // strip exactly the outer quotes and run the remainder literally, so the
+        // approved command line is what actually executes.
+        builder.raw_arg(format!("/S /C \"{command}\""));
         builder
     };
     builder

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -815,16 +815,37 @@ mod tests {
         );
     }
 
-    #[test]
-    fn render_decodes_utf8_output() {
-        // Output is UTF-8 on every target (unix by convention; windows via the
-        // chcp-65001 normalization), so multi-byte text must survive intact.
-        let captured = Captured {
-            head: "café — 日本語".as_bytes().to_vec(),
+    fn captured_from(bytes: &[u8]) -> Captured {
+        Captured {
+            head: bytes.to_vec(),
             tail: VecDeque::new(),
             dropped: 0,
             abandoned: false,
-        };
-        assert_eq!(render(captured), "café — 日本語");
+        }
+    }
+
+    #[test]
+    fn render_passes_ascii_through_unchanged() {
+        // ASCII decodes identically under every code page, so this holds on unix and
+        // on windows regardless of the active console code page — unlike a hard-coded
+        // multi-byte UTF-8 fixture, which windows decodes per code page.
+        assert_eq!(
+            render(captured_from(b"ok: build passed [42/42]")),
+            "ok: build passed [42/42]"
+        );
+    }
+
+    // Multi-byte UTF-8 is only guaranteed to round-trip where output is decoded as
+    // UTF-8: unix always is. On windows `render` decodes with the active console code
+    // page (`GetConsoleOutputCP`), so these exact UTF-8 bytes would decode differently
+    // under a legacy code page — asserting them there would wrongly fail a local
+    // `cargo test`.
+    #[cfg(not(windows))]
+    #[test]
+    fn render_decodes_multibyte_utf8_output() {
+        assert_eq!(
+            render(captured_from("café — 日本語".as_bytes())),
+            "café — 日本語"
+        );
     }
 }

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -392,11 +392,82 @@ fn take_capture(slot: &CaptureSlot, abandoned: bool) -> Captured {
 }
 
 fn render(stream: Captured) -> String {
-    let mut text = String::from_utf8_lossy(&stream.bytes).into_owned();
+    let mut text = decode_output(&stream.bytes);
     if stream.truncated {
         text.push_str("\n… [truncated]");
     }
     text
+}
+
+/// Decode captured child output to text. Unix streams are UTF-8 by convention, so a
+/// lossy decode is exactly right.
+#[cfg(not(windows))]
+fn decode_output(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+/// Decode captured child output on Windows, where one pipe can carry two encodings
+/// with no in-band marker: `cmd` built-ins (`echo`, `dir`) emit the OEM console code
+/// page (e.g. 936/932/437), while modern tools (`git`, `node`) emit UTF-8.
+///
+/// Auto-detect by trying UTF-8 first — it is self-validating, so a legacy-code-page
+/// run of non-ASCII bytes almost never forms a valid multi-byte UTF-8 sequence.
+/// Bytes that are valid UTF-8 (or valid except for an incomplete final char left by
+/// the output cap) are taken as UTF-8; anything with a genuine mid-stream invalid
+/// byte is decoded via the OEM code page. Pure ASCII is identical under both, so the
+/// common case is lossless regardless of which branch runs.
+#[cfg(windows)]
+fn decode_output(bytes: &[u8]) -> String {
+    match std::str::from_utf8(bytes) {
+        Ok(text) => text.to_string(),
+        // `error_len() == None` means the only fault is an incomplete multi-byte char
+        // at the very end — i.e. UTF-8 truncated at the byte cap. The prefix is valid
+        // UTF-8, so keep decoding it as such rather than misfiring the OEM path.
+        Err(err) if err.error_len().is_none() => String::from_utf8_lossy(bytes).into_owned(),
+        Err(_) => decode_oem_codepage(bytes),
+    }
+}
+
+/// Decode bytes using the system OEM code page (`GetOEMCP` + `MultiByteToWideChar`),
+/// the encoding `cmd`'s built-in commands write to a redirected pipe. Falls back to
+/// UTF-8 lossy if the conversion is unavailable, so output is never dropped.
+#[cfg(windows)]
+fn decode_oem_codepage(bytes: &[u8]) -> String {
+    use windows_sys::Win32::Globalization::{GetOEMCP, MultiByteToWideChar};
+
+    if bytes.is_empty() {
+        return String::new();
+    }
+    // The API is `i32`-bounded; the output cap keeps `bytes` far below `i32::MAX`, but
+    // clamp defensively so a hypothetical oversized buffer can never wrap negative.
+    let len = bytes.len().min(i32::MAX as usize) as i32;
+    // Safety: `GetOEMCP` takes no arguments and returns the active OEM code page id.
+    let code_page = unsafe { GetOEMCP() };
+    // Safety: first call with a null output buffer and zero length asks only for the
+    // required wide-char count; `bytes`/`len` describe a valid readable range.
+    let wide_len =
+        unsafe { MultiByteToWideChar(code_page, 0, bytes.as_ptr(), len, std::ptr::null_mut(), 0) };
+    if wide_len <= 0 {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    let mut wide = vec![0u16; wide_len as usize];
+    // Safety: `wide` has exactly `wide_len` slots, matching the length passed here;
+    // the input range is the same one measured above.
+    let written = unsafe {
+        MultiByteToWideChar(
+            code_page,
+            0,
+            bytes.as_ptr(),
+            len,
+            wide.as_mut_ptr(),
+            wide_len,
+        )
+    };
+    if written <= 0 {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    wide.truncate(written as usize);
+    String::from_utf16_lossy(&wide)
 }
 
 /// Best-effort kill of the whole process tree. On unix, `SIGKILL` the negative
@@ -611,6 +682,27 @@ mod tests {
             started.elapsed() < Duration::from_secs(5),
             "cancel must fire promptly, took {:?}",
             started.elapsed()
+        );
+    }
+
+    #[test]
+    fn decode_output_passes_through_valid_utf8() {
+        // The UTF-8 branch must be taken for valid UTF-8 on every platform (git/node
+        // output on Windows, all output on unix), leaving multi-byte text intact.
+        let bytes = "café — 日本語".as_bytes();
+        assert_eq!(decode_output(bytes), "café — 日本語");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn decode_output_recovers_non_utf8_via_oem_codepage() {
+        // A genuine mid-stream invalid-UTF-8 byte routes through the OEM code page
+        // instead of being lost to U+FFFD. The exact glyph depends on the runner's
+        // code page, so assert only that it does not panic and yields non-empty text.
+        let decoded = decode_output(&[0x48, 0x69, 0x81, 0x40]); // "Hi" + a high-byte pair
+        assert!(
+            !decoded.is_empty(),
+            "OEM decode must not drop the stream: {decoded:?}"
         );
     }
 }

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -7,10 +7,10 @@
 //! and the user approves the exact command line before it runs.
 //!
 //! Runtime discipline:
-//! - Each call spawns `/bin/sh -c <command>` with `current_dir` set to the
-//!   workspace root, stdin closed (`Stdio::null`, so a command that reads stdin —
-//!   `cat` — sees EOF and terminates instead of hanging the turn), and stdout /
-//!   stderr piped.
+//! - Each call spawns the platform shell — `/bin/sh -c <command>` on unix, `cmd /C
+//!   <command>` on windows — with `current_dir` set to the workspace root, stdin
+//!   closed (`Stdio::null`, so a command that reads stdin sees EOF and terminates
+//!   instead of hanging the turn), and stdout / stderr piped.
 //! - stdout and stderr are drained concurrently, each capped at
 //!   [`MAX_SHELL_CAPTURE`]. The drain *keeps reading and discarding* past the cap,
 //!   so a chatty child never blocks on a full pipe (which would deadlock against
@@ -22,8 +22,9 @@
 //! - A [`ShellTool::timeout`] and the turn's [`CancellationToken`] both race the
 //!   process; either one kills the whole process tree and returns `Err`. Tree kill
 //!   is best-effort: on unix we `SIGKILL` the negative process-group id (the child
-//!   leads its own group via `process_group(0)`), then also call `child.kill()` as
-//!   a fallback; on other platforms only `child.kill()` is available.
+//!   leads its own group via `process_group(0)`), on windows we `taskkill /T /F`
+//!   the pid tree, and both then also call `child.kill()` as a fallback; on other
+//!   platforms only `child.kill()` is available.
 
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
@@ -161,16 +162,28 @@ async fn run_command(
     cancel: CancellationToken,
     timeout: Duration,
 ) -> ToolResult {
-    let mut builder = Command::new("/bin/sh");
+    // Pick the platform shell: unix runs `/bin/sh -c <command>`, windows runs
+    // `cmd /C <command>`. Both take the whole command line as one argument.
+    #[cfg(unix)]
+    let mut builder = {
+        let mut builder = Command::new("/bin/sh");
+        builder.arg("-c").arg(&command);
+        builder
+    };
+    #[cfg(windows)]
+    let mut builder = {
+        let mut builder = Command::new("cmd");
+        builder.arg("/C").arg(&command);
+        builder
+    };
     builder
-        .arg("-c")
-        .arg(&command)
         .current_dir(&workspace_root)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    // Put the child in its own process group so a timeout / cancel can kill the
-    // whole tree, not just the leader.
+    // On unix, put the child in its own process group so a timeout / cancel can kill
+    // the whole tree, not just the leader. Windows has no process groups; tree kill
+    // there goes through `taskkill /T` by pid (see `kill_tree`), so nothing to set.
     #[cfg(unix)]
     builder.process_group(0);
 
@@ -331,7 +344,9 @@ fn render(stream: Captured) -> String {
 
 /// Best-effort kill of the whole process tree. On unix, `SIGKILL` the negative
 /// process-group id (set up via `process_group(0)`), then also `child.kill()` as a
-/// fallback; elsewhere only `child.kill()` is available.
+/// fallback. On windows, `taskkill /T /F` terminates the pid's whole tree (the
+/// `cmd` leader and anything it spawned), then `child.kill()` as a fallback.
+/// Elsewhere only `child.kill()` is available.
 async fn kill_tree(child: &mut Child, pid: Option<u32>) {
     #[cfg(unix)]
     if let Some(pid) = pid {
@@ -341,7 +356,20 @@ async fn kill_tree(child: &mut Child, pid: Option<u32>) {
             libc::kill(-(pid as i32), libc::SIGKILL);
         }
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    if let Some(pid) = pid {
+        // Windows has no process-group signal; `taskkill /T` walks the pid tree and
+        // `/F` forces termination. Best-effort, mirroring the unix group kill: its
+        // own output is discarded and a failure falls through to `child.kill()`.
+        let _ = Command::new("taskkill")
+            .args(["/T", "/F", "/PID", &pid.to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+    }
+    #[cfg(not(any(unix, windows)))]
     let _ = pid;
     let _ = child.kill().await;
 }
@@ -364,6 +392,47 @@ mod tests {
         }
     }
 
+    /// A command that runs long enough (~30s) to be killed by a short timeout or a
+    /// cancel. Unix has `sleep`; windows has no `sleep` builtin, so a 31-ping loop
+    /// (~30s at one ping/second) stands in.
+    fn long_running() -> &'static str {
+        #[cfg(unix)]
+        {
+            "sleep 30"
+        }
+        #[cfg(windows)]
+        {
+            "ping -n 31 127.0.0.1"
+        }
+    }
+
+    /// A command that writes to both stdout and stderr, so capture + `[stderr]`
+    /// labelling can be checked. The command separator differs: `;` on unix, `&` on
+    /// windows `cmd`.
+    fn writes_both_streams() -> &'static str {
+        #[cfg(unix)]
+        {
+            "echo out; echo err 1>&2"
+        }
+        #[cfg(windows)]
+        {
+            "echo out& echo err 1>&2"
+        }
+    }
+
+    /// A command that reads stdin to EOF and then exits, proving a closed stdin does
+    /// not hang the turn: `cat` on unix, `sort` on windows.
+    fn reads_stdin() -> &'static str {
+        #[cfg(unix)]
+        {
+            "cat"
+        }
+        #[cfg(windows)]
+        {
+            "sort"
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn echo_returns_stdout() {
         let tool = ShellTool::new(DEFAULT_SHELL_TIMEOUT);
@@ -375,7 +444,7 @@ mod tests {
     async fn stderr_is_captured_and_labelled() {
         let tool = ShellTool::new(DEFAULT_SHELL_TIMEOUT);
         let out = tool
-            .run(&ctx(), &prepared("echo out; echo err 1>&2"))
+            .run(&ctx(), &prepared(writes_both_streams()))
             .await
             .unwrap();
         assert!(out.contains("out"), "stdout present, got: {out}");
@@ -395,12 +464,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn command_reading_stdin_terminates() {
-        // stdin is closed, so `cat` sees EOF and exits instead of hanging.
+        // stdin is closed, so a stdin reader sees EOF and exits instead of hanging.
         let tool = ShellTool::new(Duration::from_secs(5));
-        let out = tool.run(&ctx(), &prepared("cat")).await.unwrap();
-        assert_eq!(out, "", "cat on empty stdin yields no output");
+        let out = tool.run(&ctx(), &prepared(reads_stdin())).await.unwrap();
+        assert_eq!(out, "", "a stdin reader on empty input yields no output");
     }
 
+    // Unix-only: the drain-cap logic is platform-agnostic Rust; a clean `yes | head`
+    // flood exercises it without leaning on a fragile `cmd` output loop on windows.
+    #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread")]
     async fn large_output_is_truncated_but_command_completes() {
         // ~100 KiB of output, well past the 32 KiB cap: the drain keeps reading so
@@ -418,6 +490,10 @@ mod tests {
         );
     }
 
+    // Unix-only: relies on `&` job-control backgrounding a `sleep` that inherits the
+    // pipe. `cmd` has no equivalent one-liner; the abandon-drain logic it exercises
+    // is platform-agnostic and covered here.
+    #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread")]
     async fn background_survivor_does_not_pin_the_turn() {
         // The command exits immediately but backgrounds a `sleep` that inherits
@@ -446,7 +522,7 @@ mod tests {
         let tool = ShellTool::new(Duration::from_millis(200));
         let started = Instant::now();
         let err = tool
-            .run(&ctx(), &prepared("sleep 30"))
+            .run(&ctx(), &prepared(long_running()))
             .await
             .expect_err("a timed-out command must be an error");
         assert!(err.contains("timed out"), "got: {err}");
@@ -462,7 +538,7 @@ mod tests {
         let context = ctx();
         let cancel = context.cancel.clone();
         let tool = ShellTool::new(Duration::from_secs(30));
-        let call = prepared("sleep 30");
+        let call = prepared(long_running());
         let started = Instant::now();
         let canceller = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(200)).await;

--- a/crates/pawwork-core/src/tool/shell.rs
+++ b/crates/pawwork-core/src/tool/shell.rs
@@ -194,10 +194,17 @@ async fn run_command(
         }
         _ = cancel.cancelled() => {
             kill_tree(&mut child, pid).await;
+            // A descendant that escaped the process group (setsid) survives the
+            // kill and can hold the pipes open; abort the drains so they cannot
+            // outlive the turn.
+            stdout_task.abort();
+            stderr_task.abort();
             return Err("cancelled".to_string());
         }
         _ = tokio::time::sleep(timeout) => {
             kill_tree(&mut child, pid).await;
+            stdout_task.abort();
+            stderr_task.abort();
             return Err(format!("command timed out after {}s", timeout.as_secs()));
         }
     };


### PR DESCRIPTION
## Summary

Implements the write-side tool set for the Rust agent core (M0 implementation step 4, tool half — the CLI half lands separately):

- `PreparedCall` becomes a per-action enum (`Read`/`Edit`/`Write`/`Shell`); only `prepare` mints one, and a mismatched variant is a recoverable `Err`, never a panic.
- **edit**: exact single-occurrence substring replacement (deliberately no fuzzy-match cascade), UTF-8 only, 8 MiB work bound, atomic temp+rename write.
- **write**: whole-file create/overwrite via a new `resolve_new_in_workspace` fence that canonicalizes and fences the parent directory for not-yet-existing targets (missing parents are an error, never auto-created).
- **shell**: `/bin/sh -c` under always-on confirmation, workspace cwd, stdin closed, stdout/stderr drained concurrently with a 32 KiB per-stream cap (draining past the cap so a chatty child never deadlocks on a full pipe), 120 s default timeout, and turn cancellation — timeout/cancel kill the whole process group (unix, via a new cfg(unix) `libc` dependency). After the child exits, the drain gets a 2 s grace so a backgrounded survivor (`server &`) holding the pipe cannot pin the turn; the capture so far is returned marked truncated.
- `PermissionRequest` now carries the structured `PreparedCall` action alongside the rendered summary (the design doc's typed-action requirement; ledger schema unchanged).
- `list` is removed per the design doc; `read` gains directory mode (sorted, capped listing). `ToolRuntime::with_read_only()` → `with_builtins()`.
- `Tool` trait gains `description()`/`parameters()`; `ToolRuntime::schemas()` emits OpenAI function schemas, sorted by name, ready for the CLI PR to wire into `openai_compat`'s `tools`.
- `ToolContext` gains the turn's `CancellationToken` (the seam `shell` was waiting on). Core tokio features widen locally to `process`/`time`/`io-util`/`macros`; the workspace baseline stays `sync`-only and the core remains runtime-agnostic.

## Why

Rust agent v0 (experimental line), step 4 of the implementation order. PR1 #1497 landed the ledger, PR2 #1499 the loop/permissions/interruption, PR3 #1503 the openai_compat SSE client. This PR completes the four-tool target set (`read`/`edit`/`write`/`shell`) so the CLI PR only has to add the adapter (chat, confirm UI, resume, Ctrl-C, config).

## Related Issue

No issue — the Rust v0 experimental line is tracked in the local agent board and design doc; PR chain: #1497 → #1499 → #1503 → this.

## Human Review Status

Pending

## Review Focus

- `resolve_new_in_workspace` (fence.rs): the create-case parent fencing and final-component validation — this is the new security-relevant surface.
- shell.rs process lifecycle: the select between wait/cancel/timeout, the process-group kill, and the post-exit drain grace (abandoned drains keep partial output via a shared capture slot).
- The `PreparedCall` enum reshaping and its use as the structured permission action.

## Risk Notes

- New dependency: `libc` (cfg(unix) only) for `kill(2)` on a negative pgid — std does not expose process-group kill. Tree kill is best-effort by design.
- The fence remains advisory (documented): no TOCTOU defense, no OS sandbox; `shell`'s boundary is confirmation, not the fence.
- Unticked conditional item: no visible UI or copy changed (Rust core only). Windows impact considered and ticked: the shell tool is unix-shaped (`/bin/sh`, process groups) with a documented `child.kill()` fallback on other platforms; M0 explicitly validates macOS first.

## How To Verify

```text
cargo fmt --check: clean
cargo clippy --workspace --all-targets -- -D warnings: clean
cargo test --workspace --locked: 96 passed, 0 failed
  (covers fence create-case incl. symlinked-parent escape, edit no-match/ambiguity/non-UTF-8/size-cap,
   write create/overwrite/missing-parent, shell timeout/cancel/stdin-EOF/output-cap/orphan-pipe grace,
   agent-loop write allow+deny integration, schemas shape)
```

## Screenshots or Recordings

Not applicable (no UI).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation-gated built-in tools: `read`, `edit`, `write`, and `shell`.
  * `read` now handles both files and directories (sorted listings with truncation).
  * `edit`/`write` provide workspace-safe atomic updates; `shell` runs one approved command with timeout-aware termination and labeled, capped stdout/stderr.
* **Bug Fixes**
  * Improved cancellation and permission-approval race handling to avoid unintended tool starts and ensure prepared data remains available.
* **Documentation**
  * Updated tool-layer and permission documentation to reflect structured permission actions.
* **Tests / CI**
  * Expanded coverage for `write`/`shell`, deterministic tool schema ordering, and workspace fencing; Rust CI now runs on a Windows+Linux matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->