### PR TITLE
fix(server): log redacted session API failures

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
@@ -17,6 +17,7 @@ import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import z from "zod"
 import { ExperimentalApi } from "../groups/experimental"
+import { logHttpApiFailure } from "./failure"
 
 const ConsoleSwitchBody = z.object({
   accountID: z.string(),
@@ -58,14 +59,17 @@ function parseJsonBody<T>(request: HttpServerRequest.HttpServerRequest, schema: 
 }
 
 function experimentalFailure(error: unknown) {
+  const report = logHttpApiFailure("experimental", error)
   if (error instanceof NamedError) {
     const status = error.name.startsWith("Worktree") ? 400 : 500
-    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status }))
+    return report.pipe(Effect.as(HttpServerResponse.jsonUnsafe(error.toObject(), { status })))
   }
-  return Effect.succeed(
-    HttpServerResponse.jsonUnsafe(
-      new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
-      { status: 500 },
+  return report.pipe(
+    Effect.as(
+      HttpServerResponse.jsonUnsafe(
+        new NamedError.Unknown({ message: "Unexpected server error. Check server logs for details." }).toObject(),
+        { status: 500 },
+      ),
     ),
   )
 }

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/failure.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/failure.ts
@@ -4,17 +4,18 @@ import { HttpServerRequest } from "effect/unstable/http"
 
 const log = Log.create({ service: "server" })
 
-export function logHttpApiFailure(handler: "experimental" | "session", error: unknown) {
-  return Effect.gen(function* () {
-    const request = yield* HttpServerRequest.HttpServerRequest
-    const url = new URL(request.url, "http://localhost")
-    log.error("failed", {
-      error,
-      httpapi: handler,
-      request: {
-        method: request.method,
-        path: url.pathname,
-      },
-    })
+export const logHttpApiFailure = Effect.fn("HttpApi.logHttpApiFailure")(function* (
+  handler: "experimental" | "session",
+  error: unknown,
+) {
+  const request = yield* HttpServerRequest.HttpServerRequest
+  const url = new URL(request.url, "http://localhost")
+  log.error("failed", {
+    error,
+    httpapi: handler,
+    request: {
+      method: request.method,
+      path: url.pathname,
+    },
   })
-}
+})

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/failure.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/failure.ts
@@ -1,0 +1,20 @@
+import { Log } from "@opencode-ai/core/util/log"
+import { Effect } from "effect"
+import { HttpServerRequest } from "effect/unstable/http"
+
+const log = Log.create({ service: "server" })
+
+export function logHttpApiFailure(handler: "experimental" | "session", error: unknown) {
+  return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const url = new URL(request.url, "http://localhost")
+    log.error("failed", {
+      error,
+      httpapi: handler,
+      request: {
+        method: request.method,
+        path: url.pathname,
+      },
+    })
+  })
+}

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -19,6 +19,7 @@ import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import z from "zod"
 import { SessionApi } from "../groups/session"
+import { logHttpApiFailure } from "./failure"
 
 const log = Log.create({ service: "server" })
 
@@ -102,15 +103,20 @@ function unknownError(message = "Unexpected server error. Check server logs for 
 }
 
 function sessionFailure(error: unknown) {
-  if (error instanceof NotFoundError) return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 404 }))
+  if (error instanceof NotFoundError) {
+    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 404 }))
+  }
+  const report = logHttpApiFailure("session", error)
   if (error instanceof Provider.ModelNotFoundError) {
-    return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 400 }))
+    return report.pipe(Effect.as(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 400 })))
   }
   if (error instanceof SessionNs.BusyError) {
-    return Effect.succeed(HttpServerResponse.jsonUnsafe(unknownError(error.message), { status: 409 }))
+    return report.pipe(Effect.as(HttpServerResponse.jsonUnsafe(unknownError(error.message), { status: 409 })))
   }
