### PR TITLE
fix(app): keep session status timeout off the project reload toast

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, mock, test } from "bun:test"
+import { describe, expect, mock, spyOn, test } from "bun:test"
 import type { Config, Path, Project, ProviderListResponse, VcsInfo } from "@opencode-ai/sdk/v2/client"
+import * as uiToast from "@opencode-ai/ui/toast"
 import { QueryClient } from "@tanstack/solid-query"
 import { createStore } from "solid-js/store"
 import {
@@ -400,7 +401,7 @@ describe("bootstrapDirectory", () => {
     }
   })
 
-  test("times out status hydration and records a diagnostic when the endpoint never settles", async () => {
+  test("times out status hydration, records a diagnostic, and keeps the timeout off the project reload toast", async () => {
     const originalError = console.error
     console.error = mock(() => undefined) as typeof console.error
     const directory = "/tmp/project"
@@ -409,6 +410,11 @@ describe("bootstrapDirectory", () => {
     const status = deferred<{ data: Record<string, never> }>()
     let statusSignal: AbortSignal | undefined
     const diagnostics: Array<{ name: string; level?: "info" | "warn"; data?: Record<string, unknown> }> = []
+    const toasts: Array<{ title?: string }> = []
+    const toastSpy = spyOn(uiToast, "showToast").mockImplementation((toast) => {
+      toasts.push(toast as { title?: string })
+      return 0
+    })
 
     const sdk = {
       app: { agents: async () => ({ data: [] }) },
@@ -464,7 +470,13 @@ describe("bootstrapDirectory", () => {
           data: { timeout_ms: 10 },
         },
       ])
+      // The timeout is best-effort: it must not escalate into the project-level
+      // "reloadFailed" toast (the #1550 spam), and the bootstrap must still finish.
+      await waitFor(() => store.status === "complete")
+      expect(toasts).toEqual([])
+      expect(store.status).toBe("complete")
     } finally {
+      toastSpy.mockRestore()
       status.resolve({ data: {} })
       console.error = originalError
     }

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -539,7 +539,8 @@ export async function bootstrapDirectory(input: {
             input.setStore("session_status_ready", true)
           }),
         ).catch(async (err) => {
-          if (err instanceof SessionStatusHydrationTimeoutError) {
+          const timedOut = err instanceof SessionStatusHydrationTimeoutError
+          if (timedOut) {
             await Promise.resolve(
               input.emitDiagnostic?.({
                 name: "incident.session_status_hydration_timeout",
@@ -550,7 +551,14 @@ export async function bootstrapDirectory(input: {
           }
           input.setStore("session_status_state", "error")
           input.setStore("session_status_ready", false)
-          throw err
+          // A timed-out status snapshot is best-effort: the timeout is already recorded
+          // as a diagnostic, session_status_state tells the UI the snapshot is stale, and
+          // the next SSE status event or bootstrap pass restores it. Rethrowing lands it
+          // in slowErrs, firing the project-level "reloadFailed" toast on every bootstrap
+          // pass (app launch and after each assistant turn) on machines where the snapshot
+          // just takes longer than the timeout - the #1550 toast spam. Real fetch failures
+          // still escalate.
+          if (!timedOut) throw err
         }),
       () =>
         seededProject


### PR DESCRIPTION
## Summary

In `bootstrapDirectory`, a timed-out `session.status` snapshot no longer rethrows into the slow-bootstrap error path. The timeout is already recorded as an `incident.session_status_hydration_timeout` diagnostic and degrades `session_status_state` to `error`; after that it is now swallowed (best-effort, matching the external-result hydrate pattern in the same file) instead of escalating into `slowErrs`. Real fetch failures still throw and surface the toast.

The extended bootstrap test also pins that the bootstrap pass finishes (`status` reaches `complete`) despite the timeout - previously the project stayed unfinished on slow machines.

## Why

Fixes #1550. The `session.status` fetch is wrapped in a 5-second timeout (`SESSION_STATUS_TIMEOUT_MS`). On machines where the full status snapshot takes longer, the timeout error landed in `slowErrs` and fired the project-level "Failed to reload {project}" toast on every bootstrap pass - once at app launch and again after every assistant turn (or interrupt), exactly the spam reported on Windows 11 in v2026.8.1. The data itself recovers on the next SSE status event or bootstrap pass, so the toast was neither actionable nor accurate.

Supersedes #1556 (closed): that PR only raised the `bun test` per-test timeout, which does not affect the shipped app.

## Related Issue

Fixes #1550

## Human Review Status

Approved by @Astro-Han

## Review Focus

- The swallow happens only for `SessionStatusHydrationTimeoutError` (`timedOut` flag); every other status fetch failure still escalates to the reload toast.
- The bootstrap-complete path: with the timeout swallowed, `slowErrs` stays empty and `status` reaches `complete` while `session_status_state` remains `error` until SSE recovery - confirm that combination is the intended degraded state.

## Risk Notes

- On a genuinely stuck status endpoint the user now sees no toast; observability is preserved via the existing diagnostic event and `session_status_state: error`. I judge that the right trade: the toast was not actionable and the state self-heals.
- No E2E was added: forcing a real >5s status hang through the packaged app would need route interception against the sidecar server and would be flaky at the 5s boundary. The unit test drives the public `bootstrapDirectory` seam with the real `showToast` host spied, which is where the spam originated.
- No visible UI or copy changed (an erroneous toast is removed from a timeout path), so no screenshot applies.
- Docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, and local-file contracts are unchanged.

## How To Verify

```text
RED check: extended test failed before the fix (store.status never reached complete, toast fired)
Focused tests: bootstrap.test.ts 25 passed, 0 failed
App unit suite: 2016 passed, 0 failed
Typecheck: 9 tasks successful (repo-wide turbo typecheck)
```

## Screenshots or Recordings

Not applicable: no visible UI or copy change; the change removes a spurious error toast from a timeout path.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run - return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** - this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** - this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** - this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [ ] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [ ] I linked the related issue, or stated in Summary why there is no issue.
- [ ] I described the review focus and any meaningful risks.
- [ ] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [ ] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked if no platform/packaging surface was touched.
- [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked if none of those surfaces was touched.
- [ ] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [ ] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
