### PR TITLE
fix(session): persist terminal prompt failures

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -203,11 +203,12 @@ export interface Interface {
   }) => Effect.Effect<"continue" | "stop">
   readonly create: (input: {
     sessionID: SessionID
+    messageID?: MessageID
     agent: string
     model: { providerID: ProviderID; modelID: ModelID }
     auto: boolean
     overflow?: boolean
-  }) => Effect.Effect<void>
+  }) => Effect.Effect<MessageV2.User>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionCompaction") {}
@@ -726,27 +727,46 @@ export const layer: Layer.Layer<
 
     const create = Effect.fn("SessionCompaction.create")(function* (input: {
       sessionID: SessionID
+      messageID?: MessageID
       agent: string
       model: { providerID: ProviderID; modelID: ModelID }
       auto: boolean
       overflow?: boolean
     }) {
       const msg = yield* session.updateMessage({
-        id: MessageID.ascending(),
+        id: input.messageID ?? MessageID.ascending(),
         role: "user",
         model: input.model,
         sessionID: input.sessionID,
         agent: input.agent,
         time: { created: Date.now() },
       })
-      yield* session.updatePart({
-        id: PartID.ascending(),
-        messageID: msg.id,
-        sessionID: msg.sessionID,
-        type: "compaction",
-        auto: input.auto,
-        overflow: input.overflow,
-      })
+      yield* session
+        .updatePart({
+          id: PartID.ascending(),
+          messageID: msg.id,
+          sessionID: msg.sessionID,
+          type: "compaction",
+          auto: input.auto,
+          overflow: input.overflow,
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            session.removeMessage({ sessionID: msg.sessionID, messageID: msg.id }).pipe(
+              Effect.uninterruptible,
+              Effect.catchCause((cleanupCause) =>
+                Effect.sync(() =>
+                  log.error("failed to roll back incomplete compaction marker", {
+                    messageID: msg.id,
+                    error: Cause.pretty(cleanupCause),
+                  }),
+                ),
+              ),
+              Effect.andThen(Effect.failCause(cause)),
+            ),
+          ),
+        )
+      return msg
     })
 
     return Service.of({

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -13,7 +13,7 @@ import { Plugin } from "@/plugin"
 import { Config } from "@/config"
 import { Storage } from "@/storage/storage"
 import { ModelID, ProviderID } from "@/provider/schema"
-import { Effect, Layer, Context, Schema } from "effect"
+import { Cause, Effect, Layer, Context, Schema } from "effect"
 import { isOverflow as overflow, usable } from "./overflow"
 
 const log = Log.create({ service: "session.compaction" })
@@ -207,7 +207,7 @@ export interface Interface {
     model: { providerID: ProviderID; modelID: ModelID }
     auto: boolean
     overflow?: boolean
-  }) => Effect.Effect<MessageV2.User>
+  }) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionCompaction") {}
@@ -519,9 +519,14 @@ export const layer: Layer.Layer<
           })
           return { ok: true as const, stalled: false as const, result, processor, replay, selected }
         }).pipe(
-          Effect.catch((error: unknown) => Effect.succeed({ ok: false as const, error })),
-          // Interrupts (abort signal) bypass `Effect.catch` since they live on
-          // the Cause channel, not the error channel. Without this finalizer
+          Effect.catchCause((cause) =>
+            Cause.hasInterruptsOnly(cause)
+              ? Effect.failCause(cause)
+              : Effect.succeed({ ok: false as const, error: Cause.squash(cause) }),
+          ),
+          // Pure interrupts are rethrown above so this finalizer records an
+          // aborted terminal state instead of treating cancellation as setup failure.
+          // Without this finalizer
           // the placeholder would persist with no error/finish — the divider
           // state machine would read it as `pending` forever after an abort.
           Effect.onInterrupt(() =>
@@ -742,7 +747,6 @@ export const layer: Layer.Layer<
         auto: input.auto,
         overflow: input.overflow,
       })
-      return msg
     })
 
     return Service.of({

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -207,7 +207,7 @@ export interface Interface {
     model: { providerID: ProviderID; modelID: ModelID }
     auto: boolean
     overflow?: boolean
-  }) => Effect.Effect<void>
+  }) => Effect.Effect<MessageV2.User>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionCompaction") {}
@@ -742,6 +742,7 @@ export const layer: Layer.Layer<
         auto: input.auto,
         overflow: input.overflow,
       })
