### PR TITLE
fix(terminal): keep app XDG namespace out of user-command environments

### DIFF
--- a/packages/app/e2e/backend.ts
+++ b/packages/app/e2e/backend.ts
@@ -97,6 +97,8 @@ export function createBackendEnv(input: {
   sandbox: string
   llmUrl?: string
 }): Record<string, string | undefined> {
+  const base = input.base ?? process.env
+  const sandboxXdgKeys = ["XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME"] as const
   const env = {
     ...(input.base ?? process.env),
     OPENCODE_DISABLE_LSP_DOWNLOAD: "true",
@@ -112,6 +114,14 @@ export function createBackendEnv(input: {
     OPENCODE_E2E_ENABLED: "true",
     OPENCODE_E2E_LLM_URL: input.llmUrl,
   }
+  // Mirror the PawWork desktop injector (desktop-electron server.ts): the
+  // sandbox XDG namespaces the e2e backend itself, and the restore
+  // instruction carries the host's pre-existing values so user-command
+  // surfaces (terminals, bash tool) see the user's environment, not the
+  // sandbox. Same wire contract: the key list lives with the injector.
+  env.PAWWORK_USER_ENV_RESTORE = JSON.stringify(
+    Object.fromEntries(sandboxXdgKeys.map((key) => [key, base[key] ?? null])),
+  )
   for (const key of Object.keys(env)) {
     if (INTERNAL_SERVER_AUTH_ENV.has(key.toLowerCase())) delete env[key]
     else if (PROVIDER_ENV_PATTERN.test(key) || PROVIDER_ENV_EXTRA.has(key)) delete env[key]

--- a/packages/app/e2e/terminal/terminal-user-env.spec.ts
+++ b/packages/app/e2e/terminal/terminal-user-env.spec.ts
@@ -1,0 +1,25 @@
+import { runTerminal, waitTerminalReady } from "../actions"
+import { test, expect } from "../fixtures"
+import { terminalSelector } from "../selectors"
+import { terminalToggleKey } from "../utils"
+
+// The backend sandbox namespaces its own XDG dirs and publishes the PawWork
+// restore instruction, exactly like the desktop app. A terminal is a user
+// shell: XDG-following CLIs (crush in #1528) must see the user's config home,
+// and the instruction itself must never reach the child.
+test("a terminal shows the user's XDG env, not the app's sandbox namespace", async ({ page, project }) => {
+  await project.open()
+
+  const term = page.locator(terminalSelector).first()
+  if (!(await term.isVisible().catch(() => false))) await page.keyboard.press(terminalToggleKey)
+  await waitTerminalReady(page, { term })
+
+  // On a clean host runner every XDG key is unset: the markers must render
+  // their "unset" fallback. If the sandbox leaked, the marker would carry the
+  // sandbox path instead and the token would never appear.
+  const cmd = "echo XDG_MARKER_${XDG_CONFIG_HOME:-unset} RESTORE_MARKER_${PAWWORK_USER_ENV_RESTORE:-unset}"
+  await runTerminal(page, { term, cmd, token: "XDG_MARKER_unset RESTORE_MARKER_unset" })
+
+  const rendered = await term.textContent()
+  expect(rendered).not.toContain("opencode-e2e-")
+})

--- a/packages/app/e2e/terminal/terminal-user-env.spec.ts
+++ b/packages/app/e2e/terminal/terminal-user-env.spec.ts
@@ -14,11 +14,14 @@ test("a terminal shows the user's XDG env, not the app's sandbox namespace", asy
   if (!(await term.isVisible().catch(() => false))) await page.keyboard.press(terminalToggleKey)
   await waitTerminalReady(page, { term })
 
-  // On a clean host runner every XDG key is unset: the markers must render
-  // their "unset" fallback. If the sandbox leaked, the marker would carry the
-  // sandbox path instead and the token would never appear.
+  // The restore instruction carries the host's pre-existing XDG values, so
+  // the terminal renders whatever the host had ("unset" when clean, the path
+  // otherwise). Derive the expected marker from the same host env the harness
+  // used, so the spec is host-deterministic. The real leak check is below:
+  // a sandbox path in the rendered output means the namespace leaked.
+  const expectedXdg = process.env.XDG_CONFIG_HOME ?? "unset"
   const cmd = "echo XDG_MARKER_${XDG_CONFIG_HOME:-unset} RESTORE_MARKER_${PAWWORK_USER_ENV_RESTORE:-unset}"
-  await runTerminal(page, { term, cmd, token: "XDG_MARKER_unset RESTORE_MARKER_unset" })
+  await runTerminal(page, { term, cmd, token: `XDG_MARKER_${expectedXdg} RESTORE_MARKER_unset` })
 
   const rendered = await term.textContent()
   expect(rendered).not.toContain("opencode-e2e-")

--- a/packages/desktop-electron/src/main/server.test.ts
+++ b/packages/desktop-electron/src/main/server.test.ts
@@ -84,7 +84,11 @@ describe("desktop server runtime namespace", () => {
   })
 
   test("publishes a restore instruction mapping injected XDG keys to the user's pre-existing values", async () => {
-    mockShellEnv = { XDG_CONFIG_HOME: "/shell/user-config" }
+    // CI runners may carry their own XDG_* values; control all four so the
+    // payload assertion is deterministic.
+    const xdgKeys = ["XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME"] as const
+    for (const key of xdgKeys) delete process.env[key]
+    process.env.XDG_CONFIG_HOME = "/shell/user-config"
     process.env.XDG_CACHE_HOME = "/process/user-cache"
     const { buildServerEnvForTest } = await import("./server")
 

--- a/packages/desktop-electron/src/main/server.test.ts
+++ b/packages/desktop-electron/src/main/server.test.ts
@@ -83,6 +83,23 @@ describe("desktop server runtime namespace", () => {
     expect(env.XDG_STATE_HOME).toBe(serverRoots.state)
   })
 
+  test("publishes a restore instruction mapping injected XDG keys to the user's pre-existing values", async () => {
+    mockShellEnv = { XDG_CONFIG_HOME: "/shell/user-config" }
+    process.env.XDG_CACHE_HOME = "/process/user-cache"
+    const { buildServerEnvForTest } = await import("./server")
+
+    const env = buildServerEnvForTest("secret")
+
+    // Keys the user actually had keep their value; the rest map to null so
+    // user-command surfaces (terminals, bash tool) delete the app injection.
+    expect(JSON.parse(env.PAWWORK_USER_ENV_RESTORE)).toEqual({
+      XDG_CONFIG_HOME: "/shell/user-config",
+      XDG_DATA_HOME: null,
+      XDG_CACHE_HOME: "/process/user-cache",
+      XDG_STATE_HOME: null,
+    })
+  })
+
   test("tracks the backend log file after server log init", async () => {
     const { backendLogFilePathForTest, setBackendLogFilePathForTest } = await import("./server")
 

--- a/packages/desktop-electron/src/main/server.ts
+++ b/packages/desktop-electron/src/main/server.ts
@@ -116,6 +116,19 @@ function buildServerEnv(password: string) {
     ...originalEnv,
     ...(shellEnv.PATH ? { PATH: shellEnv.PATH } : {}),
   }
+  // The XDG redirection below namespaces the embedded server's own
+  // config/data/cache/state. Because the embedded server runs in-process and
+  // reads process.env at module load, the redirection must mutate the shared
+  // environment — it cannot be scoped to the server import. Every
+  // user-command child (PTY terminals, the bash tool) inherits it, so the
+  // injector also publishes this restore instruction: each injected key
+  // mapped to the user's pre-existing value, or null when they had none.
+  // Consumers execute it verbatim (opencode util/env restoreUserEnv), which
+  // keeps the injected-key list in this single place.
+  const namespacedEnvKeys = ["XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME"] as const
+  const userEnvRestore = Object.fromEntries(
+    namespacedEnvKeys.map((key) => [key, originalEnv[key] ?? null]),
+  ) as Record<(typeof namespacedEnvKeys)[number], string | null>
   return {
     ...mergedEnv,
     OPENCODE_EXPERIMENTAL_ICON_DISCOVERY: "true",
@@ -129,6 +142,7 @@ function buildServerEnv(password: string) {
     XDG_CACHE_HOME: roots.cache,
     XDG_CONFIG_HOME: roots.config,
     XDG_STATE_HOME: roots.state,
+    PAWWORK_USER_ENV_RESTORE: JSON.stringify(userEnvRestore),
   }
 }
 

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -8,7 +8,7 @@ import { Log } from "@opencode-ai/core/util/log"
 import { lazy } from "@opencode-ai/util/lazy"
 import { Shell } from "@/shell/shell"
 import { Plugin } from "@/plugin"
-import { envValueCaseInsensitive, prependBundledTools, stripPathKeys, withoutInternalServerAuthEnv } from "@/util/env"
+import { envValueCaseInsensitive, prependBundledTools, restoreUserEnv, stripPathKeys, withoutInternalServerAuthEnv } from "@/util/env"
 import { Process } from "@/util/process"
 import { applyUvMirrorEnvDefaults, uvMirrorEnvSnapshot } from "@/util/uv-mirror"
 import { PtyID } from "./schema"
@@ -283,6 +283,17 @@ export namespace Pty {
         // being visible inside user terminals.
         env.OPENCODE_SERVER_USERNAME = envValueCaseInsensitive(input.env, "OPENCODE_SERVER_USERNAME") ?? ""
         env.OPENCODE_SERVER_PASSWORD = envValueCaseInsensitive(input.env, "OPENCODE_SERVER_PASSWORD") ?? ""
+        // A user terminal must see the user's environment, not the embedded
+        // server's: undo the app's XDG namespace injection (issue #1528).
+        // bun-pty merges the PTY parent's native environment into spawned
+        // children (same constraint as the OPENCODE_SERVER_* blanking above):
+        // deleted keys resurrect from it, so blank-override the unset ones —
+        // every mainstream XDG consumer (Go zero-value lookup, shell :-
+        // expansion, Rust dirs' empty filter) treats "" as unset.
+        const unsetUserEnvKeys = restoreUserEnv(env)
+        if (typeof Bun !== "undefined") {
+          for (const key of unsetUserEnvKeys) env[key] = ""
+        }
 
         if (process.platform === "win32") {
           env.LC_ALL = "C.UTF-8"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -50,7 +50,7 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
-import { envValueCaseInsensitive, prependBundledTools, stripPathKeys, withoutInternalServerAuthEnv } from "@/util/env"
+import { envValueCaseInsensitive, prependBundledTools, restoreUserEnv, stripPathKeys, withoutInternalServerAuthEnv } from "@/util/env"
 import { applyUvMirrorEnvDefaults, uvMirrorEnvSnapshot } from "@/util/uv-mirror"
 import { Cause, Deferred, Effect, Exit, Layer, Option, Scope, Context, Semaphore } from "effect"
 import { EffectLogger } from "@/effect"
@@ -1238,6 +1238,9 @@ export const layer = Layer.effect(
           // Non-blocking: returns the cached probe result (or {} while the
           // first background probe runs) and never overrides user-set UV_* keys.
           applyUvMirrorEnvDefaults(env, uvMirrorEnvSnapshot())
+          // User commands must see the user's environment, not the embedded
+          // server's: undo the app's XDG namespace injection (issue #1528).
+          restoreUserEnv(env)
 
           const cmd = ChildProcess.make(sh, args, {
             cwd,

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -19,7 +19,7 @@ import { Plugin } from "@/plugin"
 import { Duration, Effect, Fiber, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
-import { envValueCaseInsensitive, prependBundledTools, stripPathKeys, withoutInternalServerAuthEnv } from "@/util/env"
+import { envValueCaseInsensitive, prependBundledTools, restoreUserEnv, stripPathKeys, withoutInternalServerAuthEnv } from "@/util/env"
 import { applyUvMirrorEnvDefaults, uvMirrorEnvSnapshot } from "@/util/uv-mirror"
 import { Global } from "@opencode-ai/core/global"
 import { assertExternalDirectoryEffect, resolveExternalPathForPermission } from "./external-directory"
@@ -495,6 +495,9 @@ export const ShellTool = Tool.define(
       // Non-blocking: returns the cached probe result (or {} while the first
       // background probe runs) and never overrides user-set UV_* keys.
       applyUvMirrorEnvDefaults(env, uvMirrorEnvSnapshot())
+      // User commands must see the user's environment, not the embedded
+      // server's: undo the app's XDG namespace injection (issue #1528).
+      restoreUserEnv(env)
       return env
     })
 

--- a/packages/opencode/src/util/env.ts
+++ b/packages/opencode/src/util/env.ts
@@ -15,6 +15,44 @@ export function envValueCaseInsensitive(env: Record<string, string | undefined> 
   return Object.entries(env ?? {}).find(([key]) => key.toLowerCase() === normalized)?.[1]
 }
 
+// The PawWork desktop app injects XDG_* keys into the embedded server's
+// process environment to namespace its config/data/cache/state directories.
+// Those keys must not reach user-command children (PTY terminals, the bash
+// tool): XDG-following CLIs would then treat PawWork's data directory as
+// their config home and lose their real configuration (issue #1528). The
+// injector (desktop-electron server.ts) publishes this restore instruction
+// alongside the pollution: a JSON map of every injected key to the user's
+// pre-existing value, or null when the user had none. Executing the
+// instruction here keeps the injected-key list in exactly one place. The
+// marker name is a wire contract with the injector (desktop-electron
+// server.ts spells the same literal when publishing it). Returns every key
+// that was deleted from the record — the unset keys plus the marker itself:
+// a spawner that merges the parent environment (bun-pty) resurrects deleted
+// keys and must blank-override each returned one.
+const USER_ENV_RESTORE_INSTRUCTION_KEY = "PAWWORK_USER_ENV_RESTORE"
+
+export function restoreUserEnv(env: Record<string, string | undefined>): string[] {
+  const instruction = process.env[USER_ENV_RESTORE_INSTRUCTION_KEY]
+  const deletedKeys: string[] = [USER_ENV_RESTORE_INSTRUCTION_KEY]
+  delete env[USER_ENV_RESTORE_INSTRUCTION_KEY]
+  if (!instruction) return deletedKeys
+  let restore: Record<string, unknown>
+  try {
+    restore = JSON.parse(instruction)
+  } catch {
+    return deletedKeys
+  }
+  if (!restore || typeof restore !== "object") return deletedKeys
+  for (const [key, value] of Object.entries(restore)) {
+    if (typeof value === "string") env[key] = value
+    else {
+      delete env[key]
+      deletedKeys.push(key)
+    }
+  }
+  return deletedKeys
+}
+
 // Returns the directory holding PawWork's bundled CLI tools (uv, ...),
 // or "" when not running inside the packaged Electron app (e.g. plain `bun dev`).
 // In dev:desktop, process.resourcesPath points to the Electron framework's

--- a/packages/opencode/test/pty/pty-user-env-child.ts
+++ b/packages/opencode/test/pty/pty-user-env-child.ts
@@ -1,0 +1,42 @@
+// Child helper for pty-user-env-restore.test.ts. Runs in a Bun process whose
+// NATIVE environment carries the app-namespace pollution — only that way does
+// bun-pty's parent-env merge (the behavior under test) resurrect deleted keys.
+// Creates a PTY, dumps the child's environment, prints it between markers.
+import { mkdirSync } from "node:fs"
+import path from "node:path"
+
+const pkgRoot = path.resolve(import.meta.dir, "../..")
+const { Pty } = await import(pkgRoot + "/src/pty/index.ts")
+const { AppRuntime } = await import(pkgRoot + "/src/effect/app-runtime.ts")
+const { Instance } = await import(pkgRoot + "/src/project/instance.ts")
+
+const dir = path.join(pkgRoot, "../../test-tmp/pty-user-env-child")
+mkdirSync(dir, { recursive: true })
+
+const run = (fn: any) => AppRuntime.runPromise(Pty.Service.use(fn))
+
+await Instance.provide({
+  directory: dir,
+  fn: async () => {
+    const info = await run((svc: any) =>
+      svc.create({
+        command: "/bin/sh",
+        args: ["-c", "sleep 0.5; /usr/bin/env; sleep 0.5"],
+        title: "env probe",
+      }),
+    )
+    let out = ""
+    const ws = {
+      readyState: 1,
+      send: (data: unknown) => {
+        out += typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8")
+      },
+      close: () => undefined,
+    }
+    await run((svc: any) => svc.connect(info.id, ws as never))
+    await new Promise((resolve) => setTimeout(resolve, 2500))
+    await run((svc: any) => svc.remove(info.id))
+    process.stdout.write(`CHILD_ENV_BEGIN\n${out}\nCHILD_ENV_END\n`)
+    process.exit(0)
+  },
+})

--- a/packages/opencode/test/pty/pty-user-env-restore.test.ts
+++ b/packages/opencode/test/pty/pty-user-env-restore.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import { spawn } from "node:child_process"
+
+// Issue #1528: the desktop app injects XDG_* keys into the embedded server's
+// environment to namespace its own config/data/cache/state. A user terminal is
+// a user shell — XDG-following CLIs must see the user's values, never the
+// app's, and never the restore instruction itself.
+//
+// The pollution must be in the child Bun process's NATIVE environment: bun-pty
+// merges the PTY parent's native environment into spawned children, so keys
+// deleted from the spawn env record resurrect from it. This test exists to pin
+// exactly that resurrection-suppression path.
+describe("pty", () => {
+  test("restores user XDG env under native app-namespace pollution", async () => {
+    if (process.platform === "win32") return
+
+    const child = spawn(
+      process.execPath,
+      ["run", "--cwd", import.meta.dir, "./pty-user-env-child.ts"],
+      {
+        env: {
+          // Inherit only what the child needs to run; carry the pollution natively.
+          PATH: process.env.PATH ?? "",
+          HOME: process.env.HOME ?? "",
+          XDG_CONFIG_HOME: "/tmp/pawwork-user-data/config",
+          XDG_DATA_HOME: "/tmp/pawwork-user-data/data",
+          PAWWORK_USER_ENV_RESTORE: JSON.stringify({ XDG_CONFIG_HOME: "/Users/tester/.config", XDG_DATA_HOME: null }),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+
+    const stdout = await new Promise<string>((resolve, reject) => {
+      let text = ""
+      child.stdout!.on("data", (chunk) => (text += String(chunk)))
+      child.on("error", reject)
+      child.on("close", (code) => {
+        if (code === 0) resolve(text)
+        else reject(new Error(`child exited ${code}: ${text.slice(-400)}`))
+      })
+    })
+    const dumped = stdout.slice(stdout.indexOf("CHILD_ENV_BEGIN"), stdout.indexOf("CHILD_ENV_END"))
+
+    // User-owned value survives verbatim.
+    expect(dumped).toContain("XDG_CONFIG_HOME=/Users/tester/.config")
+    // App namespace never reaches the user shell (blanked, not just deleted:
+    // bun-pty would resurrect a deleted key from the parent's native env).
+    expect(dumped).not.toContain("/tmp/pawwork-user-data")
+    // The instruction payload itself never leaks into terminals (a blanked
+    // marker key remains — bun-pty cannot unset native keys, only blank them).
+    expect(dumped).not.toContain("XDG_CONFIG_HOME\":null")
+    expect(dumped).not.toContain("PAWWORK_USER_ENV_RESTORE={")
+  }, 30000)
+})

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -348,6 +348,59 @@ describe("tool.bash", () => {
       else process.env.PAWWORK_E2E_CUSTOM_ENV = previousCustom
     }
   })
+  each("restores user XDG env from the app restore instruction instead of leaking the app namespace", async () => {
+    const previousXdgConfig = process.env.XDG_CONFIG_HOME
+    const previousXdgData = process.env.XDG_DATA_HOME
+    const previousInstruction = process.env.PAWWORK_USER_ENV_RESTORE
+    process.env.XDG_CONFIG_HOME = "/tmp/pawwork-user-data/config"
+    process.env.XDG_DATA_HOME = "/tmp/pawwork-user-data/data"
+    process.env.PAWWORK_USER_ENV_RESTORE = JSON.stringify({
+      XDG_CONFIG_HOME: "/Users/tester/.config",
+      XDG_DATA_HOME: null,
+    })
+    await using tmp = await tmpdir()
+    const scriptPath = path.join(tmp.path, "xdg-probe.mjs")
+    fs.writeFileSync(
+      scriptPath,
+      [
+        'console.log("xdgConfig=" + (process.env.XDG_CONFIG_HOME ?? "unset"))',
+        'console.log("xdgData=" + (process.env.XDG_DATA_HOME ?? "unset"))',
+        'console.log("instruction=" + (process.env.PAWWORK_USER_ENV_RESTORE ?? "unset"))',
+      ].join("\n"),
+    )
+    const scriptArg = quote(scriptPath.replaceAll("\\", "/"))
+    const command = `${PS.has(sh()) ? "& " : ""}${bin} ${scriptArg}`
+
+    try {
+      await Instance.provide({
+        directory: projectRoot,
+        fn: async () => {
+          const result = await runBash((bash) =>
+            bash.execute(
+              {
+                command,
+                description: "Print user XDG environment",
+              },
+              ctx,
+            ),
+          )
+
+          expect(result.metadata.exit).toBe(0)
+          expect(result.output).toContain("xdgConfig=/Users/tester/.config")
+          expect(result.output).toContain("xdgData=unset")
+          expect(result.output).toContain("instruction=unset")
+          expect(result.output).not.toContain("/tmp/pawwork-user-data")
+        },
+      })
+    } finally {
+      if (previousXdgConfig === undefined) delete process.env.XDG_CONFIG_HOME
+      else process.env.XDG_CONFIG_HOME = previousXdgConfig
+      if (previousXdgData === undefined) delete process.env.XDG_DATA_HOME
+      else process.env.XDG_DATA_HOME = previousXdgData
+      if (previousInstruction === undefined) delete process.env.PAWWORK_USER_ENV_RESTORE
+      else process.env.PAWWORK_USER_ENV_RESTORE = previousInstruction
+    }
+  })
 })
 
 describe("tool.bash expected_outputs", () => {

--- a/packages/opencode/test/util/env.test.ts
+++ b/packages/opencode/test/util/env.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import path from "path"
-import { bundledToolsDir, prependBundledTools, stripPathKeys, withoutInternalServerAuthEnv } from "../../src/util/env"
+import { bundledToolsDir, prependBundledTools, restoreUserEnv, stripPathKeys, withoutInternalServerAuthEnv } from "../../src/util/env"
 
 type ResourcesPathBag = { resourcesPath?: string }
 
@@ -83,6 +83,53 @@ describe("util.env.bundledTools", () => {
     // file in cwd shadow a bundled tool. The helper must drop the delimiter.
     setResourcesPath("/r")
     expect(prependBundledTools("")).toBe(path.join("/r", "tools"))
+  })
+})
+
+describe("util.env.restoreUserEnv", () => {
+  const previousInstruction = process.env.PAWWORK_USER_ENV_RESTORE
+
+  afterEach(() => {
+    if (previousInstruction === undefined) delete process.env.PAWWORK_USER_ENV_RESTORE
+    else process.env.PAWWORK_USER_ENV_RESTORE = previousInstruction
+  })
+
+  test("restores user values, removes app-injected keys, and strips the instruction itself", () => {
+    process.env.PAWWORK_USER_ENV_RESTORE = JSON.stringify({
+      XDG_CONFIG_HOME: "/Users/tester/.config",
+      XDG_DATA_HOME: null,
+    })
+    const env: Record<string, string | undefined> = {
+      XDG_CONFIG_HOME: "/tmp/pawwork-user-data/config",
+      XDG_DATA_HOME: "/tmp/pawwork-user-data/data",
+      TERM: "xterm-256color",
+    }
+
+    const unsetKeys = restoreUserEnv(env)
+
+    expect(env).toEqual({ XDG_CONFIG_HOME: "/Users/tester/.config", TERM: "xterm-256color" })
+    expect(unsetKeys).toEqual(["PAWWORK_USER_ENV_RESTORE", "XDG_DATA_HOME"])
+  })
+
+  test("is a no-op without a PawWork instruction (standalone opencode keeps user env verbatim)", () => {
+    delete process.env.PAWWORK_USER_ENV_RESTORE
+    const env: Record<string, string | undefined> = { XDG_CONFIG_HOME: "/custom", TERM: "xterm" }
+
+    const deletedKeys = restoreUserEnv(env)
+
+    expect(env).toEqual({ XDG_CONFIG_HOME: "/custom", TERM: "xterm" })
+    // The marker itself is still reported so merging spawners can blank it.
+    expect(deletedKeys).toEqual(["PAWWORK_USER_ENV_RESTORE"])
+  })
+
+  test("ignores a malformed instruction but still strips it from the child env", () => {
+    process.env.PAWWORK_USER_ENV_RESTORE = "not-json"
+    const env: Record<string, string | undefined> = { TERM: "xterm", PAWWORK_USER_ENV_RESTORE: "not-json" }
+
+    const deletedKeys = restoreUserEnv(env)
+
+    expect(env).toEqual({ TERM: "xterm" })
+    expect(deletedKeys).toEqual(["PAWWORK_USER_ENV_RESTORE"])
   })
 })
 


### PR DESCRIPTION
## Summary

- The desktop injector (`desktop-electron` `buildServerEnv`) now publishes `PAWWORK_USER_ENV_RESTORE` alongside its XDG_* namespace injection: a JSON map of each injected key to the user's pre-existing value (or `null` when the user had none).
- New `restoreUserEnv` (`packages/opencode/src/util/env.ts`) executes that instruction at every user-command boundary — PTY terminals (`pty/index.ts`), the bash tool (`tool/shell.ts` shellEnv), and composer `!command` shells (`session/prompt.ts`) — so user terminals see the user's environment, not the app's runtime namespace.
- PTY under bun-pty blank-overrides unset keys (bun-pty merges the parent's native environment, so deleted keys resurrect); under Electron's node-pty the deletion is a true unset.
- The Playwright e2e backend harness now mirrors the injector (sandbox XDG + restore instruction), and a new terminal spec walks the real user path with native pollution.

## Why

Fixes #1528. The app injects `XDG_CONFIG_HOME` etc. to namespace the embedded server's config/data/cache/state. Because the server runs in-process and reads `process.env` at module load, the injection mutates the shared environment, and every user-command child inherited it. XDG-following CLIs (crush) then treated `%APPDATA%\ai.pawwork.desktop\config` as their config home, found nothing, and prompted for first-run setup. Same failure would hit any Go/Rust CLI that follows XDG.

The restore-instruction design keeps the injected-key list in exactly one place (the injector); consumers execute it verbatim instead of keeping a second key list. Standalone opencode has no instruction and is unaffected.

## Related Issue

Fixes #1528

## Human Review Status

Pending

## Review Focus

- `restoreUserEnv` semantics (`packages/opencode/src/util/env.ts`): restore user value / unset injected key, return deleted keys for merge-resurrect suppression.
- The bun-pty blank-override branch in `pty/index.ts` and why deletion alone is insufficient there (see the pre-existing `OPENCODE_SERVER_*` comment for the same constraint).
- The e2e harness change (`packages/app/e2e/backend.ts`) now publishes the instruction for every e2e backend — intentional, it mirrors the desktop runtime.

## Risk Notes

- Under bun-pty, keys the user never had become empty strings in terminals instead of unset (bun-pty cannot unset natively-inherited keys). Go zero-value lookup, shell `:-` expansion, and Rust `dirs`' empty filter all treat `""` as unset; exotic consumers that read an empty XDG var as a literal path would misbehave — none known.
- Composer `!command` restoration is covered through the shared executor and the two e2e-tested surfaces (no dedicated session-prompt e2e seam exists); the wiring is identical one-liner.
- Windows-specific conpty env semantics were not verified locally (no Windows host); `@lydell/node-pty` passes the env explicitly per platform and the bash-tool probe test runs cross-shell. Desktop smoke CI covers the packaged path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminals and shell commands now correctly expose the host user’s XDG configuration, data, cache, and state settings.
  * Prevented application sandbox paths and environment restoration metadata from leaking into child shells and PTY sessions.
  * Improved handling of unset or malformed environment values.

* **Tests**
  * Added coverage for terminal, PTY, shell, and environment restoration behavior across supported shells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->