### PR TITLE
fix(app): make renderer diagnostics passive at idle

### DIFF
--- a/packages/app/src/context/renderer-diagnostics.test.ts
+++ b/packages/app/src/context/renderer-diagnostics.test.ts
@@ -10,12 +10,44 @@ import type { RendererDiagnosticInput } from "./platform"
 
 describe("renderer diagnostics", () => {
   const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+  const originalSetInterval = window.setInterval
+  const originalPerformanceObserver = globalThis.PerformanceObserver
   const originalApi = window.api
 
   afterEach(() => {
     globalThis.requestAnimationFrame = originalRequestAnimationFrame
+    window.setInterval = originalSetInterval
+    globalThis.PerformanceObserver = originalPerformanceObserver
     window.api = originalApi
   })
+
+  function capturePerformanceObservers() {
+    const callbacks = new Map<string, PerformanceObserverCallback>()
+    globalThis.PerformanceObserver = class {
+      constructor(callback: PerformanceObserverCallback) {
+        this.callback = callback
+      }
+
+      private callback: PerformanceObserverCallback
+
+      observe(options: PerformanceObserverInit) {
+        if (options.type) callbacks.set(options.type, this.callback)
+      }
+
+      disconnect() {}
+      takeRecords() {
+        return []
+      }
+    } as unknown as typeof PerformanceObserver
+
+    return (type: string, entries: PerformanceEntry[]) => {
+      callbacks.get(type)?.({ getEntries: () => entries } as PerformanceObserverEntryList, {} as PerformanceObserver)
+    }
+  }
+
+  function layoutShift(startTime: number, value: number) {
+    return { startTime, value, hadRecentInput: false } as unknown as PerformanceEntry
+  }
 
   test("emits through the desktop API with monotonic time", async () => {
     const events: RendererDiagnosticInput[] = []
@@ -77,6 +109,120 @@ describe("renderer diagnostics", () => {
     expect(frames).toBe(0)
   })
 
+  test("session performance diagnostics stays passive while a visible session is idle", () => {
+    let frames = 0
+    let intervals = 0
+    globalThis.requestAnimationFrame = (() => {
+      frames += 1
+      return 1
+    }) as typeof requestAnimationFrame
+    window.setInterval = (() => {
+      intervals += 1
+      return 1
+    }) as unknown as typeof setInterval
+
+    createRoot((dispose) => {
+      createSessionPerformanceDiagnostics({
+        routeSessionID: () => "route-session",
+        visibleSessionID: () => "visible-session",
+        timelineSessionID: () => "timeline-session",
+        emit: () => {},
+      })
+      document.dispatchEvent(new Event("visibilitychange"))
+      dispose()
+    })
+
+    expect(frames).toBe(0)
+    expect(intervals).toBe(0)
+  })
+
+  test("emits a jank incident directly from a threshold long task", () => {
+    const notify = capturePerformanceObservers()
+    const events: RendererDiagnosticInput[] = []
+
+    createRoot((dispose) => {
+      createSessionPerformanceDiagnostics({
+        routeSessionID: () => "route-session",
+        visibleSessionID: () => "visible-session",
+        timelineSessionID: () => "timeline-session",
+        emit: (event) => {
+          events.push(event)
+        },
+      })
+
+      notify("longtask", [{ duration: 100.4 } as PerformanceEntry])
+      dispose()
+    })
+
+    expect(events).toEqual([
+      {
+        name: "incident.session_jank_burst",
+        level: "warn",
+        route_session_id: "route-session",
+        visible_session_id: "visible-session",
+        timeline_session_id: "timeline-session",
+        data: { long_task_max_ms: 100, phase: "performance_observer" },
+      },
+    ])
+  })
+
+  test("emits a layout-shift incident when an event-driven session window crosses the CLS threshold", () => {
+    const notify = capturePerformanceObservers()
+    const events: RendererDiagnosticInput[] = []
+
+    createRoot((dispose) => {
+      createSessionPerformanceDiagnostics({
+        routeSessionID: () => "route-session",
+        visibleSessionID: () => "visible-session",
+        timelineSessionID: () => "timeline-session",
+        emit: (event) => {
+          events.push(event)
+        },
+      })
+
+      notify("layout-shift", [
+        layoutShift(100, 0.04),
+        layoutShift(800, 0.05),
+        layoutShift(1_500, 0.02),
+        layoutShift(1_600, 0.2),
+      ])
+      dispose()
+    })
+
+    expect(events).toEqual([
+      {
+        name: "incident.session_layout_shift",
+        level: "warn",
+        route_session_id: "route-session",
+        visible_session_id: "visible-session",
+        timeline_session_id: "timeline-session",
+        data: { cls: 0.11, phase: "performance_observer" },
+      },
+    ])
+  })
+
+  test("does not emit observer or visibility events after cleanup", () => {
+    const notify = capturePerformanceObservers()
+    const events: RendererDiagnosticInput[] = []
+
+    createRoot((dispose) => {
+      createSessionPerformanceDiagnostics({
+        routeSessionID: () => "route-session",
+        visibleSessionID: () => "visible-session",
+        timelineSessionID: () => "timeline-session",
+        emit: (event) => {
+          events.push(event)
+        },
+      })
+      dispose()
+    })
+
+    notify("longtask", [{ duration: 120 } as PerformanceEntry])
+    notify("layout-shift", [layoutShift(100, 0.2)])
+    document.dispatchEvent(new Event("visibilitychange"))
+
+    expect(events).toEqual([])
+  })
 
   test("detects automatic scroll jumps to top", () => {
     const incident = detectSessionScrollJumpToTop({
@@ -216,9 +362,9 @@ describe("renderer diagnostics", () => {
     const detect = createRendererIncidentDetector()
 
     expect(detect({ name: "session.timeline.mount", timeline_session_id: "session-1", data: {} })).toEqual([])
-    expect(detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 5 } })).toEqual(
-      [],
-    )
+    expect(
+      detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 5 } }),
+    ).toEqual([])
     expect(detect({ name: "session.timeline.unmount", timeline_session_id: "session-1", data: {} })).toEqual([])
     expect(detect({ name: "session.timeline.mount", timeline_session_id: "session-1", data: {} })).toEqual([
       expect.objectContaining({
@@ -226,8 +372,12 @@ describe("renderer diagnostics", () => {
         data: { timeline_mount_count: 2, timeline_unmount_count: 1 },
       }),
     ])
-    expect(detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 0 } })).toEqual([])
-    expect(detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 4 } })).toEqual([
+    expect(
+      detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 0 } }),
+    ).toEqual([])
+    expect(
+      detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 4 } }),
+    ).toEqual([
       expect.objectContaining({
         name: "incident.session_visible_messages_cleared",
         data: { before_count: 5, during_count: 0, after_count: 4 },
@@ -239,9 +389,9 @@ describe("renderer diagnostics", () => {
     const detect = createRendererIncidentDetector()
 
     expect(detect({ name: "session.timeline.mount", timeline_session_id: "session-1", data: {} })).toEqual([])
-    expect(detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 80 } })).toEqual(
-      [],
-    )
+    expect(
+      detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 80 } }),
+    ).toEqual([])
     expect(
       detect({
         name: "session.scroll.sample",
@@ -249,9 +399,9 @@ describe("renderer diagnostics", () => {
         data: { scroll_top: 20451, distance_from_bottom: 0, client_height: 720, user_scrolled: false },
       }),
     ).toEqual([])
-    expect(detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 80 } })).toEqual(
-      [],
-    )
+    expect(
+      detect({ name: "session.timeline.visible", timeline_session_id: "session-1", data: { rendered_count: 80 } }),
+    ).toEqual([])
     expect(
       detect({
         name: "session.scroll.sample",

--- a/packages/app/src/context/renderer-diagnostics.test.ts
+++ b/packages/app/src/context/renderer-diagnostics.test.ts
@@ -166,7 +166,7 @@ describe("renderer diagnostics", () => {
     ])
   })
 
-  test("emits a layout-shift incident when an event-driven session window crosses the CLS threshold", () => {
+  test("emits once per CLS session window and resets at the gap and duration boundaries", () => {
     const notify = capturePerformanceObservers()
     const events: RendererDiagnosticInput[] = []
 
@@ -181,24 +181,35 @@ describe("renderer diagnostics", () => {
       })
 
       notify("layout-shift", [
-        layoutShift(100, 0.04),
-        layoutShift(800, 0.05),
-        layoutShift(1_500, 0.02),
-        layoutShift(1_600, 0.2),
+        layoutShift(0, 0.06),
+        layoutShift(999, 0.05),
+        layoutShift(1_500, 0.2),
+        // An exact one-second gap starts a new session window.
+        layoutShift(2_500, 0.06),
+        layoutShift(3_499, 0.05),
+        // A third window stays active until exactly five seconds after its first shift.
+        layoutShift(4_499, 0.01),
+        layoutShift(5_498, 0.01),
+        layoutShift(6_497, 0.01),
+        layoutShift(7_496, 0.01),
+        layoutShift(8_495, 0.01),
+        layoutShift(9_494, 0.01),
+        layoutShift(9_499, 0.06),
+        layoutShift(10_498, 0.05),
       ])
       dispose()
     })
 
-    expect(events).toEqual([
-      {
+    expect(events).toEqual(
+      Array.from({ length: 3 }, () => ({
         name: "incident.session_layout_shift",
         level: "warn",
         route_session_id: "route-session",
         visible_session_id: "visible-session",
         timeline_session_id: "timeline-session",
         data: { cls: 0.11, phase: "performance_observer" },
-      },
-    ])
+      })),
+    )
   })
 
   test("does not emit observer or visibility events after cleanup", () => {

--- a/packages/app/src/context/renderer-diagnostics.test.ts
+++ b/packages/app/src/context/renderer-diagnostics.test.ts
@@ -136,7 +136,7 @@ describe("renderer diagnostics", () => {
     expect(intervals).toBe(0)
   })
 
-  test("emits a jank incident directly from a threshold long task", () => {
+  test("emits one jank incident with the maximum long task in an observer batch", () => {
     const notify = capturePerformanceObservers()
     const events: RendererDiagnosticInput[] = []
 
@@ -150,7 +150,12 @@ describe("renderer diagnostics", () => {
         },
       })
 
-      notify("longtask", [{ duration: 100.4 } as PerformanceEntry])
+      notify("longtask", [
+        { duration: 99.4 } as PerformanceEntry,
+        { duration: 100.4 } as PerformanceEntry,
+        { duration: 175.6 } as PerformanceEntry,
+        { duration: 130.2 } as PerformanceEntry,
+      ])
       dispose()
     })
 
@@ -161,7 +166,7 @@ describe("renderer diagnostics", () => {
         route_session_id: "route-session",
         visible_session_id: "visible-session",
         timeline_session_id: "timeline-session",
-        data: { long_task_max_ms: 100, phase: "performance_observer" },
+        data: { long_task_max_ms: 176, phase: "performance_observer" },
       },
     ])
   })

--- a/packages/app/src/context/renderer-diagnostics.ts
+++ b/packages/app/src/context/renderer-diagnostics.ts
@@ -241,16 +241,17 @@ export function createSessionPerformanceDiagnostics(input: {
     try {
       longTaskObserver = new PerformanceObserver((list) => {
         if (!active) return
+        let maxDuration = 0
         for (const entry of list.getEntries()) {
-          const duration = Math.round(entry.duration)
-          if (duration < 100) continue
-          void emit({
-            name: "incident.session_jank_burst",
-            level: "warn",
-            ...baseEvent(),
-            data: { long_task_max_ms: duration, phase: "performance_observer" },
-          })
+          maxDuration = Math.max(maxDuration, Math.round(entry.duration))
         }
+        if (maxDuration < 100) return
+        void emit({
+          name: "incident.session_jank_burst",
+          level: "warn",
+          ...baseEvent(),
+          data: { long_task_max_ms: maxDuration, phase: "performance_observer" },
+        })
       })
       longTaskObserver.observe({ type: "longtask", buffered: true })
     } catch {}

--- a/packages/app/src/context/renderer-diagnostics.ts
+++ b/packages/app/src/context/renderer-diagnostics.ts
@@ -6,12 +6,6 @@ type DiagnosticsApi = {
   emitRendererDiagnostic?(event: RendererDiagnosticInput): Promise<void>
 }
 
-type PerformanceWithMemory = Performance & {
-  memory?: {
-    usedJSHeapSize?: number
-  }
-}
-
 let warnedRendererDiagnosticsEmitFailure = false
 
 function warnRendererDiagnosticsEmitFailure(reason: string, error?: unknown) {
@@ -20,10 +14,7 @@ function warnRendererDiagnosticsEmitFailure(reason: string, error?: unknown) {
   console.warn(`[renderer-diagnostics] ${reason}`, error)
 }
 
-export function createRendererDiagnosticsEmitter(input: {
-  api?: DiagnosticsApi
-  now?: () => number
-}) {
+export function createRendererDiagnosticsEmitter(input: { api?: DiagnosticsApi; now?: () => number }) {
   return async (event: RendererDiagnosticInput) => {
     const emit = input.api?.emitRendererDiagnostic
     if (!emit) {
@@ -232,17 +223,11 @@ export function createSessionPerformanceDiagnostics(input: {
 }) {
   if (!input.emit && (typeof window === "undefined" || !window.api?.emitRendererDiagnostic)) return
   const emit = input.emit ?? emitRendererDiagnostic
-  let running = true
-  let frame: number | undefined
-  let interval: number | undefined
-  let lastFrame = performance.now()
-  let sampleStartedAt = lastFrame
-  let frameCount = 0
-  let jankCount = 0
-  let maxFrameGap = 0
-  let longTaskMax = 0
-  let longTaskBlock = 0
+  let active = true
   let cls = 0
+  let clsWindowStartedAt: number | undefined
+  let clsLastShiftAt: number | undefined
+  let clsIncidentEmitted = false
   let longTaskObserver: PerformanceObserver | undefined
   let layoutShiftObserver: PerformanceObserver | undefined
 
@@ -252,81 +237,19 @@ export function createSessionPerformanceDiagnostics(input: {
     timeline_session_id: input.timelineSessionID(),
   })
 
-  const tick = (now: number) => {
-    const gap = now - lastFrame
-    lastFrame = now
-    frameCount += 1
-    if (gap > 50) jankCount += 1
-    maxFrameGap = Math.max(maxFrameGap, gap)
-    if (running) frame = requestAnimationFrame(tick)
-  }
-
-  const flush = () => {
-    const now = performance.now()
-    if (document.visibilityState === "hidden") {
-      frameCount = 0
-      jankCount = 0
-      maxFrameGap = 0
-      longTaskMax = 0
-      longTaskBlock = 0
-      cls = 0
-      sampleStartedAt = now
-      lastFrame = now
-      return
-    }
-    const elapsedMs = Math.max(1, now - sampleStartedAt)
-    const fps = Math.round((frameCount * 1000) / elapsedMs)
-    const memory = performance as PerformanceWithMemory
-    const roundedFrameGap = Math.round(maxFrameGap)
-    const roundedLongTaskMax = Math.round(longTaskMax)
-    const base = baseEvent()
-    void emit({
-      name: "renderer.perf.sample",
-      ...base,
-      data: {
-        fps,
-        frame_gap_ms: roundedFrameGap,
-        jank_count: jankCount,
-        long_task_max_ms: roundedLongTaskMax,
-        long_task_block_ms: Math.round(longTaskBlock),
-        cls,
-        // Chrome exposes usedJSHeapSize in bytes.
-        heap_used_mb: memory.memory?.usedJSHeapSize
-          ? Math.round(memory.memory.usedJSHeapSize / 1024 / 1024)
-          : undefined,
-      },
-    })
-    if (cls >= 0.1) {
-      void emit({
-        name: "incident.session_layout_shift",
-        level: "warn",
-        ...base,
-        data: { cls, phase: "perf_sample" },
-      })
-    }
-    if (roundedLongTaskMax >= 100 || roundedFrameGap >= 250) {
-      void emit({
-        name: "incident.session_jank_burst",
-        level: "warn",
-        ...base,
-        data: { long_task_max_ms: roundedLongTaskMax, frame_gap_ms: roundedFrameGap, phase: "perf_sample" },
-      })
-    }
-    frameCount = 0
-    jankCount = 0
-    maxFrameGap = 0
-    longTaskMax = 0
-    longTaskBlock = 0
-    cls = 0
-    sampleStartedAt = now
-  }
-
   if (typeof PerformanceObserver !== "undefined") {
     try {
       longTaskObserver = new PerformanceObserver((list) => {
+        if (!active) return
         for (const entry of list.getEntries()) {
-          longTaskMax = Math.max(longTaskMax, entry.duration)
-          longTaskBlock += entry.duration
+          const duration = Math.round(entry.duration)
+          if (duration < 100) continue
+          void emit({
+            name: "incident.session_jank_burst",
+            level: "warn",
+            ...baseEvent(),
+            data: { long_task_max_ms: duration, phase: "performance_observer" },
+          })
         }
       })
       longTaskObserver.observe({ type: "longtask", buffered: true })
@@ -334,20 +257,40 @@ export function createSessionPerformanceDiagnostics(input: {
 
     try {
       layoutShiftObserver = new PerformanceObserver((list) => {
+        if (!active) return
         for (const entry of list.getEntries() as PerformanceEntry[]) {
           const value = (entry as PerformanceEntry & { value?: number; hadRecentInput?: boolean }).value
           const hadRecentInput = (entry as PerformanceEntry & { hadRecentInput?: boolean }).hadRecentInput
-          if (!hadRecentInput && typeof value === "number") cls += value
+          if (hadRecentInput || typeof value !== "number") continue
+          const continuesWindow =
+            clsWindowStartedAt !== undefined &&
+            clsLastShiftAt !== undefined &&
+            entry.startTime - clsLastShiftAt < 1_000 &&
+            entry.startTime - clsWindowStartedAt < 5_000
+          if (continuesWindow) {
+            cls += value
+          } else {
+            cls = value
+            clsWindowStartedAt = entry.startTime
+            clsIncidentEmitted = false
+          }
+          clsLastShiftAt = entry.startTime
+          if (cls < 0.1 || clsIncidentEmitted) continue
+          clsIncidentEmitted = true
+          void emit({
+            name: "incident.session_layout_shift",
+            level: "warn",
+            ...baseEvent(),
+            data: { cls, phase: "performance_observer" },
+          })
         }
       })
       layoutShiftObserver.observe({ type: "layout-shift", buffered: true })
     } catch {}
   }
 
-  frame = requestAnimationFrame(tick)
-  interval = window.setInterval(flush, 5_000)
-
   const onVisibilityChange = () => {
+    if (!active) return
     void emit({
       name: "renderer.visibility",
       ...baseEvent(),
@@ -357,9 +300,7 @@ export function createSessionPerformanceDiagnostics(input: {
   document.addEventListener("visibilitychange", onVisibilityChange)
 
   onCleanup(() => {
-    running = false
-    if (frame !== undefined) cancelAnimationFrame(frame)
-    if (interval !== undefined) window.clearInterval(interval)
+    active = false
     longTaskObserver?.disconnect()
     layoutShiftObserver?.disconnect()
     document.removeEventListener("visibilitychange", onVisibilityChange)

--- a/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.test.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.test.ts
@@ -25,6 +25,8 @@ describe("renderer diagnostics sanitizer", () => {
 
     expect(event).toMatchObject({
       "event.name": "renderer.perf.sample",
+      app_launch_id: "launch_1",
+      window_id: "7",
       route_session_id: "ses_route",
       data: {
         fps: 60,

--- a/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.test.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.test.ts
@@ -1,7 +1,43 @@
 import { describe, expect, test } from "bun:test"
-import { sanitizeRendererDiagnosticEvent, type RendererDiagnosticInput } from "./renderer-diagnostics"
+import { parseEventLine, sanitizeRendererDiagnosticEvent, type RendererDiagnosticInput } from "./renderer-diagnostics"
 
 describe("renderer diagnostics sanitizer", () => {
+  test("keeps historical renderer performance samples readable from JSONL", () => {
+    const event = parseEventLine(
+      JSON.stringify({
+        time: "2026-05-02T10:30:12.123Z",
+        level: "info",
+        "event.name": "renderer.perf.sample",
+        app_launch_id: "launch_1",
+        window_id: "7",
+        route_session_id: "ses_route",
+        data: {
+          fps: 60,
+          frame_gap_ms: 17,
+          jank_count: 1,
+          long_task_max_ms: 120,
+          long_task_block_ms: 140,
+          cls: 0.02,
+          heap_used_mb: 256,
+        },
+      }),
+    )
+
+    expect(event).toMatchObject({
+      "event.name": "renderer.perf.sample",
+      route_session_id: "ses_route",
+      data: {
+        fps: 60,
+        frame_gap_ms: 17,
+        jank_count: 1,
+        long_task_max_ms: 120,
+        long_task_block_ms: 140,
+        cls: 0.02,
+        heap_used_mb: 256,
+      },
+    })
+  })
+
   test("accepts allowlisted scroll fields and drops hostile fields", () => {
     const input: RendererDiagnosticInput = {
       name: "session.scroll.sample",


### PR DESCRIPTION
## Summary

- Remove the session diagnostics RAF loop, five-second interval, and production `renderer.perf.sample` emission.
- Emit long-task and CLS threshold incidents directly from `PerformanceObserver` callbacks, with CLS session-window accounting and cleanup guards.
- Keep visibility and existing session/timeline/scroll/refresh diagnostics intact, and lock historical `renderer.perf.sample` JSONL parsing with a desktop regression test.

## Why

Visible idle session pages continuously scheduled animation frames and periodic diagnostics samples. That diagnostic-only activity kept the renderer and GPU awake even when the user and session were inactive.

## Related Issue

Closes #1516

Parent context: #1515 (this PR does not close the parent issue).

## Human Review Status

Pending

## Review Focus

Please focus on the event-driven long-task/CLS thresholds, the CLS session-window boundaries, and the guarantee that observer callbacks cannot emit after cleanup.

## Risk Notes

- Automatic problem reports intentionally stop receiving periodic FPS, frame-gap, jank-count, and heap samples. Historical `renderer.perf.sample` JSONL remains readable.
- The diagnostics E2E file has two unrelated `dev` baseline failures: the scroll-reason assertion and worktree entry timeout fail identically from an isolated `origin/dev` worktree. The other two scenarios pass.
- No visible UI or copy changed, so manual screenshots/recordings are not applicable.
- No platform or packaging implementation changed; a real arm64 macOS packaged build and smoke run were still verified.
- No docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated content changed.

## How To Verify

```text
Focused renderer diagnostics tests: 13 passed (RED/GREEN coverage for zero RAF/timers, event-driven long-task/CLS incidents, and cleanup)
Historical desktop diagnostics compatibility: 8 passed, including old renderer.perf.sample JSONL parsing
App unit suite: 2016 passed
Desktop host unit suite: 641 passed
App typecheck: passed
Desktop typecheck and release typecheck: passed
Changed-source ESLint and Prettier: passed (test files are excluded by the repository ESLint config)
Diagnostics E2E: 2 passed; 2 failed identically on origin/dev baseline (documented in Risk Notes)
Desktop production build: passed
Packaged arm64 macOS smoke with a real renderer CDP target: passed

Five fresh packaged visible-session idle runs, watcher disabled only as an isolation variable:
run 1 — renderer 0.013% CPU / 4.069 csw/s; GPU 0.000% CPU / 1.138 csw/s
run 2 — renderer 0.313% CPU / 15.172 csw/s; GPU 0.000% CPU / 0.828 csw/s
run 3 — renderer 0.327% CPU / 18.172 csw/s; GPU 0.040% CPU / 9.414 csw/s
run 4 — renderer 0.313% CPU / 16.414 csw/s; GPU 0.087% CPU / 17.793 csw/s
run 5 — renderer 0.240% CPU / 15.655 csw/s; GPU 0.000% CPU / 2.000 csw/s
mean  — renderer 0.241% CPU / 13.896 csw/s; GPU 0.025% CPU / 6.235 csw/s

Protocol: isolated fresh user data, real packaged session route confirmed by session.timeline.mount JSONL, 20-second settle, 31 one-second top samples, first sample discarded. No renderer.perf.sample events were produced.
```

## Screenshots or Recordings

Not applicable; there is no visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session performance diagnostics to detect long-task and layout-shift incidents more reliably.
  * Prevented duplicate or stale diagnostic events after a session ends or its interface is disposed.
  * Reduced unnecessary performance monitoring while sessions are visible but idle.
  * Preserved renderer performance data when diagnostic events are parsed and sanitized.

* **Tests**
  * Expanded coverage for performance incidents, layout shifts, session cleanup, and diagnostic event parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->