+      return msg
     })
 
     return Service.of({

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -532,8 +532,8 @@ export const layer: Layer.Layer<
           // state machine would read it as `pending` forever after an abort.
           Effect.onInterrupt(() =>
             Effect.gen(function* () {
-              if (msg.error || msg.finish) return
-              msg.error = new MessageV2.AbortedError({
+              if (msg.finish && msg.time.completed) return
+              msg.error ??= new MessageV2.AbortedError({
                 message: "Compaction aborted",
               }).toObject()
               msg.finish = "error"
@@ -541,7 +541,7 @@ export const layer: Layer.Layer<
               // `pending` memo (driven by `allMessages()`, which includes
               // the summary assistant) does not keep treating this turn
               // as in-flight.
-              msg.time.completed = Date.now()
+              msg.time.completed ??= Date.now()
               yield* session.updateMessage(msg)
             }),
           ),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -52,11 +52,12 @@ import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
 import { envValueCaseInsensitive, prependBundledTools, stripPathKeys, withoutInternalServerAuthEnv } from "@/util/env"
 import { applyUvMirrorEnvDefaults, uvMirrorEnvSnapshot } from "@/util/uv-mirror"
-import { Cause, Deferred, Effect, Exit, Layer, Option, Scope, Context } from "effect"
+import { Cause, Deferred, Effect, Exit, Layer, Option, Scope, Context, Semaphore } from "effect"
 import { EffectLogger } from "@/effect"
 import { InstanceState } from "@/effect"
 import { AgentTool, type AgentPromptOps } from "@/tool/agent"
 import { SessionRunState } from "./run-state"
+import type { InterruptMeta } from "@/effect/runner"
 import { RunLifecycle } from "./run-lifecycle"
 import { EffectBridge } from "@/effect"
 import { attachWith } from "@/effect/run-service"
@@ -1822,63 +1823,217 @@ export const layer = Layer.effect(
       return { info, parts }
     }, Effect.scoped)
 
+    const terminalWriteLock = Semaphore.makeUnsafe(1)
+    const persistTerminalErrorCarrier = Effect.fn("SessionPrompt.persistTerminalErrorCarrier")(function* (input: {
+      sessionID: SessionID
+      parentID: MessageID
+      error: unknown
+      aborted?: boolean
+      preserveCompleted?: boolean
+      diagnostics?: MessageV2.Assistant["diagnostics"]
+    }) {
+      return yield* terminalWriteLock.withPermits(1)(
+        Effect.gen(function* () {
+          const traced = yield* sessions.findMessage(
+            input.sessionID,
+            (message) => message.info.id === input.parentID,
+          )
+          const parent = Option.isSome(traced) ? traced.value : undefined
+          if (!parent || parent.info.role !== "user") return
+          const parentInfo = parent.info
+
+          const messages = yield* sessions.messages({ sessionID: input.sessionID })
+          const existing = [...messages]
+            .reverse()
+            .find((message) => message.info.role === "assistant" && message.info.parentID === parentInfo.id)
+          const completedAt = Date.now()
+          const terminalError = MessageV2.fromError(input.error, {
+            providerID: parentInfo.model.providerID,
+            aborted: input.aborted ?? false,
+          })
+          if (existing?.info.role === "assistant") {
+            const assistant = existing.info
+            if (!assistant.time.completed) {
+              const terminal = yield* sessions.updateMessage({
+                ...assistant,
+                time: { ...assistant.time, completed: completedAt },
+                error: assistant.error ?? terminalError,
+                finish: "error",
+                diagnostics: input.diagnostics
+                  ? { ...(assistant.diagnostics ?? {}), ...input.diagnostics }
+                  : assistant.diagnostics,
+              })
+              return { info: terminal, parts: existing.parts }
+            }
+            if (assistant.error?.name === "MessageAbortedError" && input.diagnostics) {
+              const terminal = yield* sessions.updateMessage({
+                ...assistant,
+                diagnostics: { ...(assistant.diagnostics ?? {}), ...input.diagnostics },
+              })
+              return { info: terminal, parts: existing.parts }
+            }
+            if (assistant.error || assistant.finish === "error") return existing
+            if (input.preserveCompleted) return existing
+          }
+
+          const terminalSession = yield* sessions.get(input.sessionID)
+          const carrier: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            parentID: parentInfo.id,
+            sessionID: input.sessionID,
+            mode: parentInfo.agent,
+            agent: parentInfo.agent,
+            variant: parentInfo.model.variant,
+            path: {
+              cwd: terminalSession.executionContext.activeDirectory,
+              root: terminalSession.executionContext.ownerDirectory,
+            },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            modelID: parentInfo.model.modelID,
+            providerID: parentInfo.model.providerID,
+            time: { created: completedAt, completed: completedAt },
+            error: terminalError,
+            finish: "error",
+            diagnostics: input.diagnostics,
+          }
+          yield* sessions.updateMessage(carrier)
+          return { info: carrier, parts: [] }
+        }),
+      )
+    })
+
     type PromptAttempt = {
+      sessionID: SessionID
+      traceMessageID?: MessageID
       interrupted: boolean
+      cancelMeta?: InterruptMeta
       activeProcessor?: SessionProcessor.Handle
       compactionMarkerID?: MessageID
     }
-    const cancelAttempt = (attempt: PromptAttempt) => () =>
+    const persistAttemptAbort = Effect.fn("SessionPrompt.persistAttemptAbort")(function* (
+      attempt: PromptAttempt,
+      propagationPoint = "session.prompt.loop.onInterrupt",
+      traceMessageID = attempt.traceMessageID,
+    ) {
+      if (!traceMessageID) return
+      const recordedAt = attempt.cancelMeta?.recordedAt ?? Date.now()
+      const abortError = new DOMException("Aborted", "AbortError")
+      return yield* persistTerminalErrorCarrier({
+        sessionID: attempt.sessionID,
+        parentID: traceMessageID,
+        error: abortError,
+        aborted: true,
+        preserveCompleted: true,
+        diagnostics: {
+          abort: {
+            source: attempt.cancelMeta?.source,
+            reason: attempt.cancelMeta?.reason,
+            title_generation_state: titleGenerationStateAtAbort(
+              titleGenerationProgress.get(attempt.sessionID),
+              recordedAt,
+            ),
+            propagation_point: attempt.cancelMeta?.propagationPoint ?? propagationPoint,
+            error_name: "MessageAbortedError",
+            error_message: "Aborted",
+            via_ctx_abort: attempt.cancelMeta?.viaCtxAbort,
+            recorded_at: recordedAt,
+          },
+        },
+      })
+    })
+    const cancelAttempt = (attempt: PromptAttempt) => (meta?: InterruptMeta) =>
       Effect.gen(function* () {
         attempt.interrupted = true
+        attempt.cancelMeta = meta
         yield* attempt.activeProcessor?.abortTools?.() ?? Effect.void
       })
 
     const prompt: (input: PromptInput, options?: PromptRuntimeOptions) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
       "SessionPrompt.prompt",
     )(function* (input: PromptInput, options?: PromptRuntimeOptions) {
-      const attempt: PromptAttempt = { interrupted: false }
+      const messageID = input.messageID ?? MessageID.ascending()
+      const promptInput = input.messageID ? input : { ...input, messageID }
+      const attempt: PromptAttempt = {
+        sessionID: input.sessionID,
+        traceMessageID: messageID,
+        interrupted: false,
+      }
       yield* state.observeCancel(input.sessionID, cancelAttempt(attempt))
-      yield* throwIfAborted(options)
-      interruptedSessions.delete(input.sessionID)
-      const session = yield* sessions.get(input.sessionID)
-      yield* revert.cleanup(session)
-      const message = yield* createUserMessage(input)
-      yield* sessions.touch(input.sessionID)
+      const run = Effect.gen(function* () {
+        yield* throwIfAborted(options)
+        interruptedSessions.delete(input.sessionID)
+        const session = yield* sessions.get(input.sessionID)
+        yield* revert.cleanup(session)
+        const message = yield* createUserMessage(promptInput)
+        yield* sessions.touch(input.sessionID)
 
-      const permissions: Permission.Ruleset = []
-      for (const [t, enabled] of Object.entries(input.tools ?? {})) {
-        permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
-      }
-      if (permissions.length > 0) {
-        // #26597: the boolean tools map is availability-only — it lists the subagent's structural
-        // denies (agent, worktree, todowrite, primary_tools), not what it inherited from its
-        // caller. The caller's deny rules are the single source of truth for inheritance and live
-        // on session.permission, forwarded at dispatch (tool/agent.ts). Rebuilding from the map
-        // alone would drop them, letting a caller regain access through the child. For agent-tool
-        // children, carry forward external_directory rules plus every caller deny the map does NOT
-        // regenerate: scoped (non-"*") denies (e.g. edit on one path) and whole-tool denies for
-        // keys absent from the map — the wildcard "*" and any tool not listed (automate, MCP,
-        // custom). Per-tool "*" denies for keys the map lists are regenerated each turn, so
-        // dropping them keeps this stable instead of accumulating.
-        // NOTE: like upstream #26597 this is forward-deny only — a caller's allow exception (e.g.
-        // a read-only "*": deny agent that also allows read) is not preserved, so its subagent
-        // loses those tools too. Matching upstream's deriveSubagentSessionPermission; toward deny.
-        const toolKeys = new Set(Object.keys(input.tools ?? {}))
-        const preserved = session.createdByAgentTool
-          ? (session.permission ?? []).filter(
-              (rule) =>
-                rule.permission === "external_directory" ||
-                (rule.action === "deny" && (rule.pattern !== "*" || !toolKeys.has(rule.permission))),
-            )
-          : []
-        const next = [...preserved, ...permissions]
-        session.permission = next
-        yield* sessions.setPermission({ sessionID: session.id, permission: next })
-      }
+        const permissions: Permission.Ruleset = []
+        for (const [t, enabled] of Object.entries(input.tools ?? {})) {
+          permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
+        }
+        if (permissions.length > 0) {
+          // #26597: the boolean tools map is availability-only — it lists the subagent's structural
+          // denies (agent, worktree, todowrite, primary_tools), not what it inherited from its
+          // caller. The caller's deny rules are the single source of truth for inheritance and live
+          // on session.permission, forwarded at dispatch (tool/agent.ts). Rebuilding from the map
+          // alone would drop them, letting a caller regain access through the child. For agent-tool
+          // children, carry forward external_directory rules plus every caller deny the map does NOT
+          // regenerate: scoped (non-"*") denies (e.g. edit on one path) and whole-tool denies for
+          // keys absent from the map — the wildcard "*" and any tool not listed (automate, MCP,
+          // custom). Per-tool "*" denies for keys the map lists are regenerated each turn, so
+          // dropping them keeps this stable instead of accumulating.
+          // NOTE: like upstream #26597 this is forward-deny only — a caller's allow exception (e.g.
+          // a read-only "*": deny agent that also allows read) is not preserved, so its subagent
+          // loses those tools too. Matching upstream's deriveSubagentSessionPermission; toward deny.
+          const toolKeys = new Set(Object.keys(input.tools ?? {}))
+          const preserved = session.createdByAgentTool
+            ? (session.permission ?? []).filter(
+                (rule) =>
+                  rule.permission === "external_directory" ||
+                  (rule.action === "deny" && (rule.pattern !== "*" || !toolKeys.has(rule.permission))),
+              )
+            : []
+          const next = [...preserved, ...permissions]
+          session.permission = next
+          yield* sessions.setPermission({ sessionID: session.id, permission: next })
+        }
 
-      yield* throwIfAborted(options)
-      if (input.noReply === true) return message
-      return yield* loopAttempt({ sessionID: input.sessionID, traceMessageID: message.info.id }, options, attempt)
+        yield* throwIfAborted(options)
+        if (input.noReply === true) return message
+        return yield* loopAttempt({ sessionID: input.sessionID, traceMessageID: message.info.id }, options, attempt)
+      })
+      return yield* run.pipe(
+        Effect.catchCause((cause) => {
+          if (input.noReply === true) return Effect.failCause(cause)
+          const interrupted = Cause.hasInterruptsOnly(cause)
+          const error = interrupted ? new DOMException("Aborted", "AbortError") : Cause.squash(cause)
+          return persistTerminalErrorCarrier({
+            sessionID: input.sessionID,
+            parentID: messageID,
+            error,
+            aborted: interrupted,
+            preserveCompleted: interrupted,
+          }).pipe(
+            Effect.uninterruptible,
+            Effect.catchCause((terminalCause) =>
+              Effect.sync(() => {
+                log.error("failed to persist terminal prompt error", {
+                  error: Cause.pretty(terminalCause),
+                  original: Cause.pretty(cause),
+                })
+              }),
+            ),
+            Effect.andThen(Effect.failCause(cause)),
+          )
+        }),
+      )
     }, Effect.scoped)
 
     const appendRunLifecycleEvent = Effect.fn("SessionPrompt.appendRunLifecycleEvent")(function* (
@@ -2377,82 +2532,13 @@ export const layer = Layer.effect(
       options: PromptRuntimeOptions | undefined,
       currentAttempt: PromptAttempt,
     ) {
-      const persistTerminalErrorCarrier = Effect.fn("SessionPrompt.persistTerminalErrorCarrier")(function* (
-        error: unknown,
-        options?: {
-          parentID?: MessageID
-          aborted?: boolean
-          diagnostics?: MessageV2.Assistant["diagnostics"]
-        },
-      ) {
-        const parentID = options?.parentID ?? input.traceMessageID
-        if (!parentID) return
-        const traced = yield* sessions.findMessage(
-          input.sessionID,
-          (message) => message.info.id === parentID,
-        )
-        const parent = Option.isSome(traced) ? traced.value : undefined
-        if (!parent || parent.info.role !== "user") return
-        const parentInfo = parent.info
-
-        const existing = yield* sessions.findMessage(
-          input.sessionID,
-          (message) => message.info.role === "assistant" && message.info.parentID === parentInfo.id,
-        )
-        const completedAt = Date.now()
-        const terminalError = MessageV2.fromError(error, {
-          providerID: parentInfo.model.providerID,
-          aborted: options?.aborted ?? false,
-        })
-        if (Option.isSome(existing) && existing.value.info.role === "assistant") {
-          const assistant = existing.value.info
-          if (!assistant.time.completed) {
-            yield* sessions.updateMessage({
-              ...assistant,
-              time: { ...assistant.time, completed: completedAt },
-              error: assistant.error ?? terminalError,
-              finish: "error",
-              diagnostics: options?.diagnostics
-                ? { ...(assistant.diagnostics ?? {}), ...options.diagnostics }
-                : assistant.diagnostics,
-            })
-            return
-          }
-          if (assistant.error || assistant.finish === "error") return
-        }
-
-        const session = yield* sessions.get(input.sessionID)
-        const carrier: MessageV2.Assistant = {
-          id: MessageID.ascending(),
-          role: "assistant",
-          parentID: parentInfo.id,
-          sessionID: input.sessionID,
-          mode: parentInfo.agent,
-          agent: parentInfo.agent,
-          variant: parentInfo.model.variant,
-          path: {
-            cwd: session.executionContext.activeDirectory,
-            root: session.executionContext.ownerDirectory,
-          },
-          cost: 0,
-          tokens: {
-            input: 0,
-            output: 0,
-            reasoning: 0,
-            cache: { read: 0, write: 0 },
-          },
-          modelID: parentInfo.model.modelID,
-          providerID: parentInfo.model.providerID,
-          time: { created: completedAt, completed: completedAt },
-          error: terminalError,
-          finish: "error",
-          diagnostics: options?.diagnostics,
-        }
-        yield* sessions.updateMessage(carrier)
-      })
       const persistFailure = (cause: Cause.Cause<unknown>) => {
-        if (Cause.hasInterruptsOnly(cause)) return Effect.void
-        return persistTerminalErrorCarrier(Cause.squash(cause)).pipe(
+        if (Cause.hasInterruptsOnly(cause) || !input.traceMessageID) return Effect.void
+        return persistTerminalErrorCarrier({
+          sessionID: input.sessionID,
+          parentID: input.traceMessageID,
+          error: Cause.squash(cause),
+        }).pipe(
           Effect.uninterruptible,
           Effect.catchCause((terminalCause) =>
             Effect.sync(() => {
@@ -2475,15 +2561,11 @@ export const layer = Layer.effect(
         const parentIndex = messages.findIndex((candidate) => candidate.info.id === parentID)
         return traceIndex >= 0 && parentIndex >= traceIndex
       })
-      const onInterrupt = (meta?: {
-        source?: string
-        reason?: string
-        viaCtxAbort?: boolean
-        propagationPoint?: string
-        recordedAt?: number
-      }) =>
+      let workStarted = false
+      const onInterrupt = (meta?: InterruptMeta) =>
         Effect.gen(function* () {
           currentAttempt.interrupted = true
+          currentAttempt.cancelMeta = meta
           interruptedSessions.add(input.sessionID)
           if (currentAttempt.compactionMarkerID) {
             const pendingMarker = yield* sessions.findMessage(
@@ -2555,94 +2637,33 @@ export const layer = Layer.effect(
                 yield* sessions.updateMessage(placeholder)
                 return { info: placeholder, parts: [] }
               }
+              return summaryChild.value
             }
           }
-          const assistant = yield* currentTurnTarget(input.sessionID)
-          if (assistant.info.role === "user") {
-            const recordedAt = meta?.recordedAt ?? Date.now()
-            const abortError = new DOMException("Aborted", "AbortError")
-            const serialized = MessageV2.fromError(abortError, {
-              providerID: assistant.info.model.providerID,
-              aborted: true,
-            })
-            yield* persistTerminalErrorCarrier(abortError, {
-              parentID: assistant.info.id,
-              aborted: true,
-              diagnostics: {
-                abort: {
-                  source: meta?.source,
-                  reason: meta?.reason,
-                  title_generation_state: titleGenerationStateAtAbort(
-                    titleGenerationProgress.get(input.sessionID),
-                    recordedAt,
-                  ),
-                  propagation_point: meta?.propagationPoint ?? "session.prompt.loop.onInterrupt",
-                  error_name: serialized.name,
-                  error_message:
-                    "data" in serialized &&
-                    serialized.data &&
-                    typeof serialized.data === "object" &&
-                    "message" in serialized.data
-                      ? String(serialized.data.message)
-                      : undefined,
-                  via_ctx_abort: meta?.viaCtxAbort,
-                  recorded_at: recordedAt,
-                },
-              },
-            })
-            return yield* lastAssistant(input.sessionID)
+          if (input.traceMessageID) {
+            const terminal = yield* persistAttemptAbort(currentAttempt)
+            return terminal ?? (yield* lastAssistant(input.sessionID))
           }
-          if (assistant.info.role === "assistant") {
-            const shouldFinalize = !assistant.info.time.completed
-            const error =
-              assistant.info.error ??
-              (shouldFinalize
-                ? MessageV2.fromError(new DOMException("Aborted", "AbortError"), {
-                    providerID: assistant.info.providerID,
-                    aborted: true,
-                  })
-                : undefined)
-            const errorMessage =
-              error && "data" in error && error.data && typeof error.data === "object" && "message" in error.data
-                ? String(error.data.message)
-                : undefined
-            const recordedAt = meta?.recordedAt ?? Date.now()
-            yield* sessions.updateMessage({
-              ...assistant.info,
-              ...(shouldFinalize
-                ? {
-                    error,
-                    time: {
-                      ...assistant.info.time,
-                      completed: recordedAt,
-                    },
-                  }
-                : {}),
-              diagnostics: {
-                ...(assistant.info.diagnostics ?? {}),
-                abort: {
-                  ...(assistant.info.diagnostics?.abort ?? {}),
-                  source: meta?.source,
-                  reason: meta?.reason,
-                  title_generation_state: titleGenerationStateAtAbort(
-                    titleGenerationProgress.get(input.sessionID),
-                    recordedAt,
-                  ),
-                  propagation_point: meta?.propagationPoint ?? "session.prompt.loop.onInterrupt",
-                  error_name: error?.name,
-                  error_message: errorMessage,
-                  via_ctx_abort: meta?.viaCtxAbort,
-                  recorded_at: recordedAt,
-                },
-              },
-            })
-            return yield* lastAssistant(input.sessionID)
+          if (input.prelude || !workStarted) return yield* lastAssistant(input.sessionID)
+
+          const target = yield* currentTurnTarget(input.sessionID)
+          if (
+            target.info.role === "assistant" &&
+            target.info.time.completed &&
+            target.info.error?.name !== "MessageAbortedError"
+          ) {
+            return target
           }
-          return assistant
+          const parentID = target.info.role === "user" ? target.info.id : target.info.parentID
+          const terminal = yield* persistAttemptAbort(currentAttempt, "session.prompt.loop.onInterrupt", parentID)
+          return terminal ?? (yield* lastAssistant(input.sessionID))
         })
-      let workStarted = false
       const work = Effect.gen(function* () {
         workStarted = true
+        if (currentAttempt.interrupted) {
+          const terminal = yield* persistAttemptAbort(currentAttempt)
+          return terminal ?? (yield* onInterrupt(currentAttempt.cancelMeta))
+        }
         yield* throwIfAborted(options)
         // Two reasons busy goes first. (1) The compaction part event must
         // not race ahead of `session.status: busy` — the divider's
@@ -2723,8 +2744,12 @@ export const layer = Layer.effect(
           runLifecycle,
         })
       const exit = yield* runOnce().pipe(Effect.exit)
+      if (currentAttempt.interrupted) {
+        const terminal = yield* persistAttemptAbort(currentAttempt).pipe(Effect.uninterruptible)
+        if (terminal) return terminal
+        if (Exit.isSuccess(exit)) return exit.value
+      }
       if (Exit.isSuccess(exit)) {
-        if (currentAttempt.interrupted) return exit.value
         if (yield* tracedMessageCoveredBy(exit.value)) return exit.value
 
         // A prompt can land after the active run's final message scan but
@@ -2735,7 +2760,11 @@ export const layer = Layer.effect(
         workStarted = false
         currentAttempt.activeProcessor = undefined
         const retry = yield* runOnce().pipe(Effect.exit)
-        if (Exit.isSuccess(retry) && currentAttempt.interrupted) return retry.value
+        if (currentAttempt.interrupted) {
+          const terminal = yield* persistAttemptAbort(currentAttempt).pipe(Effect.uninterruptible)
+          if (terminal) return terminal
+          if (Exit.isSuccess(retry)) return retry.value
+        }
         if (Exit.isSuccess(retry) && (yield* tracedMessageCoveredBy(retry.value))) return retry.value
         if (Exit.isFailure(retry)) {
           if (!workStarted) yield* persistFailure(retry.cause)
@@ -2759,7 +2788,11 @@ export const layer = Layer.effect(
     ) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
       "SessionPrompt.loop",
     )(function* (input: z.infer<typeof LoopInput>, options?: PromptRuntimeOptions) {
-      const attempt: PromptAttempt = { interrupted: false }
+      const attempt: PromptAttempt = {
+        sessionID: input.sessionID,
+        traceMessageID: input.traceMessageID,
+        interrupted: false,
+      }
       yield* state.observeCancel(input.sessionID, cancelAttempt(attempt))
       return yield* loopAttempt(input, options, attempt)
     }, Effect.scoped)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2337,6 +2337,87 @@ export const layer = Layer.effect(
       "SessionPrompt.loop",
     )(function* (input: z.infer<typeof LoopInput>, options?: PromptRuntimeOptions) {
       let activeProcessor: SessionProcessor.Handle | undefined
+      let interrupted = false
+      let preludeMarkerID: MessageID | undefined
+      const persistTerminalErrorCarrier = Effect.fn("SessionPrompt.persistTerminalErrorCarrier")(function* (
+        error: unknown,
+      ) {
+        let parent: MessageV2.WithParts | undefined
+        if (input.traceMessageID) {
+          const traced = yield* sessions.findMessage(
+            input.sessionID,
+            (message) => message.info.id === input.traceMessageID,
+          )
+          if (Option.isSome(traced)) parent = traced.value
+        } else if (preludeMarkerID) {
+          const marker = yield* sessions.findMessage(
+            input.sessionID,
+            (message) => message.info.id === preludeMarkerID,
+          )
+          if (Option.isSome(marker)) parent = marker.value
+        }
+        if (!parent || parent.info.role !== "user") return
+        const parentInfo = parent.info
+
+        const existing = yield* sessions.findMessage(
+          input.sessionID,
+          (message) => message.info.role === "assistant" && message.info.parentID === parentInfo.id,
+        )
+        const completedAt = Date.now()
+        const terminalError = MessageV2.fromError(error, {
+          providerID: parentInfo.model.providerID,
+          aborted: false,
+        })
+        if (Option.isSome(existing) && existing.value.info.role === "assistant") {
+          const assistant = existing.value.info
+          if (assistant.time.completed) return
+          yield* sessions.updateMessage({
+            ...assistant,
+            time: { ...assistant.time, completed: completedAt },
+            error: assistant.error ?? (assistant.finish ? undefined : terminalError),
+            finish: assistant.finish ?? "error",
+          })
+          return
+        }
+
+        const session = yield* sessions.get(input.sessionID)
+        const isCompaction = parent.parts.some((part) => part.type === "compaction")
+        const carrier: MessageV2.Assistant = {
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: parentInfo.id,
+          sessionID: input.sessionID,
+          mode: isCompaction ? "compaction" : parentInfo.agent,
+          agent: isCompaction ? "compaction" : parentInfo.agent,
+          variant: parentInfo.model.variant,
+          ...(isCompaction ? { summary: true } : {}),
+          path: {
+            cwd: session.executionContext.activeDirectory,
+            root: session.executionContext.ownerDirectory,
+          },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          modelID: parentInfo.model.modelID,
+          providerID: parentInfo.model.providerID,
+          time: { created: completedAt, completed: completedAt },
+          error: terminalError,
+          finish: "error",
+        }
+        yield* sessions.updateMessage(carrier)
+      })
+      const tracedMessageHasAssistant = Effect.fn("SessionPrompt.tracedMessageHasAssistant")(function* () {
+        if (!input.traceMessageID) return true
+        const child = yield* sessions.findMessage(
+          input.sessionID,
+          (message) => message.info.role === "assistant" && message.info.parentID === input.traceMessageID,
+        )
+        return Option.isSome(child)
+      })
       const onInterrupt = (meta?: {
         source?: string
         reason?: string
@@ -2345,6 +2426,7 @@ export const layer = Layer.effect(
         recordedAt?: number
       }) =>
         Effect.gen(function* () {
+          interrupted = true
           interruptedSessions.add(input.sessionID)
           // Sweep any pending compaction marker first — a user message with
           // a `compaction` part but no summary assistant child. Covers two
@@ -2525,12 +2607,13 @@ export const layer = Layer.effect(
               }
             }
           }
-          yield* compaction.create({
+          const marker = yield* compaction.create({
             sessionID: input.sessionID,
             agent,
             model: input.prelude.model,
             auto: input.prelude.auto,
           })
+          preludeMarkerID = marker.id
         }
         return yield* runLoop(input.sessionID, {
           onProcessor: (handle) => {
@@ -2557,11 +2640,37 @@ export const layer = Layer.effect(
           }
         : undefined
       yield* throwIfAborted(options)
-      return yield* state.ensureRunning(input.sessionID, onInterrupt, work, {
-        rejectIfBusy: input.prelude !== undefined,
-        runLifecycle,
-        onCancel: () => activeProcessor?.abortTools?.() ?? Effect.void,
-      })
+      const runOnce = () =>
+        state.ensureRunning(input.sessionID, onInterrupt, work, {
+          rejectIfBusy: input.prelude !== undefined,
+          runLifecycle,
+          onCancel: () => activeProcessor?.abortTools?.() ?? Effect.void,
+        })
+      const exit = yield* runOnce().pipe(Effect.exit)
+      if (Exit.isSuccess(exit)) {
+        if (interrupted) return exit.value
+        if (yield* tracedMessageHasAssistant()) return exit.value
+
+        // A prompt can land after the active run's final message scan but
+        // before Runner transitions to Idle. In that narrow window
+        // ensureRunning joins the finishing run and its work is intentionally
+        // ignored. Retry once after the joined run has completed so the saved
+        // user message receives its own turn instead of becoming an orphan.
+        const retry = yield* runOnce().pipe(Effect.exit)
+        if (Exit.isSuccess(retry) && (yield* tracedMessageHasAssistant())) return retry.value
+        if (Exit.isFailure(retry)) {
+          if (!Cause.hasInterruptsOnly(retry.cause)) yield* persistTerminalErrorCarrier(Cause.squash(retry.cause))
+          return yield* Effect.failCause(retry.cause)
+        }
+
+        const error = new NamedError.Unknown({
+          message: "Session run completed without handling the submitted message",
+        })
+        yield* persistTerminalErrorCarrier(error)
+        return yield* Effect.die(error)
+      }
+      if (!Cause.hasInterruptsOnly(exit.cause)) yield* persistTerminalErrorCarrier(Cause.squash(exit.cause))
+      return yield* Effect.failCause(exit.cause)
     })
 
     const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.shell")(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2051,14 +2051,7 @@ export const layer = Layer.effect(
               history: msgs,
             }).pipe(Effect.ignore, Effect.forkIn(scope))
 
-          const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
           const task = tasks.pop()
-
-          if (task?.type === "subtask") {
-            yield* handleSubtask({ subtask: task, model, lastUser, sessionID, session, msgs })
-            continue
-          }
-
           if (task?.type === "compaction") {
             const result = yield* compaction.process({
               messages: msgs,
@@ -2069,6 +2062,12 @@ export const layer = Layer.effect(
               executionContext: session.executionContext,
             })
             if (result === "stop") break
+            continue
+          }
+
+          const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
+          if (task?.type === "subtask") {
+            yield* handleSubtask({ subtask: task, model, lastUser, sessionID, session, msgs })
             continue
           }
 
@@ -2338,24 +2337,15 @@ export const layer = Layer.effect(
     )(function* (input: z.infer<typeof LoopInput>, options?: PromptRuntimeOptions) {
       let activeProcessor: SessionProcessor.Handle | undefined
       let interrupted = false
-      let preludeMarkerID: MessageID | undefined
       const persistTerminalErrorCarrier = Effect.fn("SessionPrompt.persistTerminalErrorCarrier")(function* (
         error: unknown,
       ) {
-        let parent: MessageV2.WithParts | undefined
-        if (input.traceMessageID) {
-          const traced = yield* sessions.findMessage(
-            input.sessionID,
-            (message) => message.info.id === input.traceMessageID,
-          )
-          if (Option.isSome(traced)) parent = traced.value
-        } else if (preludeMarkerID) {
-          const marker = yield* sessions.findMessage(
-            input.sessionID,
-            (message) => message.info.id === preludeMarkerID,
-          )
-          if (Option.isSome(marker)) parent = marker.value
-        }
+        if (!input.traceMessageID) return
+        const traced = yield* sessions.findMessage(
+          input.sessionID,
+          (message) => message.info.id === input.traceMessageID,
+        )
+        const parent = Option.isSome(traced) ? traced.value : undefined
         if (!parent || parent.info.role !== "user") return
         const parentInfo = parent.info
 
@@ -2370,27 +2360,26 @@ export const layer = Layer.effect(
         })
         if (Option.isSome(existing) && existing.value.info.role === "assistant") {
           const assistant = existing.value.info
-          if (assistant.time.completed) return
-          yield* sessions.updateMessage({
-            ...assistant,
-            time: { ...assistant.time, completed: completedAt },
-            error: assistant.error ?? (assistant.finish ? undefined : terminalError),
-            finish: assistant.finish ?? "error",
-          })
-          return
+          if (!assistant.time.completed) {
+            yield* sessions.updateMessage({
+              ...assistant,
+              time: { ...assistant.time, completed: completedAt },
+              error: assistant.error ?? terminalError,
+              finish: assistant.finish ?? "error",
+            })
+            return
+          }
         }
 
         const session = yield* sessions.get(input.sessionID)
-        const isCompaction = parent.parts.some((part) => part.type === "compaction")
         const carrier: MessageV2.Assistant = {
           id: MessageID.ascending(),
           role: "assistant",
           parentID: parentInfo.id,
           sessionID: input.sessionID,
-          mode: isCompaction ? "compaction" : parentInfo.agent,
-          agent: isCompaction ? "compaction" : parentInfo.agent,
+          mode: parentInfo.agent,
+          agent: parentInfo.agent,
           variant: parentInfo.model.variant,
-          ...(isCompaction ? { summary: true } : {}),
           path: {
             cwd: session.executionContext.activeDirectory,
             root: session.executionContext.ownerDirectory,
@@ -2410,14 +2399,26 @@ export const layer = Layer.effect(
         }
         yield* sessions.updateMessage(carrier)
       })
-      const tracedMessageHasAssistant = Effect.fn("SessionPrompt.tracedMessageHasAssistant")(function* () {
-        if (!input.traceMessageID) return true
-        const child = yield* sessions.findMessage(
-          input.sessionID,
-          (message) => message.info.role === "assistant" && message.info.parentID === input.traceMessageID,
+      const persistFailure = (cause: Cause.Cause<unknown>) => {
+        if (Cause.hasInterruptsOnly(cause)) return Effect.void
+        return persistTerminalErrorCarrier(Cause.squash(cause)).pipe(
+          Effect.uninterruptible,
+          Effect.catchCause((terminalCause) =>
+            Effect.sync(() => {
+              log.error("failed to persist terminal prompt error", {
+                error: Cause.pretty(terminalCause),
+                original: Cause.pretty(cause),
+              })
+            }),
+          ),
         )
-        return Option.isSome(child)
-      })
+      }
+      // One run may merge several user messages into the assistant turn parented
+      // by the newest message. ID ordering proves an older traced message was
+      // included without requiring every merged user to own a separate child.
+      const tracedMessageCoveredBy = (message: MessageV2.WithParts) =>
+        !input.traceMessageID ||
+        (message.info.role === "assistant" && message.info.summary !== true && message.info.id > input.traceMessageID)
       const onInterrupt = (meta?: {
         source?: string
         reason?: string
@@ -2572,7 +2573,9 @@ export const layer = Layer.effect(
           }
           return assistant
         })
+      let workStarted = false
       const work = Effect.gen(function* () {
+        workStarted = true
         yield* throwIfAborted(options)
         // Two reasons busy goes first. (1) The compaction part event must
         // not race ahead of `session.status: busy` — the divider's
@@ -2607,20 +2610,21 @@ export const layer = Layer.effect(
               }
             }
           }
-          const marker = yield* compaction.create({
+          yield* compaction.create({
             sessionID: input.sessionID,
             agent,
             model: input.prelude.model,
             auto: input.prelude.auto,
           })
-          preludeMarkerID = marker.id
         }
         return yield* runLoop(input.sessionID, {
           onProcessor: (handle) => {
             activeProcessor = handle
           },
         })
-      })
+      }).pipe(
+        Effect.catchCause((cause) => persistFailure(cause).pipe(Effect.andThen(Effect.failCause(cause)))),
+      )
       // rejectIfBusy is the prelude path's safety net: a prelude's side
       // effects (writing the compaction marker) only run when ensureRunning
       // actually executes `work`, and that only happens from the Idle branch
@@ -2644,12 +2648,16 @@ export const layer = Layer.effect(
         state.ensureRunning(input.sessionID, onInterrupt, work, {
           rejectIfBusy: input.prelude !== undefined,
           runLifecycle,
-          onCancel: () => activeProcessor?.abortTools?.() ?? Effect.void,
+          onCancel: () =>
+            Effect.gen(function* () {
+              interrupted = true
+              yield* activeProcessor?.abortTools?.() ?? Effect.void
+            }),
         })
       const exit = yield* runOnce().pipe(Effect.exit)
       if (Exit.isSuccess(exit)) {
         if (interrupted) return exit.value
-        if (yield* tracedMessageHasAssistant()) return exit.value
+        if (tracedMessageCoveredBy(exit.value)) return exit.value
 
         // A prompt can land after the active run's final message scan but
         // before Runner transitions to Idle. In that narrow window
@@ -2657,9 +2665,10 @@ export const layer = Layer.effect(
         // ignored. Retry once after the joined run has completed so the saved
         // user message receives its own turn instead of becoming an orphan.
         const retry = yield* runOnce().pipe(Effect.exit)
-        if (Exit.isSuccess(retry) && (yield* tracedMessageHasAssistant())) return retry.value
+        if (Exit.isSuccess(retry) && interrupted) return retry.value
+        if (Exit.isSuccess(retry) && tracedMessageCoveredBy(retry.value)) return retry.value
         if (Exit.isFailure(retry)) {
-          if (!Cause.hasInterruptsOnly(retry.cause)) yield* persistTerminalErrorCarrier(Cause.squash(retry.cause))
+          if (!workStarted) yield* persistFailure(retry.cause)
           return yield* Effect.failCause(retry.cause)
         }
 
@@ -2669,7 +2678,7 @@ export const layer = Layer.effect(
         yield* persistTerminalErrorCarrier(error)
         return yield* Effect.die(error)
       }
-      if (!Cause.hasInterruptsOnly(exit.cause)) yield* persistTerminalErrorCarrier(Cause.squash(exit.cause))
+      if (!workStarted) yield* persistFailure(exit.cause)
       return yield* Effect.failCause(exit.cause)
     })
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1822,9 +1822,22 @@ export const layer = Layer.effect(
       return { info, parts }
     }, Effect.scoped)
 
+    type PromptAttempt = {
+      interrupted: boolean
+      activeProcessor?: SessionProcessor.Handle
+      compactionMarkerID?: MessageID
+    }
+    const cancelAttempt = (attempt: PromptAttempt) => () =>
+      Effect.gen(function* () {
+        attempt.interrupted = true
+        yield* attempt.activeProcessor?.abortTools?.() ?? Effect.void
+      })
+
     const prompt: (input: PromptInput, options?: PromptRuntimeOptions) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
       "SessionPrompt.prompt",
     )(function* (input: PromptInput, options?: PromptRuntimeOptions) {
+      const attempt: PromptAttempt = { interrupted: false }
+      yield* state.observeCancel(input.sessionID, cancelAttempt(attempt))
       yield* throwIfAborted(options)
       interruptedSessions.delete(input.sessionID)
       const session = yield* sessions.get(input.sessionID)
@@ -1865,8 +1878,8 @@ export const layer = Layer.effect(
 
       yield* throwIfAborted(options)
       if (input.noReply === true) return message
-      return yield* loop({ sessionID: input.sessionID, traceMessageID: message.info.id }, options)
-    })
+      return yield* loopAttempt({ sessionID: input.sessionID, traceMessageID: message.info.id }, options, attempt)
+    }, Effect.scoped)
 
     const appendRunLifecycleEvent = Effect.fn("SessionPrompt.appendRunLifecycleEvent")(function* (
       sessionID: SessionID,
@@ -1957,9 +1970,18 @@ export const layer = Layer.effect(
 
     const runLoop: (
       sessionID: SessionID,
-      options?: { onProcessor?: (handle: SessionProcessor.Handle) => void },
+      options?: {
+        onProcessor?: (handle: SessionProcessor.Handle) => void
+        onCompactionMarker?: (messageID: MessageID | undefined) => void
+      },
     ) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
-      function* (sessionID: SessionID, options?: { onProcessor?: (handle: SessionProcessor.Handle) => void }) {
+      function* (
+        sessionID: SessionID,
+        options?: {
+          onProcessor?: (handle: SessionProcessor.Handle) => void
+          onCompactionMarker?: (messageID: MessageID | undefined) => void
+        },
+      ) {
         const ctx = yield* InstanceState.context
         const automation = yield* AutomationRunContext.current
         const slog = elog.with({ sessionID })
@@ -2005,7 +2027,7 @@ export const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastAssistant.parentID === lastUser.id
           ) {
             const tokens = lastFinished?.tokens
             const hasTokenUsage =
@@ -2019,8 +2041,11 @@ export const layer = Layer.effect(
             if (lastFinished && lastFinished.summary !== true && hasTokenUsage) {
               const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
               if (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model })) {
+                const markerID = MessageID.ascending()
+                options?.onCompactionMarker?.(markerID)
                 yield* compaction.create({
                   sessionID,
+                  messageID: markerID,
                   agent: lastUser.agent,
                   model: lastUser.model,
                   auto: true,
@@ -2061,6 +2086,7 @@ export const layer = Layer.effect(
               overflow: task.overflow,
               executionContext: session.executionContext,
             })
+            options?.onCompactionMarker?.(undefined)
             if (result === "stop") break
             continue
           }
@@ -2076,7 +2102,15 @@ export const layer = Layer.effect(
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
-            yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+            const markerID = MessageID.ascending()
+            options?.onCompactionMarker?.(markerID)
+            yield* compaction.create({
+              sessionID,
+              messageID: markerID,
+              agent: lastUser.agent,
+              model: lastUser.model,
+              auto: true,
+            })
             continue
           }
 
@@ -2310,8 +2344,11 @@ export const layer = Layer.effect(
 
             if (result === "stop") return "break" as const
             if (result === "compact") {
+              const markerID = MessageID.ascending()
+              options?.onCompactionMarker?.(markerID)
               yield* compaction.create({
                 sessionID,
+                messageID: markerID,
                 agent: lastUser.agent,
                 model: lastUser.model,
                 auto: true,
@@ -2329,21 +2366,30 @@ export const layer = Layer.effect(
       },
     )
 
-    const loop: (
+    const loopAttempt: (
       input: z.infer<typeof LoopInput>,
-      options?: PromptRuntimeOptions,
+      options: PromptRuntimeOptions | undefined,
+      attempt: PromptAttempt,
     ) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
-      "SessionPrompt.loop",
-    )(function* (input: z.infer<typeof LoopInput>, options?: PromptRuntimeOptions) {
-      let activeProcessor: SessionProcessor.Handle | undefined
-      let interrupted = false
+      "SessionPrompt.loopAttempt",
+    )(function* (
+      input: z.infer<typeof LoopInput>,
+      options: PromptRuntimeOptions | undefined,
+      currentAttempt: PromptAttempt,
+    ) {
       const persistTerminalErrorCarrier = Effect.fn("SessionPrompt.persistTerminalErrorCarrier")(function* (
         error: unknown,
+        options?: {
+          parentID?: MessageID
+          aborted?: boolean
+          diagnostics?: MessageV2.Assistant["diagnostics"]
+        },
       ) {
-        if (!input.traceMessageID) return
+        const parentID = options?.parentID ?? input.traceMessageID
+        if (!parentID) return
         const traced = yield* sessions.findMessage(
           input.sessionID,
-          (message) => message.info.id === input.traceMessageID,
+          (message) => message.info.id === parentID,
         )
         const parent = Option.isSome(traced) ? traced.value : undefined
         if (!parent || parent.info.role !== "user") return
@@ -2356,7 +2402,7 @@ export const layer = Layer.effect(
         const completedAt = Date.now()
         const terminalError = MessageV2.fromError(error, {
           providerID: parentInfo.model.providerID,
-          aborted: false,
+          aborted: options?.aborted ?? false,
         })
         if (Option.isSome(existing) && existing.value.info.role === "assistant") {
           const assistant = existing.value.info
@@ -2365,10 +2411,14 @@ export const layer = Layer.effect(
               ...assistant,
               time: { ...assistant.time, completed: completedAt },
               error: assistant.error ?? terminalError,
-              finish: assistant.finish ?? "error",
+              finish: "error",
+              diagnostics: options?.diagnostics
+                ? { ...(assistant.diagnostics ?? {}), ...options.diagnostics }
+                : assistant.diagnostics,
             })
             return
           }
+          if (assistant.error || assistant.finish === "error") return
         }
 
         const session = yield* sessions.get(input.sessionID)
@@ -2396,6 +2446,7 @@ export const layer = Layer.effect(
           time: { created: completedAt, completed: completedAt },
           error: terminalError,
           finish: "error",
+          diagnostics: options?.diagnostics,
         }
         yield* sessions.updateMessage(carrier)
       })
@@ -2413,12 +2464,17 @@ export const layer = Layer.effect(
           ),
         )
       }
-      // One run may merge several user messages into the assistant turn parented
-      // by the newest message. ID ordering proves an older traced message was
-      // included without requiring every merged user to own a separate child.
-      const tracedMessageCoveredBy = (message: MessageV2.WithParts) =>
-        !input.traceMessageID ||
-        (message.info.role === "assistant" && message.info.summary !== true && message.info.id > input.traceMessageID)
+      const tracedMessageCoveredBy = Effect.fn("SessionPrompt.tracedMessageCoveredBy")(function* (
+        message: MessageV2.WithParts,
+      ) {
+        if (!input.traceMessageID) return true
+        if (message.info.role !== "assistant") return false
+        const parentID = message.info.parentID
+        const messages = yield* sessions.messages({ sessionID: input.sessionID })
+        const traceIndex = messages.findIndex((candidate) => candidate.info.id === input.traceMessageID)
+        const parentIndex = messages.findIndex((candidate) => candidate.info.id === parentID)
+        return traceIndex >= 0 && parentIndex >= traceIndex
+      })
       const onInterrupt = (meta?: {
         source?: string
         reason?: string
@@ -2427,41 +2483,18 @@ export const layer = Layer.effect(
         recordedAt?: number
       }) =>
         Effect.gen(function* () {
-          interrupted = true
+          currentAttempt.interrupted = true
           interruptedSessions.add(input.sessionID)
-          // Sweep any pending compaction marker first — a user message with
-          // a `compaction` part but no summary assistant child. Covers two
-          // race shapes: (1) marker just written, processCompaction has not
-          // reached its placeholder yet; (2) a normal SessionPrompt.prompt
-          // landed while compaction was running and persisted its user
-          // message before awaitRun, so currentTurnTarget now points at
-          // that newer user instead of the marker. Both leave the marker
-          // orphaned and the divider would render `failed` even though the
-          // cancel was a clean abort.
-          //
-          // Semantic boundary — only handle the *newest* compaction marker,
-          // and only if it lacks a summary child. Do NOT iterate older
-          // markers looking for any orphan. A historical orphan (e.g. left
-          // by a crashed prior session) is rendered `failed` by the divider
-          // because it *actually* failed; rewriting it as `aborted` here
-          // would attribute a past crash to the current cancel and stamp
-          // it with this cancel's `propagation_point`, which is a lie.
-          //
-          // The "newest marker = the marker this cancel can be attributed
-          // to" invariant rests on two upstream guarantees: (a) the Runner
-          // is per-session and serial — only one work effect can be writing
-          // a marker at any moment; (b) the prelude path uses rejectIfBusy
-          // (run-state.ts ~L173), so a second /summarize cannot land
-          // concurrently and produce a competing newer marker. If either
-          // guarantee weakens, this sweep would need run-local attribution
-          // (e.g. capture a high-water-mark message id at work entry and
-          // only match markers above it).
-          const pendingMarker = yield* sessions.findMessage(input.sessionID, (m) =>
-            m.info.role === "user" && m.parts.some((p) => p.type === "compaction"),
-          )
-          if (Option.isSome(pendingMarker)) {
-            const markerInfo = pendingMarker.value.info
-            if (markerInfo.role === "user") {
+          if (currentAttempt.compactionMarkerID) {
+            const pendingMarker = yield* sessions.findMessage(
+              input.sessionID,
+              (message) => message.info.id === currentAttempt.compactionMarkerID,
+            )
+            if (Option.isNone(pendingMarker)) {
+              currentAttempt.compactionMarkerID = undefined
+              if (!input.traceMessageID) return yield* lastAssistant(input.sessionID)
+            } else if (pendingMarker.value.info.role === "user") {
+              const markerInfo = pendingMarker.value.info
               const summaryChild = yield* sessions.findMessage(
                 input.sessionID,
                 (m) =>
@@ -2525,6 +2558,40 @@ export const layer = Layer.effect(
             }
           }
           const assistant = yield* currentTurnTarget(input.sessionID)
+          if (assistant.info.role === "user") {
+            const recordedAt = meta?.recordedAt ?? Date.now()
+            const abortError = new DOMException("Aborted", "AbortError")
+            const serialized = MessageV2.fromError(abortError, {
+              providerID: assistant.info.model.providerID,
+              aborted: true,
+            })
+            yield* persistTerminalErrorCarrier(abortError, {
+              parentID: assistant.info.id,
+              aborted: true,
+              diagnostics: {
+                abort: {
+                  source: meta?.source,
+                  reason: meta?.reason,
+                  title_generation_state: titleGenerationStateAtAbort(
+                    titleGenerationProgress.get(input.sessionID),
+                    recordedAt,
+                  ),
+                  propagation_point: meta?.propagationPoint ?? "session.prompt.loop.onInterrupt",
+                  error_name: serialized.name,
+                  error_message:
+                    "data" in serialized &&
+                    serialized.data &&
+                    typeof serialized.data === "object" &&
+                    "message" in serialized.data
+                      ? String(serialized.data.message)
+                      : undefined,
+                  via_ctx_abort: meta?.viaCtxAbort,
+                  recorded_at: recordedAt,
+                },
+              },
+            })
+            return yield* lastAssistant(input.sessionID)
+          }
           if (assistant.info.role === "assistant") {
             const shouldFinalize = !assistant.info.time.completed
             const error =
@@ -2610,8 +2677,11 @@ export const layer = Layer.effect(
               }
             }
           }
+          const markerID = MessageID.ascending()
+          currentAttempt.compactionMarkerID = markerID
           yield* compaction.create({
             sessionID: input.sessionID,
+            messageID: markerID,
             agent,
             model: input.prelude.model,
             auto: input.prelude.auto,
@@ -2619,7 +2689,10 @@ export const layer = Layer.effect(
         }
         return yield* runLoop(input.sessionID, {
           onProcessor: (handle) => {
-            activeProcessor = handle
+            currentAttempt.activeProcessor = handle
+          },
+          onCompactionMarker: (messageID) => {
+            currentAttempt.compactionMarkerID = messageID
           },
         })
       }).pipe(
@@ -2648,25 +2721,22 @@ export const layer = Layer.effect(
         state.ensureRunning(input.sessionID, onInterrupt, work, {
           rejectIfBusy: input.prelude !== undefined,
           runLifecycle,
-          onCancel: () =>
-            Effect.gen(function* () {
-              interrupted = true
-              yield* activeProcessor?.abortTools?.() ?? Effect.void
-            }),
         })
       const exit = yield* runOnce().pipe(Effect.exit)
       if (Exit.isSuccess(exit)) {
-        if (interrupted) return exit.value
-        if (tracedMessageCoveredBy(exit.value)) return exit.value
+        if (currentAttempt.interrupted) return exit.value
+        if (yield* tracedMessageCoveredBy(exit.value)) return exit.value
 
         // A prompt can land after the active run's final message scan but
         // before Runner transitions to Idle. In that narrow window
         // ensureRunning joins the finishing run and its work is intentionally
         // ignored. Retry once after the joined run has completed so the saved
         // user message receives its own turn instead of becoming an orphan.
+        workStarted = false
+        currentAttempt.activeProcessor = undefined
         const retry = yield* runOnce().pipe(Effect.exit)
-        if (Exit.isSuccess(retry) && interrupted) return retry.value
-        if (Exit.isSuccess(retry) && tracedMessageCoveredBy(retry.value)) return retry.value
+        if (Exit.isSuccess(retry) && currentAttempt.interrupted) return retry.value
+        if (Exit.isSuccess(retry) && (yield* tracedMessageCoveredBy(retry.value))) return retry.value
         if (Exit.isFailure(retry)) {
           if (!workStarted) yield* persistFailure(retry.cause)
           return yield* Effect.failCause(retry.cause)
@@ -2675,12 +2745,24 @@ export const layer = Layer.effect(
         const error = new NamedError.Unknown({
           message: "Session run completed without handling the submitted message",
         })
-        yield* persistTerminalErrorCarrier(error)
-        return yield* Effect.die(error)
+        const cause = Cause.die(error)
+        yield* persistFailure(cause)
+        return yield* Effect.failCause(cause)
       }
       if (!workStarted) yield* persistFailure(exit.cause)
       return yield* Effect.failCause(exit.cause)
     })
+
+    const loop: (
+      input: z.infer<typeof LoopInput>,
+      options?: PromptRuntimeOptions,
+    ) => Effect.Effect<MessageV2.WithParts> = Effect.fn(
+      "SessionPrompt.loop",
+    )(function* (input: z.infer<typeof LoopInput>, options?: PromptRuntimeOptions) {
+      const attempt: PromptAttempt = { interrupted: false }
+      yield* state.observeCancel(input.sessionID, cancelAttempt(attempt))
+      return yield* loopAttempt(input, options, attempt)
+    }, Effect.scoped)
 
     const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.shell")(
       function* (input: ShellInput) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1915,6 +1915,7 @@ export const layer = Layer.effect(
       interrupted: boolean
       cancelMeta?: InterruptMeta
       activeProcessor?: SessionProcessor.Handle
+      activeParentID?: MessageID
       compactionMarkerID?: MessageID
     }
     const persistAttemptAbort = Effect.fn("SessionPrompt.persistAttemptAbort")(function* (
@@ -2063,18 +2064,6 @@ export const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
-    const currentTurnTarget = Effect.fnUntraced(function* (sessionID: SessionID) {
-      const latestUser = yield* sessions.findMessage(sessionID, (message) => message.info.role === "user")
-      if (Option.isNone(latestUser)) return yield* lastAssistant(sessionID)
-
-      const currentAssistant = yield* sessions.findMessage(
-        sessionID,
-        (message) => message.info.role === "assistant" && message.info.parentID === latestUser.value.info.id,
-      )
-      if (Option.isSome(currentAssistant)) return currentAssistant.value
-      return latestUser.value
-    })
-
     const shellCancelledAssistant = Effect.fnUntraced(function* (sessionID: SessionID) {
       const message = yield* lastAssistant(sessionID)
       if (message.info.role !== "assistant") return message
@@ -2127,6 +2116,7 @@ export const layer = Layer.effect(
       sessionID: SessionID,
       options?: {
         onProcessor?: (handle: SessionProcessor.Handle) => void
+        onTurnParent?: (messageID: MessageID) => void
         onCompactionMarker?: (messageID: MessageID | undefined) => void
       },
     ) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
@@ -2134,6 +2124,7 @@ export const layer = Layer.effect(
         sessionID: SessionID,
         options?: {
           onProcessor?: (handle: SessionProcessor.Handle) => void
+          onTurnParent?: (messageID: MessageID) => void
           onCompactionMarker?: (messageID: MessageID | undefined) => void
         },
       ) {
@@ -2168,6 +2159,7 @@ export const layer = Layer.effect(
           }
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
+          options?.onTurnParent?.(lastUser.id)
           // Some providers return "stop" even when the assistant message contains tool calls.
           // Keep the loop running so tool results can be sent back to the model, but ignore
           // cleanup-marked interrupted orphans — those are abandoned, not pending work.
@@ -2645,17 +2637,12 @@ export const layer = Layer.effect(
             return terminal ?? (yield* lastAssistant(input.sessionID))
           }
           if (input.prelude || !workStarted) return yield* lastAssistant(input.sessionID)
-
-          const target = yield* currentTurnTarget(input.sessionID)
-          if (
-            target.info.role === "assistant" &&
-            target.info.time.completed &&
-            target.info.error?.name !== "MessageAbortedError"
-          ) {
-            return target
-          }
-          const parentID = target.info.role === "user" ? target.info.id : target.info.parentID
-          const terminal = yield* persistAttemptAbort(currentAttempt, "session.prompt.loop.onInterrupt", parentID)
+          if (!currentAttempt.activeParentID) return yield* lastAssistant(input.sessionID)
+          const terminal = yield* persistAttemptAbort(
+            currentAttempt,
+            "session.prompt.loop.onInterrupt",
+            currentAttempt.activeParentID,
+          )
           return terminal ?? (yield* lastAssistant(input.sessionID))
         })
       const work = Effect.gen(function* () {
@@ -2711,6 +2698,9 @@ export const layer = Layer.effect(
         return yield* runLoop(input.sessionID, {
           onProcessor: (handle) => {
             currentAttempt.activeProcessor = handle
+          },
+          onTurnParent: (messageID) => {
+            currentAttempt.activeParentID = messageID
           },
           onCompactionMarker: (messageID) => {
             currentAttempt.compactionMarkerID = messageID

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -16,6 +16,10 @@ type RunLifecycleObserver = {
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void>
   readonly cancel: (sessionID: SessionID, meta?: InterruptMeta) => Effect.Effect<void>
+  readonly observeCancel: (
+    sessionID: SessionID,
+    observer: (meta?: InterruptMeta) => Effect.Effect<void>,
+  ) => Effect.Effect<void, never, Scope.Scope>
   readonly ensureRunning: (
     sessionID: SessionID,
     onInterrupt: (meta?: InterruptMeta) => Effect.Effect<MessageV2.WithParts>,
@@ -23,7 +27,6 @@ export interface Interface {
     options?: {
       rejectIfBusy?: boolean
       runLifecycle?: RunLifecycleObserver
-      onCancel?: (meta?: InterruptMeta) => Effect.Effect<void>
     },
   ) => Effect.Effect<MessageV2.WithParts>
   readonly startShell: (
@@ -258,15 +261,11 @@ export const layer = Layer.effect(
       options?: {
         rejectIfBusy?: boolean
         runLifecycle?: RunLifecycleObserver
-        onCancel?: (meta?: InterruptMeta) => Effect.Effect<void>
       },
     ) {
       const data = yield* InstanceState.get(state)
       const runnerOptions =
         options?.rejectIfBusy === undefined ? undefined : { rejectIfBusy: options.rejectIfBusy }
-      const unregisterCancelObserver = options?.onCancel
-        ? data.registerCancelObserver(sessionID, options.onCancel)
-        : undefined
       return yield* withActiveRun(
         data.directory,
         sessionID,
@@ -276,8 +275,17 @@ export const layer = Layer.effect(
           return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work, runnerOptions)
         }),
         options?.runLifecycle,
-      ).pipe(Effect.ensuring(Effect.sync(() => unregisterCancelObserver?.())))
+      )
     })
+
+    const observeCancel: Interface["observeCancel"] = (sessionID, observer) =>
+      Effect.acquireRelease(
+        Effect.gen(function* () {
+          const data = yield* InstanceState.get(state)
+          return data.registerCancelObserver(sessionID, observer)
+        }),
+        (unregister) => Effect.sync(unregister),
+      ).pipe(Effect.asVoid)
 
     const startShell = Effect.fn("SessionRunState.startShell")(function* (
       sessionID: SessionID,
@@ -295,7 +303,7 @@ export const layer = Layer.effect(
       )
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, cancel, observeCancel, ensureRunning, startShell })
   }),
 )
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -3293,11 +3293,16 @@ it.live(
           .pipe(Effect.forkChild)
 
         const deadline = Date.now() + 5000
+        let saved = false
         while (Date.now() < deadline) {
           const messages = yield* sessions.messages({ sessionID: chat.id })
-          if (messages.some((message) => message.info.id === messageID)) break
+          if (messages.some((message) => message.info.id === messageID)) {
+            saved = true
+            break
+          }
           yield* Effect.sleep("5 millis")
         }
+        expect(saved).toBe(true)
         gate.resolve()
 
         expect(Exit.isSuccess(yield* Fiber.await(occupying))).toBe(true)

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -301,7 +301,7 @@ function makeHttp(httpLayer: Layer.Layer<HttpClient.HttpClient> = FetchHttpClien
   return Layer.mergeAll(
     TestLLMServer.layer,
     SessionPrompt.layer.pipe(
-      Layer.provide(SessionRevert.defaultLayer),
+      Layer.provideMerge(SessionRevert.defaultLayer),
       Layer.provide(summary),
       Layer.provideMerge(run),
       Layer.provideMerge(compact),
@@ -811,6 +811,48 @@ it.live("prompt persists a terminal assistant when setup fails after the user me
   ),
 )
 
+it.live("prompt persists a terminal assistant when a user part fails to save", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "User part persistence failure" })
+      const mutableSessions = sessions as Mutable<typeof sessions>
+      const originalUpdatePart = sessions.updatePart
+      mutableSessions.updatePart = ((part: MessageV2.Part) =>
+        part.type === "text"
+          ? Effect.die(new Error("user part write failed"))
+          : originalUpdatePart(part)) as typeof sessions.updatePart
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => void (mutableSessions.updatePart = originalUpdatePart)),
+      )
+
+      const exit = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "hello" }],
+        })
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const savedUser = messages.find((message) => message.info.role === "user")
+      expect(savedUser?.info.role).toBe("user")
+      expect(
+        messages.some(
+          (message) =>
+            message.info.role === "assistant" &&
+            message.info.parentID === savedUser?.info.id &&
+            message.info.finish === "error",
+        ),
+      ).toBe(true)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("prompt finalizes its assistant carrier when later setup fails", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* () {
@@ -1041,6 +1083,64 @@ it.live("cancel prevents a queued prompt from starting after lifecycle wait", ()
             }
           }
           expect(yield* llm.calls).toBe(0)
+        } finally {
+          releaseClose()
+        }
+      }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("cancel finalizes every prompt queued behind a lifecycle wait without starting the model", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Cancel multiple lifecycle waits" })
+        const releaseClose = beginLifecycleClose([dir])
+        const messageIDs = [MessageID.ascending(), MessageID.ascending()]
+        const fibers = yield* Effect.forEach(messageIDs, (messageID, index) =>
+          prompt
+            .prompt({
+              sessionID: chat.id,
+              messageID,
+              agent: "build",
+              parts: [{ type: "text", text: `queued ${index}` }],
+            })
+            .pipe(Effect.forkChild),
+        )
+
+        try {
+          const deadline = Date.now() + 1000
+          while (Date.now() < deadline) {
+            const pending = yield* sessions.messages({ sessionID: chat.id })
+            const waiting = pending.filter(
+              (message) =>
+                message.info.role === "user" &&
+                messageIDs.includes(message.info.id) &&
+                message.info.diagnostics?.run_lifecycle?.some((event) => event.type === "run_wait_started"),
+            )
+            if (waiting.length === messageIDs.length) break
+            yield* Effect.sleep("5 millis")
+          }
+
+          expect(yield* prompt.cancel(chat.id)).toBe(true)
+          releaseClose()
+          const exits = yield* Effect.forEach(fibers, (fiber) => Fiber.await(fiber))
+          expect(exits.every(Exit.isSuccess)).toBe(true)
+          expect(yield* llm.calls).toBe(0)
+
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          for (const messageID of messageIDs) {
+            const terminals = messages.filter(
+              (message) => message.info.role === "assistant" && message.info.parentID === messageID,
+            )
+            expect(terminals).toHaveLength(1)
+            expect(terminals[0]?.info.role === "assistant" && terminals[0].info.error?.name).toBe(
+              "MessageAbortedError",
+            )
+          }
         } finally {
           releaseClose()
         }
@@ -2450,6 +2550,64 @@ it.live(
         expect(summary).toBeDefined()
         if (summary?.info.role === "assistant") {
           expect(summary.info.error?.name).toBe("MessageAbortedError")
+          expect(summary.info.finish).toBe("error")
+          expect(summary.info.time.completed).toBeNumber()
+        }
+      }),
+      { git: true, config: providerCfg },
+    ),
+)
+
+it.live(
+  "cancel before a compaction marker exists leaves completed history unchanged",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const revert = yield* SessionRevert.Service
+        const chat = yield* sessions.create({ title: "Early compaction prelude cancel" })
+        const seeded = yield* seed(chat.id, { finish: "stop" })
+        yield* sessions.updateMessage({
+          ...seeded.assistant,
+          time: { ...seeded.assistant.time, completed: Date.now() },
+        })
+
+        const started = defer<void>()
+        const mutableRevert = revert as Mutable<typeof revert>
+        const originalCleanup = revert.cleanup
+        mutableRevert.cleanup = ((session: Parameters<typeof revert.cleanup>[0]) =>
+          originalCleanup(session).pipe(
+            Effect.andThen(Effect.sync(() => started.resolve())),
+            Effect.andThen(Effect.never),
+          )) as typeof revert.cleanup
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => void (mutableRevert.cleanup = originalCleanup)),
+        )
+
+        const fiber = yield* prompt
+          .loop({
+            sessionID: chat.id,
+            prelude: {
+              type: "compaction",
+              agent: "build",
+              model: ref,
+              auto: false,
+            },
+          })
+          .pipe(Effect.forkChild)
+        yield* Effect.promise(() => started.promise)
+        expect(yield* prompt.cancel(chat.id)).toBe(true)
+        expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        expect(messages.some((message) => message.parts.some((part) => part.type === "compaction"))).toBe(false)
+        const historical = messages.find((message) => message.info.id === seeded.assistant.id)
+        expect(historical?.info.role).toBe("assistant")
+        if (historical?.info.role === "assistant") {
+          expect(historical.info.finish).toBe("stop")
+          expect(historical.info.error).toBeUndefined()
+          expect(historical.info.diagnostics?.abort).toBeUndefined()
         }
       }),
       { git: true, config: providerCfg },
@@ -2780,6 +2938,43 @@ it.live(
         if (Exit.isSuccess(exitA) && Exit.isSuccess(exitB)) {
           expect(exitA.value.info.id).toBe(exitB.value.info.id)
         }
+      }),
+      { git: true, config: providerCfg },
+    ),
+)
+
+it.live(
+  "concurrent traced callers create one abort carrier for the same user message",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "One terminal carrier" })
+        const submitted = yield* user(chat.id, "hello")
+        yield* llm.hang
+
+        const first = yield* prompt
+          .loop({ sessionID: chat.id, traceMessageID: submitted.id })
+          .pipe(Effect.forkChild)
+        yield* llm.wait(1)
+        const second = yield* prompt
+          .loop({ sessionID: chat.id, traceMessageID: submitted.id })
+          .pipe(Effect.forkChild)
+        yield* Effect.sleep("25 millis")
+
+        expect(yield* prompt.cancel(chat.id)).toBe(true)
+        const exits = yield* Effect.all([Fiber.await(first), Fiber.await(second)])
+        expect(exits.every(Exit.isSuccess)).toBe(true)
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const terminals = messages.filter(
+          (message) => message.info.role === "assistant" && message.info.parentID === submitted.id,
+        )
+        expect(terminals).toHaveLength(1)
+        expect(terminals[0]?.info.role === "assistant" && terminals[0].info.error?.name).toBe(
+          "MessageAbortedError",
+        )
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -745,48 +745,41 @@ it.live("prompt persists a terminal assistant when setup fails after the user me
   ),
 )
 
-it.live("prompt finalizes its existing assistant carrier when later setup fails", () =>
+it.live("prompt finalizes its assistant carrier when later setup fails", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* () {
       const prompt = yield* SessionPrompt.Service
       const sessions = yield* Session.Service
+      const plugin = yield* Plugin.Service
       const chat = yield* sessions.create({ title: "Existing pre-carrier failure" })
-      const savedUser = yield* prompt.prompt({
-        sessionID: chat.id,
-        agent: "build",
-        model: {
-          providerID: ProviderID.make("missing-provider"),
-          modelID: ModelID.make("missing-model"),
-        },
-        noReply: true,
-        parts: [{ type: "text", text: "hello" }],
-      })
-      const pending: MessageV2.Assistant = {
-        id: MessageID.ascending(),
-        role: "assistant",
-        parentID: savedUser.info.id,
-        sessionID: chat.id,
-        mode: "build",
-        agent: "build",
-        path: { cwd: chat.executionContext.activeDirectory, root: chat.executionContext.ownerDirectory },
-        cost: 0,
-        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-        modelID: ModelID.make("missing-model"),
-        providerID: ProviderID.make("missing-provider"),
-        time: { created: Date.now() },
-      }
-      yield* sessions.updateMessage(pending)
+      const mutablePlugin = plugin as Mutable<typeof plugin>
+      const originalTrigger = plugin.trigger
+      mutablePlugin.trigger = ((name: Parameters<typeof plugin.trigger>[0], input: unknown, output: unknown) => {
+        if (name === "experimental.chat.messages.transform") {
+          return Effect.die(new Error("message transform failed"))
+        }
+        return originalTrigger(name as never, input as never, output as never)
+      }) as typeof plugin.trigger
+      yield* Effect.addFinalizer(() => Effect.sync(() => void (mutablePlugin.trigger = originalTrigger)))
 
-      const exit = yield* prompt.loop({ sessionID: chat.id, traceMessageID: savedUser.info.id }).pipe(Effect.exit)
+      const exit = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "hello" }],
+        })
+        .pipe(Effect.exit)
 
       expect(Exit.isFailure(exit)).toBe(true)
       const messages = yield* sessions.messages({ sessionID: chat.id })
+      const savedUser = messages.find((message) => message.info.role === "user")
+      expect(savedUser?.info.role).toBe("user")
       const assistants = messages.filter(
-        (message) => message.info.role === "assistant" && message.info.parentID === savedUser.info.id,
+        (message) => message.info.role === "assistant" && message.info.parentID === savedUser?.info.id,
       )
       expect(assistants).toHaveLength(1)
       const terminal = assistants[0]
-      expect(terminal.info.id).toBe(pending.id)
       if (terminal.info.role === "assistant") {
         expect(terminal.info.finish).toBe("error")
         expect(terminal.info.error).toBeDefined()
@@ -820,7 +813,7 @@ it.live("compaction persists a terminal summary when setup fails after its marke
         })
         .pipe(Effect.exit)
 
-      expect(Exit.isFailure(exit)).toBe(true)
+      expect(Exit.isSuccess(exit)).toBe(true)
       const messages = yield* sessions.messages({ sessionID: chat.id })
       const marker = messages.find((message) => message.parts.some((part) => part.type === "compaction"))
       expect(marker).toBeDefined()
@@ -2223,146 +2216,6 @@ it.live(
 )
 
 it.live(
-  "cancel after compaction marker but before placeholder yields aborted carrier",
-  () =>
-    provideTmpdirServer(
-      Effect.fnUntraced(function* ({ llm }) {
-        const prompt = yield* SessionPrompt.Service
-        const sessions = yield* Session.Service
-        const chat = yield* sessions.create({ title: "Compaction prelude race cancel" })
-        yield* seed(chat.id, { finish: "stop" })
-        yield* llm.hang
-
-        const fiber = yield* prompt
-          .loop({
-            sessionID: chat.id,
-            prelude: { type: "compaction", agent: "build", model: ref, auto: false },
-          })
-          .pipe(Effect.forkChild)
-
-        // Polling targets the precise race window: marker present, summary
-        // placeholder not yet written. Breaking only on that combined state
-        // (rather than the marker alone) guarantees the cancel lands inside
-        // the window the new onInterrupt fallback was added to cover.
-        // observedRaceWindow distinguishes "loop hit the window then broke"
-        // from "deadline expired" — a setup failure (placeholder beat
-        // polling) fails explicitly here instead of producing a confusing
-        // propagation_point mismatch downstream.
-        const deadline = Date.now() + 5000
-        let observedRaceWindow = false
-        while (Date.now() < deadline) {
-          const snapshot = yield* sessions.messages({ sessionID: chat.id })
-          const hasMarker = snapshot.some((m) => m.parts.some((p) => p.type === "compaction"))
-          const hasPlaceholder = snapshot.some((m) => m.info.role === "assistant" && m.info.summary === true)
-          if (hasMarker && !hasPlaceholder) {
-            observedRaceWindow = true
-            break
-          }
-          yield* Effect.sleep("1 millis")
-        }
-        expect(observedRaceWindow).toBe(true)
-
-        const cancelled = yield* prompt.cancel(chat.id)
-        expect(cancelled).toBe(true)
-
-        const exit = yield* Fiber.await(fiber)
-        expect(Exit.isSuccess(exit)).toBe(true)
-
-        const msgs = yield* sessions.messages({ sessionID: chat.id })
-        const marker = msgs.find((m) => m.parts.some((p) => p.type === "compaction"))
-        expect(marker).toBeDefined()
-        const summary = msgs.find((m) => m.info.role === "assistant" && m.info.summary === true)
-        expect(summary).toBeDefined()
-        if (summary?.info.role === "assistant" && marker) {
-          expect(summary.info.error?.name).toBe("MessageAbortedError")
-          expect(summary.info.finish).toBe("error")
-          expect(typeof summary.info.time.completed).toBe("number")
-          expect(summary.info.parentID).toBe(marker.info.id)
-          // Locks the new onInterrupt fallback branch — if the test ever
-          // misses the race window and the existing processCompaction
-          // finalizer handles the cancel, propagation_point would differ.
-          expect(summary.info.diagnostics?.abort?.propagation_point).toBe(
-            "session.prompt.loop.onInterrupt.compaction_prelude",
-          )
-        }
-      }),
-      { git: true, config: providerCfg },
-    ),
-)
-
-it.live(
-  "cancel after a queued user message still resolves the orphaned compaction marker",
-  () =>
-    provideTmpdirServer(
-      Effect.fnUntraced(function* ({ llm }) {
-        const prompt = yield* SessionPrompt.Service
-        const sessions = yield* Session.Service
-        const chat = yield* sessions.create({ title: "Compaction queued-prompt race cancel" })
-        yield* seed(chat.id, { finish: "stop" })
-        yield* llm.hang
-
-        const fiber = yield* prompt
-          .loop({
-            sessionID: chat.id,
-            prelude: { type: "compaction", agent: "build", model: ref, auto: false },
-          })
-          .pipe(Effect.forkChild)
-
-        const deadline = Date.now() + 5000
-        let observedRaceWindow = false
-        while (Date.now() < deadline) {
-          const snapshot = yield* sessions.messages({ sessionID: chat.id })
-          const hasMarker = snapshot.some((m) => m.parts.some((p) => p.type === "compaction"))
-          const hasPlaceholder = snapshot.some((m) => m.info.role === "assistant" && m.info.summary === true)
-          if (hasMarker && !hasPlaceholder) {
-            observedRaceWindow = true
-            break
-          }
-          yield* Effect.sleep("1 millis")
-        }
-        expect(observedRaceWindow).toBe(true)
-
-        // Inject a queued user message ahead of the cancel — mirrors what
-        // SessionPrompt.prompt does when it lands while compaction is
-        // running: createUserMessage persists the new user before
-        // ensureRunning awaitRuns the existing run. After this,
-        // currentTurnTarget returns the queued user instead of the
-        // marker, so the older "current turn is marker" gate would skip
-        // the carrier write and leave the marker as an orphan rendering
-        // `failed`. The sweep must find the marker regardless.
-        const queuedUser = yield* user(chat.id, "queued prompt")
-
-        const cancelled = yield* prompt.cancel(chat.id)
-        expect(cancelled).toBe(true)
-
-        const exit = yield* Fiber.await(fiber)
-        expect(Exit.isSuccess(exit)).toBe(true)
-
-        const msgs = yield* sessions.messages({ sessionID: chat.id })
-        const marker = msgs.find((m) => m.parts.some((p) => p.type === "compaction"))
-        expect(marker).toBeDefined()
-        expect(queuedUser.id).not.toBe(marker?.info.id)
-        const summary = msgs.find(
-          (m) =>
-            m.info.role === "assistant" &&
-            m.info.summary === true &&
-            m.info.parentID === marker?.info.id,
-        )
-        expect(summary).toBeDefined()
-        if (summary?.info.role === "assistant" && marker) {
-          expect(summary.info.error?.name).toBe("MessageAbortedError")
-          expect(summary.info.finish).toBe("error")
-          expect(typeof summary.info.time.completed).toBe("number")
-          expect(summary.info.diagnostics?.abort?.propagation_point).toBe(
-            "session.prompt.loop.onInterrupt.compaction_prelude",
-          )
-        }
-      }),
-      { git: true, config: providerCfg },
-    ),
-)
-
-it.live(
   "prelude derives compaction agent from the post-cleanup latest user",
   () =>
     provideTmpdirServer(
@@ -2797,6 +2650,140 @@ it.live(
         const inputs = yield* llm.inputs
         expect(inputs).toHaveLength(2)
         expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("second")
+      }),
+      { git: true, config: providerCfg },
+    ),
+)
+
+it.live(
+  "multiple prompts submitted during an active run share the next assistant turn",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const gate = defer<void>()
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Merged active-run prompts" })
+
+        yield* llm.hold("first", gate.promise)
+        yield* llm.text("combined followup")
+
+        const first = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "first" }],
+          })
+          .pipe(Effect.forkChild)
+        yield* llm.wait(1)
+
+        const secondID = MessageID.ascending()
+        const second = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            messageID: secondID,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "second" }],
+          })
+          .pipe(Effect.forkChild)
+        const thirdID = MessageID.ascending()
+        const third = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            messageID: thirdID,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "third" }],
+          })
+          .pipe(Effect.forkChild)
+
+        const deadline = Date.now() + 5000
+        while (Date.now() < deadline) {
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          const secondSaved = messages.some((message) => message.info.id === secondID)
+          const thirdSaved = messages.some((message) => message.info.id === thirdID)
+          if (secondSaved && thirdSaved) {
+            break
+          }
+          yield* Effect.sleep("5 millis")
+        }
+        gate.resolve()
+
+        const exits = yield* Effect.all([Fiber.await(first), Fiber.await(second), Fiber.await(third)])
+        expect(exits.every(Exit.isSuccess)).toBe(true)
+        expect(yield* llm.calls).toBe(2)
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const followup = messages.find(
+          (message) => message.info.role === "assistant" && message.info.parentID === thirdID,
+        )
+        expect(followup?.parts.some((part) => part.type === "text" && part.text === "combined followup")).toBe(true)
+        expect(
+          messages.some(
+            (message) =>
+              message.info.role === "assistant" &&
+              message.info.parentID === secondID &&
+              message.info.finish === "error",
+          ),
+        ).toBe(false)
+      }),
+      { git: true, config: providerCfg },
+    ),
+)
+
+it.live(
+  "cancel does not restart a prompt joined to the active run",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Cancel joined prompt" })
+
+        yield* llm.hang
+        yield* llm.text("must not run after cancel")
+
+        const active = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "active" }],
+          })
+          .pipe(Effect.forkChild)
+        yield* llm.wait(1)
+
+        const queuedID = MessageID.ascending()
+        const queued = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            messageID: queuedID,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "queued" }],
+          })
+          .pipe(Effect.forkChild)
+
+        const deadline = Date.now() + 5000
+        while (Date.now() < deadline) {
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          if (messages.some((message) => message.info.id === queuedID)) break
+          yield* Effect.sleep("5 millis")
+        }
+
+        yield* prompt.cancel(chat.id)
+        const exits = yield* Effect.all([Fiber.await(active), Fiber.await(queued)])
+        expect(exits.every(Exit.isSuccess)).toBe(true)
+        expect(yield* llm.calls).toBe(1)
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        expect(
+          messages.some(
+            (message) => message.info.role === "assistant" && message.info.parentID === queuedID,
+          ),
+        ).toBe(false)
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -2228,7 +2228,7 @@ it.live(
 )
 
 it.live(
-  "cancel after assistant scaffold save finalizes before processor handle",
+  "cancel finalizes the active scaffold and queued prompt against their own parents",
   () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* () {
@@ -2261,10 +2261,30 @@ it.live(
           Effect.exit,
         )
         expect(Exit.isSuccess(startedExit)).toBe(true)
+
+        const queuedID = MessageID.ascending()
+        const queued = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            messageID: queuedID,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "queued" }],
+          })
+          .pipe(Effect.forkChild)
+        const queuedDeadline = Date.now() + 1000
+        while (Date.now() < queuedDeadline) {
+          const pending = yield* sessions.messages({ sessionID: chat.id })
+          if (pending.some((message) => message.info.id === queuedID)) break
+          yield* Effect.sleep("5 millis")
+        }
+
         const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout(cancelRaceCheckpointTimeout), Effect.exit)
         expect(Exit.isSuccess(cancelExit)).toBe(true)