-  if (error instanceof NamedError) return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 500 }))
-  return Effect.succeed(HttpServerResponse.jsonUnsafe(unknownError(), { status: 500 }))
+  if (error instanceof NamedError) {
+    return report.pipe(Effect.as(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 500 })))
+  }
+  return report.pipe(Effect.as(HttpServerResponse.jsonUnsafe(unknownError(), { status: 500 })))
 }
 
 function jsonResponse<A>(effect: Effect.Effect<A, unknown, unknown>) {

--- a/packages/opencode/test/server/workspace-router.test.ts
+++ b/packages/opencode/test/server/workspace-router.test.ts
@@ -57,6 +57,18 @@ function disableWorkspaceSync() {
   return spyOn(Workspace, "ensureSync").mockImplementation(() => {})
 }
 
+async function captureServerErrorLogs<T>(fn: () => Promise<T>) {
+  const logger = Log.create({ service: "server" })
+  const original = logger.error
+  const calls: { message?: unknown; extra?: Record<string, unknown> }[] = []
+  logger.error = (message, extra) => calls.push({ message, extra })
+  try {
+    return { result: await fn(), calls }
+  } finally {
+    logger.error = original
+  }
+}
+
 async function readEffectContext() {
   return AppRuntime.runPromise(
     Effect.gen(function* () {
@@ -394,11 +406,13 @@ describe("workspace router", () => {
 
     try {
       const app = Server.Default().app
-      const response = await app.request(`/session?workspace=${workspace.id}`, {
-        headers: {
-          "x-opencode-directory": tmp.path,
-        },
-      })
+      const { result: response, calls } = await captureServerErrorLogs(() =>
+        app.request(`/session?workspace=${workspace.id}`, {
+          headers: {
+            "x-opencode-directory": tmp.path,
+          },
+        }),
+      )
 
       expect(response.status).toBe(500)
       const body = await response.json()
@@ -406,6 +420,19 @@ describe("workspace router", () => {
       // The unexpected 500 body is intentionally redacted to a constant (the internal
       // routing error stays in the server log only); see ErrorMiddleware.
       expect(body.data.message).toBe("Unexpected server error. Check server logs for details.")
+      expect(calls).toEqual([
+        {
+          message: "failed",
+          extra: {
+            error: expect.any(Error),
+            httpapi: "session",
+            request: {
+              method: "GET",
+              path: "/session",
+            },
+          },
+        },
+      ])
       expect(remoteHits).toBe(0)
     } finally {
       ensureSync.mockRestore()


### PR DESCRIPTION
## Summary

Record the real server-side cause when session or experimental-session HttpApi routes return a redacted error response. The log entry includes only the HttpApi group and request method/path; query strings, directories, headers, and credentials remain excluded.

## Why

A user reported intermittent stacked failures across the global session window, project session list, and project bootstrap. All three surfaces displayed `Unexpected server error. Check server logs for details.`, but the handlers producing that response swallowed the original Effect failure without writing it to the server log. That made the intermittent root cause impossible to recover from a diagnostics package.

This PR closes that evidence gap; it does not claim to fix the still-intermittent underlying failure.

## Related Issue

Closes #1538

## Human Review Status

Pending

## Review Focus

Please verify that every non-404 session/experimental failure is logged once, the client response remains redacted, and the captured request context cannot contain a query string or local directory.

## Risk Notes

The backend log now retains the same internal error object that the legacy Hono error boundary already records. Error stacks can contain local paths, but problem-report export already redacts backend logs. No visible UI or copy changed, no platform-specific behavior changed, and no docs, dependency, permission, credential, deletion, generated-content, or local-file contract changed.

## How To Verify

```text
RED: workspace-router regression test failed with expected [] server log calls while GET /session returned the redacted 500.
Focused server tests: 54 passed across middleware, production-boundary, and workspace-router suites.
Typecheck: packages/opencode `tsgo --noEmit` passed.
Desktop smoke: `bun run dev:desktop` built Electron main/preload/renderer, spawned the sidecar, and reached server ready on macOS.
Diff check: `git diff --check` passed; generated models snapshot from predev was removed from the final diff.
```

## Screenshots or Recordings

Not applicable; there is no visible UI change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for failed experimental and session HTTP API requests.
  * Unexpected server errors now include request details and the underlying error for easier troubleshooting.
  * Not-found responses continue to return normally without unnecessary error logging.
* **Tests**
  * Added coverage verifying that internal API failures are logged with relevant request metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->