### PR TITLE
fix(app): keep sessions sendable during status sync

### DIFF
--- a/packages/app/e2e/app/composer-send.spec.ts
+++ b/packages/app/e2e/app/composer-send.spec.ts
@@ -15,3 +15,41 @@ test("send enabled with non-empty input", async ({ page, project }) => {
   const send = page.locator(sessionComposerDockSelector).locator('[data-action="prompt-submit"]')
   await expect(send).toBeEnabled()
 })
+
+test("existing session stays sendable while status hydration is pending", async ({ page, project, assistant }) => {
+  let statusRequested = false
+  await page.route(/\/session\/status(?:\?|$)/, async () => {
+    statusRequested = true
+    await new Promise<never>(() => undefined)
+  })
+
+  let sessionID = ""
+  await project.open({
+    beforeGoto: async ({ sdk }) => {
+      const session = await sdk.session.create({ title: "Pending status hydration" }).then((response) => response.data)
+      if (!session?.id) throw new Error("Failed to create pending-status session")
+      sessionID = session.id
+      await sdk.session.prompt({
+        sessionID,
+        noReply: true,
+        parts: [{ type: "text", text: "Seed an existing conversation." }],
+      })
+    },
+  })
+  project.trackSession(sessionID)
+  await project.gotoSession(sessionID)
+  await expect.poll(() => statusRequested).toBe(true)
+
+  const prompt = page.locator(promptSelector)
+  await prompt.click()
+  await page.keyboard.type("/compact")
+
+  const send = page.locator(sessionComposerDockSelector).locator('[data-action="prompt-submit"]')
+  await expect(send).toBeEnabled()
+
+  const compact = page.locator('[data-slash-id="session.compact"]')
+  await expect(compact).toBeVisible()
+  await assistant.reply("Compacted conversation summary.")
+  await compact.click()
+  await expect(page.locator('[data-slot="session-turn-compaction"]')).toBeVisible()
+})

--- a/packages/app/e2e/app/composer-send.spec.ts
+++ b/packages/app/e2e/app/composer-send.spec.ts
@@ -29,6 +29,7 @@ test("existing session stays sendable while status hydration is pending", async 
       const session = await sdk.session.create({ title: "Pending status hydration" }).then((response) => response.data)
       if (!session?.id) throw new Error("Failed to create pending-status session")
       sessionID = session.id
+      project.trackSession(sessionID)
       await sdk.session.prompt({
         sessionID,
         noReply: true,
@@ -36,7 +37,6 @@ test("existing session stays sendable while status hydration is pending", async 
       })
     },
   })
-  project.trackSession(sessionID)
   await project.gotoSession(sessionID)
   await expect.poll(() => statusRequested).toBe(true)
 

--- a/packages/app/e2e/snap/session-status-readiness.snap.ts
+++ b/packages/app/e2e/snap/session-status-readiness.snap.ts
@@ -1,5 +1,4 @@
-import { expect } from "@playwright/test"
-import { test } from "../fixtures"
+import { expect, test } from "../fixtures"
 import { promptSelector, sessionComposerDockSelector } from "../selectors"
 import { composeGrid, snapOutputPath } from "./_compose"
 
