### PR TITLE
fix(provider): resolve model discovery capabilities centrally

### DIFF
--- a/packages/app/e2e/settings/settings-models.spec.ts
+++ b/packages/app/e2e/settings/settings-models.spec.ts
@@ -3,6 +3,8 @@ import { promptSelector } from "../selectors"
 import { closeSettingsPanel, openSettings } from "../actions"
 
 test("fetches models for Kimi even though inference uses the Anthropic adapter", async ({ page, project }) => {
+  let fetchMethod: string | undefined
+
   await project.open({
     beforeGoto: async ({ sdk }) => {
       await sdk.auth.set({
@@ -12,7 +14,7 @@ test("fetches models for Kimi even though inference uses the Anthropic adapter",
     },
   })
   await page.route(/\/provider\/kimi-for-coding\/models(?:\?|$)/, async (route) => {
-    expect(route.request().method()).toBe("POST")
+    fetchMethod = route.request().method()
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -23,12 +25,13 @@ test("fetches models for Kimi even though inference uses the Anthropic adapter",
   const settings = await openSettings(page)
   await settings.getByRole("tab", { name: "Models" }).click()
 
-  const heading = settings.getByText("Kimi For Coding", { exact: true }).last()
-  await expect(heading).toBeVisible()
+  const kimi = settings.locator('[data-component="provider-models"][data-provider="kimi-for-coding"]')
+  await expect(kimi).toBeVisible()
   const beforeFetch = page.url()
-  await heading.locator("..").getByRole("button", { name: "Fetch models" }).click()
+  await kimi.getByRole("button", { name: "Fetch models" }).click()
 
   await expect(settings.getByRole("switch", { name: "Kimi E2E Live" })).not.toBeChecked()
+  expect(fetchMethod).toBe("POST")
   await expect(page).toHaveURL(beforeFetch)
 })
 

--- a/packages/app/e2e/settings/settings-models.spec.ts
+++ b/packages/app/e2e/settings/settings-models.spec.ts
@@ -2,6 +2,24 @@ import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { closeSettingsPanel, openSettings } from "../actions"
 
+test("shows model discovery for Kimi even though inference uses the Anthropic adapter", async ({ page, project }) => {
+  await project.open({
+    beforeGoto: async ({ sdk }) => {
+      await sdk.auth.set({
+        providerID: "kimi-for-coding",
+        auth: { type: "api", key: "e2e-kimi-key" },
+      })
+    },
+  })
+
+  const settings = await openSettings(page)
+  await settings.getByRole("tab", { name: "Models" }).click()
+
+  const heading = settings.getByText("Kimi For Coding", { exact: true }).last()
+  await expect(heading).toBeVisible()
+  await expect(heading.locator("..").getByRole("button", { name: "Fetch models" })).toBeVisible()
+})
+
 test("hiding a model removes it from the model picker", async ({ page, gotoSession }) => {
   await gotoSession()
 

--- a/packages/app/e2e/settings/settings-models.spec.ts
+++ b/packages/app/e2e/settings/settings-models.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { closeSettingsPanel, openSettings } from "../actions"
 
-test("shows model discovery for Kimi even though inference uses the Anthropic adapter", async ({ page, project }) => {
+test("fetches models for Kimi even though inference uses the Anthropic adapter", async ({ page, project }) => {
   await project.open({
     beforeGoto: async ({ sdk }) => {
       await sdk.auth.set({
@@ -11,13 +11,25 @@ test("shows model discovery for Kimi even though inference uses the Anthropic ad
       })
     },
   })
+  await page.route(/\/provider\/kimi-for-coding\/models(?:\?|$)/, async (route) => {
+    expect(route.request().method()).toBe("POST")
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ models: [{ id: "kimi-e2e-live", name: "Kimi E2E Live" }] }),
+    })
+  })
 
   const settings = await openSettings(page)
   await settings.getByRole("tab", { name: "Models" }).click()
 
   const heading = settings.getByText("Kimi For Coding", { exact: true }).last()
   await expect(heading).toBeVisible()
-  await expect(heading.locator("..").getByRole("button", { name: "Fetch models" })).toBeVisible()
+  const beforeFetch = page.url()
+  await heading.locator("..").getByRole("button", { name: "Fetch models" }).click()
+
+  await expect(settings.getByRole("switch", { name: "Kimi E2E Live" })).not.toBeChecked()
+  await expect(page).toHaveURL(beforeFetch)
 })
 
 test("hiding a model removes it from the model picker", async ({ page, gotoSession }) => {

--- a/packages/app/e2e/snap/settings-models-fetch.snap.ts
+++ b/packages/app/e2e/snap/settings-models-fetch.snap.ts
@@ -27,18 +27,13 @@ test("settings-models-fetch", async ({ page, project }) => {
   const settings = await openSettings(page)
   await settings.getByRole("tab", { name: "Models" }).click()
 
-  const kimiHeading = settings.getByText("Kimi For Coding", { exact: true }).last()
-  await expect(kimiHeading).toBeVisible({ timeout: 30_000 })
-  const fetchButton = kimiHeading.locator("..").getByRole("button", { name: "Fetch models" })
+  const kimi = settings.locator('[data-component="provider-models"][data-provider="kimi-for-coding"]')
+  await expect(kimi).toBeVisible({ timeout: 30_000 })
+  const fetchButton = kimi.getByRole("button", { name: "Fetch models" })
   await expect(fetchButton).toBeVisible({ timeout: 30_000 })
   await fetchButton.scrollIntoViewIfNeeded()
 
-  // Frame the provider group (button -> header (..) -> group (..)) so the shot stays on the header +
-  // model rows rather than the providers list stacked above it.
-  const group = fetchButton.locator("xpath=../..")
-  await expect(group).toBeVisible({ timeout: 10_000 })
-
-  const shots: Shot[] = [{ name: "default", buf: await group.screenshot() }]
+  const shots: Shot[] = [{ name: "default", buf: await kimi.screenshot() }]
   const out = snapOutputPath("settings-models-fetch")
   await composeGrid(shots, out)
   process.stdout.write(`\n[snap] settings-models-fetch grid -> ${out}\n\n`)

--- a/packages/app/e2e/snap/settings-models-fetch.snap.ts
+++ b/packages/app/e2e/snap/settings-models-fetch.snap.ts
@@ -2,16 +2,23 @@ import { test, expect } from "../fixtures"
 import { openSettings } from "../actions"
 import { composeGrid, snapOutputPath, type Shot } from "./_compose"
 
-// Visual contract for the Settings > Models "Fetch models" action (issue #1463): an OpenAI-compatible
-// provider group shows a ghost button with the refresh icon in its header, above the model rows. The
-// default OpenCode Zen provider is OpenAI-compatible, so the button renders without seeding anything.
+// Visual contract for the Settings > Models "Fetch models" action (issue #1463): a provider with model
+// discovery shows a ghost button with the refresh icon in its header, above the model rows. Kimi uses
+// the Anthropic adapter for inference, so this also guards the capability against SDK-based inference.
 // Captured at rest — clicking would call the provider's live /models endpoint.
 test.use({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 })
 
 test("settings-models-fetch", async ({ page, project }) => {
   test.setTimeout(180_000)
 
-  await project.open()
+  await project.open({
+    beforeGoto: async ({ sdk }) => {
+      await sdk.auth.set({
+        providerID: "kimi-for-coding",
+        auth: { type: "api", key: "snap-kimi-key" },
+      })
+    },
+  })
 
   // App-shell toasts (e.g. server health checks) float over the page and bleed into block screenshots;
   // they are environment chrome, not the surface under test.
@@ -20,7 +27,9 @@ test("settings-models-fetch", async ({ page, project }) => {
   const settings = await openSettings(page)
   await settings.getByRole("tab", { name: "Models" }).click()
 
-  const fetchButton = settings.getByRole("button", { name: "Fetch models" }).first()
+  const kimiHeading = settings.getByText("Kimi For Coding", { exact: true }).last()
+  await expect(kimiHeading).toBeVisible({ timeout: 30_000 })
+  const fetchButton = kimiHeading.locator("..").getByRole("button", { name: "Fetch models" })
   await expect(fetchButton).toBeVisible({ timeout: 30_000 })
   await fetchButton.scrollIntoViewIfNeeded()
 

--- a/packages/app/src/components/settings-models.tsx
+++ b/packages/app/src/components/settings-models.tsx
@@ -19,10 +19,6 @@ import { compareModelsForDisplay } from "@/utils/model-order"
 
 type ModelItem = ReturnType<ReturnType<typeof useModels>["list"]>[number]
 
-// Only OpenAI-compatible providers (custom providers + gateways like Kilo) expose a /models endpoint
-// we can discover from. Native SDKs (anthropic, etc.) do not, so the action stays hidden for them.
-const OPENAI_COMPATIBLE = "@ai-sdk/openai-compatible"
-
 const ListLoadingState: Component<{ label: string }> = (props) => {
   return (
     <div class="flex flex-col items-center justify-center py-12 text-center">
@@ -159,7 +155,7 @@ export const SettingsModels: Component = () => {
                   <div class="flex items-center gap-2 pb-2">
                     <ProviderIcon id={group.category} class="size-5 shrink-0 text-icon-strong" />
                     <span class="text-h3 text-fg-strong">{group.items[0].provider.name}</span>
-                    <Show when={group.items.some((item) => item.api?.npm === OPENAI_COMPATIBLE)}>
+                    <Show when={group.items[0].provider.canFetchModels}>
                       <Button
                         type="button"
                         variant="ghost"

--- a/packages/app/src/components/settings-models.tsx
+++ b/packages/app/src/components/settings-models.tsx
@@ -151,7 +151,7 @@ export const SettingsModels: Component = () => {
           >
             <For each={list.grouped.latest}>
               {(group) => (
-                <div class="flex flex-col gap-1">
+                <div class="flex flex-col gap-1" data-component="provider-models" data-provider={group.category}>
                   <div class="flex items-center gap-2 pb-2">
                     <ProviderIcon id={group.category} class="size-5 shrink-0 text-icon-strong" />
                     <span class="text-h3 text-fg-strong">{group.items[0].provider.name}</span>

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -49,6 +49,10 @@ function createState(): State {
   }
 }
 
+function listedProvider(id: string, name: string): ProviderListResponse["all"][number] {
+  return { id, name, source: "custom", env: [], options: {}, models: {}, canFetchModels: false }
+}
+
 function createVcsCache(): VcsCache {
   const [store, setStore] = createStore({ value: undefined as VcsInfo | undefined })
   return {
@@ -249,32 +253,12 @@ describe("bootstrapDirectory", () => {
     setStore("session_status", "ses_stale", { type: "idle" })
     const providers = [
       {
-        all: [
-          {
-            id: "dir-provider-a",
-            name: "Dir Provider A",
-            source: "custom",
-            env: [],
-            options: {},
-            models: {},
-            canFetchModels: false,
-          },
-        ],
+        all: [listedProvider("dir-provider-a", "Dir Provider A")],
         connected: ["dir-provider-a"],
         default: {},
       },
       {
-        all: [
-          {
-            id: "dir-provider-b",
-            name: "Dir Provider B",
-            source: "custom",
-            env: [],
-            options: {},
-            models: {},
-            canFetchModels: false,
-          },
-        ],
+        all: [listedProvider("dir-provider-b", "Dir Provider B")],
         connected: ["dir-provider-b"],
         default: {},
       },
@@ -638,17 +622,7 @@ describe("bootstrapDirectory", () => {
     const [store, setStore] = createStore(createState())
     const permission = deferred<{ data: [] }>()
     const providers = {
-      all: [
-        {
-          id: "dir-provider",
-          name: "Dir Provider",
-          source: "custom",
-          env: [],
-          options: {},
-          models: {},
-          canFetchModels: false,
-        },
-      ],
+      all: [listedProvider("dir-provider", "Dir Provider")],
       connected: ["dir-provider"],
       default: {},
     } satisfies ProviderListResponse
@@ -827,32 +801,12 @@ describe("bootstrapDirectory", () => {
     const first = deferred<{ data: ProviderListResponse }>()
     let calls = 0
     const oldProviders = {
-      all: [
-        {
-          id: "old-provider",
-          name: "Old Provider",
-          source: "custom",
-          env: [],
-          options: {},
-          models: {},
-          canFetchModels: false,
-        },
-      ],
+      all: [listedProvider("old-provider", "Old Provider")],
       connected: ["old-provider"],
       default: {},
     } satisfies ProviderListResponse
     const newProviders = {
-      all: [
-        {
-          id: "new-provider",
-          name: "New Provider",
-          source: "custom",
-          env: [],
-          options: {},
-          models: {},
-          canFetchModels: false,
-        },
-      ],
+      all: [listedProvider("new-provider", "New Provider")],
       connected: ["new-provider"],
       default: {},
     } satisfies ProviderListResponse

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -249,12 +249,32 @@ describe("bootstrapDirectory", () => {
     setStore("session_status", "ses_stale", { type: "idle" })
     const providers = [
       {
-        all: [{ id: "dir-provider-a", name: "Dir Provider A", source: "custom", env: [], options: {}, models: {} }],
+        all: [
+          {
+            id: "dir-provider-a",
+            name: "Dir Provider A",
+            source: "custom",
+            env: [],
+            options: {},
+            models: {},
+            canFetchModels: false,
+          },
+        ],
         connected: ["dir-provider-a"],
         default: {},
       },
       {
-        all: [{ id: "dir-provider-b", name: "Dir Provider B", source: "custom", env: [], options: {}, models: {} }],
+        all: [
+          {
+            id: "dir-provider-b",
+            name: "Dir Provider B",
+            source: "custom",
+            env: [],
+            options: {},
+            models: {},
+            canFetchModels: false,
+          },
+        ],
         connected: ["dir-provider-b"],
         default: {},
       },
@@ -618,7 +638,17 @@ describe("bootstrapDirectory", () => {
     const [store, setStore] = createStore(createState())
     const permission = deferred<{ data: [] }>()
     const providers = {
-      all: [{ id: "dir-provider", name: "Dir Provider", source: "custom", env: [], options: {}, models: {} }],
+      all: [
+        {
+          id: "dir-provider",
+          name: "Dir Provider",
+          source: "custom",
+          env: [],
+          options: {},
+          models: {},
+          canFetchModels: false,
+        },
+      ],
       connected: ["dir-provider"],
       default: {},
     } satisfies ProviderListResponse
@@ -797,12 +827,32 @@ describe("bootstrapDirectory", () => {
     const first = deferred<{ data: ProviderListResponse }>()
     let calls = 0
     const oldProviders = {
-      all: [{ id: "old-provider", name: "Old Provider", source: "custom", env: [], options: {}, models: {} }],
+      all: [
+        {
+          id: "old-provider",
+          name: "Old Provider",
+          source: "custom",
+          env: [],
+          options: {},
+          models: {},
+          canFetchModels: false,
+        },
+      ],
       connected: ["old-provider"],
       default: {},
     } satisfies ProviderListResponse
     const newProviders = {
-      all: [{ id: "new-provider", name: "New Provider", source: "custom", env: [], options: {}, models: {} }],
+      all: [
+        {
+          id: "new-provider",
+          name: "New Provider",
+          source: "custom",
+          env: [],
+          options: {},
+          models: {},
+          canFetchModels: false,
+        },
+      ],
       connected: ["new-provider"],
       default: {},
     } satisfies ProviderListResponse

--- a/packages/opencode/src/provider/fetch-models.test.ts
+++ b/packages/opencode/src/provider/fetch-models.test.ts
@@ -8,6 +8,12 @@ test("parses OpenAI-compatible { data: [...] } shape", () => {
   ])
 })
 
+test("uses Anthropic display_name when normalizing a model list", () => {
+  expect(FetchModels.parse({ data: [{ id: "claude-sonnet", display_name: "Claude Sonnet" }] })).toEqual([
+    { id: "claude-sonnet", name: "Claude Sonnet" },
+  ])
+})
+
 test("parses { models: [...] } shape", () => {
   expect(FetchModels.parse({ models: [{ id: "m" }] })).toEqual([{ id: "m", name: "m" }])
 })
@@ -95,4 +101,155 @@ test("request: does not overwrite an explicit Authorization header from config",
     configOptions: { headers: { authorization: "Token preset" } },
   })
   expect(result?.headers).toEqual({ authorization: "Token preset" })
+})
+
+test("resolves Kimi model discovery independently of its Anthropic inference adapter", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "kimi-for-coding",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      catalogBaseURL: "https://api.kimi.com/coding/v1",
+      authKey: "kimi-key",
+    }),
+  ).toEqual({
+    endpoint: "https://api.kimi.com/coding/v1/models",
+    headers: { Authorization: "Bearer kimi-key" },
+  })
+})
+
+test("uses MiniMax's OpenAI-compatible endpoint for model discovery", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "minimax",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      catalogBaseURL: "https://api.minimax.io/anthropic/v1",
+      authKey: "minimax-key",
+    }),
+  ).toEqual({
+    endpoint: "https://api.minimax.io/v1/models",
+    headers: { Authorization: "Bearer minimax-key" },
+  })
+})
+
+test("uses the region-specific OpenAI-compatible endpoint for MiniMax variants", () => {
+  const providers = [
+    ["minimax-coding-plan", "https://api.minimax.io/v1"],
+    ["minimax-cn", "https://api.minimaxi.com/v1"],
+    ["minimax-cn-coding-plan", "https://api.minimaxi.com/v1"],
+  ] as const
+
+  for (const [providerID, discoveryBaseURL] of providers) {
+    expect(
+      FetchModels.resolve({
+        providerID,
+        providerNPMs: ["@ai-sdk/anthropic"],
+        authKey: "minimax-key",
+      }),
+    ).toEqual({
+      endpoint: `${discoveryBaseURL}/models`,
+      headers: { Authorization: "Bearer minimax-key" },
+    })
+  }
+})
+
+test("resolves Anthropic discovery with its native base URL and version header", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "anthropic",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      authKey: "anthropic-key",
+    }),
+  ).toEqual({
+    endpoint: "https://api.anthropic.com/v1/models",
+    headers: {
+      "X-Api-Key": "anthropic-key",
+      "anthropic-version": "2023-06-01",
+    },
+  })
+})
+
+test("resolves a dual-protocol provider that shares one OpenAI-compatible base URL", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "freemodel",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      catalogBaseURL: "https://cc.freemodel.dev/v1",
+    }),
+  ).toEqual({
+    endpoint: "https://cc.freemodel.dev/v1/models",
+    headers: {},
+  })
+})
+
+test("resolves Subconscious discovery despite its Anthropic inference adapter", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "subconscious",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      catalogBaseURL: "https://api.subconscious.dev/v1",
+      authKey: "subconscious-key",
+    }),
+  ).toEqual({
+    endpoint: "https://api.subconscious.dev/v1/models",
+    headers: { Authorization: "Bearer subconscious-key" },
+  })
+})
+
+test("resolves the native OpenAI provider without treating its SDK as the discovery contract", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "openai",
+      providerNPMs: ["@ai-sdk/openai"],
+      authKey: "openai-key",
+    }),
+  ).toEqual({
+    endpoint: "https://api.openai.com/v1/models",
+    headers: { Authorization: "Bearer openai-key" },
+  })
+})
+
+test("preserves discovery for generic OpenAI-compatible providers", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "custom-gateway",
+      providerNPMs: ["@ai-sdk/openai-compatible"],
+      configOptions: { baseURL: "https://gateway.example/v1" },
+      authKey: "gateway-key",
+    }),
+  ).toEqual({
+    endpoint: "https://gateway.example/v1/models",
+    headers: { Authorization: "Bearer gateway-key" },
+  })
+})
+
+test("does not infer discovery support from an Anthropic inference adapter", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "custom-anthropic-provider",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      catalogBaseURL: "https://api.example.com/v1",
+    }),
+  ).toBeUndefined()
+})
+
+test("lets explicit config headers override a provider discovery profile", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "anthropic",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      authKey: "ignored-key",
+      configOptions: {
+        headers: {
+          "x-api-key": "configured-key",
+          "anthropic-version": "configured-version",
+        },
+      },
+    }),
+  ).toEqual({
+    endpoint: "https://api.anthropic.com/v1/models",
+    headers: {
+      "x-api-key": "configured-key",
+      "anthropic-version": "configured-version",
+    },
+  })
 })

