### PR TITLE
test(desktop): diagnose Windows session concurrency

### DIFF
--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -421,6 +421,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
         with:
+          # Load-bearing for `bun audit` exit semantics; do not bump without re-verifying advisory exit codes.
           bun-version: "1.3.14"
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0

--- a/.github/workflows/windows-advisory.yml
+++ b/.github/workflows/windows-advisory.yml
@@ -398,3 +398,66 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: ${{ matrix.report_path }}
+
+  electron-cdp-windows:
+    name: electron-cdp-windows
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # actions/cache@v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Prepare uv
+        run: bun ./scripts/prepare-uv.ts --platform win32 --arch x64
+        working-directory: packages/desktop-electron
+
+      - name: Build desktop app
+        run: bun run build
+        working-directory: packages/desktop-electron
+        env:
+          OPENCODE_CHANNEL: dev
+          PAWWORK_FEEDBACK_FORM_URL: https://example.com/pawwork-feedback
+
+      - name: Run Electron CDP session concurrency
+        run: bun run smoke:ci
+        working-directory: packages/desktop-electron
+        env:
+          PAWWORK_CI_SMOKE_CDP: "true"
+          PAWWORK_CI_SMOKE_SESSION_CONCURRENCY: "true"
+          PAWWORK_CI_SMOKE_ARTIFACT_DIR: .artifacts/session-concurrency
+
+      - name: Upload Electron session concurrency logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # actions/upload-artifact@v7
+        with:
+          name: electron-cdp-windows-${{ github.sha }}-${{ github.run_attempt }}
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 7
+          path: packages/desktop-electron/.artifacts/session-concurrency

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -112,6 +112,13 @@ describe("ci smoke helpers", () => {
     expect(env.PAWWORK_CI_SMOKE_CDP_PORT).toBe("48291")
   })
 