@@ -16,6 +15,7 @@ test("session-status-readiness", async ({ page, project }) => {
       const session = await sdk.session.create({ title: "Pending status hydration" }).then((response) => response.data)
       if (!session?.id) throw new Error("Failed to create pending-status session")
       sessionID = session.id
+      project.trackSession(sessionID)
       await sdk.session.prompt({
         sessionID,
         noReply: true,
@@ -23,7 +23,6 @@ test("session-status-readiness", async ({ page, project }) => {
       })
     },
   })
-  project.trackSession(sessionID)
   await project.gotoSession(sessionID)
 
   const prompt = page.locator(promptSelector)

--- a/packages/app/e2e/snap/session-status-readiness.snap.ts
+++ b/packages/app/e2e/snap/session-status-readiness.snap.ts
@@ -1,0 +1,39 @@
+import { expect } from "@playwright/test"
+import { test } from "../fixtures"
+import { promptSelector, sessionComposerDockSelector } from "../selectors"
+import { composeGrid, snapOutputPath } from "./_compose"
+
+test.use({ viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 })
+
+test("session-status-readiness", async ({ page, project }) => {
+  await page.route(/\/session\/status(?:\?|$)/, async () => {
+    await new Promise<never>(() => undefined)
+  })
+
+  let sessionID = ""
+  await project.open({
+    beforeGoto: async ({ sdk }) => {
+      const session = await sdk.session.create({ title: "Pending status hydration" }).then((response) => response.data)
+      if (!session?.id) throw new Error("Failed to create pending-status session")
+      sessionID = session.id
+      await sdk.session.prompt({
+        sessionID,
+        noReply: true,
+        parts: [{ type: "text", text: "Seed an existing conversation." }],
+      })
+    },
+  })
+  project.trackSession(sessionID)
+  await project.gotoSession(sessionID)
+
+  const prompt = page.locator(promptSelector)
+  await prompt.click()
+  await page.keyboard.type("/compact")
+
+  const composer = page.locator(sessionComposerDockSelector)
+  await expect(composer.locator('[data-action="prompt-submit"]')).toBeEnabled()
+
+  const out = snapOutputPath("session-status-readiness")
+  await composeGrid([{ name: "pending-status-send-enabled", buf: await composer.screenshot() }], out, { cols: 1 })
+  process.stdout.write(`\n[snap] session-status-readiness grid -> ${out}\n\n`)
+})

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -19,6 +19,7 @@ import { getFilename } from "@opencode-ai/util/path"
 import { createContext, getOwner, onCleanup, onMount, type ParentProps, untrack, useContext } from "solid-js"
 import { createStore, produce, reconcile, type SetStoreFunction } from "solid-js/store"
 import { useLanguage } from "@/context/language"
+import { emitRendererDiagnostic } from "@/context/renderer-diagnostics"
 import { Persist, persisted } from "@/utils/persist"
 import { clientActionHeaders } from "@/utils/server"
 import type { InitError } from "../pages/error"
@@ -523,6 +524,7 @@ function createGlobalSync() {
         translate: language.t,
         queryClient,
         pendingQuestions: { reconcile: questions.reconcile },
+        emitDiagnostic: emitRendererDiagnostic,
       })
     })
 

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -396,6 +396,76 @@ describe("bootstrapDirectory", () => {
     }
   })
 
