### PR TITLE
fix(app): keep artifact stats out of suspense

### DIFF
--- a/packages/app/src/components/session/artifact-file-exists.test.ts
+++ b/packages/app/src/components/session/artifact-file-exists.test.ts
@@ -1,0 +1,77 @@
+import { test } from "bun:test"
+import { runBrowserCheck } from "@/testing/browser-subprocess"
+
+const browserCheck = `
+import { createComponent, createSignal, Show, Suspense } from "solid-js"
+import { insert, render } from "solid-js/web"
+import { createArtifactFileExists } from "./src/components/session/artifact-file-exists.ts"
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message)
+}
+
+const path = "/workspace/report.md"
+let resolveStats
+const pendingStats = new Promise((resolve) => {
+  resolveStats = resolve
+})
+const root = document.createElement("div")
+const fallback = document.createElement("span")
+fallback.dataset.state = "fallback"
+fallback.textContent = "Loading"
+let loadArtifact
+
+const Content = () => {
+  const [paths, setPaths] = createSignal([])
+  loadArtifact = () => setPaths([path])
+  const fileExists = createArtifactFileExists(paths, () => pendingStats)
+  const session = document.createElement("span")
+  session.dataset.state = "session"
+  session.textContent = "Session"
+  const Artifact = () => {
+    const content = document.createElement("span")
+    content.dataset.state = "content"
+    insert(content, () => fileExists(path) ? "available" : "missing")
+    return content
+  }
+  return [
+    session,
+    createComponent(Show, {
+      get when() {
+        return paths().length > 0
+      },
+      get children() {
+        return createComponent(Artifact, {})
+      },
+    }),
+  ]
+}
+
+const dispose = render(
+  () => createComponent(Suspense, {
+    fallback,
+    get children() {
+      return createComponent(Content, {})
+    },
+  }),
+  root,
+)
+
+await Promise.resolve()
+await Promise.resolve()
+loadArtifact()
+await new Promise((resolve) => setTimeout(resolve, 10))
+assert(!root.querySelector('[data-state="fallback"]'), "pending stats replaced the existing content")
+assert(root.querySelector('[data-state="session"]')?.textContent === "Session", "pending stats detached the session")
+assert(root.querySelector('[data-state="content"]')?.textContent === "available", "pending stats should assume the file exists")
+
+resolveStats({ [path]: { size: 0, exists: false } })
+await pendingStats
+await Promise.resolve()
+assert(root.querySelector('[data-state="content"]')?.textContent === "missing", "resolved stats should update the file state")
+dispose()
+`
+
+test("keeps existing UI visible while file stats are pending", () => {
+  runBrowserCheck(browserCheck)
+})

--- a/packages/app/src/components/session/artifact-file-exists.ts
+++ b/packages/app/src/components/session/artifact-file-exists.ts
@@ -1,0 +1,19 @@
+import { createResource, type Accessor } from "solid-js"
+
+type ArtifactStats = Record<string, { size: number; exists: boolean }>
+
+export function createArtifactFileExists(
+  paths: Accessor<string[]>,
+  statPaths: (paths: string[]) => Promise<ArtifactStats> | undefined,
+) {
+  const [stats] = createResource(
+    paths,
+    async (nextPaths) => {
+      if (nextPaths.length === 0) return {} as ArtifactStats
+      return statPaths(nextPaths) ?? Object.fromEntries(nextPaths.map((path) => [path, { size: 0, exists: true }]))
+    },
+    { initialValue: {} as ArtifactStats },
+  )
+
+  return (path: string) => stats.latest[path]?.exists ?? true
+}

--- a/packages/app/src/components/session/session-status-panel.tsx
+++ b/packages/app/src/components/session/session-status-panel.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createResource, type Accessor } from "solid-js"
+import { createMemo, type Accessor } from "solid-js"
 import { useParams } from "@solidjs/router"
 import { showToast } from "@opencode-ai/ui/toast"
 import type { Part } from "@opencode-ai/sdk/v2"
@@ -9,6 +9,7 @@ import { useServer } from "@/context/server"
 import { useSync } from "@/context/sync"
 import { normalizeArtifactPathKey, type FilesTabEntry } from "@/pages/session/files-tab-state"
 import { aggregateFiles } from "@/pages/session/session-aggregate-files"
+import { createArtifactFileExists } from "./artifact-file-exists"
 import { SessionStatusSummary } from "./session-status-summary"
 
 export function SessionStatusPanel(props: {
@@ -74,18 +75,11 @@ export function SessionStatusPanel(props: {
   // capability) every file is treated as existing — clicking still no-ops
   // because canOpenLocalPath returns false there.
   const artifactPaths = createMemo(() => (props.artifactFiles?.() ?? []).map((file) => file.path))
-  const [artifactStats] = createResource(artifactPaths, async (paths) => {
-    if (paths.length === 0) return {} as Record<string, { size: number; exists: boolean }>
-    if (!platform.statPaths) {
-      return Object.fromEntries(paths.map((path) => [path, { size: 0, exists: true }]))
-    }
-    return platform.statPaths(paths)
-  })
   // While the resource is pending the row should still feel actionable, so
   // assume the file exists until we know otherwise. This matches how the row
   // first renders right after a turn — the file did exist when the agent wrote
   // it, and the click is no-op-safe even if stat later reports missing.
-  const artifactExists = (path: string) => artifactStats()?.[path]?.exists ?? true
+  const artifactExists = createArtifactFileExists(artifactPaths, (paths) => platform.statPaths?.(paths))
 
   const reportFailure = (error: unknown) => {
     showToast({


### PR DESCRIPTION
## Summary

Keep the session UI visible while desktop artifact file stats are pending.

The status panel now reads the resource's latest resolved value, seeded with an empty value, and continues to optimistically treat newly written files as available until the native stat result arrives.

## Why

Each artifact path update started a native `statPaths` resource request. Reading the pending resource from the open status panel propagated to the route-level Suspense boundary, replacing the conversation with the startup fallback for a few milliseconds after every edit tool call. The effect was especially visible as full-window flicker on Windows.

This fixes the resource read at its owner instead of weakening the app-level Suspense boundary or adding platform-specific timing workarounds.

## Related Issue

Fixes #1537

## Human Review Status

Pending

## Review Focus

Please verify that `stats.latest` preserves the existing optimistic file-row behavior without allowing artifact stat refreshes to suspend the session route.

## Risk Notes

Low. The change only affects the pending state of artifact existence checks; resolved missing-file results still update the row normally. macOS and Windows were both exercised with the native Electron path.

The docs/release/dependency/permission/credential/deletion/generated-content conditional checklist item is not applicable because none of those surfaces changed.

## How To Verify

```text
Regression test: 1 passed; the same test fails on the previous implementation because pending stats replace existing Suspense content
Related app tests: 5 passed across artifact file existence and session status summary
App typecheck: passed
Biome lint: 3 changed files checked with no findings
Desktop build: passed
macOS native Electron: 10 completed patch cards, 10 changed files, 0 fallbacks
Windows native Electron: 10 completed patch cards, 10 changed files, 0 fallbacks (Actions run 30790201886)
Diff check: no whitespace errors
```

## Screenshots or Recordings

Reviewed the native Electron session route with the status panel open after 10 sequential `apply_patch` calls. The conversation, all patch cards, and all 10 changed files remained visible; the Windows Actions run also uploaded its final screenshot and diagnostic result.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [x] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact file status handling while file statistics are loading.
  * Existing session content remains visible during status checks.
  * Artifact files now update correctly to reflect missing files after verification completes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->