+  test("buildSmokeEnv routes completed-task diagnostics through the controlled e2e model", () => {
+    const env = buildSmokeEnv("/tmp/pawwork-ci-smoke", "dev", {}, { e2eLlmUrl: "http://127.0.0.1:48292" })
+
+    expect(env.OPENCODE_E2E_ENABLED).toBe("true")
+    expect(env.OPENCODE_E2E_LLM_URL).toBe("http://127.0.0.1:48292")
+  })
+
   test("parseSmokeCdpPort accepts only concrete TCP ports", () => {
     expect(parseSmokeCdpPort("48291")).toBe(48291)
     expect(parseSmokeCdpPort(undefined)).toBeUndefined()

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { desktopShellMainSelector, titlebarShellSelector } from "../src/renderer/ci-smoke-selectors"
@@ -8,6 +8,7 @@ import {
   allocateCiSmokeCdpPort,
   appIdForSmoke,
   buildSmokeEnv,
+  collectCiSmokeArtifacts,
   isCiSmokeRendererTarget,
   parseSmokeArgs,
   parseSmokeCdpPort,
@@ -20,6 +21,32 @@ import {
 } from "./ci-smoke"
 
 describe("ci smoke helpers", () => {
+  test("collectCiSmokeArtifacts preserves isolated main and backend logs", async () => {
+    const homeDir = mkdtempSync(path.join(tmpdir(), "pawwork-ci-smoke-home-"))
+    const artifactDir = mkdtempSync(path.join(tmpdir(), "pawwork-ci-smoke-artifacts-"))
+    try {
+      const mainLog = path.join(homeDir, "app", "logs", "main.log")
+      const backendLog = path.join(homeDir, "data", "opencode", "log", "backend.log")
+      mkdirSync(path.dirname(mainLog), { recursive: true })
+      mkdirSync(path.dirname(backendLog), { recursive: true })
+      writeFileSync(mainLog, "main diagnostic")
+      writeFileSync(backendLog, "backend diagnostic")
+      writeFileSync(path.join(homeDir, "ignore.txt"), "not a log")
+
+      const copied = await collectCiSmokeArtifacts(homeDir, artifactDir)
+
+      expect(copied.sort()).toEqual(["app/logs/main.log", "data/opencode/log/backend.log"])
+      expect(readFileSync(path.join(artifactDir, "app", "logs", "main.log"), "utf8")).toBe("main diagnostic")
+      expect(readFileSync(path.join(artifactDir, "data", "opencode", "log", "backend.log"), "utf8")).toBe(
+        "backend diagnostic",
+      )
+      expect(existsSync(path.join(artifactDir, "ignore.txt"))).toBe(false)
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true })
+      rmSync(artifactDir, { recursive: true, force: true })
+    }
+  })
+
   test("resolveMainEntry points at the built Electron main process bundle", () => {
     expect(resolveMainEntry().endsWith(path.join("packages", "desktop-electron", "out", "main", "index.js"))).toBe(true)
   })

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -40,10 +40,12 @@ type ProbeOptions = {
 
 type BuildSmokeEnvOptions = {
   cdpPort?: number
+  e2eLlmUrl?: string
 }
 
 type LaunchAppOptions = {
   cdpPort?: number
+  e2eLlmUrl?: string
 }
 
 const APP_ID_BY_CHANNEL: Record<SmokeChannel, string> = {
@@ -98,6 +100,9 @@ export function buildSmokeEnv(
     XDG_STATE_HOME: homeDir,
     OPENCODE_CHANNEL: channel,
     ...(options.cdpPort !== undefined ? { PAWWORK_CI_SMOKE_CDP_PORT: String(options.cdpPort) } : {}),
+    ...(options.e2eLlmUrl !== undefined
+      ? { OPENCODE_E2E_ENABLED: "true", OPENCODE_E2E_LLM_URL: options.e2eLlmUrl }
+      : {}),
   }
 }
 
@@ -266,7 +271,10 @@ function launchApp(homeDir: string, target: SmokeTarget, options: LaunchAppOptio
   const spawnError = { current: undefined as Error | undefined }
   try {
     const child = spawn(launch.command, launch.args, {
-      env: buildSmokeEnv(homeDir, target.channel, process.env, { cdpPort: options.cdpPort }),
+      env: buildSmokeEnv(homeDir, target.channel, process.env, {
+        cdpPort: options.cdpPort,
+        e2eLlmUrl: options.e2eLlmUrl,
+      }),
       stdio: ["ignore", "pipe", "pipe"],
     })
     child.on("error", (error) => {
@@ -352,7 +360,18 @@ async function main() {
   const target = parseSmokeArgs(Bun.argv.slice(2))
   const homeDir = mkdtempSync(join(tmpdir(), "pawwork-ci-smoke-"))
   const cdpPort = await resolveCiSmokeCdpPort(process.env)
-  const { child, spawnError } = launchApp(homeDir, target, { cdpPort })
+  const sessionConcurrency = process.env.PAWWORK_CI_SMOKE_SESSION_CONCURRENCY === "true"
+  const llm = sessionConcurrency
+    ? await import("../../opencode/test/lib/llm-server").then(({ startTestLLMServer }) => startTestLLMServer())
+    : undefined
+  if (llm) {
+    await Promise.all(
+      [0, 1, 2].map((index) =>
+        llm.textMatch(`run Windows Electron task ${index}`, `completed task ${index}`),
+      ),
+    )
+  }
+  const { child, spawnError } = launchApp(homeDir, target, { cdpPort, e2eLlmUrl: llm?.url })
   const logs = watchChildLogs(child)
 
   const artifactDir = process.env.PAWWORK_CI_SMOKE_ARTIFACT_DIR
@@ -364,15 +383,20 @@ async function main() {
   try {
     await waitForCiSmokeReady(homeDir, target, child, spawnError, logs.recent)
     if (cdpPort !== undefined) await probeCiSmokeCdpTarget(cdpPort)
-    if (process.env.PAWWORK_CI_SMOKE_SESSION_CONCURRENCY === "true") {
+    if (sessionConcurrency) {
       if (cdpPort === undefined) throw new Error("Electron session concurrency diagnostic requires CDP")
       diagnostic = await runSessionConcurrencyCdpWithNode(cdpPort, homeDir)
+      const pendingResponses = await llm!.pending()
+      if (pendingResponses !== 0) {
+        throw new Error(`Electron session concurrency diagnostic left ${pendingResponses} model responses unused`)
+      }
     }
   } catch (error) {
     failure = error
   } finally {
     logs.close()
     await stopChild(child)
+    await llm?.dispose()
     if (artifactDir) {
       try {
         const copiedLogs = await collectCiSmokeArtifacts(homeDir, artifactDir)

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -1,10 +1,11 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { once } from "node:events"
 import { existsSync, mkdtempSync } from "node:fs"
+import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import process from "node:process"
 import readline from "node:readline"
 import { rendererOrigin } from "../src/main/renderer-protocol"
@@ -290,6 +291,63 @@ async function stopChild(child: ChildProcessWithoutNullStreams) {
   }
 }
 
+export async function collectCiSmokeArtifacts(homeDir: string, artifactDir: string) {
+  const copied: string[] = []
+  const visit = async (directory: string): Promise<void> => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const source = join(directory, entry.name)
+      if (entry.isDirectory()) {
+        await visit(source)
+        continue
+      }
+      const relative = source.slice(homeDir.length + 1).split("\\").join("/")
+      const segments = relative.toLowerCase().split("/")
+      if (
+        !entry.isFile() ||
+        !entry.name.endsWith(".log") ||
+        !segments.some((part) => part === "log" || part === "logs")
+      ) {
+        continue
+      }
+      const destination = join(artifactDir, relative)
+      await mkdir(dirname(destination), { recursive: true })
+      await copyFile(source, destination)
+      copied.push(relative)
+    }
+  }
+
+  await mkdir(artifactDir, { recursive: true })
+  await visit(homeDir)
+  return copied
+}
+
+async function runSessionConcurrencyCdpWithNode(port: number, homeDir: string) {
+  const outdir = resolve(import.meta.dir, "../.artifacts/session-concurrency-harness")
+  const build = await Bun.build({
+    entrypoints: [resolve(import.meta.dir, "session-concurrency-cdp-runner.ts")],
+    target: "node",
+    external: ["@playwright/test"],
+    outdir,
+    naming: "runner.mjs",
+  })
+  if (!build.success) {
+    throw new Error(`Failed to build Electron CDP harness: ${build.logs.map((item) => item.message).join("\n")}`)
+  }
+
+  const child = Bun.spawn(["node", join(outdir, "runner.mjs"), String(port), homeDir], {
+    cwd: resolve(import.meta.dir, ".."),
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  if (exitCode !== 0) throw new Error(`Electron CDP harness failed (exit ${exitCode}):\n${stdout}${stderr}`)
+  return JSON.parse(stdout.trim()) as unknown
+}
+
 async function main() {
   const target = parseSmokeArgs(Bun.argv.slice(2))
   const homeDir = mkdtempSync(join(tmpdir(), "pawwork-ci-smoke-"))
@@ -297,13 +355,47 @@ async function main() {
   const { child, spawnError } = launchApp(homeDir, target, { cdpPort })
   const logs = watchChildLogs(child)
 
+  const artifactDir = process.env.PAWWORK_CI_SMOKE_ARTIFACT_DIR
+    ? resolve(process.env.PAWWORK_CI_SMOKE_ARTIFACT_DIR)
+    : undefined
+  let failure: unknown
+  let diagnostic: unknown
+
   try {
     await waitForCiSmokeReady(homeDir, target, child, spawnError, logs.recent)
     if (cdpPort !== undefined) await probeCiSmokeCdpTarget(cdpPort)
+    if (process.env.PAWWORK_CI_SMOKE_SESSION_CONCURRENCY === "true") {
+      if (cdpPort === undefined) throw new Error("Electron session concurrency diagnostic requires CDP")
+      diagnostic = await runSessionConcurrencyCdpWithNode(cdpPort, homeDir)
+    }
+  } catch (error) {
+    failure = error
   } finally {
     logs.close()
     await stopChild(child)
+    if (artifactDir) {
+      try {
+        const copiedLogs = await collectCiSmokeArtifacts(homeDir, artifactDir)
+        await writeFile(
+          join(artifactDir, "summary.json"),
+          JSON.stringify(
+            {
+              status: failure ? "failed" : "passed",
+              diagnostic,
+              error: failure instanceof Error ? failure.stack ?? failure.message : failure ? String(failure) : undefined,
+              copiedLogs,
+            },
+            null,
+            2,
+          ),
+        )
+      } catch (error) {
+        if (!failure) failure = error
+      }
+    }
   }
+
+  if (failure) throw failure
 }
 
 if (import.meta.main) {

--- a/packages/desktop-electron/scripts/session-concurrency-cdp-runner.ts
+++ b/packages/desktop-electron/scripts/session-concurrency-cdp-runner.ts
@@ -1,0 +1,10 @@
+import { runSessionConcurrencyCdp } from "./session-concurrency-cdp"
+
+const [portValue, homeDir] = process.argv.slice(2)
+const port = Number(portValue)
+if (!Number.isInteger(port) || port < 1 || port > 65_535 || !homeDir) {
+  throw new Error("Usage: session-concurrency-cdp-runner <cdp-port> <isolated-home>")
+}
+
+const result = await runSessionConcurrencyCdp({ port, homeDir })
+console.log(JSON.stringify(result))

--- a/packages/desktop-electron/scripts/session-concurrency-cdp.ts
+++ b/packages/desktop-electron/scripts/session-concurrency-cdp.ts
@@ -94,15 +94,33 @@ async function seedCompletedSessions(page: Page, directories: string[]): Promise
           body: JSON.stringify({ title: `windows-electron-concurrency-${index}` }),
         }).then((response) => response.json() as Promise<{ id: string }>)
 
-        await request(`/session/${created.id}/message`, directory, {
+        const completed = await request(`/session/${created.id}/message`, directory, {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
-            noReply: true,
-            model: { providerID: "test", modelID: "test" },
-            parts: [{ type: "text", text: `completed Windows Electron task ${index}` }],
+            model: { providerID: "opencode", modelID: "big-pickle" },
+            parts: [{ type: "text", text: `run Windows Electron task ${index}` }],
           }),
-        })
+        }).then(
+          (response) =>
+            response.json() as Promise<{
+              info?: { role?: string }
+              parts?: Array<{ type?: string; text?: string }>
+            }>,
+        )
+        if (completed.info?.role !== "assistant") {
+          throw new Error(`session ${created.id} did not complete an assistant turn`)
+        }
+        if (!completed.parts?.some((part) => part.type === "text" && part.text === `completed task ${index}`)) {
+          throw new Error(`session ${created.id} did not return the controlled completion`)
+        }
+
+        const statuses = await request("/session/status", directory).then(
+          (response) => response.json() as Promise<Record<string, { type?: string }>>,
+        )
+        if (statuses[created.id] && statuses[created.id].type !== "idle") {
+          throw new Error(`session ${created.id} remained ${statuses[created.id].type ?? "busy"} after completion`)
+        }
 
         return { directory, sessionID: created.id }
       }),
@@ -217,7 +235,7 @@ export async function runSessionConcurrencyCdp(input: { port: number; homeDir: s
       )
     }
 
-    return { projects: projects.length, switches: 12, failedResponses: 0 }
+    return { projects: projects.length, completedTasks: projects.length, switches: 12, failedResponses: 0 }
   } finally {
     await browser.close()
   }

--- a/packages/desktop-electron/scripts/session-concurrency-cdp.ts
+++ b/packages/desktop-electron/scripts/session-concurrency-cdp.ts
@@ -1,0 +1,224 @@
+import { execFileSync } from "node:child_process"
+import { mkdir, realpath, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { chromium, type Page } from "@playwright/test"
+
+const bootstrapPaths = [
+  "/provider",
+  "/agent",
+  "/config",
+  "/config/errors",
+  "/session/status",
+  "/project/current",
+  "/path",
+  "/vcs",
+  "/command",
+  "/permission",
+  "/external-result",
+  "/mcp",
+  "/automation",
+] as const
+
+type SeededProject = {
+  directory: string
+  sessionID: string
+}
+
+type HttpFailure = {
+  status: number
+  url: string
+  body: string
+}
+
+async function createProject(directory: string, index: number) {
+  await mkdir(directory, { recursive: true })
+  await writeFile(path.join(directory, "README.md"), `# Windows Electron concurrency ${index}\n`)
+  execFileSync("git", ["init"], { cwd: directory, stdio: "ignore" })
+  await writeFile(path.join(directory, ".git", "opencode"), `windows-electron-${index}`)
+  execFileSync("git", ["config", "core.fsmonitor", "false"], { cwd: directory, stdio: "ignore" })
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: directory, stdio: "ignore" })
+  execFileSync("git", ["add", "README.md"], { cwd: directory, stdio: "ignore" })
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PawWork CI",
+      "-c",
+      "user.email=ci@pawwork.ai",
+      "commit",
+      "-m",
+      "test fixture",
+    ],
+    { cwd: directory, stdio: "ignore" },
+  )
+  return await realpath(directory)
+}
+
+async function rendererPage(port: number) {
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`)
+  const page = browser
+    .contexts()
+    .flatMap((context) => context.pages())
+    .find((candidate) => !candidate.url().startsWith("devtools://") && candidate.url() !== "about:blank")
+  if (!page) {
+    await browser.close()
+    throw new Error("Electron CDP endpoint did not expose the PawWork renderer page")
+  }
+  return { browser, page }
+}
+
+async function seedCompletedSessions(page: Page, directories: string[]): Promise<SeededProject[]> {
+  return await page.evaluate(async (projectDirectories) => {
+    const sidecar = await window.api.awaitInitialization(() => undefined)
+    const auth = btoa(`${sidecar.username ?? "opencode"}:${sidecar.password ?? ""}`)
+
+    const request = async (pathname: string, directory: string, init?: RequestInit) => {
+      const url = new URL(pathname, sidecar.url)
+      url.searchParams.set("directory", directory)
+      const response = await fetch(url, {
+        ...init,
+        headers: {
+          authorization: `Basic ${auth}`,
+          ...(init?.headers ?? {}),
+        },
+      })
+      if (response.ok) return response
+      throw new Error(`${response.status} ${url.pathname}: ${await response.text()}`)
+    }
+
+    const projects = await Promise.all(
+      projectDirectories.map(async (directory, index) => {
+        const created = await request("/session", directory, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ title: `windows-electron-concurrency-${index}` }),
+        }).then((response) => response.json() as Promise<{ id: string }>)
+
+        await request(`/session/${created.id}/message`, directory, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            noReply: true,
+            model: { providerID: "test", modelID: "test" },
+            parts: [{ type: "text", text: `completed Windows Electron task ${index}` }],
+          }),
+        })
+
+        return { directory, sessionID: created.id }
+      }),
+    )
+
+    await window.api.storeSet(
+      "pawwork.global.dat",
+      "server",
+      JSON.stringify({
+        list: [],
+        projects: {
+          local: projectDirectories.map((directory) => ({ worktree: directory, expanded: true })),
+        },
+        lastProject: { local: projectDirectories[0] },
+      }),
+    )
+    return projects
+  }, directories)
+}
+
+async function concurrentReads(page: Page, projects: SeededProject[], activeDirectory: string) {
+  await page.evaluate(
+    async ({ active, directories, bootstrap }) => {
+      const sidecar = await window.api.awaitInitialization(() => undefined)
+      const auth = btoa(`${sidecar.username ?? "opencode"}:${sidecar.password ?? ""}`)
+      const request = async (pathname: string, directory?: string) => {
+        const url = new URL(pathname, sidecar.url)
+        if (directory) url.searchParams.set("directory", directory)
+        const response = await fetch(url, { headers: { authorization: `Basic ${auth}` } })
+        if (response.ok) return
+        throw new Error(`${response.status} ${url.pathname}: ${await response.text()}`)
+      }
+
+      await Promise.all([
+        request("/experimental/session?roots=true&limit=100&sort=activity"),
+        ...directories.map((directory) => request("/session?roots=true&limit=100&sort=created", directory)),
+        ...bootstrap.map((pathname) => request(pathname, active)),
+      ])
+    },
+    { active: activeDirectory, directories: projects.map((project) => project.directory), bootstrap: bootstrapPaths },
+  )
+}
+
+export async function runSessionConcurrencyCdp(input: { port: number; homeDir: string }) {
+  const directories = await Promise.all(
+    [0, 1, 2].map((index) =>
+      createProject(path.join(input.homeDir, "session-concurrency-projects", String(index)), index),
+    ),
+  )
+
+  const { browser, page } = await rendererPage(input.port)
+  const httpFailures: Promise<HttpFailure>[] = []
+  const rendererFailures: string[] = []
+
+  page.on("response", (response) => {
+    if (response.status() < 500) return
+    httpFailures.push(
+      response
+        .text()
+        .catch(() => "<unavailable>")
+        .then((body) => ({ status: response.status(), url: response.url(), body })),
+    )
+  })
+  page.on("pageerror", (error) => rendererFailures.push(error.stack ?? error.message))
+  page.on("console", (message) => {
+    if (message.type() === "error" && message.text().includes("[e2e:error-boundary]")) {
+      rendererFailures.push(message.text())
+    }
+  })
+
+  try {
+    const projects = await seedCompletedSessions(page, directories)
+    await page.addInitScript(() => {
+      ;(window as Window & { __opencode_e2e?: Record<string, unknown> }).__opencode_e2e = {}
+    })
+    await page.reload({ waitUntil: "domcontentloaded" })
+
+    const sidebarToggle = page.locator('[data-action="pawwork-sidebar-toggle"]')
+    await sidebarToggle.waitFor({ state: "visible", timeout: 30_000 })
+    if ((await sidebarToggle.getAttribute("aria-expanded")) !== "true") await sidebarToggle.click()
+    await sidebarToggle.waitFor({ state: "visible" })
+
+    for (const project of projects) {
+      await page
+        .locator(`[data-session-id="${project.sessionID}"][data-component="pawwork-session-row"] a`)
+        .first()
+        .waitFor({ state: "visible", timeout: 30_000 })
+    }
+
+    for (let round = 0; round < 12; round += 1) {
+      const active = projects[round % projects.length]
+      const link = page
+        .locator(`[data-session-id="${active.sessionID}"][data-component="pawwork-session-row"] a`)
+        .first()
+      await link.click()
+      await page.waitForFunction(
+        (sessionID) =>
+          document
+            .querySelector(`[data-session-id="${sessionID}"][data-component="pawwork-session-row"] a`)
+            ?.classList.contains("active") === true,
+        active.sessionID,
+        { timeout: 30_000 },
+      )
+      await concurrentReads(page, projects, active.directory)
+      await page.locator('[data-component="prompt-input"]').waitFor({ state: "visible", timeout: 30_000 })
+    }
+
+    const failedResponses = await Promise.all(httpFailures)
+    if (failedResponses.length || rendererFailures.length) {
+      throw new Error(
+        JSON.stringify({ httpFailures: failedResponses, rendererFailures }, null, 2),
+      )
+    }
+
+    return { projects: projects.length, switches: 12, failedResponses: 0 }
+  } finally {
+    await browser.close()
+  }
+}

--- a/packages/opencode/test/github/bun-version-workflow.test.ts
+++ b/packages/opencode/test/github/bun-version-workflow.test.ts
@@ -92,6 +92,7 @@ describe("GitHub workflow Bun version pin", () => {
       '.github/workflows/mirror-release-to-r2.yml:mirror:step-2:bun-version: "1.3.14"',
       '.github/workflows/perf-probe-baseline.yml:perf-probe-baseline:step-7:bun-version: "1.3.14"',
       '.github/workflows/windows-advisory.yml:unit-windows:step-3:bun-version: "1.3.14"',
+      '.github/workflows/windows-advisory.yml:electron-cdp-windows:step-3:bun-version: "1.3.14"',
     ])
     expect(missingComments).toEqual([])
 

--- a/packages/opencode/test/github/ci-workflow.test.ts
+++ b/packages/opencode/test/github/ci-workflow.test.ts
@@ -27,6 +27,7 @@ const githubSha = "${{ github.sha }}"
 const lintJobName = "lint"
 const frontendArchitectureJobName = "frontend-architecture"
 const windowsUnitJobName = "unit-windows"
+const windowsElectronCdpJobName = "electron-cdp-windows"
 const setupAction = "./.github/actions/setup"
 const actionlintJobName = "actionlint"
 const actionlintVersion = "1.7.12"
@@ -687,6 +688,57 @@ describe("ci workflow", () => {
     // The final exit code is the last attempt's status, not the first.
     // Otherwise a recovered run would still turn the advisory red.
     expect(unitRun).toMatch(/exit "\$status"\s*$/)
+  })
+
+  test("runs the Electron session concurrency diagnostic once and always uploads logs", () => {
+    const parsed = parseWorkflow(windowsAdvisoryWorkflowPath)
+    const job = parsed.jobs?.[windowsElectronCdpJobName]
+    const diagnostic = stepByName(
+      windowsElectronCdpJobName,
+      "Run Electron CDP session concurrency",
+      windowsAdvisoryWorkflowPath,
+    )
+    const artifact = stepByName(
+      windowsElectronCdpJobName,
+      "Upload Electron session concurrency logs",
+      windowsAdvisoryWorkflowPath,
+    )
+
+    expect(job?.name).toBe("electron-cdp-windows")
+    expect(job?.needs).toBe("changes")
+    expect(job?.if).toBe("needs.changes.outputs.docs_only != 'true'")
+    expect(job?.["runs-on"]).toBe("windows-latest")
+    expect(job?.["timeout-minutes"]).toBe(30)
+    expect(job?.["continue-on-error"]).toBeUndefined()
+    expect(job?.defaults?.run?.shell).toBe("bash")
+    expect(checkoutStep(windowsElectronCdpJobName, windowsAdvisoryWorkflowPath)?.uses).toBe(pinned.checkout)
+    expect(
+      steps(windowsElectronCdpJobName, windowsAdvisoryWorkflowPath).find((step) =>
+        step.uses?.startsWith("actions/setup-node@"),
+      )?.uses,
+    ).toBe(pinned.setupNode)
+    expect(
+      steps(windowsElectronCdpJobName, windowsAdvisoryWorkflowPath).find((step) =>
+        step.uses?.startsWith("oven-sh/setup-bun@"),
+      )?.uses,
+    ).toBe(pinned.setupBun)
+    expect(diagnostic?.run).toBe("bun run smoke:ci")
+    expect(diagnostic?.["working-directory"]).toBe("packages/desktop-electron")
+    expect(diagnostic?.env).toEqual({
+      PAWWORK_CI_SMOKE_CDP: "true",
+      PAWWORK_CI_SMOKE_SESSION_CONCURRENCY: "true",
+      PAWWORK_CI_SMOKE_ARTIFACT_DIR: ".artifacts/session-concurrency",
+    })
+    expect(diagnostic?.run).not.toContain("retry")
+    expect(diagnostic?.run).not.toContain("attempt")
+    expect(diagnostic?.["continue-on-error"]).toBeUndefined()
+    expect(artifact?.if).toBe("always()")
+    expect(artifact?.uses).toBe(pinned.artifact)
+    expect(artifact?.with?.name).toBe(
+      "electron-cdp-windows-${{ github.sha }}-${{ github.run_attempt }}",
+    )
+    expect(artifact?.with?.path).toBe("packages/desktop-electron/.artifacts/session-concurrency")
+    expect(artifact?.with?.["if-no-files-found"]).toBe("error")
   })
 
   test("defines Windows unit packages and opencode shards", () => {

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -1,6 +1,6 @@
 import { NodeHttpServer, NodeHttpServerRequest } from "@effect/platform-node"
 import * as Http from "node:http"
-import { Deferred, Effect, Layer, Context, Stream } from "effect"
+import { Deferred, Effect, Layer, Context, ManagedRuntime, Stream } from "effect"
 import * as HttpServer from "effect/unstable/http/HttpServer"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 
@@ -840,4 +840,16 @@ export class TestLLMServer extends Context.Service<TestLLMServer, TestLLMServer.
       })
     }),
   ).pipe(Layer.provide(HttpRouter.layer), Layer.provide(NodeHttpServer.layer(() => Http.createServer(), { port: 0 })))
+}
+
+export async function startTestLLMServer() {
+  const runtime = ManagedRuntime.make(TestLLMServer.layer)
+  const service = await runtime.runPromise(TestLLMServer)
+  return {
+    url: service.url,
+    textMatch: (requestText: string, responseText: string) =>
+      runtime.runPromise(service.textMatch((hit) => JSON.stringify(hit.body).includes(requestText), responseText)),
+    pending: () => runtime.runPromise(service.pending),
+    dispose: () => runtime.dispose(),
+  }
 }

--- a/packages/opencode/test/server/windows-session-concurrency.test.ts
+++ b/packages/opencode/test/server/windows-session-concurrency.test.ts
@@ -1,13 +1,32 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import type { Session } from "../../src/session"
 import { tmpdir } from "../fixture/fixture"
+import { startTestLLMServer } from "../lib/llm-server"
 
 type SeededProject = {
   directory: string
   session: Session.Info
 }
+
+const originalE2EEnabled = process.env.OPENCODE_E2E_ENABLED
+const originalE2ELlmURL = process.env.OPENCODE_E2E_LLM_URL
+let llm: Awaited<ReturnType<typeof startTestLLMServer>>
+
+beforeAll(async () => {
+  llm = await startTestLLMServer()
+  process.env.OPENCODE_E2E_ENABLED = "true"
+  process.env.OPENCODE_E2E_LLM_URL = llm.url
+})
+
+afterAll(async () => {
+  if (originalE2EEnabled === undefined) delete process.env.OPENCODE_E2E_ENABLED
+  else process.env.OPENCODE_E2E_ENABLED = originalE2EEnabled
+  if (originalE2ELlmURL === undefined) delete process.env.OPENCODE_E2E_LLM_URL
+  else process.env.OPENCODE_E2E_LLM_URL = originalE2ELlmURL
+  await llm.dispose()
+})
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -38,19 +57,31 @@ async function seedProject(directory: string, index: number): Promise<SeededProj
   )
   const session = (await sessionResponse.json()) as Session.Info
 
-  await requestOk(
+  await llm.textMatch(`run task ${index}`, `completed task ${index}`)
+  const completed = await requestOk(
     `project ${index} completed prompt`,
     withDirectory(`/session/${session.id}/message`, directory),
     {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        noReply: true,
-        model: { providerID: "test", modelID: "test" },
-        parts: [{ type: "text", text: `completed task ${index}` }],
+        model: { providerID: "opencode", modelID: "big-pickle" },
+        parts: [{ type: "text", text: `run task ${index}` }],
       }),
     },
   )
+  const assistant = (await completed.json()) as {
+    info?: { role?: string }
+    parts?: Array<{ type?: string; text?: string }>
+  }
+  expect(assistant.info?.role).toBe("assistant")
+  expect(assistant.parts).toContainEqual(expect.objectContaining({ type: "text", text: `completed task ${index}` }))
+
+  const statuses = (await requestOk(
+    `project ${index} completed status`,
+    withDirectory("/session/status", directory),
+  ).then((response) => response.json())) as Record<string, { type?: string }>
+  expect(statuses[session.id]?.type ?? "idle").toBe("idle")
 
   return { directory, session }
 }
@@ -81,6 +112,7 @@ describe("Windows multi-project session concurrency", () => {
       const projects = await Promise.all(
         [first.path, second.path, third.path].map((directory, index) => seedProject(directory, index)),
       )
+      expect(await llm.pending()).toBe(0)
 
       for (let round = 0; round < 12; round++) {
         const active = projects[round % projects.length]

--- a/packages/opencode/test/server/windows-session-concurrency.test.ts
+++ b/packages/opencode/test/server/windows-session-concurrency.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import type { Session } from "../../src/session"
+import { tmpdir } from "../fixture/fixture"
+
+type SeededProject = {
+  directory: string
+  session: Session.Info
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+function withDirectory(pathname: string, directory: string) {
+  const url = new URL(pathname, "http://localhost")
+  url.searchParams.set("directory", directory)
+  return `${url.pathname}${url.search}`
+}
+
+async function requestOk(label: string, pathname: string, init?: RequestInit) {
+  const response = await Server.Default().app.request(pathname, init)
+  if (response.ok) return response
+  const body = await response.text()
+  throw new Error(`${label} returned ${response.status}: ${body}`)
+}
+
+async function seedProject(directory: string, index: number): Promise<SeededProject> {
+  const sessionResponse = await requestOk(
+    `project ${index} session create`,
+    withDirectory("/session", directory),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: `windows-concurrency-${index}` }),
+    },
+  )
+  const session = (await sessionResponse.json()) as Session.Info
+
+  await requestOk(
+    `project ${index} completed prompt`,
+    withDirectory(`/session/${session.id}/message`, directory),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        noReply: true,
+        model: { providerID: "test", modelID: "test" },
+        parts: [{ type: "text", text: `completed task ${index}` }],
+      }),
+    },
+  )
+
+  return { directory, session }
+}
+
+const bootstrapPaths = [
+  "/provider",
+  "/agent",
+  "/config",
+  "/config/errors",
+  "/session/status",
+  "/project/current",
+  "/path",
+  "/vcs",
+  "/command",
+  "/permission",
+  "/external-result",
+  "/mcp",
+  "/automation",
+] as const
+
+describe("Windows multi-project session concurrency", () => {
+  test(
+    "keeps session lists and bootstrap reads healthy after completed tasks while switching projects",
+    async () => {
+      await using first = await tmpdir({ git: true })
+      await using second = await tmpdir({ git: true })
+      await using third = await tmpdir({ git: true })
+      const projects = await Promise.all(
+        [first.path, second.path, third.path].map((directory, index) => seedProject(directory, index)),
+      )
+
+      for (let round = 0; round < 12; round++) {
+        const active = projects[round % projects.length]
+        const reads = [
+          requestOk(
+            `round ${round} global session list`,
+            "/experimental/session?roots=true&limit=100&sort=activity",
+          ),
+          ...projects.map((project, index) =>
+            requestOk(
+              `round ${round} project ${index} session list`,
+              withDirectory("/session?roots=true&limit=100&sort=created", project.directory),
+            ),
+          ),
+          ...bootstrapPaths.map((pathname) =>
+            requestOk(`round ${round} active bootstrap ${pathname}`, withDirectory(pathname, active.directory)),
+          ),
+        ]
+
+        await Promise.all(reads)
+      }
+
+      const global = await requestOk("final global session list", "/experimental/session?roots=true&limit=100")
+      const ids = ((await global.json()) as Session.Info[]).map((session) => session.id)
+      expect(ids).toEqual(expect.arrayContaining(projects.map((project) => project.session.id)))
+    },
+    30_000,
+  )
+})


### PR DESCRIPTION
## Summary

Add deterministic server and Electron/CDP concurrency diagnostics for the intermittent Windows project/session failures. Both Windows layers passed on their first execution, so this Draft intentionally contains reproduction coverage and log capture only; it does not add a speculative product fix or retry.

## Why

Windows users reported stacked 500 responses across the global session window, project session list, and project bootstrap after normal work completed. The server test completes deterministic agent streams through the public HTTP boundary, verifies each session returned to idle, then drives those reads concurrently across three projects. When that did not reproduce on `windows-latest`, the Electron/CDP job exercised the visible multi-project session-switch path and always uploaded isolated backend/main logs.

The Electron artifact contains one optional file-watcher binding load error, also observed on the passing local macOS run. Because session creation, bootstrap, and all 12 switches remained healthy with zero 5xx responses, this PR does not treat that independent warning as the #1538 root cause.

## Related Issue

Refs #1538

## Human Review Status

Pending

## Review Focus

Verify that both diagnostics exercise the real server and desktop boundaries used by multi-project session listing, post-task bootstrap, and project switching; that the Electron job executes once without a retry; and that backend/main logs upload even when the diagnostic fails.

## Risk Notes

- This remains a Draft diagnostic PR, not a root-cause fix.
- Neither the Windows server layer nor the Windows Electron/CDP layer reproduced #1538 on its first execution.
- The workflow adds an advisory `windows-latest` Electron build, so it increases Windows runner time while this diagnosis is active.
- The desktop smoke harness is shared across macOS and Windows; it was exercised locally on macOS and in Actions on Windows.
- There is no visible UI or copy change.
- Docs, dependencies, permissions, credentials, deletion behavior, generated content, and local-file contracts are unchanged.

## How To Verify

```text
Server regression: the completed-turn concurrency test passed locally; the Windows session shard passed 1427 tests with 0 failures.
Desktop smoke tests: 26 passed.
Typecheck: packages/opencode and packages/desktop-electron passed.
Desktop build: local macOS raw Electron build passed.
Local Electron/CDP: 3 projects / 3 completed tasks / 12 switches / 0 failed responses; isolated backend and main logs collected.
Windows server: run 30790858011, job 91613908312 passed on the first attempt; the session shard reported 1427 passed / 0 failed.
Windows Electron/CDP: run 30790858011, job 91613908205 passed on the first execution; artifact `electron-cdp-windows-3166d053acee82e5452cd9c7142f7ba3a1b2f5b3-1` reports 3 projects / 3 completed tasks / 12 switches / 0 failed responses and includes backend/main logs.
Diff check: `git diff --check` passed.
```

## Screenshots or Recordings

Not applicable; there is no visible UI change. The real desktop route was exercised through Electron/CDP on local macOS and `windows-latest`.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