+  test("times out status hydration and records a diagnostic when the endpoint never settles", async () => {
+    const originalError = console.error
+    console.error = mock(() => undefined) as typeof console.error
+    const directory = "/tmp/project"
+    const queryClient = new QueryClient()
+    const [store, setStore] = createStore(createState())
+    const status = deferred<{ data: Record<string, never> }>()
+    let statusSignal: AbortSignal | undefined
+    const diagnostics: Array<{ name: string; level?: "info" | "warn"; data?: Record<string, unknown> }> = []
+
+    const sdk = {
+      app: { agents: async () => ({ data: [] }) },
+      config: { get: async () => ({ data: {} as Config }), errors: async () => ({ data: [] }) },
+      session: {
+        status: async (_parameters: unknown, options?: { signal?: AbortSignal }) => {
+          statusSignal = options?.signal
+          return status.promise
+        },
+        get: async () => ({ data: undefined }),
+      },
+      project: { current: async () => ({ data: { id: "project-1" } }) },
+      path: { get: async () => ({ data: { state: "", config: "", skills: "", worktree: "", directory, home: "" } as Path }) },
+      vcs: { get: async () => ({ data: undefined }) },
+      command: { list: async () => ({ data: [] }) },
+      permission: { list: async () => ({ data: [] }) },
+      externalResult: { list: async () => ({ data: [] }) },
+      mcp: { status: async () => ({ data: {} }) },
+      automation: { list: async () => ({ data: { items: [] } }) },
+      provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+    } as any
+
+    try {
+      await bootstrapDirectory({
+        directory,
+        sdk,
+        store,
+        setStore,
+        vcsCache: createVcsCache(),
+        loadSessions: () => undefined,
+        pendingQuestions: { reconcile() {} },
+        translate: (key) => key,
+        global: {
+          config: {} as Config,
+          path: { state: "", config: "", skills: "", worktree: "", directory: "", home: "" } as Path,
+          project: [] as Project[],
+          provider: { all: [], connected: [], default: {} },
+        },
+        queryClient,
+        sessionStatusTimeoutMs: 10,
+        emitDiagnostic: (event) => {
+          diagnostics.push(event)
+        },
+      })
+
+      await waitFor(() => store.session_status_state === "error")
+      expect(store.session_status_ready).toBe(false)
+      expect(statusSignal?.aborted).toBe(true)
+      expect(diagnostics).toEqual([
+        {
+          name: "incident.session_status_hydration_timeout",
+          level: "warn",
+          data: { timeout_ms: 10 },
+        },
+      ])
+    } finally {
+      status.resolve({ data: {} })
+      console.error = originalError
+    }
+  })
+
   test("skips pending interaction entries when warm session lookup returns 404", async () => {
     const directory = "/tmp/project"
     const queryClient = new QueryClient()

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -20,6 +20,7 @@ import { mergeAutomationList } from "./automation-store"
 import { pendingExternalResultQuestionFromPart, type PendingExternalResultQuestion } from "./external-result-question"
 import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
+import type { RendererDiagnosticInput } from "@/context/platform"
 import { QueryClient, queryOptions } from "@tanstack/solid-query"
 import { loadSessionsQuery, type GlobalStore } from "../global-sync"
 
@@ -55,6 +56,30 @@ function isNotFoundError(error: unknown) {
 }
 
 const providerRev = new Map<string, number>()
+const SESSION_STATUS_TIMEOUT_MS = 5_000
+
+class SessionStatusHydrationTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Session status hydration timed out after ${timeoutMs}ms`)
+    this.name = "SessionStatusHydrationTimeoutError"
+  }
+}
+
+async function withSessionStatusTimeout<T>(request: (signal: AbortSignal) => Promise<T>, timeoutMs: number) {
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new SessionStatusHydrationTimeoutError(timeoutMs))
+      controller.abort()
+    }, timeoutMs)
+  })
+  try {
+    return await Promise.race([request(controller.signal), timeout])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
 
 export function clearProviderRev(directory: string) {
   providerRev.delete(directory)
@@ -409,6 +434,8 @@ export async function bootstrapDirectory(input: {
   }
   queryClient: QueryClient
   pendingQuestions: { reconcile: (directory: string, entries: PendingExternalResultQuestion[]) => void }
+  sessionStatusTimeoutMs?: number
+  emitDiagnostic?: (event: RendererDiagnosticInput) => Promise<void> | void
 }) {
   const loading = input.store.status !== "complete"
   const seededProject = projectID(input.directory, input.global.project)
@@ -494,7 +521,10 @@ export async function bootstrapDirectory(input: {
           .catch((err) => console.error("Failed to load config errors", err)),
       () =>
         retry(() =>
-          input.sdk.session.status().then((x) => {
+          withSessionStatusTimeout(
+            (signal) => input.sdk.session.status(undefined, { signal }),
+            input.sessionStatusTimeoutMs ?? SESSION_STATUS_TIMEOUT_MS,
+          ).then((x) => {
             input.setStore(
               "session_status",
               reconcile(
@@ -508,7 +538,16 @@ export async function bootstrapDirectory(input: {
             input.setStore("session_status_state", "ready")
             input.setStore("session_status_ready", true)
           }),
-        ).catch((err) => {
+        ).catch(async (err) => {
+          if (err instanceof SessionStatusHydrationTimeoutError) {
+            await Promise.resolve(
+              input.emitDiagnostic?.({
+                name: "incident.session_status_hydration_timeout",
+                level: "warn",
+                data: { timeout_ms: err.timeoutMs },
+              }),
+            ).catch((diagnosticError) => console.warn("Failed to record session status timeout", diagnosticError))
+          }
           input.setStore("session_status_state", "error")
           input.setStore("session_status_ready", false)
           throw err

--- a/packages/app/src/pages/session/session-action-readiness.test.ts
+++ b/packages/app/src/pages/session/session-action-readiness.test.ts
@@ -78,13 +78,9 @@ describe("session action readiness", () => {
     ).toBe(false)
   })
 
-  test("session actions wait for cache and status", () => {
-    expect(currentSessionActionReady({ sessionID: "ses_1", sessionInfo: {}, rawMessages: [], statusReady: true })).toBe(
-      true,
-    )
-    expect(
-      currentSessionActionReady({ sessionID: "ses_1", sessionInfo: undefined, rawMessages: [], statusReady: true }),
-    ).toBe(false)
+  test("session actions stay available while status hydration is pending", () => {
+    expect(currentSessionActionReady({ sessionID: "ses_1", sessionInfo: {}, rawMessages: [] })).toBe(true)
+    expect(currentSessionActionReady({ sessionID: "ses_1", sessionInfo: undefined, rawMessages: [] })).toBe(false)
   })
 
   test("submit waits for local model and provider usability", () => {
@@ -93,7 +89,6 @@ describe("session action readiness", () => {
         sessionID: "ses_1",
         sessionInfo: {},
         rawMessages: [],
-        statusReady: true,
         localReady: true,
         providerUsable: true,
       }),
@@ -103,7 +98,6 @@ describe("session action readiness", () => {
         sessionID: "ses_1",
         sessionInfo: {},
         rawMessages: [],
-        statusReady: true,
         localReady: false,
         providerUsable: true,
       }),

--- a/packages/app/src/pages/session/session-action-readiness.ts
+++ b/packages/app/src/pages/session/session-action-readiness.ts
@@ -47,17 +47,15 @@ export function currentSessionActionReady(input: {
   sessionID: string | undefined
   sessionInfo: unknown
   rawMessages: unknown
-  statusReady: boolean
 }) {
   if (!input.sessionID) return true
-  return currentSessionCacheReady(input) && input.statusReady
+  return currentSessionCacheReady(input)
 }
 
 export function currentSessionSubmitReady(input: {
   sessionID: string | undefined
   sessionInfo: unknown
   rawMessages: unknown
-  statusReady: boolean
   localReady: boolean
   providerUsable: boolean
 }) {

--- a/packages/app/src/pages/session/session-action-readiness.ts
+++ b/packages/app/src/pages/session/session-action-readiness.ts
@@ -48,7 +48,6 @@ export function currentSessionActionReady(input: {
   sessionInfo: unknown
   rawMessages: unknown
 }) {
-  if (!input.sessionID) return true
   return currentSessionCacheReady(input)
 }
 

--- a/packages/app/src/pages/session/use-session-timeline-data.test.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.test.ts
@@ -361,44 +361,12 @@ describe("currentSessionCacheReady", () => {
 })
 
 describe("currentSessionActionReady", () => {
-  test("waits for the directory status list as well as cache hydration", () => {
+  test("does not let status hydration block an otherwise hydrated session", () => {
     expect(
       currentSessionActionReady({
         sessionID: "ses",
         sessionInfo: { id: "ses" },
         rawMessages: [],
-        statusReady: false,
-      }),
-    ).toBe(false)
-
-    expect(
-      currentSessionActionReady({
-        sessionID: "ses",
-        sessionInfo: { id: "ses" },
-        rawMessages: [],
-        statusReady: true,
-      }),
-    ).toBe(true)
-  })
-
-  test("does not wait for model selection or provider hydration", () => {
-    expect(
-      currentSessionActionReady({
-        sessionID: "ses",
-        sessionInfo: { id: "ses" },
-        rawMessages: [],
-        statusReady: true,
-      }),
-    ).toBe(true)
-  })
-
-  test("treats a loaded empty status list as idle for an otherwise hydrated session", () => {
-    expect(
-      currentSessionActionReady({
-        sessionID: "ses",
-        sessionInfo: { id: "ses" },
-        rawMessages: [],
-        statusReady: true,
       }),
     ).toBe(true)
   })
@@ -410,7 +378,6 @@ describe("currentSessionSubmitReady", () => {
       sessionID: "ses",
       sessionInfo: { id: "ses" },
       rawMessages: [],
-      statusReady: true,
     }
 
     expect(currentSessionSubmitReady({ ...ready, localReady: false, providerUsable: true })).toBe(false)
@@ -455,17 +422,7 @@ describe("sessionStatusKnown", () => {
     ).toBe(true)
   })
 
-  test("allows degraded actions after status list hydration fails", () => {
+  test("treats a failed status list as known degraded state", () => {
     expect(sessionStatusKnown({ statusState: "error", status: undefined })).toBe(true)
-    expect(
-      currentSessionSubmitReady({
-        sessionID: "ses",
-        sessionInfo: { id: "ses" },
-        rawMessages: [],
-        statusReady: sessionStatusKnown({ statusState: "error", status: undefined }),
-        localReady: true,
-        providerUsable: true,
-      }),
-    ).toBe(true)
   })
 })

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -188,7 +188,6 @@ export function createSessionTimelineData(input: {
       sessionID: id,
       sessionInfo: sessionInfo(),
       rawMessages: id ? input.sync.data.message[id] : undefined,
-      statusReady: statusKnown(),
     })
   })
   const actionReady = createMemo(() => {
@@ -197,7 +196,6 @@ export function createSessionTimelineData(input: {
       sessionID: id,
       sessionInfo: sessionInfo(),
       rawMessages: id ? input.sync.data.message[id] : undefined,
-      statusReady: statusKnown(),
       localReady: input.local.session.ready(),
       providerUsable: currentDirectoryProviderUsable({
         providerReady: input.sync.data.provider_ready,

--- a/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.test.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.test.ts
@@ -2,6 +2,42 @@ import { describe, expect, test } from "bun:test"
 import { parseEventLine, sanitizeRendererDiagnosticEvent, type RendererDiagnosticInput } from "./renderer-diagnostics"
 
 describe("renderer diagnostics sanitizer", () => {
+  test("keeps session readiness gates and status hydration timeouts", () => {
+    const context = {
+      appLaunchID: "launch_1",
+      now: () => new Date("2026-05-02T10:30:12.123Z"),
+      windowID: 7,
+    }
+    const view = sanitizeRendererDiagnosticEvent(
+      {
+        name: "session.view.state",
+        data: {
+          action_ready: true,
+          message_cache_present: true,
+          session_info_present: true,
+          status_known: false,
+        },
+      },
+      context,
+    )
+    const timeout = sanitizeRendererDiagnosticEvent(
+      {
+        name: "incident.session_status_hydration_timeout",
+        level: "warn",
+        data: { timeout_ms: 5_000 },
+      },
+      context,
+    )
+
+    expect(view?.data).toEqual({
+      action_ready: true,
+      message_cache_present: true,
+      session_info_present: true,
+      status_known: false,
+    })
+    expect(timeout?.data).toEqual({ timeout_ms: 5_000 })
+  })
+
   test("keeps historical renderer performance samples readable from JSONL", () => {
     const event = parseEventLine(
       JSON.stringify({

--- a/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.ts
+++ b/packages/desktop-electron/src/main/renderer-diagnostics-sanitize.ts
@@ -12,6 +12,10 @@ const eventDataFields = {
     "timeline_session_id",
     "route_ready",
     "visible_ready",
+    "action_ready",
+    "message_cache_present",
+    "session_info_present",
+    "status_known",
     "transitioning",
     "message_count",
     "part_count",
@@ -105,6 +109,7 @@ const eventDataFields = {
   "incident.session_visible_messages_cleared": ["before_count", "during_count", "after_count"],
   "incident.session_layout_shift": ["cls", "phase"],
   "incident.session_jank_burst": ["long_task_max_ms", "frame_gap_ms", "phase"],
+  "incident.session_status_hydration_timeout": ["timeout_ms"],
 } as const
 
 export const highFrequencyDiagnosticEvents = new Set([


### PR DESCRIPTION
## Summary

- Keep existing sessions sendable while the advisory session-status snapshot is still hydrating.
- Bound status hydration to five seconds, abort timed-out requests, and emit a privacy-sanitized diagnostic incident.
- Preserve the readiness facts needed to diagnose future composer lockouts in problem reports.
- There is no related issue; this fix follows a production problem report received on July 15, 2026.

## Why

The composer treated completion of `session.status` hydration as a hard prerequisite for every existing-session action. If that advisory request never settled, commands such as `/compact` remained permanently disabled even though the session, model, provider, and message cache were ready. The server is authoritative for session conflicts, so the client snapshot should improve queueing and presentation without becoming a permanent send lock.

## Related Issue

None — production problem report investigation.

## Human Review Status

Approved by @Astro-Han

## Review Focus

- The boundary between action readiness and advisory status state.
- Timeout and AbortController cleanup, including late request settlement.
- The narrow Electron diagnostic allowlist for readiness facts and timeout metadata.

## Risk Notes

When the status snapshot is unavailable, an action can reach the authoritative server instead of being locally queued from cached busy state; the server still validates session conflicts. The behavior is shared across macOS and Windows, and the Electron startup path was checked. Docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, and persistent local-file behavior were not changed.

## How To Verify

```text
App readiness/timeline/prompt unit tests: 88 passed
Status bootstrap unit tests: 25 passed, including timeout and request cancellation
Electron diagnostics sanitizer/slice tests: 13 passed
App and Electron TypeScript checks: passed
Focused Playwright path (pending status -> /compact -> visible compaction divider): passed
Focused snap target session-status-readiness: passed; generated grid reviewed
Desktop development startup: main/preload builds passed and sidecar reached ready
Changed-file ESLint and git diff --check: passed
```

## Screenshots or Recordings

Reviewed the `session-status-readiness` snap target: the existing-session composer shows `/compact` with the send action enabled while status hydration remains pending.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session actions and the send button remain available while session status is still loading.
  * Compact mode can be opened and used during pending status hydration.
  * Session status loading now times out gracefully instead of blocking indefinitely.
  * Added diagnostics for status hydration timeouts to improve error visibility.

* **Tests**
  * Added end-to-end coverage for pending status hydration, composer readiness, and compact mode behavior.
  * Added validation for timeout handling and diagnostic data sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
