### PR TITLE
fix(provider): classify Zen model unavailability

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -2,7 +2,7 @@ import { APICallError } from "ai"
 import { STATUS_CODES } from "http"
 import z from "zod"
 import { iife } from "@/util/iife"
-import type { ProviderID } from "./schema"
+import { ProviderID } from "./schema"
 
 // Canonical, serializable classification of a provider/API failure. Populated
 // once where the payload is parsed and carried on APIError.data.providerFailure
@@ -212,6 +212,15 @@ function extractProviderCode(body: unknown): string | undefined {
   if (error && typeof error.status === "string") return error.status
   if (typeof body.status === "string") return body.status
   return undefined
+}
+
+function isOpenCodeModelUnavailable(providerID: ProviderID, body: unknown) {
+  if (providerID !== ProviderID.opencode || !isRecord(body) || body.type !== "error") return false
+  const error = isRecord(body.error) ? body.error : undefined
+  // Zen uses 401 for this router-capacity failure, so the structured body must
+  // override the status without weakening genuine auth handling for any other
+  // provider or error shape.
+  return error?.type === "ModelError" && error.message === "No provider available"
 }
 
 function message(providerID: ProviderID, e: APICallError) {
@@ -460,6 +469,7 @@ export function parseAPICallError(input: { providerID: ProviderID; error: APICal
   const m = message(input.providerID, input.error)
   const body = json(input.error.responseBody)
   const code = extractProviderCode(body)
+  const modelUnavailable = isOpenCodeModelUnavailable(input.providerID, body)
   if (isOverflow(m) || input.error.statusCode === 413 || code === "context_length_exceeded") {
     return {
       type: "context_overflow",
@@ -482,11 +492,15 @@ export function parseAPICallError(input: { providerID: ProviderID; error: APICal
     type: "api_error",
     message: m,
     statusCode: input.error.statusCode,
-    isRetryable: input.providerID.startsWith("openai") ? isOpenAiErrorRetryable(input.error) : input.error.isRetryable,
+    isRetryable: modelUnavailable
+      ? true
+      : input.providerID.startsWith("openai")
+        ? isOpenAiErrorRetryable(input.error)
+        : input.error.isRetryable,
     responseHeaders: input.error.responseHeaders,
     responseBody: input.error.responseBody,
     metadata,
-    kind: billingKind ?? apiCallErrorKind(input.error.statusCode, code),
+    kind: modelUnavailable ? "server_overload" : (billingKind ?? apiCallErrorKind(input.error.statusCode, code)),
     code,
   }
 }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -2234,6 +2234,36 @@ describe("session.message-v2.fromError — PR1 classification completeness", () 
     expect((result as MessageV2.APIError).data.providerFailure?.kind).toBe("rate_limit")
   })
 
+  test("classifies OpenCode Zen's 401 No provider available response as a retryable server overload", () => {
+    const responseBody = JSON.stringify({
+      type: "error",
+      error: { type: "ModelError", message: "No provider available" },
+    })
+    const result = MessageV2.fromError(
+      makeApiError({
+        message: "No provider available",
+        statusCode: 401,
+        responseBody,
+      }),
+      { providerID: ProviderID.opencode },
+    )
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data).toMatchObject({
+      isRetryable: true,
+      providerFailure: { kind: "server_overload", code: "ModelError" },
+    })
+
+    const otherProvider = MessageV2.fromError(
+      makeApiError({ message: "No provider available", statusCode: 401, responseBody }),
+      { providerID },
+    )
+    expect((otherProvider as MessageV2.APIError).data).toMatchObject({
+      isRetryable: false,
+      providerFailure: { kind: "auth", code: "ModelError" },
+    })
+  })
+
   test("does not let a rate-limit signal on a billing-shaped status become terminal quota_exhausted", () => {
     // The weak billing patterns ("quota exceeded") fire only on a 400/402/403
     // with no rate-limit signal. A Retry-After header means the provider is


### PR DESCRIPTION
## Summary

Classify OpenCode Zen's structured `ModelError: No provider available` response as a retryable `server_overload` instead of an authentication failure. No issue was opened because this fix comes directly from a user diagnostic report.

## Why

Zen can return HTTP 401 when its router temporarily has no upstream provider for the selected model. PawWork previously let the status code dominate the structured response body, displayed “Sign-in expired,” and stopped retrying even though signing in again could not resolve the outage.

The override is intentionally narrow: it requires the `opencode` provider and the exact typed error body. Genuine 401 responses and identical messages from other providers remain authentication failures.

## Related Issue

None; reported through a PawWork problem report generated from version 2026.7.2 on Windows.

## Human Review Status

Pending

## Review Focus

Verify that the provider-specific structured-body match is narrow enough and that reusing the existing `server_overload` path is preferable to adding a new failure kind.

## Risk Notes

Low risk. The only behavior change is for the exact OpenCode Zen error shape. A regression guard proves that the same 401 body from another provider remains a non-retryable auth failure. No docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local files changed.

## How To Verify

```text
Focused provider and retry tests: 128 passed
Error-card presentation tests: 8 passed
OpenCode package typecheck: passed
Diff whitespace check: passed
Chromium visual snap: error-card target passed; inspected zh/en collapsed and detail states
```

## Screenshots or Recordings

Ran `bun run snap error-card` and reviewed `docs/design/preview/screenshots/error-card.png`. The existing target covers the error-card component in Chinese and English, collapsed and expanded; this PR changes classification only, not component geometry or copy.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