-        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout(cancelRaceCheckpointTimeout))
-        expect(Exit.isSuccess(exit)).toBe(true)
+        const exits = yield* Effect.all([Fiber.await(fiber), Fiber.await(queued)]).pipe(
+          Effect.timeout(cancelRaceCheckpointTimeout),
+        )
+        expect(exits.every(Exit.isSuccess)).toBe(true)
 
         const messages = yield* sessions.messages({ sessionID: chat.id })
         const assistant = messages.find(
@@ -2281,6 +2301,14 @@ it.live(
           propagation_point: "session.prompt.loop.onInterrupt",
           error_name: "MessageAbortedError",
         })
+        const queuedTerminal = messages.find(
+          (message) => message.info.role === "assistant" && message.info.parentID === queuedID,
+        )
+        expect(queuedTerminal?.info.role).toBe("assistant")
+        if (queuedTerminal?.info.role === "assistant") {
+          expect(queuedTerminal.info.error?.name).toBe("MessageAbortedError")
+          expect(queuedTerminal.info.time.completed).toBeNumber()
+        }
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -708,6 +708,137 @@ it.live("loop calls LLM and returns assistant message", () =>
   ),
 )
 
+it.live("prompt persists a terminal assistant when setup fails after the user message is saved", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pre-carrier failure" })
+
+      const exit = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          agent: "build",
+          model: {
+            providerID: ProviderID.make("missing-provider"),
+            modelID: ModelID.make("missing-model"),
+          },
+          parts: [{ type: "text", text: "hello" }],
+        })
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const savedUser = messages.find((message) => message.info.role === "user")
+      expect(savedUser).toBeDefined()
+      const terminal = messages.find(
+        (message) => message.info.role === "assistant" && message.info.parentID === savedUser?.info.id,
+      )
+      expect(terminal?.info.role).toBe("assistant")
+      if (terminal?.info.role === "assistant") {
+        expect(terminal.info.finish).toBe("error")
+        expect(terminal.info.error).toBeDefined()
+        expect(typeof terminal.info.time.completed).toBe("number")
+      }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("prompt finalizes its existing assistant carrier when later setup fails", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Existing pre-carrier failure" })
+      const savedUser = yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: {
+          providerID: ProviderID.make("missing-provider"),
+          modelID: ModelID.make("missing-model"),
+        },
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      const pending: MessageV2.Assistant = {
+        id: MessageID.ascending(),
+        role: "assistant",
+        parentID: savedUser.info.id,
+        sessionID: chat.id,
+        mode: "build",
+        agent: "build",
+        path: { cwd: chat.executionContext.activeDirectory, root: chat.executionContext.ownerDirectory },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: ModelID.make("missing-model"),
+        providerID: ProviderID.make("missing-provider"),
+        time: { created: Date.now() },
+      }
+      yield* sessions.updateMessage(pending)
+
+      const exit = yield* prompt.loop({ sessionID: chat.id, traceMessageID: savedUser.info.id }).pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const assistants = messages.filter(
+        (message) => message.info.role === "assistant" && message.info.parentID === savedUser.info.id,
+      )
+      expect(assistants).toHaveLength(1)
+      const terminal = assistants[0]
+      expect(terminal.info.id).toBe(pending.id)
+      if (terminal.info.role === "assistant") {
+        expect(terminal.info.finish).toBe("error")
+        expect(terminal.info.error).toBeDefined()
+        expect(typeof terminal.info.time.completed).toBe("number")
+      }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("compaction persists a terminal summary when setup fails after its marker is saved", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Compaction pre-carrier failure" })
+      yield* seed(chat.id, { finish: "stop" })
+
+      const exit = yield* prompt
+        .loop({
+          sessionID: chat.id,
+          prelude: {
+            type: "compaction",
+            agent: "build",
+            model: {
+              providerID: ProviderID.make("missing-provider"),
+              modelID: ModelID.make("missing-model"),
+            },
+            auto: false,
+          },
+        })
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const marker = messages.find((message) => message.parts.some((part) => part.type === "compaction"))
+      expect(marker).toBeDefined()
+      const terminal = messages.find(
+        (message) =>
+          message.info.role === "assistant" && message.info.summary === true && message.info.parentID === marker?.info.id,
+      )
+      expect(terminal?.info.role).toBe("assistant")
+      if (terminal?.info.role === "assistant") {
+        expect(terminal.info.finish).toBe("error")
+        expect(terminal.info.error).toBeDefined()
+        expect(typeof terminal.info.time.completed).toBe("number")
+      }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("prompt records lifecycle wait diagnostics on the queued user message", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
@@ -2666,6 +2797,63 @@ it.live(
         const inputs = yield* llm.inputs
         expect(inputs).toHaveLength(2)
         expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("second")
+      }),
+      { git: true, config: providerCfg },
+    ),
+)
+
+it.live(
+  "prompt starts a new run when the joined run exits without handling its user message",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const gate = defer<void>()
+        const ready = defer<void>()
+        const { prompt, run, sessions, chat } = yield* boot({ title: "Joined run exits" })
+        const seeded = yield* seed(chat.id, { finish: "stop" })
+        const previous = { info: seeded.assistant, parts: [] } satisfies MessageV2.WithParts
+
+        const occupying = yield* run
+          .ensureRunning(
+            chat.id,
+            () => Effect.succeed(previous),
+            Effect.gen(function* () {
+              ready.resolve()
+              yield* Effect.promise(() => gate.promise)
+              return previous
+            }),
+          )
+          .pipe(Effect.forkChild)
+        yield* Effect.promise(() => ready.promise)
+
+        yield* llm.text("handled after join")
+        const messageID = MessageID.ascending()
+        const submitted = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            messageID,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "queued at runner exit" }],
+          })
+          .pipe(Effect.forkChild)
+
+        const deadline = Date.now() + 5000
+        while (Date.now() < deadline) {
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          if (messages.some((message) => message.info.id === messageID)) break
+          yield* Effect.sleep("5 millis")
+        }
+        gate.resolve()
+
+        expect(Exit.isSuccess(yield* Fiber.await(occupying))).toBe(true)
+        expect(Exit.isSuccess(yield* Fiber.await(submitted))).toBe(true)
+        expect(yield* llm.calls).toBe(1)
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const assistant = messages.find(
+          (message) => message.info.role === "assistant" && message.info.parentID === messageID,
+        )
+        expect(assistant?.parts.some((part) => part.type === "text" && part.text === "handled after join")).toBe(true)
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -708,6 +708,72 @@ it.live("loop calls LLM and returns assistant message", () =>
   ),
 )
 
