### PR TITLE
fix(session): preserve message order after ID rollover

### DIFF
--- a/packages/app/e2e/session/session-message-rollover.spec.ts
+++ b/packages/app/e2e/session/session-message-rollover.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "../fixtures"
+import { withSession } from "../actions"
+import { sessionMessageItemSelector } from "../selectors"
+
+test("keeps newly sent messages at the end of a session after message IDs wrap", async ({ page, project, assistant }) => {
+  test.setTimeout(120_000)
+
+  await project.open()
+  await withSession(project.sdk, `e2e message rollover ${Date.now()}`, async (session) => {
+    project.trackSession(session.id)
+    const olderID = "msg_fd0000000000old"
+    await project.sdk.session.promptAsync({
+      sessionID: session.id,
+      messageID: olderID,
+      noReply: true,
+      parts: [{ type: "text", text: "message before rollover" }],
+    })
+    await project.gotoSession(session.id)
+    await expect(page.locator(`[data-message-id="${olderID}"]`)).toBeVisible()
+
+    const userToken = `rollover_user_${Date.now()}`
+    const assistantToken = `rollover_assistant_${Date.now()}`
+    await assistant.reply(assistantToken)
+    expect(await project.prompt(userToken)).toBe(session.id)
+
+    let userID = ""
+    let assistantID = ""
+    await expect
+      .poll(
+        async () => {
+          const messages = await project.sdk.session
+            .messages({ sessionID: session.id, limit: 100 })
+            .then((response) => response.data ?? [])
+          const user = messages.find(
+            (message) =>
+              message.info.role === "user" &&
+              message.parts.some((part) => part.type === "text" && part.text.includes(userToken)),
+          )
+          const reply = user
+            ? messages.find(
+                (message) =>
+                  message.info.role === "assistant" &&
+                  message.info.parentID === user.info.id &&
+                  message.parts.some((part) => part.type === "text" && part.text.includes(assistantToken)),
+              )
+            : undefined
+          userID = user?.info.id ?? ""
+          assistantID = reply?.info.id ?? ""
+          return !!userID && !!assistantID
+        },
+        { timeout: 30_000 },
+      )
+      .toBe(true)
+
+    const renderedIDs = async () =>
+      page.locator(sessionMessageItemSelector).evaluateAll((messages) =>
+        messages.map((message) => message.getAttribute("data-message-id")).filter((id): id is string => !!id),
+      )
+
+    const latestTurn = page.locator(`[data-message-id="${userID}"]`)
+    await expect(latestTurn).toBeVisible()
+    await expect(latestTurn).toContainText(assistantToken)
+    await expect.poll(renderedIDs).toEqual([olderID, userID])
+
+    await page.reload({ waitUntil: "domcontentloaded" })
+    await expect.poll(renderedIDs).toEqual([olderID, userID])
+    await expect(page.locator(`[data-message-id="${userID}"]`)).toContainText(assistantToken)
+    expect(page.url()).toContain(`/session/${session.id}`)
+  })
+})

--- a/packages/app/e2e/session/session-message-rollover.spec.ts
+++ b/packages/app/e2e/session/session-message-rollover.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from "../fixtures"
 import { withSession } from "../actions"
 import { sessionMessageItemSelector } from "../selectors"
 