--- a/packages/opencode/src/provider/fetch-models.test.ts
+++ b/packages/opencode/src/provider/fetch-models.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "bun:test"
 import { FetchModels } from "@/provider/fetch-models"
 
+const resolveCompatible = (input: Omit<FetchModels.ResolveInput, "providerID" | "providerNPMs">) =>
+  FetchModels.resolve({
+    providerID: "custom-gateway",
+    providerNPMs: ["@ai-sdk/openai-compatible"],
+    ...input,
+  })
+
 test("parses OpenAI-compatible { data: [...] } shape", () => {
   expect(FetchModels.parse({ data: [{ id: "a" }, { id: "b", name: "Model B" }] })).toEqual([
     { id: "a", name: "a" },
@@ -44,49 +51,72 @@ test("throws on an unrecognized response shape", () => {
 })
 
 test("builds the /models endpoint and normalizes trailing slashes", () => {
-  expect(FetchModels.endpoint("https://gateway.example/v1")).toBe("https://gateway.example/v1/models")
-  expect(FetchModels.endpoint("https://gateway.example/v1/")).toBe("https://gateway.example/v1/models")
-  expect(FetchModels.endpoint("  https://gateway.example/v1//  ")).toBe("https://gateway.example/v1/models")
+  expect(resolveCompatible({ providerBaseURL: "https://gateway.example/v1" })?.endpoint).toBe(
+    "https://gateway.example/v1/models",
+  )
+  expect(resolveCompatible({ providerBaseURL: "https://gateway.example/v1/" })?.endpoint).toBe(
+    "https://gateway.example/v1/models",
+  )
+  expect(resolveCompatible({ providerBaseURL: "  https://gateway.example/v1//  " })?.endpoint).toBe(
+    "https://gateway.example/v1/models",
+  )
 })
 
-test("request: base URL precedence is endpoint > baseURL > catalog", () => {
+test("resolves base URL precedence as endpoint > baseURL > configured provider API > catalog", () => {
   expect(
-    FetchModels.request({
+    resolveCompatible({
       configOptions: { endpoint: "https://endpoint.example", baseURL: "https://base.example" },
+      providerBaseURL: "https://configured.example",
       catalogBaseURL: "https://catalog.example",
-    })?.baseURL,
-  ).toBe("https://endpoint.example")
+    })?.endpoint,
+  ).toBe("https://endpoint.example/models")
   expect(
-    FetchModels.request({ configOptions: { baseURL: "https://base.example" }, catalogBaseURL: "https://catalog.example" })
-      ?.baseURL,
-  ).toBe("https://base.example")
-  expect(FetchModels.request({ catalogBaseURL: "https://catalog.example" })?.baseURL).toBe("https://catalog.example")
+    resolveCompatible({
+      configOptions: { baseURL: "https://base.example" },
+      providerBaseURL: "https://configured.example",
+      catalogBaseURL: "https://catalog.example",
+    })?.endpoint,
+  ).toBe("https://base.example/models")
+  expect(
+    resolveCompatible({
+      providerBaseURL: "https://configured.example",
+      catalogBaseURL: "https://catalog.example",
+    })?.endpoint,
+  ).toBe("https://configured.example/models")
+  expect(resolveCompatible({ catalogBaseURL: "https://catalog.example" })?.endpoint).toBe(
+    "https://catalog.example/models",
+  )
 })
 
-test("request: returns undefined when no base URL is known", () => {
-  expect(FetchModels.request({})).toBeUndefined()
-  expect(FetchModels.request({ configOptions: {} })).toBeUndefined()
+test("returns undefined when no model discovery base URL is known", () => {
+  expect(resolveCompatible({})).toBeUndefined()
+  expect(resolveCompatible({ configOptions: {} })).toBeUndefined()
 })
 
-test("request: copies string config headers and drops non-string values", () => {
-  const result = FetchModels.request({
+test("returns undefined for an unresolved or invalid model discovery base URL", () => {
+  expect(resolveCompatible({ providerBaseURL: "https://${GATEWAY_HOST}/v1" })).toBeUndefined()
+  expect(resolveCompatible({ providerBaseURL: "not a URL" })).toBeUndefined()
+})
+
+test("copies string config headers and drops non-string values", () => {
+  const result = resolveCompatible({
     catalogBaseURL: "https://catalog.example",
     configOptions: { headers: { "X-Title": "pawwork", "X-Bad": 5 as unknown as string } },
   })
   expect(result?.headers).toEqual({ "X-Title": "pawwork" })
 })
 
-test("request: adds a Bearer header from the auth key, preferring it over a config apiKey", () => {
+test("adds a Bearer header from the auth key, preferring it over a config apiKey", () => {
   expect(
-    FetchModels.request({ catalogBaseURL: "https://catalog.example", authKey: "auth-key" })?.headers["Authorization"],
+    resolveCompatible({ catalogBaseURL: "https://catalog.example", authKey: "auth-key" })?.headers["Authorization"],
   ).toBe("Bearer auth-key")
   expect(
-    FetchModels.request({ catalogBaseURL: "https://catalog.example", configOptions: { apiKey: "config-key" } })?.headers[
+    resolveCompatible({ catalogBaseURL: "https://catalog.example", configOptions: { apiKey: "config-key" } })?.headers[
       "Authorization"
     ],
   ).toBe("Bearer config-key")
   expect(
-    FetchModels.request({
+    resolveCompatible({
       catalogBaseURL: "https://catalog.example",
       authKey: "auth-key",
       configOptions: { apiKey: "config-key" },
@@ -94,8 +124,8 @@ test("request: adds a Bearer header from the auth key, preferring it over a conf
   ).toBe("Bearer auth-key")
 })
 
-test("request: does not overwrite an explicit Authorization header from config", () => {
-  const result = FetchModels.request({
+test("does not overwrite an explicit Authorization header from config", () => {
+  const result = resolveCompatible({
     catalogBaseURL: "https://catalog.example",
     authKey: "auth-key",
     configOptions: { headers: { authorization: "Token preset" } },
@@ -131,18 +161,49 @@ test("uses MiniMax's OpenAI-compatible endpoint for model discovery", () => {
   })
 })
 
+test("keeps MiniMax discovery on its OpenAI endpoint when inference overrides use Anthropic", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "minimax",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      providerBaseURL: "https://api.minimax.io/anthropic/v1",
+      configOptions: { baseURL: "https://api.minimax.io/anthropic/v1" },
+      authKey: "minimax-key",
+    }),
+  ).toEqual({
+    endpoint: "https://api.minimax.io/v1/models",
+    headers: { Authorization: "Bearer minimax-key" },
+  })
+})
+
+test("lets an explicit MiniMax discovery endpoint override the official profile", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "minimax",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      providerBaseURL: "https://api.minimax.io/anthropic/v1",
+      configOptions: { endpoint: "https://corp-proxy.example/openai/v1" },
+      authKey: "proxy-secret",
+    }),
+  ).toEqual({
+    endpoint: "https://corp-proxy.example/openai/v1/models",
+    headers: { Authorization: "Bearer proxy-secret" },
+  })
+})
+
 test("uses the region-specific OpenAI-compatible endpoint for MiniMax variants", () => {
   const providers = [
-    ["minimax-coding-plan", "https://api.minimax.io/v1"],
-    ["minimax-cn", "https://api.minimaxi.com/v1"],
-    ["minimax-cn-coding-plan", "https://api.minimaxi.com/v1"],
+    ["minimax-coding-plan", "https://api.minimax.io/anthropic/v1", "https://api.minimax.io/v1"],
+    ["minimax-cn", "https://api.minimaxi.com/anthropic/v1", "https://api.minimaxi.com/v1"],
+    ["minimax-cn-coding-plan", "https://api.minimaxi.com/anthropic/v1", "https://api.minimaxi.com/v1"],
   ] as const
 
-  for (const [providerID, discoveryBaseURL] of providers) {
+  for (const [providerID, catalogBaseURL, discoveryBaseURL] of providers) {
     expect(
       FetchModels.resolve({
         providerID,
         providerNPMs: ["@ai-sdk/anthropic"],
+        catalogBaseURL,
         authKey: "minimax-key",
       }),
     ).toEqual({
@@ -160,7 +221,7 @@ test("resolves Anthropic discovery with its native base URL and version header",
       authKey: "anthropic-key",
     }),
   ).toEqual({
-    endpoint: "https://api.anthropic.com/v1/models",
+    endpoint: "https://api.anthropic.com/v1/models?limit=1000",
     headers: {
       "X-Api-Key": "anthropic-key",
       "anthropic-version": "2023-06-01",
@@ -246,10 +307,53 @@ test("lets explicit config headers override a provider discovery profile", () =>
       },
     }),
   ).toEqual({
-    endpoint: "https://api.anthropic.com/v1/models",
+    endpoint: "https://api.anthropic.com/v1/models?limit=1000",
     headers: {
       "x-api-key": "configured-key",
       "anthropic-version": "configured-version",
+    },
+  })
+})
+
+test("overrides provider profile headers case-insensitively", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "anthropic",
+      providerNPMs: ["@ai-sdk/anthropic"],
+      authKey: "anthropic-key",
+      configOptions: {
+        headers: {
+          "Anthropic-Version": "configured-version",
+        },
+      },
+    }),
+  ).toEqual({
+    endpoint: "https://api.anthropic.com/v1/models?limit=1000",
+    headers: {
+      "Anthropic-Version": "configured-version",
+      "X-Api-Key": "anthropic-key",
+    },
+  })
+})
+
+test("keeps a routing API key while adding Bearer authentication", () => {
+  expect(
+    FetchModels.resolve({
+      providerID: "custom-gateway",
+      providerNPMs: ["@ai-sdk/openai-compatible"],
+      authKey: "gateway-key",
+      configOptions: {
+        baseURL: "https://gateway.example/v1",
+        headers: {
+          "x-api-key": "routing-key",
+        },
+      },
+    }),
+  ).toEqual({
+    endpoint: "https://gateway.example/v1/models",
+    headers: {
+      "x-api-key": "routing-key",
+      Authorization: "Bearer gateway-key",
     },
   })
 })

--- a/packages/opencode/src/provider/fetch-models.test.ts
+++ b/packages/opencode/src/provider/fetch-models.test.ts
@@ -62,29 +62,21 @@ test("builds the /models endpoint and normalizes trailing slashes", () => {
   )
 })
 
-test("resolves base URL precedence as endpoint > baseURL > configured provider API > catalog", () => {
+test("resolves base URL precedence as endpoint > baseURL > resolved provider API", () => {
   expect(
     resolveCompatible({
       configOptions: { endpoint: "https://endpoint.example", baseURL: "https://base.example" },
       providerBaseURL: "https://configured.example",
-      catalogBaseURL: "https://catalog.example",
     })?.endpoint,
   ).toBe("https://endpoint.example/models")
   expect(
     resolveCompatible({
       configOptions: { baseURL: "https://base.example" },
       providerBaseURL: "https://configured.example",
-      catalogBaseURL: "https://catalog.example",
     })?.endpoint,
   ).toBe("https://base.example/models")
-  expect(
-    resolveCompatible({
-      providerBaseURL: "https://configured.example",
-      catalogBaseURL: "https://catalog.example",
-    })?.endpoint,
-  ).toBe("https://configured.example/models")
-  expect(resolveCompatible({ catalogBaseURL: "https://catalog.example" })?.endpoint).toBe(
-    "https://catalog.example/models",
+  expect(resolveCompatible({ providerBaseURL: "https://configured.example" })?.endpoint).toBe(
+    "https://configured.example/models",
   )
 })
 
@@ -100,7 +92,7 @@ test("returns undefined for an unresolved or invalid model discovery base URL", 
 
 test("copies string config headers and drops non-string values", () => {
   const result = resolveCompatible({
-    catalogBaseURL: "https://catalog.example",
+    providerBaseURL: "https://provider.example",
     configOptions: { headers: { "X-Title": "pawwork", "X-Bad": 5 as unknown as string } },
   })
   expect(result?.headers).toEqual({ "X-Title": "pawwork" })
@@ -108,16 +100,17 @@ test("copies string config headers and drops non-string values", () => {
 
 test("adds a Bearer header from the auth key, preferring it over a config apiKey", () => {
   expect(
-    resolveCompatible({ catalogBaseURL: "https://catalog.example", authKey: "auth-key" })?.headers["Authorization"],
+    resolveCompatible({ providerBaseURL: "https://provider.example", authKey: "auth-key" })?.headers["Authorization"],
   ).toBe("Bearer auth-key")
   expect(
-    resolveCompatible({ catalogBaseURL: "https://catalog.example", configOptions: { apiKey: "config-key" } })?.headers[
+    resolveCompatible({ providerBaseURL: "https://provider.example", configOptions: { apiKey: "config-key" } })
+      ?.headers[
       "Authorization"
     ],
   ).toBe("Bearer config-key")
   expect(
     resolveCompatible({
-      catalogBaseURL: "https://catalog.example",
+      providerBaseURL: "https://provider.example",
       authKey: "auth-key",
       configOptions: { apiKey: "config-key" },
     })?.headers["Authorization"],
@@ -126,40 +119,99 @@ test("adds a Bearer header from the auth key, preferring it over a config apiKey
 
 test("does not overwrite an explicit Authorization header from config", () => {
   const result = resolveCompatible({
-    catalogBaseURL: "https://catalog.example",
+    providerBaseURL: "https://provider.example",
     authKey: "auth-key",
     configOptions: { headers: { authorization: "Token preset" } },
   })
   expect(result?.headers).toEqual({ authorization: "Token preset" })
 })
 
-test("resolves Kimi model discovery independently of its Anthropic inference adapter", () => {
-  expect(
-    FetchModels.resolve({
-      providerID: "kimi-for-coding",
-      providerNPMs: ["@ai-sdk/anthropic"],
-      catalogBaseURL: "https://api.kimi.com/coding/v1",
-      authKey: "kimi-key",
-    }),
-  ).toEqual({
-    endpoint: "https://api.kimi.com/coding/v1/models",
-    headers: { Authorization: "Bearer kimi-key" },
-  })
-})
-
-test("uses MiniMax's OpenAI-compatible endpoint for model discovery", () => {
-  expect(
-    FetchModels.resolve({
-      providerID: "minimax",
-      providerNPMs: ["@ai-sdk/anthropic"],
-      catalogBaseURL: "https://api.minimax.io/anthropic/v1",
-      authKey: "minimax-key",
-    }),
-  ).toEqual({
-    endpoint: "https://api.minimax.io/v1/models",
-    headers: { Authorization: "Bearer minimax-key" },
-  })
-})
+test.each([
+  [
+    "resolves Kimi independently of its Anthropic inference adapter",
+    "kimi-for-coding",
+    "@ai-sdk/anthropic",
+    "https://api.kimi.com/coding/v1",
+    "kimi-key",
+    "https://api.kimi.com/coding/v1/models",
+    { Authorization: "Bearer kimi-key" },
+  ],
+  [
+    "maps MiniMax's global Anthropic endpoint to OpenAI discovery",
+    "minimax",
+    "@ai-sdk/anthropic",
+    "https://api.minimax.io/anthropic/v1",
+    "minimax-key",
+    "https://api.minimax.io/v1/models",
+    { Authorization: "Bearer minimax-key" },
+  ],
+  [
+    "maps the MiniMax global coding plan endpoint",
+    "minimax-coding-plan",
+    "@ai-sdk/anthropic",
+    "https://api.minimax.io/anthropic/v1",
+    "minimax-key",
+    "https://api.minimax.io/v1/models",
+    { Authorization: "Bearer minimax-key" },
+  ],
+  [
+    "maps MiniMax's China endpoint",
+    "minimax-cn",
+    "@ai-sdk/anthropic",
+    "https://api.minimaxi.com/anthropic/v1",
+    "minimax-key",
+    "https://api.minimaxi.com/v1/models",
+    { Authorization: "Bearer minimax-key" },
+  ],
+  [
+    "maps the MiniMax China coding plan endpoint",
+    "minimax-cn-coding-plan",
+    "@ai-sdk/anthropic",
+    "https://api.minimaxi.com/anthropic/v1",
+    "minimax-key",
+    "https://api.minimaxi.com/v1/models",
+    { Authorization: "Bearer minimax-key" },
+  ],
+  [
+    "resolves FreeModel independently of its Anthropic inference adapter",
+    "freemodel",
+    "@ai-sdk/anthropic",
+    "https://cc.freemodel.dev/v1",
+    undefined,
+    "https://cc.freemodel.dev/v1/models",
+    {},
+  ],
+  [
+    "resolves Subconscious independently of its Anthropic inference adapter",
+    "subconscious",
+    "@ai-sdk/anthropic",
+    "https://api.subconscious.dev/v1",
+    "subconscious-key",
+    "https://api.subconscious.dev/v1/models",
+    { Authorization: "Bearer subconscious-key" },
+  ],
+  [
+    "resolves native OpenAI without treating its SDK as the discovery contract",
+    "openai",
+    "@ai-sdk/openai",
+    undefined,
+    "openai-key",
+    "https://api.openai.com/v1/models",
+    { Authorization: "Bearer openai-key" },
+  ],
+] as const)(
+  "%s",
+  (_name, providerID, providerNPM, providerBaseURL, authKey, endpoint, headers) => {
+    expect(
+      FetchModels.resolve({
+        providerID,
+        providerNPMs: [providerNPM],
+        providerBaseURL,
+        authKey,
+      }),
+    ).toEqual({ endpoint, headers })
+  },
+)
 
 test("keeps MiniMax discovery on its OpenAI endpoint when inference overrides use Anthropic", () => {
   expect(
@@ -191,28 +243,6 @@ test("lets an explicit MiniMax discovery endpoint override the official profile"
   })
 })
 
-test("uses the region-specific OpenAI-compatible endpoint for MiniMax variants", () => {
-  const providers = [
-    ["minimax-coding-plan", "https://api.minimax.io/anthropic/v1", "https://api.minimax.io/v1"],
-    ["minimax-cn", "https://api.minimaxi.com/anthropic/v1", "https://api.minimaxi.com/v1"],
-    ["minimax-cn-coding-plan", "https://api.minimaxi.com/anthropic/v1", "https://api.minimaxi.com/v1"],
-  ] as const
-
-  for (const [providerID, catalogBaseURL, discoveryBaseURL] of providers) {
-    expect(
-      FetchModels.resolve({
-        providerID,
-        providerNPMs: ["@ai-sdk/anthropic"],
-        catalogBaseURL,
-        authKey: "minimax-key",
-      }),
-    ).toEqual({
-      endpoint: `${discoveryBaseURL}/models`,
-      headers: { Authorization: "Bearer minimax-key" },
-    })
-  }
-})
-
 test("resolves Anthropic discovery with its native base URL and version header", () => {
   expect(
     FetchModels.resolve({
@@ -226,46 +256,6 @@ test("resolves Anthropic discovery with its native base URL and version header",
       "X-Api-Key": "anthropic-key",
       "anthropic-version": "2023-06-01",
     },
-  })
-})
-
-test("resolves a dual-protocol provider that shares one OpenAI-compatible base URL", () => {
-  expect(
-    FetchModels.resolve({
-      providerID: "freemodel",
-      providerNPMs: ["@ai-sdk/anthropic"],
-      catalogBaseURL: "https://cc.freemodel.dev/v1",
-    }),
-  ).toEqual({
-    endpoint: "https://cc.freemodel.dev/v1/models",
-    headers: {},
-  })
-})
-
-test("resolves Subconscious discovery despite its Anthropic inference adapter", () => {
-  expect(
-    FetchModels.resolve({
-      providerID: "subconscious",
-      providerNPMs: ["@ai-sdk/anthropic"],
-      catalogBaseURL: "https://api.subconscious.dev/v1",
-      authKey: "subconscious-key",
-    }),
-  ).toEqual({
-    endpoint: "https://api.subconscious.dev/v1/models",
-    headers: { Authorization: "Bearer subconscious-key" },
-  })
-})
-
-test("resolves the native OpenAI provider without treating its SDK as the discovery contract", () => {
-  expect(
-    FetchModels.resolve({
-      providerID: "openai",
-      providerNPMs: ["@ai-sdk/openai"],
-      authKey: "openai-key",
-    }),
-  ).toEqual({
-    endpoint: "https://api.openai.com/v1/models",
-    headers: { Authorization: "Bearer openai-key" },
   })
 })
 
@@ -288,7 +278,7 @@ test("does not infer discovery support from an Anthropic inference adapter", () 
     FetchModels.resolve({
       providerID: "custom-anthropic-provider",
       providerNPMs: ["@ai-sdk/anthropic"],
-      catalogBaseURL: "https://api.example.com/v1",
+      providerBaseURL: "https://api.example.com/v1",
     }),
   ).toBeUndefined()
 })

--- a/packages/opencode/src/provider/fetch-models.ts
+++ b/packages/opencode/src/provider/fetch-models.ts
@@ -94,8 +94,6 @@ export namespace FetchModels {
     authKey?: string
     // Resolved provider API for providers whose discovery follows their inference base.
     providerBaseURL?: string
-    // models.dev catalog base URL, used when the user has not overridden one.
-    catalogBaseURL?: string
   }
 
   export type ResolveInput = ResolveOptions & {
@@ -121,8 +119,7 @@ export namespace FetchModels {
     profile: DiscoveryProfile | undefined,
   ): { baseURL: string; headers: Record<string, string> } | undefined {
     const options = input.configOptions
-    const inferredBaseURL =
-      options?.baseURL ?? input.providerBaseURL ?? input.catalogBaseURL ?? profile?.defaultBaseURL ?? ""
+    const inferredBaseURL = options?.baseURL ?? input.providerBaseURL ?? profile?.defaultBaseURL ?? ""
     const normalizedBaseURL = inferredBaseURL.trim().replace(/\/+$/, "")
     const baseURL = (options?.endpoint ?? profile?.baseURLAliases?.[normalizedBaseURL] ?? inferredBaseURL).trim()
     if (!baseURL || baseURL.includes("${") || !URL.canParse(baseURL)) return undefined

--- a/packages/opencode/src/provider/fetch-models.ts
+++ b/packages/opencode/src/provider/fetch-models.ts
@@ -10,22 +10,31 @@ export namespace FetchModels {
   // discovery protocol is native or differs from the adapter/base URL used for inference.
   type DiscoveryProfile = {
     apiKeyHeader?: "authorization" | "x-api-key"
-    baseURL?: string
+    baseURLAliases?: Record<string, string>
+    defaultBaseURL?: string
     headers?: Record<string, string>
+    query?: Record<string, string>
+  }
+  const minimaxGlobal: DiscoveryProfile = {
+    baseURLAliases: { "https://api.minimax.io/anthropic/v1": "https://api.minimax.io/v1" },
+  }
+  const minimaxChina: DiscoveryProfile = {
+    baseURLAliases: { "https://api.minimaxi.com/anthropic/v1": "https://api.minimaxi.com/v1" },
   }
   const discoveryProfiles: Record<string, DiscoveryProfile> = {
     anthropic: {
       apiKeyHeader: "x-api-key",
-      baseURL: "https://api.anthropic.com/v1",
+      defaultBaseURL: "https://api.anthropic.com/v1",
       headers: { "anthropic-version": "2023-06-01" },
+      query: { limit: "1000" },
     },
     freemodel: {},
     "kimi-for-coding": {},
-    minimax: { baseURL: "https://api.minimax.io/v1" },
-    "minimax-coding-plan": { baseURL: "https://api.minimax.io/v1" },
-    "minimax-cn": { baseURL: "https://api.minimaxi.com/v1" },
-    "minimax-cn-coding-plan": { baseURL: "https://api.minimaxi.com/v1" },
-    openai: { baseURL: "https://api.openai.com/v1" },
+    minimax: minimaxGlobal,
+    "minimax-coding-plan": minimaxGlobal,
+    "minimax-cn": minimaxChina,
+    "minimax-cn-coding-plan": minimaxChina,
+    openai: { defaultBaseURL: "https://api.openai.com/v1" },
     subconscious: {},
   }
 
@@ -67,11 +76,13 @@ export namespace FetchModels {
     return result
   }
 
-  export function endpoint(baseURL: string): string {
-    return `${baseURL.trim().replace(/\/+$/, "")}/models`
+  function endpoint(baseURL: string, query?: Record<string, string>): string {
+    const url = `${baseURL.trim().replace(/\/+$/, "")}/models`
+    const params = new URLSearchParams(query).toString()
+    return params ? `${url}?${params}` : url
   }
 
-  export type RequestInput = {
+  type ResolveOptions = {
     // Provider config `options` (user override): endpoint/baseURL/apiKey/headers.
     configOptions?: {
       endpoint?: string
@@ -81,16 +92,13 @@ export namespace FetchModels {
     }
     // API key from the auth store (preferred over a config-embedded apiKey).
     authKey?: string
+    // Resolved provider API for providers whose discovery follows their inference base.
+    providerBaseURL?: string
     // models.dev catalog base URL, used when the user has not overridden one.
     catalogBaseURL?: string
   }
 
-  type ProfileRequestInput = RequestInput & {
-    apiKeyHeader?: DiscoveryProfile["apiKeyHeader"]
-    defaultHeaders?: Record<string, string>
-  }
-
-  export type ResolveInput = RequestInput & {
+  export type ResolveInput = ResolveOptions & {
     providerID: string
     providerNPMs: Iterable<string>
   }
@@ -100,48 +108,47 @@ export namespace FetchModels {
     if (!profile && !Array.from(input.providerNPMs).includes(OPENAI_COMPATIBLE)) {
       return undefined
     }
-    const resolved = prepareRequest({
-      ...input,
-      apiKeyHeader: profile?.apiKeyHeader,
-      catalogBaseURL: profile?.baseURL ?? input.catalogBaseURL,
-      defaultHeaders: profile?.headers,
-    })
+    const resolved = prepareRequest(input, profile)
     if (!resolved) return undefined
     return {
-      endpoint: endpoint(resolved.baseURL),
+      endpoint: endpoint(resolved.baseURL, profile?.query),
       headers: resolved.headers,
     }
   }
 
-  // Resolve the base URL and request headers for the /models call. Base URL precedence: config
-  // endpoint, then config baseURL, then the catalog entry — so a connected provider like Kilo Gateway
-  // works untouched. Returns undefined when no base URL is known. Adds a Bearer header from the key
-  // unless the config already carries an explicit authentication header.
-  export function request(input: RequestInput): { baseURL: string; headers: Record<string, string> } | undefined {
-    return prepareRequest(input)
-  }
-
   function prepareRequest(
-    input: ProfileRequestInput,
+    input: ResolveOptions,
+    profile: DiscoveryProfile | undefined,
   ): { baseURL: string; headers: Record<string, string> } | undefined {
     const options = input.configOptions
-    const baseURL = (options?.endpoint ?? options?.baseURL ?? input.catalogBaseURL ?? "").trim()
-    if (!baseURL) return undefined
+    const inferredBaseURL =
+      options?.baseURL ?? input.providerBaseURL ?? input.catalogBaseURL ?? profile?.defaultBaseURL ?? ""
+    const normalizedBaseURL = inferredBaseURL.trim().replace(/\/+$/, "")
+    const baseURL = (options?.endpoint ?? profile?.baseURLAliases?.[normalizedBaseURL] ?? inferredBaseURL).trim()
+    if (!baseURL || baseURL.includes("${") || !URL.canParse(baseURL)) return undefined
 
-    const headers: Record<string, string> = { ...input.defaultHeaders }
+    const headers: Record<string, string> = {}
+    for (const [key, value] of Object.entries(profile?.headers ?? {})) {
+      setHeader(headers, key, value)
+    }
     if (options?.headers) {
       for (const [key, value] of Object.entries(options.headers)) {
-        if (typeof value === "string") headers[key] = value
+        if (typeof value === "string") setHeader(headers, key, value)
       }
     }
     const key = input.authKey ?? (typeof options?.apiKey === "string" ? options.apiKey : undefined)
-    const hasAuthHeader = Object.keys(headers).some((header) =>
-      ["authorization", "x-api-key"].includes(header.toLowerCase()),
-    )
+    const authHeader = profile?.apiKeyHeader === "x-api-key" ? "x-api-key" : "authorization"
+    const hasAuthHeader = Object.keys(headers).some((header) => header.toLowerCase() === authHeader)
     if (key && !hasAuthHeader) {
-      if (input.apiKeyHeader === "x-api-key") headers["X-Api-Key"] = key
+      if (profile?.apiKeyHeader === "x-api-key") headers["X-Api-Key"] = key
       else headers["Authorization"] = `Bearer ${key}`
     }
     return { baseURL, headers }
+  }
+
+  function setHeader(headers: Record<string, string>, key: string, value: string) {
+    const existing = Object.keys(headers).find((header) => header.toLowerCase() === key.toLowerCase())
+    if (existing) delete headers[existing]
+    headers[key] = value
   }
 }

--- a/packages/opencode/src/provider/fetch-models.ts
+++ b/packages/opencode/src/provider/fetch-models.ts
@@ -5,7 +5,35 @@ import { z } from "zod"
 // generic: we only keep id + display name, never infer capabilities from arbitrary
 // gateway IDs (wrong metadata would break agent behavior — see issue #1463).
 export namespace FetchModels {
-  const Item = z.object({ id: z.string(), name: z.string().optional() })
+  const OPENAI_COMPATIBLE = "@ai-sdk/openai-compatible"
+  // Inference adapters are not model-discovery contracts. Profiles describe providers whose
+  // discovery protocol is native or differs from the adapter/base URL used for inference.
+  type DiscoveryProfile = {
+    apiKeyHeader?: "authorization" | "x-api-key"
+    baseURL?: string
+    headers?: Record<string, string>
+  }
+  const discoveryProfiles: Record<string, DiscoveryProfile> = {
+    anthropic: {
+      apiKeyHeader: "x-api-key",
+      baseURL: "https://api.anthropic.com/v1",
+      headers: { "anthropic-version": "2023-06-01" },
+    },
+    freemodel: {},
+    "kimi-for-coding": {},
+    minimax: { baseURL: "https://api.minimax.io/v1" },
+    "minimax-coding-plan": { baseURL: "https://api.minimax.io/v1" },
+    "minimax-cn": { baseURL: "https://api.minimaxi.com/v1" },
+    "minimax-cn-coding-plan": { baseURL: "https://api.minimaxi.com/v1" },
+    openai: { baseURL: "https://api.openai.com/v1" },
+    subconscious: {},
+  }
+
+  const Item = z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    display_name: z.string().optional(),
+  })
   const Shape = z.union([
     z.object({ data: z.array(z.unknown()) }),
     z.object({ models: z.array(z.unknown()) }),
@@ -34,7 +62,7 @@ export namespace FetchModels {
       const id = item.data.id.trim()
       if (!id || seen.has(id)) continue
       seen.add(id)
-      result.push({ id, name: item.data.name?.trim() || id })
+      result.push({ id, name: item.data.name?.trim() || item.data.display_name?.trim() || id })
     }
     return result
   }
@@ -57,24 +85,62 @@ export namespace FetchModels {
     catalogBaseURL?: string
   }
 
+  type ProfileRequestInput = RequestInput & {
+    apiKeyHeader?: DiscoveryProfile["apiKeyHeader"]
+    defaultHeaders?: Record<string, string>
+  }
+
+  export type ResolveInput = RequestInput & {
+    providerID: string
+    providerNPMs: Iterable<string>
+  }
+
+  export function resolve(input: ResolveInput): { endpoint: string; headers: Record<string, string> } | undefined {
+    const profile = discoveryProfiles[input.providerID]
+    if (!profile && !Array.from(input.providerNPMs).includes(OPENAI_COMPATIBLE)) {
+      return undefined
+    }
+    const resolved = prepareRequest({
+      ...input,
+      apiKeyHeader: profile?.apiKeyHeader,
+      catalogBaseURL: profile?.baseURL ?? input.catalogBaseURL,
+      defaultHeaders: profile?.headers,
+    })
+    if (!resolved) return undefined
+    return {
+      endpoint: endpoint(resolved.baseURL),
+      headers: resolved.headers,
+    }
+  }
+
   // Resolve the base URL and request headers for the /models call. Base URL precedence: config
   // endpoint, then config baseURL, then the catalog entry — so a connected provider like Kilo Gateway
   // works untouched. Returns undefined when no base URL is known. Adds a Bearer header from the key
-  // unless the config already carries an explicit Authorization header.
+  // unless the config already carries an explicit authentication header.
   export function request(input: RequestInput): { baseURL: string; headers: Record<string, string> } | undefined {
+    return prepareRequest(input)
+  }
+
+  function prepareRequest(
+    input: ProfileRequestInput,
+  ): { baseURL: string; headers: Record<string, string> } | undefined {
     const options = input.configOptions
     const baseURL = (options?.endpoint ?? options?.baseURL ?? input.catalogBaseURL ?? "").trim()
     if (!baseURL) return undefined
 
-    const headers: Record<string, string> = {}
+    const headers: Record<string, string> = { ...input.defaultHeaders }
     if (options?.headers) {
       for (const [key, value] of Object.entries(options.headers)) {
         if (typeof value === "string") headers[key] = value
       }
     }
     const key = input.authKey ?? (typeof options?.apiKey === "string" ? options.apiKey : undefined)
-    if (key && !Object.keys(headers).some((header) => header.toLowerCase() === "authorization")) {
-      headers["Authorization"] = `Bearer ${key}`
+    const hasAuthHeader = Object.keys(headers).some((header) =>
+      ["authorization", "x-api-key"].includes(header.toLowerCase()),
+    )
+    if (key && !hasAuthHeader) {
+      if (input.apiKeyHeader === "x-api-key") headers["X-Api-Key"] = key
+      else headers["Authorization"] = `Bearer ${key}`
     }
     return { baseURL, headers }
   }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -957,8 +957,16 @@ const defaultModelOverride: Record<string, string> = {
   [VOLCENGINE_PLAN_PROVIDER_ID]: VOLCENGINE_PLAN_DEFAULT_MODEL_ID,
 }
 
+export const ListInfo = Schema.Struct({
+  ...Info.fields,
+  canFetchModels: Schema.Boolean,
+})
+  .annotate({ identifier: "ListedProvider" })
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+export type ListInfo = Types.DeepMutable<Schema.Schema.Type<typeof ListInfo>>
+
 export const ListResult = Schema.Struct({
-  all: Schema.Array(Info),
+  all: Schema.Array(ListInfo),
   default: DefaultModelIDs,
   connected: Schema.Array(Schema.String),
 }).pipe(withStatics((s) => ({ zod: zod(s) })))
@@ -1922,6 +1930,7 @@ const ProviderServiceValue = Service
 const ProviderDefaultLayerValue = defaultLayer
 const ProviderModelValue = Model
 const ProviderInfoValue = Info
+const ProviderListInfoValue = ListInfo
 const ProviderListResultValue = ListResult
 const ProviderConfigProvidersResultValue = ConfigProvidersResult
 const ProviderDefaultModelIDValue = defaultModelID
@@ -1938,6 +1947,7 @@ export namespace Provider {
   export type Interface = import("./provider").Interface
   export type Service = import("./provider").Service
   export type Info = import("./provider").Info
+  export type ListInfo = import("./provider").ListInfo
   export type Model = import("./provider").Model
   export type Language = import("./provider").Language
 
@@ -1945,6 +1955,7 @@ export namespace Provider {
   export const defaultLayer = ProviderDefaultLayerValue
   export const Model = ProviderModelValue.zod
   export const Info = ProviderInfoValue.zod
+  export const ListInfo = ProviderListInfoValue.zod
   export const ListResult = ProviderListResultValue.zod
   export const ConfigProvidersResult = ProviderConfigProvidersResultValue.zod
   export const defaultModelID = ProviderDefaultModelIDValue

--- a/packages/opencode/src/server/instance/provider-actions.ts
+++ b/packages/opencode/src/server/instance/provider-actions.ts
@@ -10,32 +10,25 @@ import { ProviderAuth } from "../../provider/auth"
 import { Provider } from "../../provider/provider"
 import { ModelID, ProviderID } from "../../provider/schema"
 
-function resolveModelDiscovery(input: {
-  providerID: string
-  provider?: Provider.Info
-  catalog?: ModelsDev.Provider
-  auth?: Auth.Info
-}) {
-  if (input.auth?.type === "oauth") return undefined
+function resolveModelDiscovery(provider: Provider.Info | undefined, auth: Auth.Info | undefined) {
+  if (!provider || auth?.type === "oauth") return undefined
 
-  const provider = input.provider
   const providerNPMs = new Set<string>()
-  for (const model of Object.values(provider?.models ?? {})) providerNPMs.add(model.api.npm)
+  for (const model of Object.values(provider.models)) providerNPMs.add(model.api.npm)
 
   const providerModelAPIs = new Set(
-    Object.values(provider?.models ?? {})
+    Object.values(provider.models)
       .map((model) => model.api.url.trim())
       .filter((api): api is string => Boolean(api)),
   )
   const providerBaseURL = providerModelAPIs.size === 1 ? providerModelAPIs.values().next().value : undefined
 
   return FetchModels.resolve({
-    providerID: input.providerID,
+    providerID: provider.id,
     providerNPMs,
-    configOptions: provider?.options,
-    authKey: provider?.key ?? (input.auth?.type === "api" ? input.auth.key : undefined),
+    configOptions: provider.options,
+    authKey: provider.key,
     providerBaseURL,
-    catalogBaseURL: input.catalog?.api,
   })
 }
 
@@ -66,14 +59,7 @@ export const listProviders = Effect.fn("ProviderHttpApi.list")(function* () {
   return {
     all: Object.values(providers).map((item) => ({
       ...item,
-      canFetchModels: Boolean(
-        resolveModelDiscovery({
-          providerID: item.id,
-          provider: item,
-          catalog: allProviders[item.id],
-          auth: authInfo[item.id],
-        }),
-      ),
+      canFetchModels: Boolean(resolveModelDiscovery(item, authInfo[item.id])),
     })),
     default: mapValues(providers, (item) => Provider.defaultModelID(item)),
     connected: Object.keys(connected),
@@ -120,25 +106,14 @@ export const fetchProviderModels = Effect.fn("ProviderHttpApi.models.fetch")(fun
   providerID: ProviderID
 }) {
   const auth = yield* Auth.Service
-  const modelsDev = yield* ModelsDev.Service
   const provider = yield* Provider.Service
 
-  const [authInfo, modelsDevProviders, connected] = yield* Effect.all(
-    [
-      auth.get(input.providerID).pipe(Effect.orElseSucceed(() => undefined)),
-      modelsDev.data().pipe(Effect.orElseSucceed(() => ({}) as Record<string, ModelsDev.Provider>)),
-      provider.list(),
-    ],
+  const [authInfo, connected] = yield* Effect.all(
+    [auth.get(input.providerID).pipe(Effect.orElseSucceed(() => undefined)), provider.list()],
     { concurrency: "unbounded" },
   )
 
-  const catalog = withPawWorkProviders(modelsDevProviders)[input.providerID]
-  const resolved = resolveModelDiscovery({
-    providerID: input.providerID,
-    provider: connected[input.providerID],
-    catalog,
-    auth: authInfo,
-  })
+  const resolved = resolveModelDiscovery(connected[input.providerID], authInfo)
   if (!resolved) {
     return { ok: false as const, message: "Model discovery is not supported for this provider" }
   }

--- a/packages/opencode/src/server/instance/provider-actions.ts
+++ b/packages/opencode/src/server/instance/provider-actions.ts
@@ -10,6 +10,33 @@ import { ProviderAuth } from "../../provider/auth"
 import { Provider } from "../../provider/provider"
 import { ModelID, ProviderID } from "../../provider/schema"
 
+function resolveModelDiscovery(input: {
+  providerID: string
+  provider?: Provider.Info
+  catalog?: ModelsDev.Provider
+  configProvider?: NonNullable<Config.Info["provider"]>[string]
+  authKey?: string
+}) {
+  const providerNPMs = new Set<string>()
+  if (input.catalog?.npm) providerNPMs.add(input.catalog.npm)
+  if (input.configProvider?.npm) providerNPMs.add(input.configProvider.npm)
+  for (const model of Object.values(input.provider?.models ?? {})) providerNPMs.add(model.api.npm)
+  for (const model of Object.values(input.catalog?.models ?? {})) {
+    if (model.provider?.npm) providerNPMs.add(model.provider.npm)
+  }
+  for (const model of Object.values(input.configProvider?.models ?? {})) {
+    if (model.provider?.npm) providerNPMs.add(model.provider.npm)
+  }
+
+  return FetchModels.resolve({
+    providerID: input.providerID,
+    providerNPMs,
+    configOptions: input.configProvider?.options,
+    authKey: input.authKey,
+    catalogBaseURL: input.catalog?.api,
+  })
+}
+
 export const listProviders = Effect.fn("ProviderHttpApi.list")(function* () {
   const config = yield* Config.Service
   const modelsDev = yield* ModelsDev.Service
@@ -34,7 +61,17 @@ export const listProviders = Effect.fn("ProviderHttpApi.list")(function* () {
     connected,
   )
   return {
-    all: Object.values(providers),
+    all: Object.values(providers).map((item) => ({
+      ...item,
+      canFetchModels: Boolean(
+        resolveModelDiscovery({
+          providerID: item.id,
+          provider: item,
+          catalog: allProviders[item.id],
+          configProvider: configInfo.provider?.[item.id],
+        }),
+      ),
+    })),
     default: mapValues(providers, (item) => Provider.defaultModelID(item)),
     connected: Object.keys(connected),
   }
@@ -74,41 +111,44 @@ export type FetchProviderModelsResult =
   // verbatim and does not branch on a code, so no numeric status is returned. Issue #1463.
   | { ok: false; message: string }
 
-// Live-discover an OpenAI-compatible provider's models by calling its `/models` endpoint with the
-// provider's already-configured base URL + auth + headers. The base URL comes from the user's config
-// override when present, otherwise the models.dev catalog entry (so connected providers like Kilo
-// Gateway work without re-entering anything). This only reads and returns the parsed list; persisting
-// the chosen additions is the app's job (merge into config.provider.<id>.models). Issue #1463.
+// Live-discover a provider's models with the same capability resolver used by provider.list. This only
+// reads and returns the parsed list; persisting chosen additions is the app's job. Issue #1463.
 export const fetchProviderModels = Effect.fn("ProviderHttpApi.models.fetch")(function* (input: {
   providerID: ProviderID
 }) {
   const config = yield* Config.Service
   const auth = yield* Auth.Service
   const modelsDev = yield* ModelsDev.Service
+  const provider = yield* Provider.Service
 
-  const [configInfo, authInfo, modelsDevProviders] = yield* Effect.all(
+  const [configInfo, authInfo, modelsDevProviders, connected] = yield* Effect.all(
     [
       config.get(),
       auth.get(input.providerID).pipe(Effect.orElseSucceed(() => undefined)),
       modelsDev.data().pipe(Effect.orElseSucceed(() => ({}) as Record<string, ModelsDev.Provider>)),
+      provider.list(),
     ],
     { concurrency: "unbounded" },
   )
 
   const catalog = withPawWorkProviders(modelsDevProviders)[input.providerID]
-  const resolved = FetchModels.request({
-    configOptions: configInfo.provider?.[input.providerID]?.options,
+  const resolved = resolveModelDiscovery({
+    providerID: input.providerID,
+    provider: connected[input.providerID],
+    catalog,
+    configProvider: configInfo.provider?.[input.providerID],
     authKey: authInfo?.type === "api" ? authInfo.key : undefined,
-    catalogBaseURL: catalog?.api,
   })
   if (!resolved) {
-    return { ok: false as const, message: "No base URL configured for this provider" }
+    return { ok: false as const, message: "Model discovery is not supported for this provider" }
   }
-  const { baseURL, headers } = resolved
 
   return yield* Effect.promise(async (): Promise<FetchProviderModelsResult> => {
     try {
-      const response = await fetch(FetchModels.endpoint(baseURL), { headers, signal: AbortSignal.timeout(10_000) })
+      const response = await fetch(resolved.endpoint, {
+        headers: resolved.headers,
+        signal: AbortSignal.timeout(10_000),
+      })
       if (!response.ok) {
         return {
           ok: false,

--- a/packages/opencode/src/server/instance/provider-actions.ts
+++ b/packages/opencode/src/server/instance/provider-actions.ts
@@ -14,35 +14,38 @@ function resolveModelDiscovery(input: {
   providerID: string
   provider?: Provider.Info
   catalog?: ModelsDev.Provider
-  configProvider?: NonNullable<Config.Info["provider"]>[string]
-  authKey?: string
+  auth?: Auth.Info
 }) {
+  if (input.auth?.type === "oauth") return undefined
+
+  const provider = input.provider
   const providerNPMs = new Set<string>()
-  if (input.catalog?.npm) providerNPMs.add(input.catalog.npm)
-  if (input.configProvider?.npm) providerNPMs.add(input.configProvider.npm)
-  for (const model of Object.values(input.provider?.models ?? {})) providerNPMs.add(model.api.npm)
-  for (const model of Object.values(input.catalog?.models ?? {})) {
-    if (model.provider?.npm) providerNPMs.add(model.provider.npm)
-  }
-  for (const model of Object.values(input.configProvider?.models ?? {})) {
-    if (model.provider?.npm) providerNPMs.add(model.provider.npm)
-  }
+  for (const model of Object.values(provider?.models ?? {})) providerNPMs.add(model.api.npm)
+
+  const providerModelAPIs = new Set(
+    Object.values(provider?.models ?? {})
+      .map((model) => model.api.url.trim())
+      .filter((api): api is string => Boolean(api)),
+  )
+  const providerBaseURL = providerModelAPIs.size === 1 ? providerModelAPIs.values().next().value : undefined
 
   return FetchModels.resolve({
     providerID: input.providerID,
     providerNPMs,
-    configOptions: input.configProvider?.options,
-    authKey: input.authKey,
+    configOptions: provider?.options,
+    authKey: provider?.key ?? (input.auth?.type === "api" ? input.auth.key : undefined),
+    providerBaseURL,
     catalogBaseURL: input.catalog?.api,
   })
 }
 
 export const listProviders = Effect.fn("ProviderHttpApi.list")(function* () {
   const config = yield* Config.Service
+  const auth = yield* Auth.Service
   const modelsDev = yield* ModelsDev.Service
   const provider = yield* Provider.Service
-  const [configInfo, modelsDevProviders, connected] = yield* Effect.all(
-    [config.get(), modelsDev.data().pipe(Effect.orDie), provider.list()],
+  const [configInfo, authInfo, modelsDevProviders, connected] = yield* Effect.all(
+    [config.get(), auth.all().pipe(Effect.orDie), modelsDev.data().pipe(Effect.orDie), provider.list()],
     { concurrency: "unbounded" },
   )
   const allProviders = withPawWorkProviders(modelsDevProviders)
@@ -68,7 +71,7 @@ export const listProviders = Effect.fn("ProviderHttpApi.list")(function* () {
           providerID: item.id,
           provider: item,
           catalog: allProviders[item.id],
-          configProvider: configInfo.provider?.[item.id],
+          auth: authInfo[item.id],
         }),
       ),
     })),
@@ -116,14 +119,12 @@ export type FetchProviderModelsResult =
 export const fetchProviderModels = Effect.fn("ProviderHttpApi.models.fetch")(function* (input: {
   providerID: ProviderID
 }) {
-  const config = yield* Config.Service
   const auth = yield* Auth.Service
   const modelsDev = yield* ModelsDev.Service
   const provider = yield* Provider.Service
 
-  const [configInfo, authInfo, modelsDevProviders, connected] = yield* Effect.all(
+  const [authInfo, modelsDevProviders, connected] = yield* Effect.all(
     [
-      config.get(),
       auth.get(input.providerID).pipe(Effect.orElseSucceed(() => undefined)),
       modelsDev.data().pipe(Effect.orElseSucceed(() => ({}) as Record<string, ModelsDev.Provider>)),
       provider.list(),
@@ -136,8 +137,7 @@ export const fetchProviderModels = Effect.fn("ProviderHttpApi.models.fetch")(fun
     providerID: input.providerID,
     provider: connected[input.providerID],
     catalog,
-    configProvider: configInfo.provider?.[input.providerID],
-    authKey: authInfo?.type === "api" ? authInfo.key : undefined,
+    auth: authInfo,
   })
   if (!resolved) {
     return { ok: false as const, message: "Model discovery is not supported for this provider" }

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/provider.ts
@@ -114,7 +114,7 @@ export const ProviderApi = HttpApi.make("provider")
             identifier: "provider.fetchModels",
             summary: "Fetch provider models",
             description:
-              "Discover an OpenAI-compatible provider's models live from its /models endpoint using the provider's configured base URL, auth, and headers. Returns the parsed list without persisting it.",
+              "Discover a supported provider's models live using its resolved discovery endpoint, auth, and headers. Returns the parsed list without persisting it.",
           }),
         ),
       )

--- a/packages/opencode/test/server/provider-routes.test.ts
+++ b/packages/opencode/test/server/provider-routes.test.ts
@@ -458,29 +458,33 @@ describe("provider routes", () => {
   test("does not offer API model discovery for OpenAI OAuth", async () => {
     await using tmp = await tmpdir({ git: true })
 
-    await Instance.provide({
-      directory: tmp.path,
-      init: async () => {
-        await AppRuntime.runPromise(
-          Auth.Service.use((auth) =>
-            auth.set("openai", {
-              type: "oauth",
-              refresh: "refresh-token",
-              access: "access-token",
-              expires: Date.now() + 60_000,
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        init: async () => {
+          await AppRuntime.runPromise(
+            Auth.Service.use((auth) =>
+              auth.set("openai", {
+                type: "oauth",
+                refresh: "refresh-token",
+                access: "access-token",
+                expires: Date.now() + 60_000,
+              }),
+            ),
+          )
+        },
+        fn: async () => {
+          await withProviderClient((client) =>
+            Effect.gen(function* () {
+              const providers = yield* client.provider.list({ query: {} })
+              expect(providers.connected).toContain("openai")
+              expect(providers.all.find((provider) => provider.id === "openai")?.canFetchModels).toBe(false)
             }),
-          ),
-        )
-      },
-      fn: async () => {
-        await withProviderClient((client) =>
-          Effect.gen(function* () {
-            const providers = yield* client.provider.list({ query: {} })
-            expect(providers.connected).toContain("openai")
-            expect(providers.all.find((provider) => provider.id === "openai")?.canFetchModels).toBe(false)
-          }),
-        )
-      },
-    })
+          )
+        },
+      })
+    } finally {
+      await AppRuntime.runPromise(Auth.Service.use((auth) => auth.remove("openai")))
+    }
   }, 30000)
 })

--- a/packages/opencode/test/server/provider-routes.test.ts
+++ b/packages/opencode/test/server/provider-routes.test.ts
@@ -24,7 +24,11 @@ describe("provider routes", () => {
   type ProviderClient = {
     provider: {
       list: (input?: { query?: { directory?: string; workspace?: string } }) => Effect.Effect<
-        { all: ReadonlyArray<unknown>; default: Readonly<Record<string, string>>; connected: ReadonlyArray<string> },
+        {
+          all: ReadonlyArray<{ id: string; canFetchModels: boolean }>
+          default: Readonly<Record<string, string>>
+          connected: ReadonlyArray<string>
+        },
         unknown,
         unknown
       >
@@ -195,9 +199,9 @@ describe("provider routes", () => {
             expect(providers.all).toBeArray()
             expect(providers.default).toBeObject()
             expect(providers.connected).toBeArray()
-            const hasVolcenginePlan = providers.all.some(
-              (provider) => (provider as { id?: string }).id === VOLCENGINE_PLAN_PROVIDER_ID,
-            )
+            expect(providers.all.every((provider) => typeof provider.canFetchModels === "boolean")).toBe(true)
+            expect(providers.all.find((provider) => provider.id === "kimi-for-coding")?.canFetchModels).toBe(true)
+            const hasVolcenginePlan = providers.all.some((provider) => provider.id === VOLCENGINE_PLAN_PROVIDER_ID)
             expect(hasVolcenginePlan).toBe(true)
             expect(providers.default[VOLCENGINE_PLAN_PROVIDER_ID]).toBe(VOLCENGINE_PLAN_DEFAULT_MODEL_ID)
 

--- a/packages/opencode/test/server/provider-routes.test.ts
+++ b/packages/opencode/test/server/provider-routes.test.ts
@@ -455,21 +455,6 @@ describe("provider routes", () => {
     expect(received.authorization).toBe("Bearer proxy-minimax-key")
   }, 30000)
 
-  test("maps unsupported model discovery to 400", async () => {
-    await using tmp = await tmpdir({ git: true })
-
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const response = await requestProviderHttpApi("/provider/google/models", { method: "POST" })
-        expect(response.status).toBe(400)
-        expect(await response.json()).toMatchObject({
-          message: "Model discovery is not supported for this provider",
-        })
-      },
-    })
-  }, 30000)
-
   test("does not offer API model discovery for OpenAI OAuth", async () => {
     await using tmp = await tmpdir({ git: true })
 

--- a/packages/opencode/test/server/provider-routes.test.ts
+++ b/packages/opencode/test/server/provider-routes.test.ts
@@ -8,12 +8,15 @@ import { HttpApiBuilder, HttpApiTest, OpenApi } from "effect/unstable/httpapi"
 import { NodeFileSystem, NodeHttpPlatform, NodePath } from "@effect/platform-node"
 import { VOLCENGINE_PLAN_DEFAULT_MODEL_ID, VOLCENGINE_PLAN_PROVIDER_ID } from "@opencode-ai/util/volcengine-plan"
 import { AppRuntime } from "../../src/effect/app-runtime"
+import { Auth } from "../../src/auth"
+import { Env } from "../../src/env"
 import { Instance } from "../../src/project/instance"
 import { ProviderApi } from "../../src/server/routes/instance/httpapi/groups/provider"
 import { providerHandlers } from "../../src/server/routes/instance/httpapi/handlers/provider"
 import { tmpdir } from "../fixture/fixture"
 
 const modelFile = () => path.join(Global.Path.state, "model.json")
+const setEnv = (key: string, value: string) => AppRuntime.runSync(Env.Service.use((env) => env.set(key, value)))
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -51,6 +54,10 @@ describe("provider routes", () => {
         query?: { directory?: string; workspace?: string }
         payload: { providerID: string; modelID: string }
       }) => Effect.Effect<boolean, unknown, unknown>
+      fetchModels: (input: {
+        params: { providerID: string }
+        query?: { directory?: string; workspace?: string }
+      }) => Effect.Effect<{ models: ReadonlyArray<{ id: string; name: string }> }, unknown, unknown>
     }
   }
 
@@ -201,6 +208,7 @@ describe("provider routes", () => {
             expect(providers.connected).toBeArray()
             expect(providers.all.every((provider) => typeof provider.canFetchModels === "boolean")).toBe(true)
             expect(providers.all.find((provider) => provider.id === "kimi-for-coding")?.canFetchModels).toBe(true)
+            expect(providers.all.find((provider) => provider.id === "opencode")?.canFetchModels).toBe(true)
             const hasVolcenginePlan = providers.all.some((provider) => provider.id === VOLCENGINE_PLAN_PROVIDER_ID)
             expect(hasVolcenginePlan).toBe(true)
             expect(providers.default[VOLCENGINE_PLAN_PROVIDER_ID]).toBe(VOLCENGINE_PLAN_DEFAULT_MODEL_ID)
@@ -252,6 +260,241 @@ describe("provider routes", () => {
 
         expect(response.status).toBe(400)
         expect(body.name).toBe("ProviderAuthOauthMissing")
+      },
+    })
+  }, 30000)
+
+  test("uses the resolved provider environment key for model discovery", async () => {
+    const received: { apiKey: string | null } = { apiKey: null }
+    await using remote = Bun.serve({
+      port: 0,
+      fetch(request) {
+        received.apiKey = request.headers.get("x-api-key")
+        return Response.json({ data: [{ id: "claude-test", display_name: "Claude Test" }] })
+      },
+    })
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        provider: {
+          anthropic: {
+            options: { endpoint: `${remote.url.origin}/v1` },
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        setEnv("ANTHROPIC_API_KEY", "env-anthropic-key")
+      },
+      fn: async () => {
+        await withProviderClient((client) =>
+          Effect.gen(function* () {
+            const result = yield* client.provider.fetchModels({
+              params: { providerID: "anthropic" },
+              query: {},
+            })
+            expect(result.models).toEqual([{ id: "claude-test", name: "Claude Test" }])
+          }),
+        )
+      },
+    })
+    expect(received.apiKey).toBe("env-anthropic-key")
+  }, 30000)
+
+  test("uses a custom provider's configured API for model discovery", async () => {
+    const received: { authorization: string | null } = { authorization: null }
+    let pathname = ""
+    await using remote = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url)
+        pathname = url.pathname
+        received.authorization = request.headers.get("authorization")
+        return Response.json({ data: [{ id: "custom-live-model" }] })
+      },
+    })
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        provider: {
+          "custom-gateway": {
+            npm: "@ai-sdk/openai-compatible",
+            api: `${remote.url.origin}/v1`,
+            env: ["CUSTOM_GATEWAY_KEY"],
+            models: {
+              "configured-model": {
+                limit: { context: 128_000, output: 4_096 },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        setEnv("CUSTOM_GATEWAY_KEY", "env-gateway-key")
+      },
+      fn: async () => {
+        await withProviderClient((client) =>
+          Effect.gen(function* () {
+            const providers = yield* client.provider.list({ query: {} })
+            expect(providers.all.find((provider) => provider.id === "custom-gateway")?.canFetchModels).toBe(true)
+
+            const result = yield* client.provider.fetchModels({
+              params: { providerID: "custom-gateway" },
+              query: {},
+            })
+            expect(result.models).toEqual([{ id: "custom-live-model", name: "custom-live-model" }])
+          }),
+        )
+      },
+    })
+
+    expect(pathname).toBe("/v1/models")
+    expect(received.authorization).toBe("Bearer env-gateway-key")
+  }, 30000)
+
+  test("uses a custom model's configured API for model discovery", async () => {
+    let pathname = ""
+    await using remote = Bun.serve({
+      port: 0,
+      fetch(request) {
+        pathname = new URL(request.url).pathname
+        return Response.json({ data: [{ id: "model-api-live" }] })
+      },
+    })
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        provider: {
+          "model-api-gateway": {
+            env: ["MODEL_API_GATEWAY_KEY"],
+            models: {
+              "configured-model": {
+                provider: {
+                  npm: "@ai-sdk/openai-compatible",
+                  api: `${remote.url.origin}/v1`,
+                },
+                limit: { context: 128_000, output: 4_096 },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        setEnv("MODEL_API_GATEWAY_KEY", "env-model-api-key")
+      },
+      fn: async () => {
+        await withProviderClient((client) =>
+          Effect.gen(function* () {
+            const providers = yield* client.provider.list({ query: {} })
+            expect(providers.all.find((provider) => provider.id === "model-api-gateway")?.canFetchModels).toBe(true)
+
+            const result = yield* client.provider.fetchModels({
+              params: { providerID: "model-api-gateway" },
+              query: {},
+            })
+            expect(result.models).toEqual([{ id: "model-api-live", name: "model-api-live" }])
+          }),
+        )
+      },
+    })
+
+    expect(pathname).toBe("/v1/models")
+  }, 30000)
+
+  test("uses an explicit MiniMax endpoint instead of sending its key to the official host", async () => {
+    const received: { authorization: string | null } = { authorization: null }
+    let pathname = ""
+    await using remote = Bun.serve({
+      port: 0,
+      fetch(request) {
+        pathname = new URL(request.url).pathname
+        received.authorization = request.headers.get("authorization")
+        return Response.json({ data: [{ id: "proxied-minimax-model" }] })
+      },
+    })
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        provider: {
+          minimax: {
+            options: { endpoint: `${remote.url.origin}/openai/v1` },
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        setEnv("MINIMAX_API_KEY", "proxy-minimax-key")
+      },
+      fn: async () => {
+        await withProviderClient((client) =>
+          Effect.gen(function* () {
+            const result = yield* client.provider.fetchModels({
+              params: { providerID: "minimax" },
+              query: {},
+            })
+            expect(result.models).toEqual([{ id: "proxied-minimax-model", name: "proxied-minimax-model" }])
+          }),
+        )
+      },
+    })
+
+    expect(pathname).toBe("/openai/v1/models")
+    expect(received.authorization).toBe("Bearer proxy-minimax-key")
+  }, 30000)
+
+  test("maps unsupported model discovery to 400", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const response = await requestProviderHttpApi("/provider/google/models", { method: "POST" })
+        expect(response.status).toBe(400)
+        expect(await response.json()).toMatchObject({
+          message: "Model discovery is not supported for this provider",
+        })
+      },
+    })
+  }, 30000)
+
+  test("does not offer API model discovery for OpenAI OAuth", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        await AppRuntime.runPromise(
+          Auth.Service.use((auth) =>
+            auth.set("openai", {
+              type: "oauth",
+              refresh: "refresh-token",
+              access: "access-token",
+              expires: Date.now() + 60_000,
+            }),
+          ),
+        )
+      },
+      fn: async () => {
+        await withProviderClient((client) =>
+          Effect.gen(function* () {
+            const providers = yield* client.provider.list({ query: {} })
+            expect(providers.connected).toContain("openai")
+            expect(providers.all.find((provider) => provider.id === "openai")?.canFetchModels).toBe(false)
+          }),
+        )
       },
     })
   }, 30000)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3590,7 +3590,7 @@ export class Provider extends HeyApiClient {
   /**
    * Fetch provider models
    *
-   * Discover an OpenAI-compatible provider's models live from its /models endpoint using the provider's configured base URL, auth, and headers. Returns the parsed list without persisting it.
+   * Discover a supported provider's models live using its resolved discovery endpoint, auth, and headers. Returns the parsed list without persisting it.
    */
   public fetchModels<ThrowOnError extends boolean = false>(
     parameters: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2136,6 +2136,21 @@ export type SessionShareDisabledError = {
   error: "cloud_share_disabled"
 }
 
+export type ListedProvider = {
+  id: string
+  name: string
+  source: "env" | "config" | "custom" | "api"
+  env: Array<string>
+  key?: string
+  options: {
+    [key: string]: unknown
+  }
+  models: {
+    [key: string]: Model
+  }
+  canFetchModels: boolean
+}
+
 export type ProviderAuthMethod = {
   type: "oauth" | "api"
   label: string
@@ -5859,7 +5874,7 @@ export type ProviderListResponses = {
    * Success
    */
   200: {
-    all: Array<Provider>
+    all: Array<ListedProvider>
     default: {
       [key: string]: string
     }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8859,7 +8859,7 @@
                     "all": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/Provider"
+                        "$ref": "#/components/schemas/ListedProvider"
                       }
                     },
                     "default": {
@@ -19772,6 +19772,63 @@
         ],
         "additionalProperties": false,
         "description": "Cloud sharing is disabled"
+      },
+      "ListedProvider": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "env",
+              "config",
+              "custom",
+              "api"
+            ]
+          },
+          "env": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "key": {
+            "type": "string"
+          },
+          "options": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          },
+          "models": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Model"
+            }
+          },
+          "canFetchModels": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "source",
+          "env",
+          "options",
+          "models",
+          "canFetchModels"
+        ]
       },
       "ProviderAuthMethod": {
         "type": "object",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9377,7 +9377,7 @@
             }
           }
         },
-        "description": "Discover an OpenAI-compatible provider's models live from its /models endpoint using the provider's configured base URL, auth, and headers. Returns the parsed list without persisting it.",
+        "description": "Discover a supported provider's models live using its resolved discovery endpoint, auth, and headers. Returns the parsed list without persisting it.",
         "summary": "Fetch provider models",
         "x-codeSamples": [
           {


### PR DESCRIPTION
## Summary

- Move model-discovery capability detection from the Settings UI into the provider service contract.
- Add discovery profiles for providers whose inference adapter does not describe their `/models` protocol, including Kimi For Coding and MiniMax regional variants.
- Use resolved `Provider.Info` state for discovery URLs, credentials, headers, and configuration overrides.
- Expose the capability through OpenAPI/SDK types and render the existing Fetch models action from that capability.

## Why

Kimi For Coding uses the Anthropic adapter for inference but exposes an OpenAI-compatible model-list endpoint. The UI previously inferred discovery support from the inference npm package, so connected Kimi accounts did not receive the Fetch models action. Other native or dual-protocol providers had the same architectural mismatch.

This change treats inference and model discovery as separate contracts, resolves discovery once on the server, and lets both the provider list and fetch action consume that plan.

## Related Issue

Follow-up to #1463. The original feature issue is already closed; this PR fixes capability detection for providers that do not use the generic OpenAI-compatible inference adapter.

## Human Review Status\n\nApproved by @Astro-Han

## Review Focus

- Whether the discovery profile table is the narrowest accurate representation of the known protocol exceptions.
- Whether `Provider.Info` remains the sole runtime source for credentials, options, and model API URLs.
- Whether explicit endpoint overrides, MiniMax protocol aliases, OAuth gating, and case-insensitive header merging preserve credential origin and user intent.
- Whether the unit, real HTTP action, and Settings E2E tests cover the behavior without coupling to internal implementation details.

## Risk Notes

- Model discovery sends the connected provider credential to the resolved model-list endpoint. Explicit endpoint overrides remain highest priority; MiniMax aliases only rewrite known official Anthropic paths to the same-region official OpenAI-compatible origin.
- OpenAI OAuth connections deliberately do not advertise API model discovery because ChatGPT OAuth is not an API-key model-list contract.
- Generated OpenAPI and JavaScript SDK files are included and checked against the production schema.
- Platform/packaging verification is not applicable: no Electron, IPC, OS integration, path, installer, updater, or permission behavior changed.

## How To Verify

```text
Provider resolver, HTTP routes, and OpenAPI source: 46 passed, 0 failed
Settings merge/bootstrap unit tests: 31 passed, 0 failed
Settings Models E2E: 3 passed, including Kimi fetch, persisted model visibility, and route stability
Type checks: opencode, app, and sdk/js passed
SDK generation: passed
Diff check: no whitespace errors
Visual check: bun run snap settings-models-fetch passed; reviewed the local Kimi Settings > Models grid
```

## Screenshots or Recordings

Reviewed the `settings-models-fetch` snap target locally. It shows the Kimi For Coding group with the Fetch models action in the provider header and unchanged model-row layout.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded model discovery across supported providers and custom endpoints.
  - Added provider-specific authentication, endpoint, and header handling.
  - Provider listings now indicate whether model fetching is available.
  - Model names now support provider-supplied display names.

- **Bug Fixes**
  - Improved model fetching for Kimi, MiniMax, Anthropic, and OpenAI-compatible providers.
  - Prevented unsupported providers and OAuth-based OpenAI access from offering model discovery.
  - Added coverage for provider-specific discovery and authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
