### PR TITLE
feat(app): fork sessions from assistant turn footer

### DIFF
--- a/packages/app/e2e/session/session-turn-footer.spec.ts
+++ b/packages/app/e2e/session/session-turn-footer.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures"
-import { withSession } from "../actions"
+import { sessionIDFromUrl, withSession } from "../actions"
 import { bodyText } from "../prompt/mock"
+import { promptSelector } from "../selectors"
 
 test("assistant footer is hover-only and copy writes response to clipboard", async ({
   page,
@@ -29,6 +30,42 @@ test("assistant footer is hover-only and copy writes response to clipboard", asy
   await copy.click()
   const clip = await page.evaluate(() => navigator.clipboard.readText())
   expect(clip).toBe(reply)
+})
+
+test("assistant footer forks through the selected turn into a new session", async ({ page, project, llm }) => {
+  await project.open()
+
+  const firstPrompt = "seed the fork source turn"
+  const firstReply = "First reply kept in the fork."
+  const secondPrompt = "seed a later turn excluded from the fork"
+  const secondReply = "Later reply excluded from the fork."
+
+  await llm.text(firstReply)
+  const sourceSessionID = await project.prompt(firstPrompt)
+  await llm.text(secondReply)
+  expect(await project.prompt(secondPrompt)).toBe(sourceSessionID)
+
+  const firstTurn = page.locator('[data-slot="session-turn-message-container"]').filter({ hasText: firstReply })
+  await firstTurn.hover()
+  await firstTurn.getByRole("button", { name: "Fork to new session" }).click()
+
+  await expect.poll(() => sessionIDFromUrl(page.url()) ?? "").not.toBe(sourceSessionID)
+  const forkedSessionID = sessionIDFromUrl(page.url())
+  if (!forkedSessionID) throw new Error("Expected the forked session route")
+  project.trackSession(forkedSessionID)
+
+  await expect(page.getByText(firstPrompt, { exact: true })).toBeVisible()
+  await expect(page.getByText(firstReply, { exact: true })).toBeVisible()
+  await expect(page.getByText(secondPrompt, { exact: true })).toHaveCount(0)
+  await expect(page.getByText(secondReply, { exact: true })).toHaveCount(0)
+  await expect(page.locator(promptSelector).first()).toHaveText("")
+
+  const sourceMessages = await project.sdk.session
+    .messages({ sessionID: sourceSessionID, limit: 100 })
+    .then((result) => result.data ?? [])
+  expect(sourceMessages.some((message) => message.parts.some((part) => part.type === "text" && part.text === secondReply))).toBe(
+    true,
+  )
 })
 
 test("assistant footer renders below the turn changes panel in the same turn", async ({ page, project, llm }) => {

--- a/packages/app/e2e/snap/session-turn-footer.snap.ts
+++ b/packages/app/e2e/snap/session-turn-footer.snap.ts
@@ -1,0 +1,45 @@
+import { expect, type Page } from "@playwright/test"
+import { test } from "../fixtures"
+import { applyDarkModeForTests } from "../utils"
+import { composeGrid, snapOutputPath, type Shot } from "./_compose"
+
+test.use({ viewport: { width: 900, height: 560 }, deviceScaleFactor: 2 })
+
+async function captureFooter(page: Page, name: string): Promise<Shot> {
+  const turn = page.locator('[data-slot="session-turn-message-container"]').last()
+  await turn.hover()
+
+  const footer = turn.locator('[data-slot="assistant-turn-footer"]')
+  await expect(footer).toBeVisible()
+  await expect(footer.getByRole("button", { name: "Copy response" })).toBeVisible()
+  await expect(footer.getByRole("button", { name: "Fork to new session" })).toBeVisible()
+
+  const metrics = await footer.evaluate((element) => {
+    const actions = element.querySelector<HTMLElement>('[data-slot="assistant-turn-footer-actions"]')
+    return {
+      height: element.getBoundingClientRect().height,
+      actionGap: actions ? getComputedStyle(actions).columnGap : "",
+    }
+  })
+  expect(metrics.height).toBe(30)
+  expect(metrics.actionGap).toBe("0px")
+
+  return { name, buf: await turn.screenshot({ animations: "disabled" }) }
+}
+
+test("session-turn-footer", async ({ page, project, llm }) => {
+  await project.open()
+
+  await llm.text("A useful answer with a natural branch point.")
+  const sessionID = await project.prompt("Show me the footer actions.")
+
+  const shots: Shot[] = [await captureFooter(page, "light")]
+
+  await applyDarkModeForTests(page)
+  await project.gotoSession(sessionID)
+  shots.push(await captureFooter(page, "dark"))
+
+  const out = snapOutputPath("session-turn-footer")
+  await composeGrid(shots, out)
+  process.stdout.write(`\n[snap] session-turn-footer grid -> ${out}\n\n`)
+})

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,9 +1,10 @@
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createMemo, createEffect, createSignal, on } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
+import { base64Encode } from "@opencode-ai/util/encode"
 import { useLocal } from "@/context/local"
 import { useFile } from "@/context/file"
-import { useLocation, useSearchParams } from "@solidjs/router"
+import { useLocation, useNavigate, useSearchParams } from "@solidjs/router"
 import { useComments } from "@/context/comments"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -60,6 +61,7 @@ export default function Page() {
   const comments = useComments()
   const terminal = useTerminal()
   const location = useLocation()
+  const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams<{ prompt?: string; skill?: string }>()
   const { params, tabs, view } = useSessionLayout()
 
@@ -395,7 +397,28 @@ export default function Page() {
     roll: revertSupport.roll,
   })
 
-  const actions = { revert: sessionRevert.revert }
+  const fork = async (input: { sessionID: string; messageID: string }) => {
+    const nextUserMessage = sync.data.message[input.sessionID]?.find(
+      (message) => message.role === "user" && message.id > input.messageID,
+    )
+
+    try {
+      const result = await sdk.client.session.fork({
+        sessionID: input.sessionID,
+        ...(nextUserMessage ? { messageID: nextUserMessage.id } : {}),
+      })
+      const forked = result.data
+      if (!forked) {
+        fail(result.error ?? new Error("Failed to fork session"))
+        return
+      }
+      navigate(`/${base64Encode(sdk.directory)}/session/${forked.id}`)
+    } catch (error) {
+      fail(error)
+    }
+  }
+
+  const actions = { fork, revert: sessionRevert.revert }
 
   createEffect(
     on(

--- a/packages/ui/src/components/assistant-turn-footer.tsx
+++ b/packages/ui/src/components/assistant-turn-footer.tsx
@@ -9,11 +9,13 @@ export function AssistantTurnFooter(props: {
   text: string
   message: AssistantMessage
   turnDurationMs?: number
+  onFork?: () => Promise<void> | void
 }) {
   const data = useData()
   const i18n = useI18n()
   const numfmt = createMemo(() => new Intl.NumberFormat(i18n.locale()))
   const [copied, setCopied] = createSignal(false)
+  const [forking, setForking] = createSignal(false)
 
   const interrupted = createMemo(() => props.message.error?.name === "MessageAbortedError")
 
@@ -57,22 +59,50 @@ export function AssistantTurnFooter(props: {
     }
   }
 
+  const handleFork = async () => {
+    if (!props.onFork || forking()) return
+    setForking(true)
+    try {
+      await props.onFork()
+    } finally {
+      setForking(false)
+    }
+  }
+
   return (
     <div data-slot="assistant-turn-footer">
-      <Tooltip
-        value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-        placement="top"
-        gutter={4}
-      >
-        <IconButton
-          icon={copied() ? "check" : "copy"}
-          size="normal"
-          variant="ghost"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={handleCopy}
-          aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-        />
-      </Tooltip>
+      <div data-slot="assistant-turn-footer-actions">
+        <Tooltip
+          value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+          placement="top"
+          gutter={4}
+        >
+          <IconButton
+            icon={copied() ? "check" : "copy"}
+            size="normal"
+            variant="ghost"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleCopy}
+            aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+          />
+        </Tooltip>
+        <Show when={props.onFork}>
+          <Tooltip value={i18n.t("ui.message.forkMessage")} placement="top" gutter={4}>
+            <IconButton
+              icon="branch"
+              size="normal"
+              variant="ghost"
+              disabled={forking()}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={(event) => {
+                event.stopPropagation()
+                void handleFork()
+              }}
+              aria-label={i18n.t("ui.message.forkMessage")}
+            />
+          </Tooltip>
+        </Show>
+      </div>
       <Show when={metaItems().length > 0}>
         <span data-slot="assistant-turn-footer-meta" class="text-body text-fg-weak cursor-default">
           <For each={metaItems()}>{(item) => <span>{item}</span>}</For>

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -115,6 +115,12 @@
     gap: var(--space-md);
   }
 
+  [data-slot="assistant-turn-footer-actions"] {
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+  }
+
   [data-slot="session-turn-message-container"]:hover [data-slot="assistant-turn-footer"],
   [data-slot="session-turn-message-container"]:focus-within [data-slot="assistant-turn-footer"] {
     opacity: 1;

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -453,6 +453,11 @@ export function SessionTurn(
                       text={target().text}
                       message={target().message}
                       turnDurationMs={turnDurationMs()}
+                      onFork={
+                        props.actions?.fork
+                          ? () => props.actions?.fork?.({ sessionID: props.sessionID, messageID: props.messageID })
+                          : undefined
+                      }
                     />
                   )}
                 </Show>


### PR DESCRIPTION
## Summary

Add a Branch action beside Copy in each completed assistant turn footer. The action creates a new session that preserves the source conversation through the selected turn, navigates to the fork, and leaves its composer empty.

## Why

Users often want to explore a second direction after receiving a useful answer without cluttering or changing the current conversation. The existing command-palette flow forks from before a user prompt for editing; this footer action serves the distinct continuation workflow at the point where the intent naturally occurs.

## Related Issue

Closes #1534

## Human Review Status

Pending

## Review Focus

Please focus on the exclusive cutoff calculation in `packages/app/src/pages/session.tsx`: the next user message is passed to the existing fork API so the selected assistant turn is retained while later turns are excluded. Also confirm that the footer action remains secondary, accessible, and visually aligned with Copy.

## Risk Notes

The app derives the exclusive fork cutoff from the contiguous synced message list. The action is only rendered for a loaded completed turn, so its next user boundary is available whenever one exists. No backend schema, persisted lineage, dependency, permission, platform, packaging, or Electron-host behavior changed.

## How To Verify

```text
Frozen install: 2748 packages installed with no lockfile changes
Assistant footer E2E: 3 passed (copy, fork-through-selected-turn, turn-change ordering)
UI contract tests: 18 passed
App typecheck: passed
UI typecheck: passed
Frontend lint: passed
Visual snap: session-turn-footer passed; light and dark grid reviewed
Diff check: no whitespace errors
```

## Screenshots or Recordings

Focused visual target: `bun run snap session-turn-footer`. The generated light/dark grid at `docs/design/preview/screenshots/session-turn-footer.png` was reviewed locally; `docs/` remains local-only by repository policy.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.