### PR TITLE
fix(browser): isolate embedded profiles per session

### DIFF
--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -63,8 +63,8 @@ export type BrowserState = {
 export type BrowserTarget = string
 
 /**
- * Control surface for the embedded browser (one app-owned WebContentsView per
- * conversation, all sharing a persistent partition). Every call names its
+ * Control surface for the embedded browser (one app-owned WebContentsView and
+ * persistent browser profile per conversation). Every call names its
  * target conversation; main validates the target against what the calling
  * window is showing. Desktop/Electron only — undefined on web, where there is
  * no native view to drive. Gate usage with `canUseBrowser`.
@@ -87,10 +87,10 @@ export type BrowserBridge = {
   adoptDraft(sessionID: string): Promise<{ adopted: boolean; hasPage: boolean }>
   /** Destroy the target's page outright (view, history, renderer process) via
    *  the same chain as session delete/archive. WYSIWYG counterpart of the
-   *  browser tab's ×. Cookies/storage survive in the shared partition. */
+   *  browser tab's ×. Cookies/storage survive in the conversation's profile. */
   closePage(target: BrowserTarget): Promise<void>
-  /** Sign out of every site: clear cookies, storage, and cache (all targets —
-   *  the partition is shared). */
+  /** Sign out of every site across all conversation profiles: clear cookies,
+   *  storage, and cache. */
   clearData(): Promise<void>
   /** Step or reset the embedded page zoom for this conversation's view. */
   zoom(target: BrowserTarget, action: "in" | "out" | "reset"): Promise<void>

--- a/packages/desktop-electron/src/main/browser/controller-automation.ts
+++ b/packages/desktop-electron/src/main/browser/controller-automation.ts
@@ -1,6 +1,9 @@
+import { join } from "node:path"
+import { app, session } from "electron"
 import { BrowserViewController } from "./controller"
 import { BrowserControllerRegistry } from "./registry"
 import { BrowserProfileRegistry } from "./profile-registry"
+import { BrowserProfileSessions } from "./profile-sessions"
 import { getStore } from "../store"
 import { PAWWORK_RUNTIME } from "../runtime-namespace"
 
@@ -11,8 +14,17 @@ export const browserProfiles = new BrowserProfileRegistry({
   write: (profiles) => getStore(PAWWORK_RUNTIME.browserProfilesStore).set(PROFILE_MAP_KEY, profiles),
 })
 
+export const browserProfileSessions = new BrowserProfileSessions({
+  rootPath: () => join(app.getPath("sessionData"), PAWWORK_RUNTIME.browserProfilesDirectory),
+  fromPath: (path) => session.fromPath(path),
+})
+
 /** Single main-process instance of the conversation-view registry (see registry.ts). */
 export const browserControllers = new BrowserControllerRegistry((key: string) => {
   const profileID = browserProfiles.profileFor(key)
-  return new BrowserViewController(key, profileID, (sessionID) => browserProfiles.adopt(sessionID, profileID))
+  return new BrowserViewController(
+    key,
+    browserProfileSessions.sessionFor(profileID),
+    (sessionID) => browserProfiles.adopt(sessionID, profileID),
+  )
 })

--- a/packages/desktop-electron/src/main/browser/controller-automation.ts
+++ b/packages/desktop-electron/src/main/browser/controller-automation.ts
@@ -1,5 +1,18 @@
 import { BrowserViewController } from "./controller"
 import { BrowserControllerRegistry } from "./registry"
+import { BrowserProfileRegistry } from "./profile-registry"
+import { getStore } from "../store"
+import { PAWWORK_RUNTIME } from "../runtime-namespace"
+
+const PROFILE_MAP_KEY = "profiles"
+
+export const browserProfiles = new BrowserProfileRegistry({
+  read: () => getStore(PAWWORK_RUNTIME.browserProfilesStore).get(PROFILE_MAP_KEY),
+  write: (profiles) => getStore(PAWWORK_RUNTIME.browserProfilesStore).set(PROFILE_MAP_KEY, profiles),
+})
 
 /** Single main-process instance of the conversation-view registry (see registry.ts). */
-export const browserControllers = new BrowserControllerRegistry((key: string) => new BrowserViewController(key))
+export const browserControllers = new BrowserControllerRegistry((key: string) => {
+  const profileID = browserProfiles.profileFor(key)
+  return new BrowserViewController(key, profileID, (sessionID) => browserProfiles.adopt(sessionID, profileID))
+})

--- a/packages/desktop-electron/src/main/browser/controller.ts
+++ b/packages/desktop-electron/src/main/browser/controller.ts
@@ -1,6 +1,6 @@
-import { BrowserWindow, WebContentsView, session, shell } from "electron"
+import { BrowserWindow, WebContentsView, shell, type Session } from "electron"
 import type { BrowserState, BrowserViewLayout } from "@opencode-ai/app/desktop-api"
-import { browserPartition, browserViewWebPreferences } from "./options"
+import { browserViewWebPreferences } from "./options"
 import { configurePartitionUserAgent } from "./user-agent"
 import {
   clampPageZoom,
@@ -29,17 +29,17 @@ export const BROWSER_DISPLAY_TAKEN_CHANNEL = "browser:display-taken"
  */
 const DEFAULT_VIEW_BOUNDS = { x: 0, y: 0, width: 1280, height: 720 }
 
-const configuredUserAgentPartitions = new Set<string>()
+const configuredUserAgentSessions = new WeakSet<Session>()
 /**
- * Configure the browser partition's UA before the first view/request, exactly
- * once: present the partition as the faithful Chrome it is (rewrite + rationale
- * in user-agent.ts and the PR). Scoped to the browser partition; the app
+ * Configure the browser profile Session's UA before the first view/request,
+ * exactly once: present the profile as the faithful Chrome it is (rewrite +
+ * rationale in user-agent.ts and the PR). Scoped to the browser Session; the app
  * renderer keeps its own UA.
  */
-function ensureBrowserPartitionUserAgent(partitionName: string) {
-  if (configuredUserAgentPartitions.has(partitionName)) return
-  configuredUserAgentPartitions.add(partitionName)
-  configurePartitionUserAgent(session.fromPartition(partitionName), process.versions.chrome ?? "")
+function ensureBrowserSessionUserAgent(profileSession: Session) {
+  if (configuredUserAgentSessions.has(profileSession)) return
+  configuredUserAgentSessions.add(profileSession)
+  configurePartitionUserAgent(profileSession, process.versions.chrome ?? "")
 }
 
 /**
@@ -69,13 +69,13 @@ export class BrowserViewController {
 
   constructor(
     private target: string,
-    private readonly profileID: string,
+    profileSession: Session,
     private readonly onRetarget: (target: string) => void = () => {},
   ) {
-    // Configure the partition UA before the view exists, so its very first
+    // Configure the profile UA before the view exists, so its very first
     // request already carries the faithful Chrome UA.
-    ensureBrowserPartitionUserAgent(browserPartition(profileID))
-    this.view = new WebContentsView({ webPreferences: browserViewWebPreferences(profileID) })
+    ensureBrowserSessionUserAgent(profileSession)
+    this.view = new WebContentsView({ webPreferences: browserViewWebPreferences(profileSession) })
     this.view.setVisible(false)
     this.view.setBounds(DEFAULT_VIEW_BOUNDS)
     this.wireEvents()
@@ -89,10 +89,6 @@ export class BrowserViewController {
   retarget(target: string) {
     this.target = target
     this.onRetarget(target)
-  }
-
-  browserProfileID() {
-    return this.profileID
   }
 
   private wireEvents() {

--- a/packages/desktop-electron/src/main/browser/controller.ts
+++ b/packages/desktop-electron/src/main/browser/controller.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, WebContentsView, session, shell } from "electron"
 import type { BrowserState, BrowserViewLayout } from "@opencode-ai/app/desktop-api"
-import { BROWSER_PARTITION, browserViewWebPreferences } from "./options"
+import { browserPartition, browserViewWebPreferences } from "./options"
 import { configurePartitionUserAgent } from "./user-agent"
 import {
   clampPageZoom,
@@ -29,17 +29,17 @@ export const BROWSER_DISPLAY_TAKEN_CHANNEL = "browser:display-taken"
  */
 const DEFAULT_VIEW_BOUNDS = { x: 0, y: 0, width: 1280, height: 720 }
 
-let partitionUserAgentConfigured = false
+const configuredUserAgentPartitions = new Set<string>()
 /**
  * Configure the browser partition's UA before the first view/request, exactly
  * once: present the partition as the faithful Chrome it is (rewrite + rationale
  * in user-agent.ts and the PR). Scoped to the browser partition; the app
  * renderer keeps its own UA.
  */
-function ensureBrowserPartitionUserAgent() {
-  if (partitionUserAgentConfigured) return
-  partitionUserAgentConfigured = true
-  configurePartitionUserAgent(session.fromPartition(BROWSER_PARTITION), process.versions.chrome ?? "")
+function ensureBrowserPartitionUserAgent(partitionName: string) {
+  if (configuredUserAgentPartitions.has(partitionName)) return
+  configuredUserAgentPartitions.add(partitionName)
+  configurePartitionUserAgent(session.fromPartition(partitionName), process.versions.chrome ?? "")
 }
 
 /**
@@ -60,18 +60,22 @@ export class BrowserViewController {
   private throttlingBefore: boolean | null = null
   /**
    * Sole source of truth for this conversation's page zoom (1 = 100%).
-   * Chromium may also remember per-origin zoom in the shared partition; we
+   * Chromium may also remember per-origin zoom in this profile's partition; we
    * reassert this value on navigate/display so the UI percent matches the page.
    */
   private pageZoom = PAGE_ZOOM_DEFAULT
   /** Suppress zoom-changed while we write setZoomFactor ourselves. */
   private applyingPageZoom = false
 
-  constructor(private target: string) {
+  constructor(
+    private target: string,
+    private readonly profileID: string,
+    private readonly onRetarget: (target: string) => void = () => {},
+  ) {
     // Configure the partition UA before the view exists, so its very first
     // request already carries the faithful Chrome UA.
-    ensureBrowserPartitionUserAgent()
-    this.view = new WebContentsView({ webPreferences: browserViewWebPreferences() })
+    ensureBrowserPartitionUserAgent(browserPartition(profileID))
+    this.view = new WebContentsView({ webPreferences: browserViewWebPreferences(profileID) })
     this.view.setVisible(false)
     this.view.setBounds(DEFAULT_VIEW_BOUNDS)
     this.wireEvents()
@@ -84,6 +88,11 @@ export class BrowserViewController {
   /** Draft adoption rekeys the controller; state pushes follow the new owner. */
   retarget(target: string) {
     this.target = target
+    this.onRetarget(target)
+  }
+
+  browserProfileID() {
+    return this.profileID
   }
 
   private wireEvents() {
@@ -92,7 +101,7 @@ export class BrowserViewController {
     wc.on("did-stop-loading", () => this.emitState())
     wc.on("did-navigate", () => {
       this.favicon = null
-      // HostZoomMap is origin-scoped in the shared partition; reassert so a new
+      // HostZoomMap is origin-scoped in the profile partition; reassert so a new
       // host does not leave the page at 100% while state still shows the old %.
       this.reassertPageZoom()
       this.emitState()

--- a/packages/desktop-electron/src/main/browser/options.test.ts
+++ b/packages/desktop-electron/src/main/browser/options.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, test } from "bun:test"
-import { BROWSER_PARTITION, browserViewWebPreferences } from "./options"
+import { browserViewWebPreferences } from "./options"
 
 describe("embedded browser security", () => {
-  test("uses a locked-down, preload-free, sandboxed view on a persistent partition", () => {
-    const prefs = browserViewWebPreferences()
+  test("uses a locked-down persistent partition isolated by browser profile", () => {
+    const first = browserViewWebPreferences("profile-a")
+    const second = browserViewWebPreferences("profile-b")
 
-    expect(prefs).toMatchObject({
+    expect(first).toMatchObject({
       sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
       webSecurity: true,
     })
     // The embedded page must never receive the app's IPC preload bridge.
-    expect(prefs.preload).toBeUndefined()
-    expect(prefs.partition).toBe(BROWSER_PARTITION)
-    expect(BROWSER_PARTITION.startsWith("persist:")).toBe(true)
+    expect(first.preload).toBeUndefined()
+    expect(first.partition).not.toBe(second.partition)
+    expect(first.partition?.startsWith("persist:")).toBe(true)
   })
 })

--- a/packages/desktop-electron/src/main/browser/options.test.ts
+++ b/packages/desktop-electron/src/main/browser/options.test.ts
@@ -1,20 +1,21 @@
 import { describe, expect, test } from "bun:test"
+import type { Session } from "electron"
 import { browserViewWebPreferences } from "./options"
 
 describe("embedded browser security", () => {
-  test("uses a locked-down persistent partition isolated by browser profile", () => {
-    const first = browserViewWebPreferences("profile-a")
-    const second = browserViewWebPreferences("profile-b")
+  test("uses the supplied profile session with locked-down web preferences", () => {
+    const profileSession = {} as Session
+    const preferences = browserViewWebPreferences(profileSession)
 
-    expect(first).toMatchObject({
+    expect(preferences).toMatchObject({
+      session: profileSession,
       sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
       webSecurity: true,
     })
     // The embedded page must never receive the app's IPC preload bridge.
-    expect(first.preload).toBeUndefined()
-    expect(first.partition).not.toBe(second.partition)
-    expect(first.partition?.startsWith("persist:")).toBe(true)
+    expect(preferences.preload).toBeUndefined()
+    expect(preferences.partition).toBeUndefined()
   })
 })

--- a/packages/desktop-electron/src/main/browser/options.ts
+++ b/packages/desktop-electron/src/main/browser/options.ts
@@ -1,16 +1,7 @@
-import type { WebPreferences } from "electron"
+import type { Session, WebPreferences } from "electron"
 
 /** The pre-isolation shared profile, retained only so Clear Data can erase it. */
 export const LEGACY_BROWSER_PARTITION = "persist:pawwork-browser"
-
-/**
- * A persistent Electron partition owned by one browser profile. Different
- * profiles must never share a partition: Electron makes cookies, storage,
- * cache, service workers, and permission handlers session-wide.
- */
-export function browserPartition(profileID: string): string {
-  return `persist:pawwork-browser-${profileID}`
-}
 
 /**
  * WebPreferences for the embedded browser's WebContentsView. It loads arbitrary
@@ -18,9 +9,9 @@ export function browserPartition(profileID: string): string {
  * renderer (window-options.ts): no preload — the page must never receive the
  * app's IPC bridge — plus sandbox, context isolation, no Node, web security on.
  */
-export function browserViewWebPreferences(profileID: string): WebPreferences {
+export function browserViewWebPreferences(profileSession: Session): WebPreferences {
   return {
-    partition: browserPartition(profileID),
+    session: profileSession,
     sandbox: true,
     contextIsolation: true,
     nodeIntegration: false,

--- a/packages/desktop-electron/src/main/browser/options.ts
+++ b/packages/desktop-electron/src/main/browser/options.ts
@@ -1,11 +1,16 @@
 import type { WebPreferences } from "electron"
 
+/** The pre-isolation shared profile, retained only so Clear Data can erase it. */
+export const LEGACY_BROWSER_PARTITION = "persist:pawwork-browser"
+
 /**
- * Single app-owned persistent partition: one browsing session shared by every
- * window, surviving restarts. `persist:` keeps cookies/storage on disk so logins
- * stick; clear-data wipes it. Multi-profile is intentionally out of scope (#1186).
+ * A persistent Electron partition owned by one browser profile. Different
+ * profiles must never share a partition: Electron makes cookies, storage,
+ * cache, service workers, and permission handlers session-wide.
  */
-export const BROWSER_PARTITION = "persist:pawwork-browser"
+export function browserPartition(profileID: string): string {
+  return `persist:pawwork-browser-${profileID}`
+}
 
 /**
  * WebPreferences for the embedded browser's WebContentsView. It loads arbitrary
@@ -13,9 +18,9 @@ export const BROWSER_PARTITION = "persist:pawwork-browser"
  * renderer (window-options.ts): no preload — the page must never receive the
  * app's IPC bridge — plus sandbox, context isolation, no Node, web security on.
  */
-export function browserViewWebPreferences(): WebPreferences {
+export function browserViewWebPreferences(profileID: string): WebPreferences {
   return {
-    partition: BROWSER_PARTITION,
+    partition: browserPartition(profileID),
     sandbox: true,
     contextIsolation: true,
     nodeIntegration: false,

--- a/packages/desktop-electron/src/main/browser/profile-registry.test.ts
+++ b/packages/desktop-electron/src/main/browser/profile-registry.test.ts
@@ -30,10 +30,9 @@ describe("BrowserProfileRegistry", () => {
 
     const restored = new BrowserProfileRegistry(memory.storage, ids("unused"))
     expect(restored.profileFor("ses_a")).toBe("profile-a")
-    expect(restored.profileIDs()).toEqual(["profile-a", "profile-b"])
   })
 
-  test("keeps draft profiles unique and binds the adopted profile to its new session", () => {
+  test("keeps draft profiles unique without persisting reusable draft owner keys", () => {
     const memory = memoryStorage()
     const profiles = new BrowserProfileRegistry(memory.storage, ids("draft-a", "draft-b"))
 
@@ -41,7 +40,14 @@ describe("BrowserProfileRegistry", () => {
     const secondDraft = profiles.profileFor(draftKey(2))
     expect(firstDraft).toBe("draft-a")
     expect(secondDraft).toBe("draft-b")
+    expect(memory.value()).toEqual({})
+  })
 
+  test("binds an adopted draft profile only to its new session", () => {
+    const memory = memoryStorage()
+    const profiles = new BrowserProfileRegistry(memory.storage, ids("draft-a"))
+
+    const firstDraft = profiles.profileFor(draftKey(1))
     profiles.adopt("ses_new", firstDraft)
     expect(profiles.profileFor("ses_new")).toBe("draft-a")
     expect(memory.value()).toEqual({ ses_new: "draft-a" })

--- a/packages/desktop-electron/src/main/browser/profile-registry.test.ts
+++ b/packages/desktop-electron/src/main/browser/profile-registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { draftKey } from "./registry"
+import { BrowserProfileRegistry, type BrowserProfileStorage } from "./profile-registry"
+
+function memoryStorage(initial: unknown = {}) {
+  let value = initial
+  const storage: BrowserProfileStorage = {
+    read: () => value,
+    write: (profiles) => {
+      value = profiles
+    },
+  }
+  return { storage, value: () => value }
+}
+
+function ids(...values: string[]) {
+  let index = 0
+  return () => values[index++] ?? `profile-${index}`
+}
+
+describe("BrowserProfileRegistry", () => {
+  test("gives each session a stable persistent profile", () => {
+    const memory = memoryStorage()
+    const profiles = new BrowserProfileRegistry(memory.storage, ids("profile-a", "profile-b"))
+
+    expect(profiles.profileFor("ses_a")).toBe("profile-a")
+    expect(profiles.profileFor("ses_a")).toBe("profile-a")
+    expect(profiles.profileFor("ses_b")).toBe("profile-b")
+    expect(memory.value()).toEqual({ ses_a: "profile-a", ses_b: "profile-b" })
+
+    const restored = new BrowserProfileRegistry(memory.storage, ids("unused"))
+    expect(restored.profileFor("ses_a")).toBe("profile-a")
+    expect(restored.profileIDs()).toEqual(["profile-a", "profile-b"])
+  })
+
+  test("keeps draft profiles unique and binds the adopted profile to its new session", () => {
+    const memory = memoryStorage()
+    const profiles = new BrowserProfileRegistry(memory.storage, ids("draft-a", "draft-b"))
+
+    const firstDraft = profiles.profileFor(draftKey(1))
+    const secondDraft = profiles.profileFor(draftKey(2))
+    expect(firstDraft).toBe("draft-a")
+    expect(secondDraft).toBe("draft-b")
+
+    profiles.adopt("ses_new", firstDraft)
+    expect(profiles.profileFor("ses_new")).toBe("draft-a")
+    expect(memory.value()).toEqual({ ses_new: "draft-a" })
+  })
+
+  test("repairs duplicate stored profiles instead of restoring shared session state", () => {
+    const memory = memoryStorage({ ses_a: "shared", ses_b: "shared" })
+    const profiles = new BrowserProfileRegistry(memory.storage, ids("profile-b"))
+
+    expect(profiles.profileFor("ses_a")).toBe("shared")
+    expect(profiles.profileFor("ses_b")).toBe("profile-b")
+    expect(memory.value()).toEqual({ ses_a: "shared", ses_b: "profile-b" })
+  })
+})

--- a/packages/desktop-electron/src/main/browser/profile-registry.ts
+++ b/packages/desktop-electron/src/main/browser/profile-registry.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from "node:crypto"
+import { draftWindowID } from "./registry"
+
+export type BrowserProfileStorage = {
+  read(): unknown
+  write(profiles: Record<string, string>): void
+}
+
+export class BrowserProfileRegistry {
+  private profiles: Record<string, string> | undefined
+
+  constructor(
+    private readonly storage: BrowserProfileStorage,
+    private readonly createID: () => string = randomUUID,
+  ) {}
+
+  private readProfiles(): Record<string, string> {
+    if (this.profiles) return this.profiles
+    const stored = this.storage.read()
+    if (!stored || typeof stored !== "object" || Array.isArray(stored)) return (this.profiles = {})
+    const used = new Set<string>()
+    this.profiles = Object.fromEntries(
+      Object.entries(stored).filter(([ownerKey, profileID]) => {
+        if (
+          draftWindowID(ownerKey) !== null ||
+          typeof profileID !== "string" ||
+          profileID.length === 0 ||
+          used.has(profileID)
+        )
+          return false
+        used.add(profileID)
+        return true
+      }),
+    )
+    return this.profiles
+  }
+
+  private persist() {
+    this.storage.write({ ...this.readProfiles() })
+  }
+
+  profileFor(ownerKey: string): string {
+    // Home drafts are window-lifetime owners. Never persist by draft:<windowID>:
+    // that key is reused after adoption and would make the old conversation and
+    // the window's next draft share a Chromium session again.
+    if (draftWindowID(ownerKey) !== null) return this.createID()
+    const profiles = this.readProfiles()
+    const existing = profiles[ownerKey]
+    if (existing) return existing
+    const created = this.createID()
+    profiles[ownerKey] = created
+    this.persist()
+    return created
+  }
+
+  /** Persist a draft controller's immutable profile under its adopted session. */
+  adopt(sessionID: string, profileID: string) {
+    if (draftWindowID(sessionID) !== null || !sessionID || !profileID) return
+    this.readProfiles()[sessionID] = profileID
+    this.persist()
+  }
+
+  profileIDs(): string[] {
+    return [...new Set(Object.values(this.readProfiles()))]
+  }
+}

--- a/packages/desktop-electron/src/main/browser/profile-registry.ts
+++ b/packages/desktop-electron/src/main/browser/profile-registry.ts
@@ -59,8 +59,4 @@ export class BrowserProfileRegistry {
     this.readProfiles()[sessionID] = profileID
     this.persist()
   }
-
-  profileIDs(): string[] {
-    return [...new Set(Object.values(this.readProfiles()))]
-  }
 }

--- a/packages/desktop-electron/src/main/browser/profile-sessions.test.ts
+++ b/packages/desktop-electron/src/main/browser/profile-sessions.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { mkdtemp, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BrowserProfileSessions } from "./profile-sessions"
+
+describe("BrowserProfileSessions", () => {
+  test("reuses a session only for the same browser profile", () => {
+    const paths: string[] = []
+    const profiles = new BrowserProfileSessions({
+      rootPath: () => "/browser-profiles",
+      fromPath: (path) => {
+        paths.push(path)
+        return { clearStorageData: async () => {}, clearCache: async () => {} }
+      },
+    })
+
+    const first = profiles.sessionFor("profile-a")
+    expect(profiles.sessionFor("profile-a")).toBe(first)
+    expect(profiles.sessionFor("profile-b")).not.toBe(first)
+    expect(paths).toHaveLength(2)
+    expect(paths[0]).not.toBe(paths[1])
+  })
+
+  test("clears successfully before the profile directory exists", async () => {
+    const root = join(tmpdir(), `pawwork-browser-profiles-missing-${randomUUID()}`)
+    const profiles = new BrowserProfileSessions({
+      rootPath: () => root,
+      fromPath: () => ({ clearStorageData: async () => {}, clearCache: async () => {} }),
+    })
+
+    await expect(profiles.clearAll()).resolves.toBeUndefined()
+  })
+
+  test("removes unopened profile data without creating an Electron session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pawwork-browser-profiles-"))
+    const historical = join(root, "historical-profile")
+    mkdirSync(historical)
+    writeFileSync(join(historical, "Cookies"), "stored browser data")
+    let createdSessions = 0
+    const profiles = new BrowserProfileSessions({
+      rootPath: () => root,
+      fromPath: () => {
+        createdSessions += 1
+        return { clearStorageData: async () => {}, clearCache: async () => {} }
+      },
+    })
+
+    try {
+      await profiles.clearAll()
+      expect(existsSync(historical)).toBe(false)
+      expect(createdSessions).toBe(0)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("clears opened Electron sessions sequentially without deleting their directories", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pawwork-browser-profiles-"))
+    let activeOperations = 0
+    let maxActiveOperations = 0
+    let storageClears = 0
+    let cacheClears = 0
+    const operation = async (record: () => void) => {
+      activeOperations += 1
+      maxActiveOperations = Math.max(maxActiveOperations, activeOperations)
+      await Promise.resolve()
+      record()
+      activeOperations -= 1
+    }
+    const profiles = new BrowserProfileSessions({
+      rootPath: () => root,
+      fromPath: (path) => {
+        mkdirSync(path, { recursive: true })
+        return {
+          clearStorageData: () => operation(() => (storageClears += 1)),
+          clearCache: () => operation(() => (cacheClears += 1)),
+        }
+      },
+    })
+
+    profiles.sessionFor("profile-a")
+    profiles.sessionFor("profile-b")
+
+    try {
+      await profiles.clearAll()
+      expect(storageClears).toBe(2)
+      expect(cacheClears).toBe(2)
+      expect(maxActiveOperations).toBe(1)
+      expect(await readdir(root)).toHaveLength(2)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("coalesces concurrent clear requests", async () => {
+    const root = join(tmpdir(), `pawwork-browser-profiles-missing-${randomUUID()}`)
+    let releaseStorage!: () => void
+    const storageReleased = new Promise<void>((resolve) => (releaseStorage = resolve))
+    let storageClears = 0
+    let cacheClears = 0
+    const profiles = new BrowserProfileSessions({
+      rootPath: () => root,
+      fromPath: () => ({
+        clearStorageData: async () => {
+          storageClears += 1
+          await storageReleased
+        },
+        clearCache: async () => {
+          cacheClears += 1
+        },
+      }),
+    })
+    profiles.sessionFor("profile-a")
+
+    const first = profiles.clearAll()
+    await Promise.resolve()
+    const second = profiles.clearAll()
+    await Promise.resolve()
+    const clearsWhileBlocked = storageClears
+    releaseStorage()
+    await Promise.all([first, second])
+
+    expect(clearsWhileBlocked).toBe(1)
+    expect(storageClears).toBe(1)
+    expect(cacheClears).toBe(1)
+  })
+})

--- a/packages/desktop-electron/src/main/browser/profile-sessions.ts
+++ b/packages/desktop-electron/src/main/browser/profile-sessions.ts
@@ -1,0 +1,83 @@
+import { createHash, randomUUID } from "node:crypto"
+import { renameSync } from "node:fs"
+import { readdir, rm } from "node:fs/promises"
+import { join } from "node:path"
+import type { Session } from "electron"
+
+export type BrowserProfileSession = Pick<Session, "clearStorageData" | "clearCache">
+
+export type BrowserProfileSessionDeps<ProfileSession extends BrowserProfileSession> = {
+  rootPath(): string
+  fromPath(path: string): ProfileSession
+}
+
+/**
+ * Owns PawWork's explicit browser-profile directories and every Electron
+ * Session opened from them in this process. Electron retains opened Sessions
+ * until exit, so Clear Data uses its API for those and removes only directories
+ * that this process never opened.
+ */
+export class BrowserProfileSessions<ProfileSession extends BrowserProfileSession = BrowserProfileSession> {
+  private readonly opened = new Map<string, ProfileSession>()
+  private clearing: Promise<void> | undefined
+
+  constructor(private readonly deps: BrowserProfileSessionDeps<ProfileSession>) {}
+
+  private profilePath(profileID: string) {
+    const directory = createHash("sha256").update(profileID).digest("hex")
+    return join(this.deps.rootPath(), directory)
+  }
+
+  sessionFor(profileID: string): ProfileSession {
+    const profilePath = this.profilePath(profileID)
+    const existing = this.opened.get(profilePath)
+    if (existing) return existing
+    const created = this.deps.fromPath(profilePath)
+    this.opened.set(profilePath, created)
+    return created
+  }
+
+  clearAll(): Promise<void> {
+    if (this.clearing) return this.clearing
+    const clearing = this.clearOnce()
+    this.clearing = clearing
+    void clearing.then(
+      () => {
+        if (this.clearing === clearing) this.clearing = undefined
+      },
+      () => {
+        if (this.clearing === clearing) this.clearing = undefined
+      },
+    )
+    return clearing
+  }
+
+  private async clearOnce(): Promise<void> {
+    for (const profileSession of this.opened.values()) {
+      await profileSession.clearStorageData()
+      await profileSession.clearCache()
+    }
+    const root = this.deps.rootPath()
+    let entries: string[]
+    try {
+      entries = await readdir(root)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+      throw error
+    }
+    for (const entry of entries) {
+      const entryPath = join(root, entry)
+      if (this.opened.has(entryPath)) continue
+      // Rename without yielding so sessionFor cannot open this path between the
+      // ownership check and removal. A concurrent open then gets a fresh path.
+      const removingPath = `${entryPath}.removing-${randomUUID()}`
+      try {
+        renameSync(entryPath, removingPath)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue
+        throw error
+      }
+      await rm(removingPath, { recursive: true, force: true })
+    }
+  }
+}

--- a/packages/desktop-electron/src/main/ipc/browser.ts
+++ b/packages/desktop-electron/src/main/ipc/browser.ts
@@ -1,8 +1,8 @@
 import { BrowserWindow, ipcMain, session, type IpcMainInvokeEvent } from "electron"
 import type { BrowserViewLayout } from "@opencode-ai/app/desktop-api"
-import { browserControllers } from "../browser/controller-automation"
+import { browserControllers, browserProfiles } from "../browser/controller-automation"
 import { draftKey } from "../browser/registry"
-import { BROWSER_PARTITION } from "../browser/options"
+import { browserPartition, LEGACY_BROWSER_PARTITION } from "../browser/options"
 
 /**
  * Wires the embedded-browser IPC. Controllers live in the shared main-process
@@ -80,14 +80,20 @@ export function registerBrowserIpc(deps: { sessionIDForWindow: (windowID: number
     const resolved = resolve(event, target)
     if (resolved) browserControllers.dispose(resolved.key)
   })
-  // Browsing data lives in the shared persistent partition, not in any one view,
-  // so clear the session directly — this works even before a view exists (e.g.
-  // opening the tab fresh after restart). Then reload any live views so they
-  // reflect the signed-out state immediately.
+  // Clear every persisted profile, including profiles without a live view, plus
+  // the pre-isolation shared partition. Then reload live views so they reflect
+  // the signed-out state immediately.
   ipcMain.handle("browser:clear-data", async () => {
-    const partition = session.fromPartition(BROWSER_PARTITION)
-    await partition.clearStorageData()
-    await partition.clearCache()
+    const profileIDs = new Set(browserProfiles.profileIDs())
+    for (const controller of browserControllers.all()) profileIDs.add(controller.browserProfileID())
+    const partitionNames = [LEGACY_BROWSER_PARTITION, ...[...profileIDs].map(browserPartition)]
+    await Promise.all(
+      partitionNames.map(async (partitionName) => {
+        const partition = session.fromPartition(partitionName)
+        await partition.clearStorageData()
+        await partition.clearCache()
+      }),
+    )
     for (const controller of browserControllers.all()) controller.reloadIfLoaded()
   })
   // Page zoom only — does not touch the app shell zoom factor. No-op without a

--- a/packages/desktop-electron/src/main/ipc/browser.ts
+++ b/packages/desktop-electron/src/main/ipc/browser.ts
@@ -1,8 +1,8 @@
 import { BrowserWindow, ipcMain, session, type IpcMainInvokeEvent } from "electron"
 import type { BrowserViewLayout } from "@opencode-ai/app/desktop-api"
-import { browserControllers, browserProfiles } from "../browser/controller-automation"
+import { browserControllers, browserProfileSessions } from "../browser/controller-automation"
 import { draftKey } from "../browser/registry"
-import { browserPartition, LEGACY_BROWSER_PARTITION } from "../browser/options"
+import { LEGACY_BROWSER_PARTITION } from "../browser/options"
 
 /**
  * Wires the embedded-browser IPC. Controllers live in the shared main-process
@@ -84,16 +84,10 @@ export function registerBrowserIpc(deps: { sessionIDForWindow: (windowID: number
   // the pre-isolation shared partition. Then reload live views so they reflect
   // the signed-out state immediately.
   ipcMain.handle("browser:clear-data", async () => {
-    const profileIDs = new Set(browserProfiles.profileIDs())
-    for (const controller of browserControllers.all()) profileIDs.add(controller.browserProfileID())
-    const partitionNames = [LEGACY_BROWSER_PARTITION, ...[...profileIDs].map(browserPartition)]
-    await Promise.all(
-      partitionNames.map(async (partitionName) => {
-        const partition = session.fromPartition(partitionName)
-        await partition.clearStorageData()
-        await partition.clearCache()
-      }),
-    )
+    await browserProfileSessions.clearAll()
+    const legacySession = session.fromPartition(LEGACY_BROWSER_PARTITION)
+    await legacySession.clearStorageData()
+    await legacySession.clearCache()
     for (const controller of browserControllers.all()) controller.reloadIfLoaded()
   })
   // Page zoom only — does not touch the app shell zoom factor. No-op without a

--- a/packages/desktop-electron/src/main/runtime-namespace.ts
+++ b/packages/desktop-electron/src/main/runtime-namespace.ts
@@ -4,6 +4,7 @@ export const PAWWORK_RUNTIME = {
   client: "desktop",
   serverUsername: "PawWork",
   settingsStore: "pawwork.settings",
+  browserProfilesStore: "pawwork.browser-profiles",
   databaseName: "pawwork.db",
 } as const
 

--- a/packages/desktop-electron/src/main/runtime-namespace.ts
+++ b/packages/desktop-electron/src/main/runtime-namespace.ts
@@ -5,6 +5,7 @@ export const PAWWORK_RUNTIME = {
   serverUsername: "PawWork",
   settingsStore: "pawwork.settings",
   browserProfilesStore: "pawwork.browser-profiles",
+  browserProfilesDirectory: "browser-profiles",
   databaseName: "pawwork.db",
 } as const
 


### PR DESCRIPTION
## Summary

- Give every conversation-owned embedded browser its own persistent Electron profile partition.
- Persist the conversation-to-profile mapping and carry a Home draft's immutable profile through adoption.
- Clear all registered profiles plus the legacy shared partition from the existing Clear Data action.

## Why

The browser controllers, pages, and CDP connections were conversation-owned, but every `WebContentsView` still used the same `persist:pawwork-browser` partition. Electron reuses one `Session` for pages with the same partition, so cookies, local storage, IndexedDB, service workers, cache, and permission handlers remained shared. Two conversations operating the same site concurrently could therefore mutate each other's browser state.

The profile partition is now part of the conversation ownership boundary instead of an app-wide singleton.

## Related Issue

Related to #1333. This concurrency bug was reported directly and does not have a dedicated issue.

## Human Review Status

Pending

## Review Focus

- Profile identity and persistence in `profile-registry.ts`, especially duplicate-map repair.
- Home draft adoption: the live page must retain its existing profile while the mapping moves to the newly created session.
- Clear Data coverage for live draft profiles, stored conversation profiles, and the legacy shared partition.

## Risk Notes

- Existing data in the legacy shared browser partition is deliberately not copied into isolated profiles. Copying mixed state would reintroduce the leak; users may need to sign in once in each conversation after upgrading.
- The profile index is local Electron state and contains opaque profile IDs keyed by session ID; it contains no cookies or credentials.
- No visible UI or copy changed, so the visual-check checklist item is not applicable.

## How To Verify

```text
Regression RED: options test confirmed both profiles resolved to persist:pawwork-browser before the fix.
Focused browser tests: 70 passed, 0 failed.
Desktop typecheck: passed.
Desktop production build: passed.
Native Electron isolation smoke: same partition exposed localStorage ("a"); distinct profile partitions returned null.
Real desktop startup: bun run dev:desktop reached sidecar ready and rendered the desktop shell without startup errors.
Diff check and targeted ESLint: passed with no errors.
```

## Screenshots or Recordings

Not applicable; this changes Electron storage ownership without changing visible UI.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate persistent browser profiles for each conversation.
  * Preserved cookies, storage, and browsing settings independently across conversations.
  * Improved profile handling when browser sessions are reopened or reassigned.

* **Bug Fixes**
  * Signing out now clears cookies, storage, and cache across all browser profiles.
  * Maintained embedded browser security protections for every profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->