+it.live("prompt handles a custom message ID without restarting the model", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Custom message ID" })
+      const messageID = MessageID.ascending("msg_zzzz")
+      yield* llm.text("world")
+      yield* llm.fail("duplicate run")
+
+      const exit = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "hello" }],
+        })
+        .pipe(Effect.exit)
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(yield* llm.calls).toBe(1)
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      expect(
+        messages.some(
+          (message) => message.info.role === "assistant" && message.info.parentID === messageID,
+        ),
+      ).toBe(true)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("prompt accepts a terminal compaction summary without retrying", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Terminal compaction summary" })
+      const seeded = yield* seed(chat.id, { finish: "stop" })
+      yield* sessions.updateMessage({
+        ...seeded.assistant,
+        tokens: { input: 95_000, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+      })
+      yield* llm.fail("compaction failed")
+
+      const exit = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "continue" }],
+        })
+        .pipe(Effect.exit)
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(yield* llm.calls).toBe(1)
+      if (Exit.isSuccess(exit)) {
+        expect(exit.value.info.role).toBe("assistant")
+        if (exit.value.info.role === "assistant") expect(exit.value.info.summary).toBe(true)
+      }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("prompt persists a terminal assistant when setup fails after the user message is saved", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* () {
@@ -832,6 +898,45 @@ it.live("compaction persists a terminal summary when setup fails after its marke
   ),
 )
 
+it.live("compaction rolls back its marker when the marker part cannot be saved", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Incomplete compaction marker" })
+      yield* seed(chat.id, { finish: "stop" })
+
+      const mutableSessions = sessions as Mutable<typeof sessions>
+      const originalUpdatePart = sessions.updatePart
+      mutableSessions.updatePart = ((part: MessageV2.Part) =>
+        part.type === "compaction"
+          ? Effect.die(new Error("compaction part write failed"))
+          : originalUpdatePart(part)) as typeof sessions.updatePart
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => void (mutableSessions.updatePart = originalUpdatePart)),
+      )
+
+      const exit = yield* prompt
+        .loop({
+          sessionID: chat.id,
+          prelude: {
+            type: "compaction",
+            agent: "build",
+            model: ref,
+            auto: false,
+          },
+        })
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      expect(messages.some((message) => message.parts.some((part) => part.type === "compaction"))).toBe(false)
+      expect(messages.filter((message) => message.info.role === "user")).toHaveLength(1)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("prompt records lifecycle wait diagnostics on the queued user message", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
@@ -929,7 +1034,11 @@ it.live("cancel prevents a queued prompt from starting after lifecycle wait", ()
           const exit = yield* Fiber.await(fiber).pipe(Effect.timeout(cancelRaceCheckpointTimeout))
           expect(Exit.isSuccess(exit)).toBe(true)
           if (Exit.isSuccess(exit) && queuedUser) {
-            expect(exit.value.info.id).toBe(queuedUser.info.id)
+            expect(exit.value.info.role).toBe("assistant")
+            if (exit.value.info.role === "assistant") {
+              expect(exit.value.info.parentID).toBe(queuedUser.info.id)
+              expect(exit.value.info.error?.name).toBe("MessageAbortedError")
+            }
           }
           expect(yield* llm.calls).toBe(0)
         } finally {
@@ -2169,6 +2278,138 @@ it.live(
 )
 
 it.live(
+  "cancel leaves a historical compaction failure unchanged",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Historical compaction failure" })
+        const historicalMarker = yield* user(chat.id, "historical marker")
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: historicalMarker.id,
+          sessionID: chat.id,
+          type: "compaction",
+          auto: false,
+        })
+        yield* llm.hang
+
+        const active = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "current prompt" }],
+          })
+          .pipe(Effect.forkChild)
+        yield* llm.wait(1)
+        yield* prompt.cancel(chat.id)
+        expect(Exit.isSuccess(yield* Fiber.await(active))).toBe(true)
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        expect(
+          messages.some(
+            (message) =>
+              message.info.role === "assistant" &&
+              message.info.parentID === historicalMarker.id &&
+              message.info.summary === true,
+          ),
+        ).toBe(false)
+        const currentUser = messages.find(
+          (message) =>
+            message.info.role === "user" &&
+            message.parts.some((part) => part.type === "text" && part.text === "current prompt"),
+        )
+        const terminal = messages.find(
+          (message) => message.info.role === "assistant" && message.info.parentID === currentUser?.info.id,
+        )
+        expect(terminal?.info.role).toBe("assistant")
+        if (terminal?.info.role === "assistant") expect(terminal.info.error?.name).toBe("MessageAbortedError")
+      }),
+      { git: true, config: providerCfg },
+    ),
+)
+
+it.live(
+  "cancel attributes a pending compaction to the current prelude marker",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* () {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const compaction = yield* SessionCompaction.Service
+        const chat = yield* sessions.create({ title: "Current compaction ownership" })
+        yield* seed(chat.id, { finish: "stop" })
+
+        const markerSaved = defer<void>()
+        const mutableCompaction = compaction as Mutable<typeof compaction>
+        const originalCreate = compaction.create
+        // Preserve the real marker write and only hold the boundary before
+        // runLoop can create its summary placeholder.
+        mutableCompaction.create = ((input: Parameters<typeof compaction.create>[0]) =>
+          originalCreate(input).pipe(
+            Effect.tap(() => Effect.sync(() => markerSaved.resolve())),
+            Effect.andThen(Effect.never),
+          )) as typeof compaction.create
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => void (mutableCompaction.create = originalCreate)),
+        )
+
+        const active = yield* prompt
+          .loop({
+            sessionID: chat.id,
+            prelude: {
+              type: "compaction",
+              agent: "build",
+              model: ref,
+              auto: false,
+            },
+          })
+          .pipe(Effect.forkChild)
+        yield* Effect.promise(() => markerSaved.promise)
+
+        const beforeCancel = yield* sessions.messages({ sessionID: chat.id })
+        const currentMarker = beforeCancel.find((message) =>
+          message.parts.some((part) => part.type === "compaction"),
+        )
+        expect(currentMarker?.info.role).toBe("user")
+        const unrelatedMarker = yield* user(chat.id, "unrelated marker")
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: unrelatedMarker.id,
+          sessionID: chat.id,
+          type: "compaction",
+          auto: false,
+        })
+
+        yield* prompt.cancel(chat.id)
+        expect(Exit.isSuccess(yield* Fiber.await(active))).toBe(true)
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const summary = messages.find(
+          (message) =>
+            message.info.role === "assistant" &&
+            message.info.summary === true &&
+            message.info.parentID === currentMarker?.info.id,
+        )
+        expect(summary?.info.role).toBe("assistant")
+        if (summary?.info.role === "assistant") expect(summary.info.error?.name).toBe("MessageAbortedError")
+        expect(
+          messages.some(
+            (message) =>
+              message.info.role === "assistant" &&
+              message.info.summary === true &&
+              message.info.parentID === unrelatedMarker.id,
+          ),
+        ).toBe(false)
+      }),
+      { git: true, config: providerCfg },
+    ),
+  10_000,
+)
+
+it.live(
   "cancel during compaction prelude interrupts the run",
   () =>
     provideTmpdirServer(
@@ -2734,7 +2975,7 @@ it.live(
 )
 
 it.live(
-  "cancel does not restart a prompt joined to the active run",
+  "cancel finalizes a prompt joined to the active run without restarting",
   () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
@@ -2779,11 +3020,14 @@ it.live(
         expect(yield* llm.calls).toBe(1)
 
         const messages = yield* sessions.messages({ sessionID: chat.id })
-        expect(
-          messages.some(
-            (message) => message.info.role === "assistant" && message.info.parentID === queuedID,
-          ),
-        ).toBe(false)
+        const terminal = messages.find(
+          (message) => message.info.role === "assistant" && message.info.parentID === queuedID,
+        )
+        expect(terminal?.info.role).toBe("assistant")
+        if (terminal?.info.role === "assistant") {
+          expect(terminal.info.error?.name).toBe("MessageAbortedError")
+          expect(terminal.info.time.completed).toBeNumber()
+        }
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/opencode/test/session/run-state.test.ts
+++ b/packages/opencode/test/session/run-state.test.ts
@@ -34,6 +34,33 @@ describe("SessionRunState", () => {
       expect(Exit.isSuccess(idle)).toBe(true)
     })
 
+  it.live("delivers cancel for the full observed attempt before a runner exists", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const run = yield* SessionRunState.Service
+        const sessionID = SessionID.make("ses_cancel_observed_attempt")
+        const ready = yield* Deferred.make<void>()
+        let observed: InterruptMeta | undefined
+
+        const attempt = yield* Effect.gen(function* () {
+          yield* run.observeCancel(sessionID, (meta) =>
+            Effect.sync(() => {
+              observed = meta
+            }),
+          )
+          yield* Deferred.succeed(ready, undefined)
+          return yield* Effect.never
+        })
+          .pipe(Effect.scoped)
+          .pipe(Effect.forkChild)
+        yield* Deferred.await(ready)
+
+        yield* run.cancel(sessionID, { source: "test", reason: "before_runner" })
+        expect(observed).toMatchObject({ source: "test", reason: "before_runner" })
+        yield* Fiber.interrupt(attempt)
+      }),
+    ))
+
   it.live("delivers cancel to an existing shell runner before it reports busy", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Persist a terminal assistant result whenever an accepted prompt or compaction marker fails during admission, setup, execution, or cancellation. Bind terminal ownership to the exact submitted trace or active turn parent, and recover the narrow runner-exit race with one bounded retry.

There is no related GitHub issue; this was reported through a PawWork problem report from a production user session.

## Why

`prompt_async` can save a user message and detach the session run before provider/model setup completes. A failure therefore left only the user message in history, while the transient bus error was the sole failure signal. Concurrent prompts and cancellation also exposed ownership races: one shared Runner result could leave queued users without their own terminal state, or a latest-message lookup could finalize the wrong turn.

The durable contract is now:

- every accepted prompt attempt owns terminal state through its exact `messageID`;
- the active Runner owns cancellation through the exact parent selected by `runLoop`;
- compaction owns terminal state through its exact marker and summary;
- same-parent terminal writes are serialized and idempotent;
- completed successful history is not rewritten by later cancellation;
- an unhandled traced prompt that joined an exiting run receives at most one retry.

## Related Issue

None. Reported through production problem report `pwr_mswmjcr7_kbnsmo`.

## Human Review Status

Pending

## Review Focus

- Terminal ownership across active Runner A plus queued prompts B/C, including lifecycle-close waits.
- Idempotence of same-parent terminal writes and preservation of completed history.
- Compaction marker/summary cancellation at pre-marker, pre-processor, and active-processor boundaries.
- The one-retry postcondition for a traced prompt that joins a finishing run.

## Risk Notes

The change touches core session execution semantics. It keeps Runner generic, adds no dependency or migration, and serializes only rare terminal-error writes. The retry remains bounded to one attempt and applies only to non-interrupted traced prompts that the joined run did not cover.

Visible UI/manual visual checks were skipped because no UI or copy changed. Platform checks were skipped because no platform, packaging, path, or permission surface changed. Docs/release/dependency checks were skipped because none of those surfaces changed.

## How To Verify

```text
SessionPrompt effect suite with EXA_API_KEY removed from the test environment: 83 passed, 0 failed, 363 assertions
SessionCompaction suite: 51 passed, 0 failed, 124 assertions
SessionRunState suite: 24 passed, 0 failed, 100 assertions
OpenCode typecheck (`bun run typecheck`): passed
Diff whitespace check (`git diff --check`): passed
Final adversarial review (concurrency, terminal semantics, simplification): PASS, no P0-P3 findings
```

## Screenshots or Recordings

Not applicable; no visible UI changed.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session reliability when prompt or compaction setup fails, preserving terminal errors and details.
  * Fixed missed prompts submitted while a previous run is finishing; they are now processed in a follow-up run.
  * Improved interruption handling to prevent unintended retries and correctly finalize interrupted work.
  * Prevented tool-call results from being associated with the wrong prompt.
* **Improvements**
  * Enhanced compaction tracking, cancellation handling, and run coordination for more consistent responses.
  * Added support for custom message IDs during compaction.
  * Expanded coverage for failures, interruptions, cancellation, and prompt queueing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->