### PR TITLE
fix(ui): prevent running subagent trow crashes

### DIFF
--- a/packages/ui/src/components/message-part-stale.test.ts
+++ b/packages/ui/src/components/message-part-stale.test.ts
@@ -37,6 +37,14 @@ test("assistant part renderers keep standalone parts stable and trow slots react
   expect(source).toContain("defaultOpen={defaultOpen()}")
 })
 
+test("trow renderers retain the last message instead of exposing a Show callback accessor", () => {
+  const source = readFileSync(join(COMPONENT_DIR, "message-part", "assistant-parts.tsx"), "utf8")
+
+  expect(source).toContain("const stableMessage = latestDefined(() => msgs().get(part().messageID))")
+  expect(source).toContain("message={stableMessage()!}")
+  expect(source).not.toMatch(/<Show when=\{message\(\)\}>\s*\{\(message\) =>/)
+})
+
 test("tool file accordions account for tool content gap in sticky offset", () => {
   const source = readMessagePartSources()
 

--- a/packages/ui/src/components/message-part/assistant-parts.tsx
+++ b/packages/ui/src/components/message-part/assistant-parts.tsx
@@ -18,7 +18,7 @@ export function AssistantParts(props: {
   const emptyTools: ToolPart[] = []
   const emptyTrowParts: TrowPart[] = []
   const msgs = createMemo(() => index(props.messages))
-  const part = createMemo(
+  const partsByMessage = createMemo(
     () =>
       new Map(
         props.messages.map((message) => [message.id, index(list(data.store.part?.[message.id], emptyParts))] as const),
@@ -56,7 +56,7 @@ export function AssistantParts(props: {
                     const entry = entryAccessor()
                     if (entry.type !== "trow") return emptyTrowParts
                     return entry.refs
-                      .map((ref) => part().get(ref.messageID)?.get(ref.partID))
+                      .map((ref) => partsByMessage().get(ref.messageID)?.get(ref.partID))
                       .filter((p): p is TrowPart => !!p && (p.type === "tool" || p.type === "reasoning"))
                   },
                   emptyTrowParts,
@@ -113,7 +113,7 @@ export function AssistantParts(props: {
                 const item = createMemo(() => {
                   const entry = entryAccessor()
                   if (entry.type !== "part") return
-                  return part().get(entry.ref.messageID)?.get(entry.ref.partID)
+                  return partsByMessage().get(entry.ref.messageID)?.get(entry.ref.partID)
                 })
                 const stableMessage = latestDefined(() => message())
                 const stableItem = latestDefined(() => item())

--- a/packages/ui/src/components/message-part/assistant-parts.tsx
+++ b/packages/ui/src/components/message-part/assistant-parts.tsx
@@ -66,24 +66,22 @@ export function AssistantParts(props: {
                 const singleTool = createMemo(() => toolParts().length === 1 && parts().length === 1)
                 const defaultOpenForTool = (tool: ToolPart) => partDefaultOpen(tool) ?? singleTool()
                 const renderPart = (part: Accessor<TrowPart>) => {
-                  const message = createMemo(() => msgs().get(part().messageID))
+                  const stableMessage = latestDefined(() => msgs().get(part().messageID))
                   const stateKey = () => `${part().type === "tool" ? "tool" : "reasoning"}:${part().id}`
                   const defaultOpen = () => {
                     const current = part()
                     return current.type === "tool" ? defaultOpenForTool(current) : false
                   }
                   return (
-                    <Show when={message()}>
-                      {(message) => (
-                        <div data-slot="trow-result-body" data-timeline-anchor={stateKey()}>
-                          <Part
-                            part={part()}
-                            message={message()}
-                            defaultOpen={defaultOpen()}
-                            stateKey={stateKey()}
-                          />
-                        </div>
-                      )}
+                    <Show when={stableMessage()}>
+                      <div data-slot="trow-result-body" data-timeline-anchor={stateKey()}>
+                        <Part
+                          part={part()}
+                          message={stableMessage()!}
+                          defaultOpen={defaultOpen()}
+                          stateKey={stateKey()}
+                        />
+                      </div>
                     </Show>
                   )
                 }


### PR DESCRIPTION
## Summary

Prevent running subagent trow rows from crashing while their streamed message is briefly unavailable.

## Why

The trow renderer passed a non-keyed Solid `<Show>` callback accessor into the nested part tree. During batched stream updates, that accessor could be read after its condition invalidated, causing `Stale read from <Show>` and replacing the app with the fatal error screen.

The existing standalone-part path already solves this lifecycle boundary with `latestDefined`. This change reuses that same extension point for trow parts and removes the stale callback accessor without changing component identity or rendering behavior.

## Related Issue

Closes #1521

## Human Review Status

Pending

## Review Focus

Confirm that retaining the latest defined message is the correct lifecycle boundary for streamed trow parts and that the source guard narrowly prevents reintroducing a callback-form `<Show>` at this site.

## Risk Notes

- The existing `session-child-navigation.spec.ts` E2E did not reach the click assertion because its setup currently fails with `Session not found`; this is unrelated to the changed UI path and was not expanded into this PR.
- Platform/packaging checklist item skipped: no Electron, OS integration, packaging, path, shell, or permission behavior changed.
- Ancillary-surface checklist item skipped: no docs, release notes, dependencies, permissions, credentials, deletion behavior, or generated content changed.

## How To Verify

```text
UI typecheck: passed (`bun run typecheck` in packages/ui)
Focused UI tests: 36 passed across message-part stale guards and trow render/reducer coverage
Targeted lint: changed production source passed with no errors
Visual renderer check: `bun run snap session-trow` passed; generated grid manually reviewed for running, collapsed, and expanded trow states
Diff check: no whitespace errors
Existing click-path E2E: blocked before interaction by pre-existing `Session not found` setup failure; no `Stale read from <Show>` was observed
```

## Screenshots or Recordings

No visible UI change. The existing `session-trow` snap target passed and its full grid was manually reviewed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when rendering assistant message parts.
  * Prevented the latest message from being replaced by an outdated or transient value during updates.

* **Tests**
  * Added coverage to verify that message rendering remains stable and avoids exposing intermediate callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->