-test("keeps newly sent messages at the end of a session after message IDs wrap", async ({ page, project, assistant }) => {
+test("@smoke keeps newly sent messages at the end of a session after message IDs wrap", async ({
+  page,
+  project,
+  assistant,
+}) => {
   test.setTimeout(120_000)
 
   await project.open()
@@ -51,6 +55,7 @@ test("keeps newly sent messages at the end of a session after message IDs wrap",
         { timeout: 30_000 },
       )
       .toBe(true)
+    expect(userID < olderID).toBe(true)
 
     const renderedIDs = async () =>
       page.locator(sessionMessageItemSelector).evaluateAll((messages) =>

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -4,7 +4,7 @@ import {
   contextUsageUsedTokens,
   deriveContextUsage,
 } from "@opencode-ai/util/context-usage"
-import { buildTurnMessagesByUserID } from "@/pages/session/session-messages"
+import { buildTurnMessagesByUserID, messagesBeforeID } from "@/pages/session/session-messages"
 
 type Provider = {
   id: string
@@ -124,17 +124,6 @@ export function getSessionContextMetrics(messages: Message[] = [], providers: Pr
   return build(messages, providers, config)
 }
 
-// The visible window is every message before the reverted one. Slice by array position rather than
-// comparing message ids: the prompt API lets a caller supply a custom message id
-// (session/prompt.ts uses `input.messageID ?? MessageID.ascending()`), so id string order is not a
-// reliable boundary. The synced messages array is already in turn order, which is the ordering the
-// turn grouping below relies on anyway.
-function visibleMessagesBeforeRevert(messages: Message[], revertID?: string): Message[] {
-  if (!revertID) return messages
-  const index = messages.findIndex((message) => message.id === revertID)
-  return index >= 0 ? messages.slice(0, index) : messages
-}
-
 // Cache hit rate is a per-turn flow metric, not a window-state snapshot, so it is computed
 // separately from the context block above. We sum tokensCumulative (per-step totals the backend
 // accumulates) across every assistant message of the most recent turn, grouped by parentID — the
@@ -143,7 +132,7 @@ function visibleMessagesBeforeRevert(messages: Message[], revertID?: string): Me
 // messages are skipped so an auto-compaction never masquerades as the user's latest turn, and
 // reverted turns are excluded so a rolled-back session does not report a turn the user no longer sees.
 export function getRecentTurnCache(messages: Message[] = [], revertID?: string): RecentTurnCache | null {
-  const visible = visibleMessagesBeforeRevert(messages, revertID)
+  const visible = messagesBeforeID(messages, revertID)
   const turns = buildTurnMessagesByUserID(visible)
 
   let recentTurnID: string | undefined
@@ -176,7 +165,7 @@ export function getRecentTurnCache(messages: Message[] = [], revertID?: string):
 // running session rate without a scope toggle. Summary and reverted turns are excluded for the same
 // reasons as the per-turn metric, so the session figure only reflects turns the user still sees.
 export function getSessionCacheAggregate(messages: Message[] = [], revertID?: string): RecentTurnCache | null {
-  const visible = visibleMessagesBeforeRevert(messages, revertID)
+  const visible = messagesBeforeID(messages, revertID)
   const turns = buildTurnMessagesByUserID(visible)
 
   let input = 0

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -13,7 +13,13 @@ import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { useLanguage } from "@/context/language"
 import { useProviders } from "@/hooks/use-providers"
 import { useSessionLayout } from "@/pages/session/session-layout"
-import { emptyMessages, emptyUserMessages, readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
+import {
+  emptyMessages,
+  emptyUserMessages,
+  messagesBeforeID,
+  readSessionMessages,
+  readUserMessages,
+} from "@/pages/session/session-messages"
 import { getRecentTurnCache, getSessionCacheAggregate, getSessionContextMetrics } from "./session-context-metrics"
 import { estimateSessionContextBreakdown, type SessionContextBreakdownKey } from "./session-context-breakdown"
 import { createSessionContextFormatter } from "./session-context-format"
@@ -212,11 +218,7 @@ export function SessionContextTab() {
   )
 
   const visibleUserMessages = createMemo(
-    () => {
-      const revert = info()?.revert?.messageID
-      if (!revert) return userMessages()
-      return userMessages().filter((m) => m.id < revert)
-    },
+    () => messagesBeforeID(userMessages(), info()?.revert?.messageID),
     emptyUserMessages,
     { equals: same },
   )

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -16,9 +16,8 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import {
   emptyMessages,
   emptyUserMessages,
-  messagesBeforeID,
   readSessionMessages,
-  readUserMessages,
+  userMessagesBeforeID,
 } from "@/pages/session/session-messages"
 import { getRecentTurnCache, getSessionCacheAggregate, getSessionContextMetrics } from "./session-context-metrics"
 import { estimateSessionContextBreakdown, type SessionContextBreakdownKey } from "./session-context-breakdown"
@@ -211,14 +210,8 @@ export function SessionContextTab() {
     { equals: same },
   )
 
-  const userMessages = createMemo(
-    () => readUserMessages(messages()),
-    emptyUserMessages,
-    { equals: same },
-  )
-
   const visibleUserMessages = createMemo(
-    () => messagesBeforeID(userMessages(), info()?.revert?.messageID),
+    () => userMessagesBeforeID(messages(), info()?.revert?.messageID),
     emptyUserMessages,
     { equals: same },
   )

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -23,6 +23,7 @@ import { formatServerError } from "@/utils/server-errors"
 import type { RendererDiagnosticInput } from "@/context/platform"
 import { QueryClient, queryOptions } from "@tanstack/solid-query"
 import { loadSessionsQuery, type GlobalStore } from "../global-sync"
+import { upsertMessageByCreated } from "./message-order"
 
 function waitForPaint() {
   return new Promise<void>((resolve) => {
@@ -332,22 +333,7 @@ export function hydratePendingExternalResults(input: {
       }
 
       const messages = input.store.message[session.id]
-      if (!messages) {
-        input.setStore("message", session.id, [message])
-      } else {
-        const result = Binary.search(messages, message.id, (m) => m.id)
-        if (result.found) {
-          input.setStore("message", session.id, result.index, reconcile(message))
-        } else {
-          input.setStore(
-            "message",
-            session.id,
-            produce((draft) => {
-              draft.splice(result.index, 0, message)
-            }),
-          )
-        }
-      }
+      input.setStore("message", session.id, reconcile(upsertMessageByCreated(messages ?? [], message), { key: "id" }))
 
       if (localTerminalQuestion) continue
       const parts = input.store.part[part.messageID]

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -31,12 +31,12 @@ const rootSession = (input: { id: string; parentID?: string; archived?: number; 
     },
   }) as Session
 
-const userMessage = (id: string, sessionID: string) =>
+const userMessage = (id: string, sessionID: string, created = 1) =>
   ({
     id,
     sessionID,
     role: "user",
-    time: { created: 1 },
+    time: { created },
     agent: "assistant",
     model: { providerID: "openai", modelID: "gpt" },
   }) as Message
@@ -543,6 +543,24 @@ describe("applyDirectoryEvent", () => {
 
     expect(store.message[sessionID]?.map((x) => x.id)).toEqual(["msg_1", "msg_3"])
     expect(store.part.msg_2).toBeUndefined()
+  })
+
+  test("appends a post-rollover message by creation time", () => {
+    const sessionID = "ses_1"
+    const older = userMessage("msg_fd0000000000old", sessionID, 1_786_000_000_000)
+    const newer = userMessage("msg_000000000000new", sessionID, 1_787_000_000_000)
+    const [store, setStore] = createStore(baseState({ message: { [sessionID]: [older] } }))
+
+    applyDirectoryEvent({
+      event: { type: "message.updated", properties: { info: newer } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    expect(store.message[sessionID]?.map((message) => message.id)).toEqual([older.id, newer.id])
   })
 
   test("upserts and prunes message parts", () => {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -21,6 +21,7 @@ import { message as clean } from "@/utils/diffs"
 import type { createBlockerTerminalCache } from "./blocker-terminal-cache"
 import type { TodoHydrateCoordinator } from "./todo-hydrate-coordinator"
 import { shouldStoreMessagePart } from "../message-part-storage"
+import { upsertMessageByCreated } from "./message-order"
 
 // A recurring automation that fails this many times in a row earns one subtle
 // toast on the rising edge. The threshold and the rising-edge gate keep SSE
@@ -284,23 +285,8 @@ export function applyDirectoryEvent(input: {
     }
     case "message.updated": {
       const info = clean((event.properties as { info: Message }).info)
-      const messages = input.store.message[info.sessionID]
-      if (!messages) {
-        input.setStore("message", info.sessionID, [info])
-        break
-      }
-      const result = Binary.search(messages, info.id, (m) => m.id)
-      if (result.found) {
-        input.setStore("message", info.sessionID, result.index, reconcile(info))
-        break
-      }
-      input.setStore(
-        "message",
-        info.sessionID,
-        produce((draft) => {
-          draft.splice(result.index, 0, info)
-        }),
-      )
+      const messages = input.store.message[info.sessionID] ?? []
+      input.setStore("message", info.sessionID, reconcile(upsertMessageByCreated(messages, info), { key: "id" }))
       break
     }
     case "message.removed": {
@@ -309,8 +295,8 @@ export function applyDirectoryEvent(input: {
         produce((draft) => {
           const messages = draft.message[props.sessionID]
           if (messages) {
-            const result = Binary.search(messages, props.messageID, (m) => m.id)
-            if (result.found) messages.splice(result.index, 1)
+            const index = messages.findIndex((message) => message.id === props.messageID)
+            if (index >= 0) messages.splice(index, 1)
           }
           delete draft.part[props.messageID]
         }),

--- a/packages/app/src/context/global-sync/message-order.ts
+++ b/packages/app/src/context/global-sync/message-order.ts
@@ -1,0 +1,30 @@
+export type OrderedMessage = {
+  id: string
+  time?: {
+    created?: number
+  }
+}
+
+const createdAt = (message: OrderedMessage) => {
+  const created = message.time?.created
+  return typeof created === "number" && Number.isFinite(created) ? created : 0
+}
+
+export function compareMessagesByCreated(a: OrderedMessage, b: OrderedMessage) {
+  const created = createdAt(a) - createdAt(b)
+  if (created !== 0) return created
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
+export function mergeMessagesByCreated<T extends OrderedMessage>(current: readonly T[], incoming: readonly T[]) {
+  const messages = new Map(current.map((message) => [message.id, message] as const))
+  for (const message of incoming) messages.set(message.id, message)
+  return [...messages.values()].sort(compareMessagesByCreated)
+}
+
+export function upsertMessageByCreated<T extends OrderedMessage>(messages: readonly T[], message: T) {
+  return mergeMessagesByCreated(
+    messages.filter((item) => item.id !== message.id),
+    [message],
+  )
+}

--- a/packages/app/src/context/sync-message-resolution.test.ts
+++ b/packages/app/src/context/sync-message-resolution.test.ts
@@ -47,6 +47,19 @@ describe("resolveLoadMessagePage", () => {
     expect(result.map((x) => x.text)).toEqual(["shell-user-db", "shell-assistant"])
   })
 
+  test("keeps newer messages after older messages when IDs wrap", () => {
+    const older = m("msg_fd0000000000old", "before rollover", 1_786_000_000_000)
+    const shared = m("msg_fe0000000000shared", "before rollover", 1_786_500_000_000)
+    const newer = m("msg_000000000000new", "after rollover", 1_787_000_000_000)
+
+    const result = resolveLoadMessagePage<TestMsg>({
+      stored: [shared, newer],
+      fetched: [older, shared],
+    })
+
+    expect(result.map((message) => message.id)).toEqual([older.id, shared.id, newer.id])
+  })
+
   test("normal refresh with cached meta keeps the loaded message set monotonic", () => {
     const stored = [m("msg_1", "old"), m("msg_2", "visible")]
     const fetched = [m("msg_1", "current")]

--- a/packages/app/src/context/sync-optimistic.test.ts
+++ b/packages/app/src/context/sync-optimistic.test.ts
@@ -4,11 +4,11 @@ import { applyOptimisticAdd, applyOptimisticRemove, mergeOptimisticPage } from "
 
 type Text = Extract<Part, { type: "text" }>
 
-const userMessage = (id: string, sessionID: string): Message => ({
+const userMessage = (id: string, sessionID: string, created = 1): Message => ({
   id,
   sessionID,
   role: "user",
-  time: { created: 1 },
+  time: { created },
   agent: "assistant",
   model: { providerID: "openai", modelID: "gpt" },
 })
@@ -37,6 +37,20 @@ describe("sync optimistic reducers", () => {
 
     expect(draft.message[sessionID]?.map((x) => x.id)).toEqual(["msg_1", "msg_2"])
     expect(draft.part.msg_1?.map((x) => x.id)).toEqual(["prt_1", "prt_2"])
+  })
+
+  test("applyOptimisticAdd keeps a post-rollover message at the chronological tail", () => {
+    const sessionID = "ses_1"
+    const older = userMessage("msg_fd0000000000old", sessionID, 1_786_000_000_000)
+    const newer = userMessage("msg_000000000000new", sessionID, 1_787_000_000_000)
+    const draft = {
+      message: { [sessionID]: [older] },
+      part: {} as Record<string, Part[] | undefined>,
+    }
+
+    applyOptimisticAdd(draft, { sessionID, message: newer, parts: [] })
+
+    expect(draft.message[sessionID]?.map((message) => message.id)).toEqual([older.id, newer.id])
   })
 
   test("applyOptimisticRemove removes message and part entries", () => {
@@ -71,6 +85,19 @@ describe("sync optimistic reducers", () => {
     expect(page.part.find((x) => x.id === "msg_2")?.part.map((x) => x.id)).toEqual(["prt_2"])
     expect(page.confirmed).toEqual([])
     expect(page.complete).toBe(true)
+  })
+
+  test("mergeOptimisticPage keeps a post-rollover optimistic message at the chronological tail", () => {
+    const sessionID = "ses_1"
+    const older = userMessage("msg_fd0000000000old", sessionID, 1_786_000_000_000)
+    const newer = userMessage("msg_000000000000new", sessionID, 1_787_000_000_000)
+
+    const page = mergeOptimisticPage(
+      { session: [older], part: [], complete: true },
+      [{ message: newer, parts: [] }],
+    )
+
+    expect(page.session.map((message) => message.id)).toEqual([older.id, newer.id])
   })
 
   test("mergeOptimisticPage keeps missing optimistic parts until the server has them", () => {

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -16,6 +16,12 @@ import { dropSessionCaches } from "./global-sync/session-cache"
 import type { TodoHydrateReason } from "./global-sync/todo-hydrate-coordinator"
 import { diffs as list, message as clean } from "@/utils/diffs"
 import { shouldStoreMessagePart } from "./message-part-storage"
+import {
+  compareMessagesByCreated,
+  mergeMessagesByCreated,
+  type OrderedMessage,
+  upsertMessageByCreated,
+} from "./global-sync/message-order"
 
 function sortParts(parts: Part[]) {
   return parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id))
@@ -43,17 +49,11 @@ function isNotFoundError(error: unknown) {
   return value.response?.status === 404
 }
 
-function merge<T extends { id: string }>(a: readonly T[], b: readonly T[]) {
-  const map = new Map(a.map((item) => [item.id, item] as const))
-  for (const item of b) map.set(item.id, item)
-  return [...map.values()].sort((x, y) => cmp(x.id, y.id))
-}
-
 function storedAfterFetchStarted<T extends { id: string }>(item: T, storedIDsBeforeFetch: ReadonlySet<string> | undefined) {
   return storedIDsBeforeFetch !== undefined && !storedIDsBeforeFetch.has(item.id)
 }
 
-export function resolveLoadMessagePage<T extends { id: string }>(params: {
+export function resolveLoadMessagePage<T extends OrderedMessage>(params: {
   mode?: "prepend" | "replace"
   stored: readonly T[] | undefined
   fetched: readonly T[]
@@ -62,7 +62,7 @@ export function resolveLoadMessagePage<T extends { id: string }>(params: {
 }): T[] {
   const { stored, fetched } = params
   if (stored && stored.length > 0) {
-    const merged = merge(stored, fetched)
+    const merged = mergeMessagesByCreated(stored, fetched)
     const fetchedIDs = new Set(fetched.map((item) => item.id))
     const hasStableOverlap = stored.some((item) => {
       if (!fetchedIDs.has(item.id)) return false
@@ -70,7 +70,7 @@ export function resolveLoadMessagePage<T extends { id: string }>(params: {
       return params.storedIDsBeforeFetch.has(item.id)
     })
     if (params.mode !== "prepend" && !params.fetchedComplete && fetched.length > 0 && !hasStableOverlap) {
-      return merge(
+      return mergeMessagesByCreated(
         stored.filter((item) => storedAfterFetchStarted(item, params.storedIDsBeforeFetch)),
         fetched,
       )
@@ -196,9 +196,8 @@ export function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) 
   const confirmed: string[] = []
 
   for (const item of items) {
-    const result = Binary.search(session, item.message.id, (message) => message.id)
-    const found = result.found
-    if (!found) session.splice(result.index, 0, item.message)
+    const found = session.some((message) => message.id === item.message.id)
+    if (!found) session.push(item.message)
 
     const current = part.get(item.message.id)
     if (found && hasParts(current, item.parts)) {
@@ -208,6 +207,7 @@ export function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) 
 
     part.set(item.message.id, mergeParts(current, item.parts))
   }
+  session.sort(compareMessagesByCreated)
 
   return {
     cursor: page.cursor,
@@ -221,8 +221,7 @@ export function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) 
 export function applyOptimisticAdd(draft: OptimisticStore, input: OptimisticAddInput) {
   const messages = draft.message[input.sessionID]
   if (messages) {
-    const result = Binary.search(messages, input.message.id, (m) => m.id)
-    messages.splice(result.index, 0, input.message)
+    messages.splice(0, messages.length, ...upsertMessageByCreated(messages, input.message))
   } else {
     draft.message[input.sessionID] = [input.message]
   }
@@ -232,8 +231,8 @@ export function applyOptimisticAdd(draft: OptimisticStore, input: OptimisticAddI
 export function applyOptimisticRemove(draft: OptimisticStore, input: OptimisticRemoveInput) {
   const messages = draft.message[input.sessionID]
   if (messages) {
-    const result = Binary.search(messages, input.messageID, (m) => m.id)
-    if (result.found) messages.splice(result.index, 1)
+    const index = messages.findIndex((message) => message.id === input.messageID)
+    if (index >= 0) messages.splice(index, 1)
   }
   delete draft.part[input.messageID]
 }
@@ -241,10 +240,7 @@ export function applyOptimisticRemove(draft: OptimisticStore, input: OptimisticR
 function setOptimisticAdd(setStore: (...args: unknown[]) => void, input: OptimisticAddInput) {
   setStore("message", input.sessionID, (messages: Message[] | undefined) => {
     if (!messages) return [input.message]
-    const result = Binary.search(messages, input.message.id, (m) => m.id)
-    const next = [...messages]
-    next.splice(result.index, 0, input.message)
-    return next
+    return upsertMessageByCreated(messages, input.message)
   })
   setStore("part", input.message.id, sortParts(input.parts))
 }
@@ -252,10 +248,10 @@ function setOptimisticAdd(setStore: (...args: unknown[]) => void, input: Optimis
 function setOptimisticRemove(setStore: (...args: unknown[]) => void, input: OptimisticRemoveInput) {
   setStore("message", input.sessionID, (messages: Message[] | undefined) => {
     if (!messages) return messages
-    const result = Binary.search(messages, input.messageID, (m) => m.id)
-    if (!result.found) return messages
+    const index = messages.findIndex((message) => message.id === input.messageID)
+    if (index < 0) return messages
     const next = [...messages]
-    next.splice(result.index, 1)
+    next.splice(index, 1)
     return next
   })
   setStore("part", (part: Record<string, Part[] | undefined>) => {
@@ -409,7 +405,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         input.client.session.messages({ sessionID: input.sessionID, limit: input.limit, before: input.before }),
       )
       const items = (messages.data ?? []).filter((x) => !!x?.info?.id)
-      const session = items.map((x) => clean(x.info)).sort((a, b) => cmp(a.id, b.id))
+      const session = items.map((x) => clean(x.info)).sort(compareMessagesByCreated)
       const part = items.map((message) => ({ id: message.info.id, part: sortParts(message.parts) }))
       const cursor = messages.response?.headers.get("x-next-cursor") ?? undefined
       return {

--- a/packages/app/src/pages/layout/pawwork-session-prefetch.ts
+++ b/packages/app/src/pages/layout/pawwork-session-prefetch.ts
@@ -15,6 +15,7 @@ import {
   shouldSkipSessionPrefetch,
 } from "@/context/global-sync/session-prefetch"
 import { workspaceKey } from "./helpers"
+import { mergeMessagesByCreated } from "@/context/global-sync/message-order"
 
 type PrefetchQueue = {
   inflight: Set<string>
@@ -39,7 +40,7 @@ const prefetchPendingLimit = 10
 const span = 4
 const PREFETCH_MAX_SESSIONS_PER_DIR = 10
 
-const mergeByID = <T extends { id: string }>(current: T[], incoming: T[]) => {
+const mergePartsByID = <T extends { id: string }>(current: T[], incoming: T[]) => {
   if (current.length === 0) {
     return incoming.slice().sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   }
@@ -135,7 +136,7 @@ export function createPawworkSessionPrefetch(input: SessionPrefetchInput) {
 
             const items = (messages.data ?? []).filter((x) => !!x?.info?.id)
             const next = items.map((x) => x.info).filter((m): m is Message => !!m?.id)
-            const sorted = mergeByID([], next)
+            const sorted = mergeMessagesByCreated([], next)
             const stale = markPrefetched(directory, sessionID)
             const cursor = messages.response?.headers.get("x-next-cursor") ?? undefined
             const meta = {
@@ -150,7 +151,7 @@ export function createPawworkSessionPrefetch(input: SessionPrefetchInput) {
             }
 
             const current = store.message[sessionID] ?? []
-            const merged = mergeByID(
+            const merged = mergeMessagesByCreated(
               current.filter((item): item is Message => !!item?.id),
               sorted,
             )
@@ -171,7 +172,7 @@ export function createPawworkSessionPrefetch(input: SessionPrefetchInput) {
 
               for (const message of items) {
                 const currentParts = store.part[message.info.id] ?? []
-                const mergedParts = mergeByID(
+                const mergedParts = mergePartsByID(
                   currentParts.filter((item): item is (typeof currentParts)[number] & { id: string } => !!item?.id),
                   message.parts.filter((item): item is (typeof message.parts)[number] & { id: string } => !!item?.id),
                 )

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -398,9 +398,9 @@ export default function Page() {
   })
 
   const fork = async (input: { sessionID: string; messageID: string }) => {
-    const nextUserMessage = sync.data.message[input.sessionID]?.find(
-      (message) => message.role === "user" && message.id > input.messageID,
-    )
+    const messages = sync.data.message[input.sessionID] ?? []
+    const messageIndex = messages.findIndex((message) => message.id === input.messageID)
+    const nextUserMessage = messageIndex >= 0 ? messages.slice(messageIndex + 1).find((message) => message.role === "user") : undefined
 
     try {
       const result = await sdk.client.session.fork({

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -7,7 +7,6 @@ import { RateLimitCardWiring } from "@/components/rate-limit-card-wiring"
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import type { AssistantMessage, Message as MessageType, Part, UserMessage } from "@opencode-ai/sdk/v2"
 import { showToast } from "@opencode-ai/ui/toast"
-import { Binary } from "@opencode-ai/util/binary"
 import { collectTimelineScrollMetrics } from "@/pages/session/session-timeline-scroll-anchors"
 import {
   type TimelineScrollControllerResult,
@@ -226,8 +225,7 @@ export function MessageTimeline(props: {
     const parentID = working() ? pending()?.parentID : undefined
     if (parentID) {
       const messages = sessionMessages()
-      const result = Binary.search(messages, parentID, (message) => message.id)
-      const message = result.found ? messages[result.index] : messages.find((item) => item.id === parentID)
+      const message = messages.find((item) => item.id === parentID)
       if (message && message.role === "user") return message.id
     }
 

--- a/packages/app/src/pages/session/session-messages.test.ts
+++ b/packages/app/src/pages/session/session-messages.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
 import {
   buildTurnMessagesByUserID,
-  messageAfterID,
-  messageBeforeID,
   messagesBeforeID,
   readSessionMessages,
   readUserMessages,
+  userMessageAfterID,
+  userMessageBeforeID,
+  userMessagesBeforeID,
 } from "./session-messages"
 
 const message = (id: string, role: Message["role"], parentID?: string): Message =>
@@ -61,14 +62,31 @@ describe("session message readers", () => {
     expect(messagesBeforeID([older, boundary], boundary.id).map((item) => item.id)).toEqual([older.id])
   })
 
-  test("navigates neighboring messages by position when IDs wrap", () => {
-    const older = message("msg_fd0000000000old", "user")
-    const boundary = message("msg_000000000000new", "user")
-    const newer = message("msg_010000000000next", "user")
-    const messages = [older, boundary, newer]
+  test("hides messages while a revert boundary is not loaded", () => {
+    const loaded = [message("msg_2", "user"), message("msg_3", "assistant", "msg_2")]
 
-    expect(messageBeforeID(messages, boundary.id)?.id).toBe(older.id)
-    expect(messageAfterID(messages, boundary.id)?.id).toBe(newer.id)
+    expect(messagesBeforeID(loaded, "msg_1")).toEqual([])
+  })
+
+  test("selects visible user messages when the revert boundary is an assistant message", () => {
+    const first = message("msg_1", "user")
+    const boundary = message("msg_2", "assistant", first.id)
+    const reverted = message("msg_3", "user")
+
+    expect(userMessagesBeforeID([first, boundary, reverted], boundary.id).map((item) => item.id)).toEqual([
+      first.id,
+    ])
+  })
+
+  test("navigates user turns around an assistant revert boundary", () => {
+    const first = message("msg_1", "user")
+    const firstReply = message("msg_2", "assistant", first.id)
+    const boundary = message("msg_3", "assistant", first.id)
+    const second = message("msg_4", "user")
+    const messages = [first, firstReply, boundary, second]
+
+    expect(userMessageBeforeID(messages, boundary.id)?.id).toBe(first.id)
+    expect(userMessageAfterID(messages, boundary.id)?.id).toBe(second.id)
   })
 })
 

--- a/packages/app/src/pages/session/session-messages.test.ts
+++ b/packages/app/src/pages/session/session-messages.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import type { Message } from "@opencode-ai/sdk/v2/client"
-import { buildTurnMessagesByUserID, readSessionMessages, readUserMessages } from "./session-messages"
+import {
+  buildTurnMessagesByUserID,
+  messageAfterID,
+  messageBeforeID,
+  messagesBeforeID,
+  readSessionMessages,
+  readUserMessages,
+} from "./session-messages"
 
 const message = (id: string, role: Message["role"], parentID?: string): Message =>
   ({
@@ -45,6 +52,23 @@ describe("session message readers", () => {
     const loaded = [null, {}, message("msg_1", "assistant"), message("msg_2", "user")]
 
     expect(readUserMessages(loaded).map((item) => item.id)).toEqual(["msg_2"])
+  })
+
+  test("selects messages before a boundary by position when IDs wrap", () => {
+    const older = message("msg_fd0000000000old", "user")
+    const boundary = message("msg_000000000000new", "user")
+
+    expect(messagesBeforeID([older, boundary], boundary.id).map((item) => item.id)).toEqual([older.id])
+  })
+
+  test("navigates neighboring messages by position when IDs wrap", () => {
+    const older = message("msg_fd0000000000old", "user")
+    const boundary = message("msg_000000000000new", "user")
+    const newer = message("msg_010000000000next", "user")
+    const messages = [older, boundary, newer]
+
+    expect(messageBeforeID(messages, boundary.id)?.id).toBe(older.id)
+    expect(messageAfterID(messages, boundary.id)?.id).toBe(newer.id)
   })
 })
 

--- a/packages/app/src/pages/session/session-messages.ts
+++ b/packages/app/src/pages/session/session-messages.ts
@@ -22,6 +22,22 @@ export function readUserMessages(messages: unknown): UserMessage[] {
   return users.length > 0 ? users : emptyUserMessages
 }
 
+export function messagesBeforeID<T extends { id: string }>(messages: T[], boundaryID?: string): T[] {
+  if (!boundaryID) return messages
+  const index = messages.findIndex((message) => message.id === boundaryID)
+  return index >= 0 ? messages.slice(0, index) : messages
+}
+
+export function messageBeforeID<T extends { id: string }>(messages: readonly T[], messageID: string) {
+  const index = messages.findIndex((message) => message.id === messageID)
+  return index > 0 ? messages[index - 1] : undefined
+}
+
+export function messageAfterID<T extends { id: string }>(messages: readonly T[], messageID: string) {
+  const index = messages.findIndex((message) => message.id === messageID)
+  return index >= 0 ? messages[index + 1] : undefined
+}
+
 export function buildTurnMessagesByUserID(messages: readonly Message[]) {
   const result = new Map<string, AssistantMessage[]>()
   const seenUserIDs = new Set<string>()

--- a/packages/app/src/pages/session/session-messages.ts
+++ b/packages/app/src/pages/session/session-messages.ts
@@ -25,17 +25,21 @@ export function readUserMessages(messages: unknown): UserMessage[] {
 export function messagesBeforeID<T extends { id: string }>(messages: T[], boundaryID?: string): T[] {
   if (!boundaryID) return messages
   const index = messages.findIndex((message) => message.id === boundaryID)
-  return index >= 0 ? messages.slice(0, index) : messages
+  return index >= 0 ? messages.slice(0, index) : []
 }
 
-export function messageBeforeID<T extends { id: string }>(messages: readonly T[], messageID: string) {
-  const index = messages.findIndex((message) => message.id === messageID)
-  return index > 0 ? messages[index - 1] : undefined
+export function userMessagesBeforeID(messages: Message[], boundaryID?: string): UserMessage[] {
+  return readUserMessages(messagesBeforeID(messages, boundaryID))
 }
 
-export function messageAfterID<T extends { id: string }>(messages: readonly T[], messageID: string) {
+export function userMessageBeforeID(messages: Message[], messageID: string): UserMessage | undefined {
+  return readUserMessages(messagesBeforeID(messages, messageID)).at(-1)
+}
+
+export function userMessageAfterID(messages: Message[], messageID: string): UserMessage | undefined {
   const index = messages.findIndex((message) => message.id === messageID)
-  return index >= 0 ? messages[index + 1] : undefined
+  if (index < 0) return
+  return messages.slice(index + 1).find(isUserMessage)
 }
 
 export function buildTurnMessagesByUserID(messages: readonly Message[]) {

--- a/packages/app/src/pages/session/use-session-active-message.test.ts
+++ b/packages/app/src/pages/session/use-session-active-message.test.ts
@@ -1,0 +1,42 @@
+import { describe, test } from "bun:test"
+import { runBrowserCheck } from "@/testing/browser-subprocess"
+
+const browserCheck = String.raw`
+import { createRoot, createSignal } from "solid-js"
+import { createSessionActiveMessage } from "./src/pages/session/use-session-active-message.ts"
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message)
+}
+
+const previous = { id: "msg_fdffffffffffffffffffffffffff", role: "user" }
+let active
+let setLatest
+const dispose = createRoot((dispose) => {
+  const [latest, setLatestID] = createSignal(previous.id)
+  setLatest = setLatestID
+  active = createSessionActiveMessage({
+    sessionKey: () => "ses_1",
+    visibleUserMessages: () => [previous],
+    lastUserMessageID: latest,
+    scroller: () => undefined,
+    resumeScroll: () => {},
+    pauseAutoScroll: () => {},
+  })
+  active.setActiveMessage(previous)
+  return dispose
+})
+
+await Promise.resolve()
+setLatest("msg_0000000000000000000000000000")
+await Promise.resolve()
+
+assert(active.messageId() === undefined, "a wrapped latest ID should clear the active message anchor")
+dispose()
+`
+
+describe("createSessionActiveMessage", () => {
+  test("clears the active anchor when the latest message ID wraps", () => {
+    runBrowserCheck(browserCheck)
+  })
+})

--- a/packages/app/src/pages/session/use-session-active-message.ts
+++ b/packages/app/src/pages/session/use-session-active-message.ts
@@ -91,7 +91,7 @@ export function createSessionActiveMessage(input: {
     on(
       input.lastUserMessageID,
       (lastId, prevLastId) => {
-        if (lastId && prevLastId && lastId > prevLastId) {
+        if (lastId && lastId !== prevLastId) {
           setStore("messageId", undefined)
         }
       },

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -17,11 +17,11 @@ import { isWorkInFlightStatus } from "@opencode-ai/ui/util/session-status"
 import { canCloseSessionTab, closeSessionTab } from "@/pages/session/close-session-tab"
 import { createSessionTabs } from "@/pages/session/helpers"
 import {
-  messageAfterID,
-  messageBeforeID,
-  messagesBeforeID,
   readSessionMessages,
   readUserMessages,
+  userMessageAfterID,
+  userMessageBeforeID,
+  userMessagesBeforeID,
 } from "@/pages/session/session-messages"
 import { createBrowserTabClose, showBrowserCloseConfirm } from "@/pages/session/browser/close-page"
 import { isSessionRunning } from "@/pages/session/session-running-state"
@@ -90,9 +90,8 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     const id = params.id
     return readSessionMessages(id ? sync.data.message[id] : undefined)
   }
-  const userMessages = () => readUserMessages(messages())
   const visibleUserMessages = () => {
-    return messagesBeforeID(userMessages(), info()?.revert?.messageID)
+    return userMessagesBeforeID(messages(), info()?.revert?.messageID)
   }
 
   const selectionPreview = (path: string, selection: FileSelection) => {
@@ -261,8 +260,8 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     }
 
     const revert = info()?.revert?.messageID
-    const users = userMessages()
-    const message = messagesBeforeID(users, revert).at(-1)
+    const all = messages()
+    const message = userMessagesBeforeID(all, revert).at(-1)
     if (!message) return
 
     await sdk.client.session.revert({ sessionID, messageID: message.id })
@@ -272,7 +271,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       prompt.set(restored)
     }
 
-    const prev = messageBeforeID(users, message.id)
+    const prev = userMessageBeforeID(all, message.id)
     setActiveMessage(prev)
   }
 
@@ -283,17 +282,19 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     const revertMessageID = info()?.revert?.messageID
     if (!revertMessageID) return
 
-    const users = userMessages()
-    const next = messageAfterID(users, revertMessageID)
+    const all = messages()
+    if (!all.some((message) => message.id === revertMessageID)) return
+
+    const next = userMessageAfterID(all, revertMessageID)
     if (!next) {
       await sdk.client.session.unrevert({ sessionID })
       prompt.reset()
-      setActiveMessage(users.at(-1))
+      setActiveMessage(readUserMessages(all).at(-1))
       return
     }
 
     await sdk.client.session.revert({ sessionID, messageID: next.id })
-    const prev = messageBeforeID(users, next.id)
+    const prev = userMessageBeforeID(all, next.id)
     setActiveMessage(prev)
   }
 

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -14,10 +14,15 @@ import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
 import { showToast } from "@opencode-ai/ui/toast"
 import { isWorkInFlightStatus } from "@opencode-ai/ui/util/session-status"
-import { findLast } from "@opencode-ai/util/array"
 import { canCloseSessionTab, closeSessionTab } from "@/pages/session/close-session-tab"
 import { createSessionTabs } from "@/pages/session/helpers"
-import { readSessionMessages, readUserMessages } from "@/pages/session/session-messages"
+import {
+  messageAfterID,
+  messageBeforeID,
+  messagesBeforeID,
+  readSessionMessages,
+  readUserMessages,
+} from "@/pages/session/session-messages"
 import { createBrowserTabClose, showBrowserCloseConfirm } from "@/pages/session/browser/close-page"
 import { isSessionRunning } from "@/pages/session/session-running-state"
 import { createCloseShellTabRouter, focusActiveTerminalTab, toggleDesktopTerminal } from "@/pages/session/terminal-shell-tab"
@@ -87,9 +92,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   }
   const userMessages = () => readUserMessages(messages())
   const visibleUserMessages = () => {
-    const revert = info()?.revert?.messageID
-    if (!revert) return userMessages()
-    return userMessages().filter((m) => m.id < revert)
+    return messagesBeforeID(userMessages(), info()?.revert?.messageID)
   }
 
   const selectionPreview = (path: string, selection: FileSelection) => {
@@ -258,7 +261,8 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     }
 
     const revert = info()?.revert?.messageID
-    const message = findLast(userMessages(), (x) => !revert || x.id < revert)
+    const users = userMessages()
+    const message = messagesBeforeID(users, revert).at(-1)
     if (!message) return
 
     await sdk.client.session.revert({ sessionID, messageID: message.id })
@@ -268,7 +272,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       prompt.set(restored)
     }
 
-    const prev = findLast(userMessages(), (x) => x.id < message.id)
+    const prev = messageBeforeID(users, message.id)
     setActiveMessage(prev)
   }
 
@@ -279,17 +283,17 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     const revertMessageID = info()?.revert?.messageID
     if (!revertMessageID) return
 
-    const next = userMessages().find((x) => x.id > revertMessageID)
+    const users = userMessages()
+    const next = messageAfterID(users, revertMessageID)
     if (!next) {
       await sdk.client.session.unrevert({ sessionID })
       prompt.reset()
-      const last = findLast(userMessages(), (x) => x.id >= revertMessageID)
-      setActiveMessage(last)
+      setActiveMessage(users.at(-1))
       return
     }
 
     await sdk.client.session.revert({ sessionID, messageID: next.id })
-    const prev = findLast(userMessages(), (x) => x.id < next.id)
+    const prev = messageBeforeID(users, next.id)
     setActiveMessage(prev)
   }
 

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -6,6 +6,7 @@ import type { SessionDiffResponse } from "@opencode-ai/sdk/v2/client"
 import {
   emptyMessages,
   emptyUserMessages,
+  messagesBeforeID,
   readSessionMessages,
   readUserMessages,
 } from "@/pages/session/session-messages"
@@ -245,11 +246,7 @@ export function createSessionTimelineData(input: {
     return input.sync.session.get(id)?.revert?.messageID
   })
   const visibleUserMessages = createMemo(
-    () => {
-      const revert = revertMessageID()
-      if (!revert) return userMessages()
-      return userMessages().filter((m) => m.id < revert)
-    },
+    () => messagesBeforeID(userMessages(), revertMessageID()),
     emptyUserMessages,
     { equals: same },
   )

--- a/packages/app/src/pages/session/use-session-timeline-data.ts
+++ b/packages/app/src/pages/session/use-session-timeline-data.ts
@@ -6,9 +6,9 @@ import type { SessionDiffResponse } from "@opencode-ai/sdk/v2/client"
 import {
   emptyMessages,
   emptyUserMessages,
-  messagesBeforeID,
   readSessionMessages,
   readUserMessages,
+  userMessagesBeforeID,
 } from "@/pages/session/session-messages"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { same } from "@/utils/same"
@@ -246,7 +246,7 @@ export function createSessionTimelineData(input: {
     return input.sync.session.get(id)?.revert?.messageID
   })
   const visibleUserMessages = createMemo(
-    () => messagesBeforeID(userMessages(), revertMessageID()),
+    () => userMessagesBeforeID(messages(), revertMessageID()),
     emptyUserMessages,
     { equals: same },
   )

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -476,11 +476,17 @@ export const layer: Layer.Layer<
             model,
           })
           const previousTailStartId = compactionPart?.tail_start_id ?? latestPrior?.tailStartId
+          const previousTailIndex = previousTailStartId
+            ? history.findIndex((message) => message.info.id === previousTailStartId)
+            : -1
+          const selectedTailIndex = selected.tail_start_id
+            ? history.findIndex((message) => message.info.id === selected.tail_start_id)
+            : -1
           const stalledTailBoundary =
             input.auto &&
-            previousTailStartId !== undefined &&
-            selected.tail_start_id !== undefined &&
-            selected.tail_start_id <= previousTailStartId
+            previousTailIndex >= 0 &&
+            selectedTailIndex >= 0 &&
+            selectedTailIndex <= previousTailIndex
           if (stalledTailBoundary) {
             return { ok: true as const, stalled: true as const, tail_start_id: selected.tail_start_id }
           }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1111,10 +1111,6 @@ export const layer = Layer.effect(
       let aborted = false
       const { msg, part, cmd, finish } = yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          const session = yield* sessions.get(input.sessionID)
-          if (session.revert) {
-            yield* revert.cleanup(session)
-          }
           const agent = yield* agents.get(input.agent)
           if (!agent) {
             const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
@@ -1123,56 +1119,60 @@ export const layer = Layer.effect(
             yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
             throw error
           }
-          const model = input.model ?? agent.model ?? (yield* lastModel(input.sessionID))
-          const userMsg: MessageV2.User = {
-            id: input.messageID ?? MessageID.ascending(),
-            sessionID: input.sessionID,
-            time: { created: Date.now() },
-            role: "user",
-            agent: input.agent,
-            model: { providerID: model.providerID, modelID: model.modelID },
-          }
-          yield* sessions.updateMessage(userMsg)
-          const userPart: MessageV2.Part = {
-            type: "text",
-            id: PartID.ascending(),
-            messageID: userMsg.id,
-            sessionID: input.sessionID,
-            text: "The following tool was executed by the user",
-            synthetic: true,
-          }
-          yield* sessions.updatePart(userPart)
-
-          const msg: MessageV2.Assistant = {
-            id: MessageID.ascending(),
-            sessionID: input.sessionID,
-            parentID: userMsg.id,
-            mode: input.agent,
-            agent: input.agent,
-            cost: 0,
-            path: { cwd: session.executionContext.activeDirectory, root: session.executionContext.ownerDirectory },
-            time: { created: Date.now() },
-            role: "assistant",
-            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-            modelID: model.modelID,
-            providerID: model.providerID,
-          }
-          yield* sessions.updateMessage(msg)
-          const part: MessageV2.ToolPart = {
-            type: "tool",
-            id: PartID.ascending(),
-            messageID: msg.id,
-            sessionID: input.sessionID,
-            tool: "bash",
-            callID: ulid(),
-            state: {
-              status: "running",
-              time: { start: Date.now() },
-              input: { command: input.command },
-            },
-          }
-          yield* sessions.updatePart(part)
-          yield* Deferred.succeed(ready, undefined).pipe(Effect.ignore)
+          const persist = Effect.gen(function* () {
+            const session = yield* sessions.get(input.sessionID)
+            const model = input.model ?? agent.model ?? (yield* lastModel(input.sessionID))
+            const userMsg: MessageV2.User = {
+              id: input.messageID ?? MessageID.ascending(),
+              sessionID: input.sessionID,
+              time: { created: Date.now() },
+              role: "user",
+              agent: input.agent,
+              model: { providerID: model.providerID, modelID: model.modelID },
+            }
+            const userPart: MessageV2.Part = {
+              type: "text",
+              id: PartID.ascending(),
+              messageID: userMsg.id,
+              sessionID: input.sessionID,
+              text: "The following tool was executed by the user",
+              synthetic: true,
+            }
+            const msg: MessageV2.Assistant = {
+              id: MessageID.ascending(),
+              sessionID: input.sessionID,
+              parentID: userMsg.id,
+              mode: input.agent,
+              agent: input.agent,
+              cost: 0,
+              path: { cwd: session.executionContext.activeDirectory, root: session.executionContext.ownerDirectory },
+              time: { created: Date.now() },
+              role: "assistant",
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              modelID: model.modelID,
+              providerID: model.providerID,
+            }
+            const part: MessageV2.ToolPart = {
+              type: "tool",
+              id: PartID.ascending(),
+              messageID: msg.id,
+              sessionID: input.sessionID,
+              tool: "bash",
+              callID: ulid(),
+              state: {
+                status: "running",
+                time: { start: Date.now() },
+                input: { command: input.command },
+              },
+            }
+            yield* sessions.updateMessage(userMsg)
+            yield* sessions.updatePart(userPart)
+            yield* sessions.updateMessage(msg)
+            yield* sessions.updatePart(part)
+            yield* Deferred.succeed(ready, undefined).pipe(Effect.ignore)
+            return { session, msg, part }
+          })
+          const { session, msg, part } = yield* revert.cleanupBeforeOrBusy(input.sessionID, persist)
 
           const sh = Shell.preferred()
           const shellName = (
@@ -1379,7 +1379,7 @@ export const layer = Layer.effect(
       return template.trim()
     })
 
-    const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {
+    const prepareUserMessage = Effect.fn("SessionPrompt.prepareUserMessage")(function* (input: PromptInput) {
       const agentName = input.agent || (yield* agents.defaultAgent())
       const ag = yield* agents.get(agentName)
       if (!ag) {
@@ -1817,11 +1817,16 @@ export const layer = Layer.effect(
         })
       })
 
-      yield* sessions.updateMessage(info)
-      for (const part of parts) yield* sessions.updatePart(part)
-
       return { info, parts }
     }, Effect.scoped)
+
+    const persistUserMessage = Effect.fn("SessionPrompt.persistUserMessage")(function* (
+      message: MessageV2.WithParts,
+    ) {
+      yield* sessions.updateMessage(message.info)
+      for (const part of message.parts) yield* sessions.updatePart(part)
+      return message
+    })
 
     const terminalWriteLock = Semaphore.makeUnsafe(1)
     const persistTerminalErrorCarrier = Effect.fn("SessionPrompt.persistTerminalErrorCarrier")(function* (input: {
@@ -1970,10 +1975,17 @@ export const layer = Layer.effect(
       const run = Effect.gen(function* () {
         yield* throwIfAborted(options)
         interruptedSessions.delete(input.sessionID)
-        const session = yield* sessions.get(input.sessionID)
-        yield* revert.cleanup(session)
-        const message = yield* createUserMessage(promptInput)
-        yield* sessions.touch(input.sessionID)
+        yield* revert.cleanup(yield* sessions.get(input.sessionID))
+        const preparedMessage = yield* prepareUserMessage(promptInput)
+        const { session, message } = yield* revert.cleanupBefore(
+          input.sessionID,
+          Effect.gen(function* () {
+            const session = yield* sessions.get(input.sessionID)
+            const message = yield* persistUserMessage(preparedMessage)
+            yield* sessions.touch(input.sessionID)
+            return { session, message }
+          }),
+        )
 
         const permissions: Permission.Ruleset = []
         for (const [t, enabled] of Object.entries(input.tools ?? {})) {
@@ -2146,7 +2158,9 @@ export const layer = Layer.effect(
           let lastAssistantMsg: MessageV2.WithParts | undefined
           let lastFinished: MessageV2.Assistant | undefined
           let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
+          const queuedUserMessageIDs = new Set<string>()
           for (const msg of MessageV2.stream(sessionID)) {
+            if (!lastFinished && msg.info.role === "user") queuedUserMessageIDs.add(msg.info.id)
             if (!lastUser && msg.info.role === "user") lastUser = msg.info
             if (!lastAssistant && msg.info.role === "assistant") {
               lastAssistant = msg.info
@@ -2376,10 +2390,8 @@ export const layer = Layer.effect(
               yield* summary.summarize({ sessionID, messageID: lastUser.id }).pipe(Effect.ignore, Effect.forkIn(scope))
 
             if (step > 1 && lastFinished) {
-              const lastFinishedIndex = msgs.findIndex((message) => message.info.id === lastFinished.id)
-              const messagesAfterFinished = lastFinishedIndex >= 0 ? msgs.slice(lastFinishedIndex + 1) : []
-              for (const m of messagesAfterFinished) {
-                if (m.info.role !== "user") continue
+              for (const m of msgs) {
+                if (m.info.role !== "user" || !queuedUserMessageIDs.has(m.info.id)) continue
                 for (const p of m.parts) {
                   if (p.type !== "text" || p.ignored || p.synthetic) continue
                   if (!p.text.trim()) continue

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2376,8 +2376,10 @@ export const layer = Layer.effect(
               yield* summary.summarize({ sessionID, messageID: lastUser.id }).pipe(Effect.ignore, Effect.forkIn(scope))
 
             if (step > 1 && lastFinished) {
-              for (const m of msgs) {
-                if (m.info.role !== "user" || m.info.id <= lastFinished.id) continue
+              const lastFinishedIndex = msgs.findIndex((message) => message.info.id === lastFinished.id)
+              const messagesAfterFinished = lastFinishedIndex >= 0 ? msgs.slice(lastFinishedIndex + 1) : []
+              for (const m of messagesAfterFinished) {
+                if (m.info.role !== "user") continue
                 for (const p of m.parts) {
                   if (p.type !== "text" || p.ignored || p.synthetic) continue
                   if (!p.text.trim()) continue

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -118,20 +118,12 @@ export const layer = Layer.effect(
       const sessionID = session.id
       const msgs = yield* sessions.messages({ sessionID })
       const messageID = session.revert.messageID
-      const remove = [] as MessageV2.WithParts[]
-      let target: MessageV2.WithParts | undefined
-      for (const msg of msgs) {
-        if (msg.info.id < messageID) continue
-        if (msg.info.id > messageID) {
-          remove.push(msg)
-          continue
-        }
-        if (session.revert.partID) {
-          target = msg
-          continue
-        }
-        remove.push(msg)
+      const targetIndex = msgs.findIndex((msg) => msg.info.id === messageID)
+      if (targetIndex < 0) {
+        return yield* Effect.die(new Error(`Cannot clean up missing revert message: ${messageID}`))
       }
+      const target = session.revert.partID ? msgs[targetIndex] : undefined
+      const remove = msgs.slice(session.revert.partID ? targetIndex + 1 : targetIndex)
       for (const msg of remove) {
         SyncEvent.run(MessageV2.Event.Removed, {
           sessionID,

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -1,5 +1,5 @@
 import z from "zod"
-import { Effect, Layer, Context } from "effect"
+import { Effect, Layer, Context, Option, Semaphore } from "effect"
 import { Bus } from "../bus"
 import { Snapshot } from "../snapshot"
 import { SyncEvent } from "../sync"
@@ -25,6 +25,14 @@ export interface Interface {
   readonly revert: (input: RevertInput) => Effect.Effect<Session.Info>
   readonly unrevert: (input: { sessionID: SessionID }) => Effect.Effect<Session.Info>
   readonly cleanup: (session: Session.Info) => Effect.Effect<void>
+  readonly cleanupBefore: <A, E, R>(
+    sessionID: SessionID,
+    work: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>
+  readonly cleanupBeforeOrBusy: <A, E, R>(
+    sessionID: SessionID,
+    work: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRevert") {}
@@ -36,6 +44,34 @@ export const layer = Layer.effect(
     const snap = yield* Snapshot.Service
     const bus = yield* Bus.Service
     const state = yield* SessionRunState.Service
+    const locks = new Map<SessionID, { semaphore: Semaphore.Semaphore; users: number }>()
+
+    const trackMutationLock = (sessionID: SessionID) => {
+      const entry = locks.get(sessionID) ?? { semaphore: Semaphore.makeUnsafe(1), users: 0 }
+      entry.users += 1
+      locks.set(sessionID, entry)
+      const release = Effect.sync(() => {
+        entry.users -= 1
+        if (entry.users === 0 && locks.get(sessionID) === entry) locks.delete(sessionID)
+      })
+      return { entry, release }
+    }
+    const withMutationLock = <A, E, R>(sessionID: SessionID, work: Effect.Effect<A, E, R>) =>
+      Effect.suspend(() => {
+        const { entry, release } = trackMutationLock(sessionID)
+        return entry.semaphore.withPermits(1)(work).pipe(Effect.ensuring(release))
+      })
+    const withMutationLockOrBusy = <A, E, R>(sessionID: SessionID, work: Effect.Effect<A, E, R>) =>
+      Effect.suspend(() => {
+        const { entry, release } = trackMutationLock(sessionID)
+        return entry.semaphore.withPermitsIfAvailable(1)(work).pipe(
+          Effect.ensuring(release),
+          Effect.flatMap((result) => {
+            if (Option.isSome(result)) return Effect.succeed(result.value)
+            throw new Session.BusyError(sessionID)
+          }),
+        )
+      })
 
     function revertSummary(diff: string | undefined) {
       if (!diff) return { additions: 0, deletions: 0, files: 0 }
@@ -57,7 +93,7 @@ export const layer = Layer.effect(
       return { additions, deletions, files: files.size }
     }
 
-    const revert = Effect.fn("SessionRevert.revert")(function* (input: RevertInput) {
+    const revertMutation = Effect.fn("SessionRevert.revertMutation")(function* (input: RevertInput) {
       yield* state.assertNotBusy(input.sessionID)
       const all = yield* sessions.messages({ sessionID: input.sessionID })
       let lastUser: MessageV2.User | undefined
@@ -101,8 +137,13 @@ export const layer = Layer.effect(
       yield* bus.publish(Session.Event.TurnChangeInvalidated, { sessionID: input.sessionID })
       return yield* sessions.get(input.sessionID)
     })
+    const revert = Effect.fn("SessionRevert.revert")((input: RevertInput) =>
+      withMutationLock(input.sessionID, revertMutation(input)),
+    )
 
-    const unrevert = Effect.fn("SessionRevert.unrevert")(function* (input: { sessionID: SessionID }) {
+    const unrevertMutation = Effect.fn("SessionRevert.unrevertMutation")(function* (input: {
+      sessionID: SessionID
+    }) {
       log.info("unreverting", input)
       yield* state.assertNotBusy(input.sessionID)
       const session = yield* sessions.get(input.sessionID)
@@ -112,19 +153,26 @@ export const layer = Layer.effect(
       yield* bus.publish(Session.Event.TurnChangeInvalidated, { sessionID: input.sessionID })
       return yield* sessions.get(input.sessionID)
     })
+    const unrevert = Effect.fn("SessionRevert.unrevert")((input: { sessionID: SessionID }) =>
+      withMutationLock(input.sessionID, unrevertMutation(input)),
+    )
 
-    const cleanup = Effect.fn("SessionRevert.cleanup")(function* (session: Session.Info) {
+    const cleanupMutation = Effect.fn("SessionRevert.cleanupMutation")(function* (sessionID: SessionID) {
+      const session = yield* sessions.get(sessionID)
       if (!session.revert) return
-      const sessionID = session.id
       const msgs = yield* sessions.messages({ sessionID })
       const messageID = session.revert.messageID
       const targetIndex = msgs.findIndex((msg) => msg.info.id === messageID)
       if (targetIndex < 0) {
-        return yield* Effect.die(new Error(`Cannot clean up missing revert message: ${messageID}`))
+        log.warn("clearing stale revert with missing boundary", { sessionID, messageID })
+        yield* sessions.clearRevert(sessionID)
+        yield* bus.publish(Session.Event.TurnChangeInvalidated, { sessionID })
+        return
       }
       const target = session.revert.partID ? msgs[targetIndex] : undefined
       const remove = msgs.slice(session.revert.partID ? targetIndex + 1 : targetIndex)
-      for (const msg of remove) {
+      // Keep the persisted boundary until its tail is gone so interrupted cleanup can resume.
+      for (const msg of remove.reverse()) {
         SyncEvent.run(MessageV2.Event.Removed, {
           sessionID,
           messageID: msg.info.id,
@@ -136,7 +184,7 @@ export const layer = Layer.effect(
         if (idx >= 0) {
           const removeParts = target.parts.slice(idx)
           target.parts = target.parts.slice(0, idx)
-          for (const part of removeParts) {
+          for (const part of removeParts.reverse()) {
             SyncEvent.run(MessageV2.Event.PartRemoved, {
               sessionID,
               messageID: target.info.id,
@@ -148,8 +196,15 @@ export const layer = Layer.effect(
       yield* sessions.clearRevert(sessionID)
       yield* bus.publish(Session.Event.TurnChangeInvalidated, { sessionID })
     })
+    const cleanup = Effect.fn("SessionRevert.cleanup")((session: Session.Info) =>
+      withMutationLock(session.id, cleanupMutation(session.id)),
+    )
+    const cleanupBefore: Interface["cleanupBefore"] = (sessionID, work) =>
+      withMutationLock(sessionID, cleanupMutation(sessionID).pipe(Effect.andThen(work)))
+    const cleanupBeforeOrBusy: Interface["cleanupBeforeOrBusy"] = (sessionID, work) =>
+      withMutationLockOrBusy(sessionID, cleanupMutation(sessionID).pipe(Effect.andThen(work)))
 
-    return Service.of({ revert, unrevert, cleanup })
+    return Service.of({ revert, unrevert, cleanup, cleanupBefore, cleanupBeforeOrBusy })
   }),
 )
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -830,6 +830,11 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
       const directory = yield* InstanceState.directory
       const original = yield* get(input.sessionID)
       const title = getForkedTitle(original.title)
+      const msgs = yield* messages({ sessionID: input.sessionID })
+      const cutoffIndex = input.messageID ? msgs.findIndex((msg) => msg.info.id === input.messageID) : msgs.length
+      if (input.messageID && cutoffIndex < 0) {
+        throw new NotFoundError({ message: `Message not found: ${input.messageID}` })
+      }
       const session = yield* createNext({
         directory,
         workspaceID: original.workspaceID,
@@ -837,11 +842,9 @@ export const layer: Layer.Layer<Service, never, Bus.Service | Storage.Service> =
         skill: original.skill,
         executionContext: original.executionContext,
       })
-      const msgs = yield* messages({ sessionID: input.sessionID })
       const idMap = new Map<string, MessageID>()
 
-      for (const msg of msgs) {
-        if (input.messageID && msg.info.id >= input.messageID) break
+      for (const msg of msgs.slice(0, cutoffIndex)) {
         const newID = MessageID.ascending()
         idMap.set(msg.info.id, newID)
 

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -5,7 +5,6 @@ import type { Agent } from "../agent/agent"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { evaluate } from "@/permission/evaluate"
 import { Config } from "../config/config"
-import { Identifier } from "../id/id"
 import { Log } from "../util"
 import { ToolID } from "./schema"
 import { TRUNCATION_DIR } from "./truncation-dir"
@@ -55,14 +54,17 @@ export namespace Truncate {
       const fs = yield* AppFileSystem.Service
 
       const cleanup = Effect.fn("Truncate.cleanup")(function* () {
-        const cutoff = Identifier.timestamp(Identifier.create("tool", false, Date.now() - Duration.toMillis(RETENTION)))
+        const cutoff = Date.now() - Duration.toMillis(RETENTION)
         const entries = yield* fs.readDirectory(TRUNCATION_DIR).pipe(
           Effect.map((all) => all.filter((name) => name.startsWith("tool_"))),
           Effect.catch(() => Effect.succeed([])),
         )
         for (const entry of entries) {
-          if (Identifier.timestamp(entry) >= cutoff) continue
-          yield* fs.remove(path.join(TRUNCATION_DIR, entry)).pipe(Effect.catch(() => Effect.void))
+          const file = path.join(TRUNCATION_DIR, entry)
+          const info = yield* fs.stat(file).pipe(Effect.option)
+          if (Option.isNone(info) || Option.isNone(info.value.mtime)) continue
+          if (info.value.mtime.value.getTime() >= cutoff) continue
+          yield* fs.remove(file).pipe(Effect.catch(() => Effect.void))
         }
       })
 

--- a/packages/opencode/test/config/e2e-smoke-tagging.test.ts
+++ b/packages/opencode/test/config/e2e-smoke-tagging.test.ts
@@ -27,6 +27,7 @@ const expectedSmokeTests = [
   "packages/app/e2e/prompt/first-message-reply.spec.ts:@smoke first replied message in a new session renders without page errors",
   "packages/app/e2e/prompt/prompt.spec.ts:@smoke can send a prompt and receive a reply",
   "packages/app/e2e/release-notes/release-notes-toast.spec.ts:@smoke shows subtle toast when stored version is older than current",
+  "packages/app/e2e/session/session-message-rollover.spec.ts:@smoke keeps newly sent messages at the end of a session after message IDs wrap",
   "packages/app/e2e/session/session-w1-contracts.spec.ts:@smoke W1 connecting indicator shows before first provider progress (nothing visible)",
   "packages/app/e2e/session/session-w1-contracts.spec.ts:@smoke W1 rendered turn locks chevron, selectability, and trow typography",
   "packages/app/e2e/settings/settings-memory.spec.ts:@smoke memory settings exposes the raw MEMORY.md controls",

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -925,9 +925,11 @@ describe("MessageV2.filterCompacted", () => {
         const session = await svc.create({})
         const older = MessageID.ascending("msg_fd0000000000old")
         const boundary = MessageID.ascending("msg_000000000000new")
+        const olderCreated = 1_786_000_000_000
+        const boundaryCreated = 1_787_000_000_000
         for (const [id, created] of [
-          [older, 1_786_000_000_000],
-          [boundary, 1_787_000_000_000],
+          [older, olderCreated],
+          [boundary, boundaryCreated],
         ] as const) {
           await svc.updateMessage({
             id,
@@ -943,7 +945,8 @@ describe("MessageV2.filterCompacted", () => {
 
         const forked = await svc.fork({ sessionID: session.id, messageID: boundary })
 
-        expect(Array.from(MessageV2.stream(forked.id))).toHaveLength(1)
+        const forkedMessages = Array.from(MessageV2.stream(forked.id))
+        expect(forkedMessages.map((message) => message.info.time.created)).toEqual([olderCreated])
         await svc.remove(forked.id)
         await svc.remove(session.id)
       },

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -918,6 +918,38 @@ describe("MessageV2.filterCompacted", () => {
     })
   })
 
+  test("fork stops at a chronological boundary when message IDs wrap", async () => {
+    await Instance.provide({
+      directory: root,
+      fn: async () => {
+        const session = await svc.create({})
+        const older = MessageID.ascending("msg_fd0000000000old")
+        const boundary = MessageID.ascending("msg_000000000000new")
+        for (const [id, created] of [
+          [older, 1_786_000_000_000],
+          [boundary, 1_787_000_000_000],
+        ] as const) {
+          await svc.updateMessage({
+            id,
+            sessionID: session.id,
+            role: "user",
+            time: { created },
+            agent: "test",
+            model: { providerID: "test", modelID: "test" },
+            tools: {},
+            mode: "",
+          } as unknown as MessageV2.Info)
+        }
+
+        const forked = await svc.fork({ sessionID: session.id, messageID: boundary })
+
+        expect(Array.from(MessageV2.stream(forked.id))).toHaveLength(1)
+        await svc.remove(forked.id)
+        await svc.remove(session.id)
+      },
+    })
+  })
+
   it.live(
     "keeps retained tail messages after successful compaction summary",
     provideTmpdirInstance(() =>

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -708,6 +708,113 @@ it.live("loop calls LLM and returns assistant message", () =>
   ),
 )
 
+it.live(
+  "prompt waits for unrevert before cleaning and saving a new message",
+  () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const { prompt, sessions, chat } = yield* boot()
+          const revert = yield* SessionRevert.Service
+          const snapshot = yield* Snapshot.Service
+          const boundary = yield* user(chat.id, "keep after restore")
+          yield* sessions.setRevert({
+            sessionID: chat.id,
+            revert: { messageID: boundary.id, snapshot: "snapshot_test" },
+            summary: { additions: 0, deletions: 0, files: 0 },
+          })
+
+          const restoreEntered = defer<void>()
+          const releaseRestore = defer<void>()
+          const mutableSnapshot = snapshot as Mutable<typeof snapshot>
+          const originalRestore = snapshot.restore
+          mutableSnapshot.restore = (() =>
+            Effect.gen(function* () {
+              restoreEntered.resolve()
+              yield* Effect.promise(() => releaseRestore.promise)
+            })) as typeof snapshot.restore
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => void (mutableSnapshot.restore = originalRestore)),
+          )
+
+          const unrevertFiber = yield* revert.unrevert({ sessionID: chat.id }).pipe(Effect.forkChild)
+          yield* Effect.promise(() => restoreEntered.promise)
+          const promptCompleted = defer<void>()
+          const promptFiber = yield* prompt
+            .prompt({
+              sessionID: chat.id,
+              agent: "build",
+              noReply: true,
+              parts: [{ type: "text", text: "sent after restore" }],
+            })
+            .pipe(Effect.ensuring(Effect.sync(() => promptCompleted.resolve())))
+            .pipe(Effect.forkChild)
+
+          const promptState = yield* Effect.race(
+            Effect.promise(() => promptCompleted.promise).pipe(Effect.as("completed" as const)),
+            Effect.sleep("50 millis").pipe(Effect.as("waiting" as const)),
+          )
+          expect(promptState).toBe("waiting")
+
+          releaseRestore.resolve()
+          yield* Fiber.join(unrevertFiber)
+          const submitted = yield* Fiber.join(promptFiber)
+          expect((yield* sessions.messages({ sessionID: chat.id })).map((message) => message.info.id)).toEqual([
+            boundary.id,
+            submitted.info.id,
+          ])
+        }),
+      { git: true },
+    ),
+)
+
+it.live(
+  "chat message hooks can reenter revert mutations without deadlocking",
+  () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const { prompt, sessions, chat } = yield* boot()
+          const revert = yield* SessionRevert.Service
+          const snapshot = yield* Snapshot.Service
+          const plugin = yield* Plugin.Service
+          const boundary = yield* user(chat.id, "restore from hook")
+          yield* sessions.setRevert({
+            sessionID: chat.id,
+            revert: { messageID: boundary.id, snapshot: "snapshot_test" },
+            summary: { additions: 0, deletions: 0, files: 0 },
+          })
+
+          const mutableSnapshot = snapshot as Mutable<typeof snapshot>
+          const originalRestore = snapshot.restore
+          mutableSnapshot.restore = (() => Effect.void) as typeof snapshot.restore
+          yield* Effect.addFinalizer(() => Effect.sync(() => void (mutableSnapshot.restore = originalRestore)))
+
+          const mutablePlugin = plugin as Mutable<typeof plugin>
+          const originalTrigger = plugin.trigger
+          mutablePlugin.trigger = ((name: Parameters<typeof plugin.trigger>[0], input: unknown, output: unknown) => {
+            if (name === "chat.message") {
+              return revert.unrevert({ sessionID: chat.id }).pipe(Effect.as(output))
+            }
+            return originalTrigger(name as never, input as never, output as never)
+          }) as typeof plugin.trigger
+          yield* Effect.addFinalizer(() => Effect.sync(() => void (mutablePlugin.trigger = originalTrigger)))
+
+          const exit = yield* prompt
+            .prompt({
+              sessionID: chat.id,
+              agent: "build",
+              noReply: true,
+              parts: [{ type: "text", text: "sent after hook" }],
+            })
+            .pipe(Effect.timeout("1 second"), Effect.exit)
+
+          expect(Exit.isSuccess(exit)).toBe(true)
+        }),
+      { git: true },
+    ),
+)
+
 it.live("prompt handles a custom message ID without restarting the model", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {
@@ -3363,6 +3470,94 @@ it.live("assertNotBusy succeeds when idle", () =>
 )
 
 // Shell semantics
+
+unix("shell derives its model from post-revert history", () =>
+  provideTmpdirInstance(
+    () =>
+      Effect.gen(function* () {
+        const { prompt, sessions, chat } = yield* boot()
+        const olderModel = ModelID.make("older-model")
+        const revertedModel = ModelID.make("reverted-model")
+        const older = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: chat.id,
+          agent: "build",
+          model: { providerID: ref.providerID, modelID: olderModel },
+          time: { created: Date.now() },
+        })
+        const reverted = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: chat.id,
+          agent: "build",
+          model: { providerID: ref.providerID, modelID: revertedModel },
+          time: { created: Date.now() + 1 },
+        })
+        yield* sessions.setRevert({
+          sessionID: chat.id,
+          revert: { messageID: reverted.id },
+          summary: { additions: 0, deletions: 0, files: 0 },
+        })
+
+        yield* prompt.shell({ sessionID: chat.id, agent: "build", command: "printf done" })
+
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        const shellUser = messages.find(
+          (message) => message.info.role === "user" && message.info.id !== older.id,
+        )
+        expect(shellUser?.info.role).toBe("user")
+        if (shellUser?.info.role === "user") expect(shellUser.info.model.modelID).toBe(olderModel)
+        expect(messages.some((message) => message.info.id === reverted.id)).toBe(false)
+      }),
+    { git: true, config: cfg },
+  ),
+)
+
+unix("shell cancellation stays responsive while a revert mutation is running", () =>
+  provideTmpdirInstance(
+    () =>
+      Effect.gen(function* () {
+        const { prompt, sessions, chat } = yield* boot()
+        const revert = yield* SessionRevert.Service
+        const snapshot = yield* Snapshot.Service
+        const boundary = yield* user(chat.id, "restore before shell")
+        yield* sessions.setRevert({
+          sessionID: chat.id,
+          revert: { messageID: boundary.id, snapshot: "snapshot_test" },
+          summary: { additions: 0, deletions: 0, files: 0 },
+        })
+
+        const restoreEntered = defer<void>()
+        const releaseRestore = defer<void>()
+        const mutableSnapshot = snapshot as Mutable<typeof snapshot>
+        const originalRestore = snapshot.restore
+        mutableSnapshot.restore = (() =>
+          Effect.gen(function* () {
+            restoreEntered.resolve()
+            yield* Effect.promise(() => releaseRestore.promise)
+          })) as typeof snapshot.restore
+        yield* Effect.addFinalizer(() => Effect.sync(() => void (mutableSnapshot.restore = originalRestore)))
+
+        const unrevertFiber = yield* revert.unrevert({ sessionID: chat.id }).pipe(Effect.forkChild)
+        yield* Effect.promise(() => restoreEntered.promise)
+        const shellFiber = yield* prompt
+          .shell({ sessionID: chat.id, agent: "build", command: "printf done" })
+          .pipe(Effect.forkChild)
+        yield* Effect.sleep("20 millis")
+
+        const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout("250 millis"), Effect.exit)
+        releaseRestore.resolve()
+        yield* Fiber.await(unrevertFiber)
+        const shellExit = yield* Fiber.await(shellFiber)
+
+        expect(Exit.isSuccess(cancelExit)).toBe(true)
+        expect(Exit.isFailure(shellExit)).toBe(true)
+        if (Exit.isFailure(shellExit)) expect(Cause.squash(shellExit.cause)).toBeInstanceOf(Session.BusyError)
+      }),
+    { git: true, config: cfg },
+  ),
+)
 
 it.live(
   "shell rejects with BusyError when loop running",

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -3539,14 +3539,30 @@ unix("shell cancellation stays responsive while a revert mutation is running", (
           })) as typeof snapshot.restore
         yield* Effect.addFinalizer(() => Effect.sync(() => void (mutableSnapshot.restore = originalRestore)))
 
+        const lockAttempted = defer<void>()
+        const releaseLockAttempt = defer<void>()
+        const mutableRevert = revert as Mutable<typeof revert>
+        const originalCleanupBeforeOrBusy = revert.cleanupBeforeOrBusy
+        mutableRevert.cleanupBeforeOrBusy = ((sessionID, work) =>
+          Effect.gen(function* () {
+            lockAttempted.resolve()
+            yield* Effect.promise(() => releaseLockAttempt.promise)
+            return yield* originalCleanupBeforeOrBusy(sessionID, work)
+          })) as typeof revert.cleanupBeforeOrBusy
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => void (mutableRevert.cleanupBeforeOrBusy = originalCleanupBeforeOrBusy)),
+        )
+
         const unrevertFiber = yield* revert.unrevert({ sessionID: chat.id }).pipe(Effect.forkChild)
         yield* Effect.promise(() => restoreEntered.promise)
         const shellFiber = yield* prompt
           .shell({ sessionID: chat.id, agent: "build", command: "printf done" })
           .pipe(Effect.forkChild)
-        yield* Effect.sleep("20 millis")
+        yield* Effect.promise(() => lockAttempted.promise)
 
-        const cancelExit = yield* prompt.cancel(chat.id).pipe(Effect.timeout("250 millis"), Effect.exit)
+        const cancelFiber = yield* prompt.cancel(chat.id).pipe(Effect.forkChild)
+        releaseLockAttempt.resolve()
+        const cancelExit = yield* Fiber.await(cancelFiber)
         releaseRestore.resolve()
         yield* Fiber.await(unrevertFiber)
         const shellExit = yield* Fiber.await(shellFiber)

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -260,6 +260,48 @@ describe("revert + compact workflow", () => {
   )
 
   it.live(
+    "keeps chronological history before a revert boundary when message IDs wrap",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+          const info = yield* session.create({})
+          const older = MessageID.ascending("msg_fd0000000000old")
+          const boundary = MessageID.ascending("msg_000000000000new")
+
+          for (const [id, created] of [
+            [older, 1_786_000_000_000],
+            [boundary, 1_787_000_000_000],
+          ] as const) {
+            yield* session.updateMessage({
+              id,
+              role: "user",
+              sessionID: info.id,
+              agent: "default",
+              model: { providerID: ProviderID.make("openai"), modelID: ModelID.make("gpt-4") },
+              time: { created },
+            })
+            yield* session.updatePart({
+              id: PartID.ascending(),
+              messageID: id,
+              sessionID: info.id,
+              type: "text",
+              text: id,
+            })
+          }
+
+          yield* revert.revert({ sessionID: info.id, messageID: boundary })
+          yield* revert.cleanup(yield* session.get(info.id))
+
+          expect((yield* session.messages({ sessionID: info.id })).map((message) => message.info.id)).toEqual([older])
+          yield* session.remove(info.id)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live(
     "should properly clean up revert state before creating compaction message",
     provideTmpdirInstance(
       (dir) =>

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -10,6 +10,7 @@ import { Snapshot } from "../../src/snapshot"
 import { Log } from "../../src/util"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { SyncEvent } from "../../src/sync"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -470,6 +471,71 @@ describe("revert + compact workflow", () => {
   )
 
   it.live(
+    "cleanup removes tail messages before the revert boundary",
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+
+          const info = yield* session.create({})
+          const boundary = yield* user(info.id)
+          const tail = yield* assistant(info.id, boundary.id, dir)
+          yield* session.setRevert({
+            sessionID: info.id,
+            revert: { messageID: boundary.id },
+            summary: { additions: 0, deletions: 0, files: 0 },
+          })
+
+          const removed: MessageID[] = []
+          const unsubscribe = SyncEvent.subscribeAll(({ def, event }) => {
+            if (def !== MessageV2.Event.Removed) return
+            removed.push(event.data.messageID as MessageID)
+          })
+          yield* revert.cleanup(yield* session.get(info.id)).pipe(
+            Effect.ensuring(Effect.sync(unsubscribe)),
+          )
+
+          expect(removed).toEqual([tail.id, boundary.id])
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live(
+    "cleanup removes later parts before the revert part boundary",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+
+          const info = yield* session.create({})
+          const message = yield* user(info.id)
+          const boundary = yield* text(info.id, message.id, "boundary")
+          const tail = yield* text(info.id, message.id, "tail")
+          yield* session.setRevert({
+            sessionID: info.id,
+            revert: { messageID: message.id, partID: boundary.id },
+            summary: { additions: 0, deletions: 0, files: 0 },
+          })
+
+          const removed: PartID[] = []
+          const unsubscribe = SyncEvent.subscribeAll(({ def, event }) => {
+            if (def !== MessageV2.Event.PartRemoved) return
+            removed.push(event.data.partID as PartID)
+          })
+          yield* revert.cleanup(yield* session.get(info.id)).pipe(
+            Effect.ensuring(Effect.sync(unsubscribe)),
+          )
+
+          expect(removed).toEqual([tail.id, boundary.id])
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live(
     "cleanup is a no-op when session has no revert state",
     provideTmpdirInstance(
       () =>
@@ -489,6 +555,36 @@ describe("revert + compact workflow", () => {
 
           const msgs = yield* session.messages({ sessionID: sid })
           expect(msgs.length).toBe(1)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live(
+    "cleanup clears a stale revert without removing remaining messages",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+
+          const info = yield* session.create({})
+          const sid = info.id
+          const remaining = yield* user(sid)
+          yield* text(sid, remaining.id, "still here")
+
+          yield* session.setRevert({
+            sessionID: sid,
+            revert: { messageID: MessageID.make("msg_missing") },
+            summary: { additions: 0, deletions: 0, files: 0 },
+          })
+
+          yield* revert.cleanup(yield* session.get(sid))
+
+          expect((yield* session.get(sid)).revert).toBeUndefined()
+          expect((yield* session.messages({ sessionID: sid })).map((message) => message.info.id)).toEqual([
+            remaining.id,
+          ])
         }),
       { git: true },
     ),

--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -174,18 +174,47 @@ describe("Truncate", () => {
   describe("cleanup", () => {
     const DAY_MS = 24 * 60 * 60 * 1000
 
+    it.live("preserves a recent file when its ID crosses the timestamp rollover", () =>
+      Effect.gen(function* () {
+        const svc = yield* Truncate.Service
+        const fs = yield* FileSystem.FileSystem
+        const now = 1_786_965_195_136
+        const recentTime = now - 3 * DAY_MS
+        const recent = path.join(Truncate.DIR, Identifier.create("tool", false, now))
+
+        yield* fs.makeDirectory(Truncate.DIR, { recursive: true })
+        yield* writeFileStringScoped(recent, "recent content")
+        yield* fs.utimes(recent, new Date(recentTime), new Date(recentTime))
+
+        const originalNow = Date.now
+        Date.now = () => now
+        yield* svc.cleanup().pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              Date.now = originalNow
+            }),
+          ),
+        )
+
+        expect(yield* fs.exists(recent)).toBe(true)
+      }),
+    )
+
     it.live("deletes files older than 7 days and preserves recent files", () =>
       Effect.gen(function* () {
         const svc = yield* Truncate.Service
         const fs = yield* FileSystem.FileSystem
+        const now = Date.now()
 
         yield* fs.makeDirectory(Truncate.DIR, { recursive: true })
 
-        const old = path.join(Truncate.DIR, Identifier.create("tool", false, Date.now() - 10 * DAY_MS))
-        const recent = path.join(Truncate.DIR, Identifier.create("tool", false, Date.now() - 3 * DAY_MS))
+        const old = path.join(Truncate.DIR, Identifier.create("tool", false, now - 10 * DAY_MS))
+        const recent = path.join(Truncate.DIR, Identifier.create("tool", false, now - 3 * DAY_MS))
 
         yield* writeFileStringScoped(old, "old content")
         yield* writeFileStringScoped(recent, "recent content")
+        yield* fs.utimes(old, new Date(now - 10 * DAY_MS), new Date(now - 10 * DAY_MS))
+        yield* fs.utimes(recent, new Date(now - 3 * DAY_MS), new Date(now - 3 * DAY_MS))
         yield* svc.cleanup()
 
         expect(yield* fs.exists(old)).toBe(false)


### PR DESCRIPTION
## Summary

- Order messages by persisted creation time while keeping IDs as opaque identity values.
- Navigate fork, revert, redo, queued-message, and compaction boundaries by chronological array position.
- Make revert cleanup crash-resumable and serialize revert mutations with new message persistence.
- Age truncated tool-output files by filesystem modification time.
- Add rollover regression coverage from reducers and service workflows through the visible send-and-reload path.

## Why

Message IDs encode a truncated timestamp. That timestamp wrapped in August 2026, so newer IDs became lexically smaller than older IDs. The database and API remained chronological, but renderer insertion and several session workflows treated ID comparison as time comparison. New messages were therefore inserted at the front and became invisible at the latest scroll position; the same invalid assumption also affected fork, revert cleanup, queued prompts, compaction progress, and temporary-output retention.

This safety patch removes relational message-ID comparisons without changing the ID format or migrating stored data. It also closes the observed cleanup/unrevert race without holding the session mutation lock across plugin hooks.

## Related Issue

Follow-up architecture work: #1561

## Human Review Status\n\nApproved by @Astro-Han

## Review Focus

- Confirm every changed comparison separates identity from chronology: equality uses ID, ordering uses `time.created`, and boundaries use array position.
- Confirm revert cleanup removes tail records before the boundary, resumes safely after interruption, and serializes with prompt/shell persistence without plugin reentrancy.
- Confirm no ID-format or persistence migration slipped into this safety patch.

## Risk Notes

- Messages without a finite creation timestamp sort before timestamped messages and use ID only as a deterministic tie-breaker. Persisted message records normally carry `time.created`.
- Tool-output retention now uses file mtime. Entries with unavailable stat or mtime are preserved rather than deleted.
- A shell command fails fast with HTTP 409 / `BusyError` instead of waiting when a revert mutation is already in progress; this avoids an uncancellable pre-ready wait and partial shell messages.
- Revert boundaries outside the loaded page remain fail-closed; redo can remain unavailable until that boundary is loaded. Full boundary-loading UX and broader session-state authority remain follow-up architecture work in #1561.
- Manual macOS Electron verification passed on the PR branch: an older `msg_fd…` turn remained above a newly sent, lexically smaller `msg_00…` turn, and both retained that order after a full renderer reload and session reopen.
- The model configured in the dev profile had an expired login, so both assistant attempts rendered the expected authentication error. This did not affect user-message persistence, ID rollover ordering, or reload verification.
- The visible-UI checklist item remains unticked because this changes behavior, not layout or copy; no visual baseline changed.
- The platform checklist item is left unticked because no platform, packaging, path, permission, or installer surface changed.

## How To Verify

```text
App unit suite: 2025 passed, 0 failed
OpenCode prompt/revert/pagination regression suite: 149 passed, 0 failed
Visible send + assistant reply + reload E2E: 1 passed, 0 failed
App typecheck: passed
OpenCode typecheck: passed
Root lint: passed
Git diff check: passed
macOS Electron manual rollover path: passed; msg_fd… stayed above newly sent msg_00… before and after reload
Fresh-eye adversarial reviews: no P0/P1 findings after final fixes
Claude Opus adversarial review: PASS; no P0/P1 findings
```

## Screenshots or Recordings

No visual presentation changed. The macOS Electron route was manually exercised on the PR branch through project open, persisted rollover fixture load, visible message send, chronological placement, full renderer reload, and session reopen.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session messages now remain in chronological order when message identifiers roll over.
  * Improved reliability for loading, syncing, navigation, undo, redo, reverting, and forking sessions.
  * Revert and prompt operations now handle concurrent changes more safely.
  * Auto-compaction and reminders follow conversation position accurately.
  * Tool-file cleanup now uses file modification dates for dependable retention handling.

* **Tests**
  * Added regression coverage for ordering, navigation, forking, reverting, concurrency, and cleanup across identifier rollovers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->