### PR TITLE
chore(release): bump desktop to 2026.8.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.8.1",
+      "version": "2026.8.2",
       "dependencies": {
         "@opencode-ai/remote-bridge": "workspace:*",
         "@opencode-ai/util": "workspace:*",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

Bump the PawWork desktop release version from 2026.8.1 to 2026.8.2 in the package manifest and Bun lockfile. This prepares the next August stable release and has no related issue.

The release scope since v2026.8.1 contains #1546 (prevent the macOS app-exit crash caused by the file watcher) and #1558 (persist terminal failures for accepted prompts in older sessions).

## Why

The next stable release needs a unique CalVer version before macOS and Windows artifacts can be built, notarized, published, and mirrored from one pinned commit.

## Related Issue

No related issue; this is the release preparation for the already-merged changes listed above.

## Human Review Status

Approved by @Astro-Han

## Review Focus

Confirm the diff changes only the desktop package version and its lockfile workspace entry to 2026.8.2.

## Risk Notes

No visible UI or copy changed, so screenshots are not applicable. The version controls release asset names and updater metadata across macOS and Windows; all three final targets must build the merged commit. Release notes will be written on the published Release after the real workflow run IDs and pinned commit are known.

## How To Verify

```text
Version contract: RED on 2026.8.1, GREEN on 2026.8.2
Release contract tests: 21 passed, 0 failed (release-metadata-contract + release-workflow-contract)
Release typecheck: passed (tsgo -p tsconfig.release.json)
Frozen install: passed with no additional lockfile changes
Diff check: no whitespace errors; exactly two version lines changed
```

## Screenshots or Recordings

Not applicable; there are no visible UI or copy changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
