### PR TITLE
fix: include updater config in macOS release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,7 +373,7 @@ jobs:
 
       - name: Package signed app
         if: ${{ runner.os == 'macOS' && (inputs.phase == 'submit' || inputs.phase == 'full') }}
-        run: pnpm exec electron-builder --mac dir --${{ matrix.arch_label }} --publish never --config electron-builder.config.ts
+        run: pnpm exec electron-builder --mac zip --${{ matrix.arch_label }} --publish never --config electron-builder.config.ts
         working-directory: packages/desktop-electron
         timeout-minutes: 30
         env:

--- a/packages/desktop-electron/scripts/release-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-workflow-contract.test.ts
@@ -45,7 +45,9 @@ describe("release workflow", () => {
     // one; --prepackaged is what makes the shipped dmg the stapled build.
     const submit = steps[indexOfStep("Package signed app")]
     const finalize = steps[indexOfStep("Package notarized artifacts")]
-    expect(submit.body).toMatch(/electron-builder --mac dir .*--publish never/)
+    // A distributable target makes electron-builder write app-update.yml into
+    // the bundle before signing; the dir-only target deliberately skips it.
+    expect(submit.body).toMatch(/electron-builder --mac zip .*--publish never/)
     expect(finalize.body).toMatch(/electron-builder --mac dmg zip .*--prepackaged "\$APP_PATH"/)
   })
 


### PR DESCRIPTION
## Summary

Make the macOS submit phase build a ZIP target so electron-builder writes `app-update.yml` into the signed bundle before notarization. No issue exists because this was discovered by the v2026.8.4 release gate after #1573 merged.

## Why

The previous `--mac dir` submit target intentionally skipped electron-builder update configuration generation. Finalize then repackaged that already-notarized bundle with `--prepackaged`, which cannot add the missing file. The release gate correctly stopped the draft before publication.

## Related Issue

Follow-up to #1573.

## Human Review Status

Pending

## Review Focus

Confirm that using the supported ZIP target is the smallest way to generate update configuration before signing while preserving the two-phase notarization boundary.

## Risk Notes

- The macOS submit phase performs one extra temporary ZIP build; the final release artifacts are still rebuilt only from the notarized prepackaged app.
- The visible-UI checklist item is intentionally left unticked because this changes only release packaging.

## How To Verify

```text
Regression contract: 5 release workflow tests passed
Related builder contract: 10 tests passed
Workflow syntax: actionlint passed
Git diff check: no whitespace errors
Original failure: run 32419962404 proved signed/notarized artifacts lacked Contents/Resources/app-update.yml
```

## Screenshots or Recordings

Not applicable: no visible UI or copy changes.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS signed releases are now packaged as distributable ZIP archives, improving compatibility for downloading and sharing.

* **Tests**
  * Updated release validation to confirm the signed macOS package uses the ZIP format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->