### PR TITLE
feat(product): refresh OpenCode Free models at runtime

### DIFF
--- a/packages/desktop-electron/resources/dsh/product/lib/index.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/index.js
@@ -1,3 +1,41 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { refreshOpenCodeFreeModels } = require('./opencode-free.cjs');
+
 export const name = "pawwork-product"
 
-export function apply() {}
+// Requires the settings service (to refresh the llm-pi-ai model list) and the
+// timer service (to re-run that refresh periodically). Activation waits for
+// both, so the first refresh runs after the pi-ai adapter has registered its
+// settings namespace rather than racing it.
+export const inject = ['settings', 'timer'];
+
+// How often to re-discover the OpenCode Free catalog. New free models appear
+// without a PawWork release; the cadence balances freshness against the two
+// cheap GETs per sweep and the (no-op when unchanged) settings write.
+const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+function runRefresh(ctx, controller) {
+	return refreshOpenCodeFreeModels({
+		settings: ctx.settings,
+		describe: () => ctx.settings.describe(),
+		logger: ctx.logger,
+		signal: controller.signal,
+	}).catch((error) => {
+		// A refresh failure must not take the backend down; the packaged model
+		// list stays and the next sweep retries.
+		ctx.logger.warn?.(
+			`OpenCode Free catalog refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	});
+}
+
+export function apply(ctx) {
+	const controller = new AbortController();
+	// Immediate refresh so a fresh launch picks up the current catalog right
+	// away, then periodic sweeps to follow upstream as it changes.
+	void runRefresh(ctx, controller);
+	ctx.interval(() => runRefresh(ctx, controller), REFRESH_INTERVAL_MS);
+	ctx.effect(() => () => controller.abort(new Error('PawWork product stopped')));
+}

--- a/packages/desktop-electron/resources/dsh/product/lib/index.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/index.js
@@ -5,21 +5,21 @@ const { refreshOpenCodeFreeModels } = require('./opencode-free.cjs');
 
 export const name = "pawwork-product"
 
-// Requires the settings service (to refresh the llm-pi-ai model list) and the
-// timer service (to re-run that refresh periodically). Activation waits for
-// both, so the first refresh runs after the pi-ai adapter has registered its
-// settings namespace rather than racing it.
-export const inject = ['settings', 'timer'];
+// Requires the settings service (to refresh the llm-pi-ai model list), the
+// timer service (to re-run that refresh periodically), and the default-model
+// service (so a refresh that retires the opencode default can move it to a
+// surviving model). Activation waits for all three.
+export const inject = ['settings', 'timer', 'agentDefaultModel'];
 
 // How often to re-discover the OpenCode Free catalog. New free models appear
-// without a PawWork release; the cadence balances freshness against the two
-// cheap GETs per sweep and the (no-op when unchanged) settings write.
+// without a PawWork release; the cadence balances freshness against the one
+// cheap GET per sweep and the (no-op when unchanged) settings write.
 const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 
 function runRefresh(ctx, controller) {
 	return refreshOpenCodeFreeModels({
 		settings: ctx.settings,
-		describe: () => ctx.settings.describe(),
+		defaultModel: ctx.agentDefaultModel,
 		logger: ctx.logger,
 		signal: controller.signal,
 	}).catch((error) => {

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -1,39 +1,12 @@
 'use strict';
 const { isDeepStrictEqual } = require('node:util');
 /**
- * OpenCode Free catalog discovery for PawWork.
- *
- * The shipped "OpenCode Free" model list is a build-time static snapshot (the
- * product patch replaces `llm-pi-ai.providers.opencode.models` with a fixed
- * set of ids). Upstream opencode adds and retires free models independently of
- * any PawWork release, so a frozen list both hides new models and keeps dead
- * ones selectable until a request 401s, which the surface mislabels as
- * "API key is invalid".
- *
- * This module restores the old v1 behavior at runtime: it reads the live
- * models.dev catalog once, selects the models that are genuinely free and not
- * deprecated, and writes them into the existing `llm-pi-ai` settings
- * namespace. The `llm-pi-ai` adapter rebuilds from its configured model list
- * on change, so streaming stays with the already-verified pi-ai adapter; this
- * module only supplies the list.
- *
- * One authority, one predicate:
- *  - `models.dev/api.json` is the pricing/metadata authority (what opencode
- *    itself reads). A model is selectable iff its cost has no nonzero numeric
- *    leaf and it is not marked `deprecated`; the gateway serves a model that
- *    is neither paid nor deprecated, so no separate serviceability probe is
- *    needed. (A model priced at zero but `deprecated` — e.g. a promotion that
- *    has ended — 401s on use and must not be offered as free.)
- *
- * Route wiring: opencode speaks `openai-completions` at
- * `https://opencode.ai/zen/v1`. The adapter only accepts models it describes,
- * plus a route-level `api`/`baseURL` for the rest; the write therefore sets
- * those two keys alongside the model list so the selectable set is servable.
- *
- * Failure policy: any fetch/parse error, or a usable set of zero models,
- * leaves the configured list untouched (the packaged bootstrap) rather than
- * writing an empty list — DSH interprets an empty configured `models` as "use
- * the entire bundled catalog".
+ * Refresh OpenCode Free membership and capabilities from models.dev without
+ * taking ownership of streaming. The explicit route protocol is required for
+ * new IDs because the bundled OpenCode catalog spans several protocols. Only
+ * zero-cost, non-deprecated models are selected. Fetch, parse, and empty-result
+ * failures leave the packaged fallback untouched because an empty configured
+ * model list means "use the entire bundled catalog" in DSH.
  */
 
 /** Live opencode catalog (what the opencode CLI itself reads). */
@@ -42,19 +15,11 @@ const OPENCODE_MODELS_URL = 'https://models.dev/api.json';
 const LLM_PI_AI_NAMESPACE = 'llm-pi-ai';
 /** Path of the opencode model list inside that namespace. */
 const MODELS_PATH = ['providers', 'opencode', 'models'];
-/** Wire protocol every opencode route uses. */
 const OPENCODE_ROUTE_API = 'openai-completions';
-/** Base URL the opencode zen gateway serves. */
 const OPENCODE_ROUTE_BASE_URL = 'https://opencode.ai/zen/v1';
 /** Capabilities the current pi-ai adapter can express. */
 const SUPPORTED_INPUT_MODALITIES = new Set(['text', 'image']);
 const SUPPORTED_REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
-
-/** Whether the opencode route already carries our api/baseURL wiring. */
-function routeConfigured(value) {
-	const provider = value?.providers?.opencode;
-	return provider?.api === OPENCODE_ROUTE_API && provider?.baseURL === OPENCODE_ROUTE_BASE_URL;
-}
 /**
  * A model is free only when its cost metadata has no nonzero numeric leaf.
  *
@@ -159,13 +124,9 @@ async function ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selec
 	if (nextIds.includes(current.model)) return;
 	const fallback = selectable[0];
 	if (fallback === undefined) return;
-	const reasoningEffort = current.reasoningEffort;
 	const next = {
 		provider: 'opencode',
 		model: fallback.id,
-		...(typeof reasoningEffort === 'string' && fallback.reasoningEfforts?.[reasoningEffort] !== undefined
-			? { reasoningEffort }
-			: {}),
 	};
 	try {
 		await defaultModel.saveSelection(next);
@@ -216,8 +177,8 @@ async function waitForNamespace(get, timeoutMs, signal) {
  *
  * A fetch/parse failure or an empty usable set leaves the packaged list
  * untouched. A successful non-empty set replaces `providers.opencode.models`
- * (plus the route `api`/`baseURL` needed to serve models the bundled catalog
- * does not yet describe), which triggers the pi-ai adapter to rebuild.
+ * and pins the gateway protocol and endpoint needed by IDs absent from the
+ * bundled mixed-protocol catalog, which triggers the pi-ai adapter to rebuild.
  * Surviving models keep their configured metadata; when the opencode default
  * model is dropped, the default selection moves to a surviving model.
  * @param deps - settings service, optional default-model service, fetch impl, logger, abort signal.
@@ -249,10 +210,12 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 	const nextIds = selectable.map((entry) => entry.id);
 	const merged = mergeModelEntries(currentValue, selectable);
 	const currentModels = currentValue?.providers?.opencode?.models;
+	const currentProvider = currentValue?.providers?.opencode;
 	// Skip the write when the live profiles and routing already match: a periodic
 	// refresh must not churn settings.yaml or rebuild the adapter every interval.
 	const unchanged = Array.isArray(currentModels)
-		&& routeConfigured(currentValue)
+		&& currentProvider?.api === OPENCODE_ROUTE_API
+		&& currentProvider?.baseURL === OPENCODE_ROUTE_BASE_URL
 		&& isDeepStrictEqual(currentModels, merged);
 	if (!unchanged) {
 		await settings.mutate(LLM_PI_AI_NAMESPACE, [
@@ -271,7 +234,6 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 
 module.exports = {
 	isZeroCost,
-	mergeModelEntries,
 	refreshOpenCodeFreeModels,
 	selectFreeAndServed,
 	waitForNamespace,

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -1,0 +1,163 @@
+'use strict';
+/**
+ * OpenCode Free catalog discovery for PawWork.
+ *
+ * The shipped "OpenCode Free" model list is a build-time static snapshot (the
+ * product patch replaces `llm-pi-ai.providers.opencode.models` with exactly
+ * seven ids). Upstream opencode adds and retires free models independently of
+ * any PawWork release, so a frozen list both hides new models and keeps dead
+ * ones selectable until a 401 surfaces as "API key is invalid".
+ *
+ * This module restores the old v1 behavior at runtime: it reads the live
+ * opencode catalog for pricing and the gateway's own model listing for
+ * serviceability, then writes the intersection into the existing `llm-pi-ai`
+ * settings namespace. The `llm-pi-ai` adapter rebuilds from its configured
+ * model list on change, so streaming stays with the already-verified pi-ai
+ * adapter; this module only supplies the list.
+ *
+ * Two authorities, one selectable set:
+ *  - `models.opencode.ai/api.json` is the pricing/metadata authority.
+ *  - `GET /zen/v1/models` (public credential) is the serviceability authority.
+ *    A model that only exists in the metadata catalog — or one the gateway no
+ *    longer serves — must not be offered as free.
+ *
+ * Failure policy: any fetch/parse error, or an intersection of zero usable
+ * models, leaves the configured list untouched (the packaged seven-model
+ * bootstrap) rather than writing an empty list — DSH interprets an empty
+ * configured `models` as "use the entire bundled catalog".
+ */
+
+const path = require('node:path');
+
+/** Live opencode catalog (what the opencode CLI itself reads). */
+const OPENCODE_MODELS_URL = 'https://models.opencode.ai/api.json';
+/** Gateway model listing under the public credential. */
+const OPENCODE_ZEN_MODELS_URL = 'https://opencode.ai/zen/v1/models';
+/** The settings namespace the pi-ai adapter owns. */
+const LLM_PI_AI_NAMESPACE = 'llm-pi-ai';
+/** Path of the opencode model list inside that namespace. */
+const MODELS_PATH = ['providers', 'opencode', 'models'];
+/** The ids currently configured for opencode, when the descriptor resolves them. */
+function configuredModelIds(descriptor) {
+	const models = descriptor?.value?.providers?.opencode?.models;
+	if (!Array.isArray(models)) return undefined;
+	const ids = models.map((entry) => entry?.id).filter((id) => typeof id === 'string');
+	return ids.length === models.length ? ids : undefined;
+}
+/** Whether two id arrays name the same set, in any order. */
+function sameModelIds(left, right) {
+	if (left.length !== right.length) return false;
+	const a = new Set(left);
+	return right.every((id) => a.has(id));
+}
+/** A model entry is free when its leading input cost is explicitly zero. */
+function isZeroCost(cost) {
+	if (cost === null || typeof cost !== 'object') return false;
+	if (Array.isArray(cost)) return cost.length > 0 && isZeroCost(cost[0]);
+	return Number(cost.input) === 0;
+}
+/**
+ * Select the free-and-served opencode models.
+ * @param catalog - the raw `models.opencode.ai/api.json` document.
+ * @param servedIds - model ids served by `GET /zen/v1/models`.
+ * @returns the selectable ids in sorted order, each shaped as a pi-ai model entry.
+ */
+function selectFreeAndServed(catalog, servedIds) {
+	const opencode = catalog?.opencode;
+	if (opencode === null || typeof opencode !== 'object') return [];
+	const models = opencode.models;
+	if (models === null || typeof models !== 'object') return [];
+	const served = new Set(servedIds);
+	const out = [];
+	for (const [id, entry] of Object.entries(models)) {
+		if (entry === null || typeof entry !== 'object') continue;
+		if (!isZeroCost(entry.cost)) continue;
+		if (!served.has(id)) continue;
+		out.push({ id });
+	}
+	return out.sort((left, right) => left.id.localeCompare(right.id));
+}
+/** Fetch one URL as JSON, honoring cancellation. */
+async function fetchJson(url, fetchImpl, signal) {
+	const response = await fetchImpl(url, {
+		headers: { accept: 'application/json' },
+		...(signal === undefined ? {} : { signal }),
+	});
+	if (!response.ok) throw new Error(`${url} answered ${response.status}`);
+	const body = await response.json();
+	if (body === null || typeof body !== 'object') throw new Error(`${url} did not answer with an object`);
+	return body;
+}
+/**
+ * Wait until the `llm-pi-ai` settings namespace is registered.
+ *
+ * DSH activates plugins by service availability, not patch order, so this
+ * plugin may apply before `llm-pi-ai` has run `installSettingsSection`; a
+ * `settings.mutate` on an unregistered namespace throws. Bounded wait keeps a
+ * slow adapter from silently dropping the refresh.
+ * @param describe - the settings service's `describe()`.
+ * @param timeoutMs - upper bound on the wait.
+ * @returns the `llm-pi-ai` descriptor, or `undefined` on timeout.
+ */
+async function waitForNamespace(describe, timeoutMs) {
+	const deadline = Date.now() + (timeoutMs === undefined ? 10000 : timeoutMs);
+	for (;;) {
+		const descriptor = describe().find((entry) => entry.ns === LLM_PI_AI_NAMESPACE);
+		if (descriptor !== undefined) return descriptor;
+		if (Date.now() >= deadline) return undefined;
+		await new Promise((resolve) => setTimeout(resolve, 200));
+	}
+}
+/**
+ * Refresh the OpenCode Free model list in the `llm-pi-ai` settings namespace.
+ *
+ * A fetch or parse failure, or an empty usable set, leaves the packaged list
+ * untouched. A successful non-empty set replaces `providers.opencode.models`,
+ * which triggers the pi-ai adapter to rebuild on the next request.
+ * @param deps - settings service, fetch impl, logger, and an optional abort signal.
+ * @returns the selectable model count written, or `undefined` when nothing was written.
+ */
+async function refreshOpenCodeFreeModels({ settings, describe, logger, fetchImpl = globalThis.fetch, signal, timeoutMs }) {
+	const descriptor = await waitForNamespace(describe ?? (() => settings.describe()), timeoutMs);
+	if (descriptor === undefined) {
+		logger?.warn?.('llm-pi-ai settings namespace is not registered; leaving the packaged OpenCode Free model list');
+		return undefined;
+	}
+	let catalog;
+	let gateway;
+	try {
+		[catalog, gateway] = await Promise.all([
+			fetchJson(OPENCODE_MODELS_URL, fetchImpl, signal),
+			fetchJson(OPENCODE_ZEN_MODELS_URL, fetchImpl, signal),
+		]);
+	} catch (error) {
+		logger?.warn?.(`OpenCode Free catalog refresh failed; leaving the packaged model list: ${error instanceof Error ? error.message : String(error)}`);
+		return undefined;
+	}
+	const servedIds = Array.isArray(gateway?.data) ? gateway.data.map((entry) => entry?.id).filter(Boolean) : [];
+	const selectable = selectFreeAndServed(catalog, servedIds);
+	if (selectable.length === 0) {
+		logger?.warn?.('OpenCode Free catalog refresh found no usable free models; leaving the packaged model list');
+		return undefined;
+	}
+	const nextIds = selectable.map((entry) => entry.id);
+	const currentIds = configuredModelIds(descriptor);
+	// Skip the write when the served set already matches: a periodic refresh
+	// must not churn settings.yaml or rebuild the adapter every interval.
+	if (currentIds !== undefined && sameModelIds(currentIds, nextIds)) return selectable.length;
+	await settings.mutate(LLM_PI_AI_NAMESPACE, [{ op: 'set', path: MODELS_PATH, value: selectable }], descriptor.revision);
+	logger?.info?.(`OpenCode Free catalog refreshed to ${selectable.length} models`);
+	return selectable.length;
+}
+
+module.exports = {
+	LLM_PI_AI_NAMESPACE,
+	OPENCODE_MODELS_URL,
+	OPENCODE_ZEN_MODELS_URL,
+	configuredModelIds,
+	isZeroCost,
+	refreshOpenCodeFreeModels,
+	sameModelIds,
+	selectFreeAndServed,
+	waitForNamespace,
+};

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -1,4 +1,5 @@
 'use strict';
+const { isDeepStrictEqual } = require('node:util');
 /**
  * OpenCode Free catalog discovery for PawWork.
  *
@@ -45,24 +46,14 @@ const MODELS_PATH = ['providers', 'opencode', 'models'];
 const OPENCODE_ROUTE_API = 'openai-completions';
 /** Base URL the opencode zen gateway serves. */
 const OPENCODE_ROUTE_BASE_URL = 'https://opencode.ai/zen/v1';
+/** Capabilities the current pi-ai adapter can express. */
+const SUPPORTED_INPUT_MODALITIES = new Set(['text', 'image']);
+const SUPPORTED_REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
 
-/** The ids currently configured for opencode, when the resolved value lists them. */
-function configuredModelIds(value) {
-	const models = value?.providers?.opencode?.models;
-	if (!Array.isArray(models)) return undefined;
-	const ids = models.map((entry) => entry?.id).filter((id) => typeof id === 'string');
-	return ids.length === models.length ? ids : undefined;
-}
 /** Whether the opencode route already carries our api/baseURL wiring. */
 function routeConfigured(value) {
 	const provider = value?.providers?.opencode;
 	return provider?.api === OPENCODE_ROUTE_API && provider?.baseURL === OPENCODE_ROUTE_BASE_URL;
-}
-/** Whether two id arrays name the same set, in any order. */
-function sameModelIds(left, right) {
-	if (left.length !== right.length) return false;
-	const a = new Set(left);
-	return right.every((id) => a.has(id));
 }
 /**
  * A model is free only when its cost metadata has no nonzero numeric leaf.
@@ -84,6 +75,33 @@ function isZeroCost(cost) {
 	};
 	return Object.keys(cost).length > 0 && walk(cost, 'root');
 }
+/** Translate one models.dev entry into fields the pi-ai settings schema owns. */
+function modelProfile(id, entry) {
+	const profile = { id };
+	if (typeof entry.name === 'string' && entry.name.length > 0) profile.name = entry.name;
+	if (Number.isInteger(entry.limit?.context) && entry.limit.context > 0) profile.contextWindow = entry.limit.context;
+	if (Number.isInteger(entry.limit?.output) && entry.limit.output > 0) profile.maxTokens = entry.limit.output;
+	const input = Array.isArray(entry.modalities?.input)
+		? entry.modalities.input.filter((modality) => SUPPORTED_INPUT_MODALITIES.has(modality))
+		: [];
+	if (input.length > 0) profile.input = [...new Set(input)];
+	if (entry.reasoning === false) profile.reasoningEfforts = false;
+	const reasoningEfforts = {};
+	if (Array.isArray(entry.reasoning_options)) {
+		if (entry.reasoning_options.some((option) => option?.type === 'toggle')) reasoningEfforts.off = null;
+		for (const option of entry.reasoning_options) {
+			if (option?.type !== 'effort' || !Array.isArray(option.values)) continue;
+			for (const effort of option.values) {
+				if (SUPPORTED_REASONING_EFFORTS.has(effort)) reasoningEfforts[effort] = effort;
+			}
+		}
+	}
+	// `reasoning: true` with no effort values means the provider may think, but
+	// exposes no selectable level. Let it use its default instead of inventing
+	// wire spellings the catalog did not advertise.
+	if (entry.reasoning !== false && Object.keys(reasoningEfforts).some((effort) => effort !== 'off')) profile.reasoningEfforts = reasoningEfforts;
+	return profile;
+}
 /**
  * Select the free, non-deprecated opencode models.
  * @param catalog - the raw `models.dev/api.json` document.
@@ -99,16 +117,27 @@ function selectFreeAndServed(catalog) {
 		if (entry === null || typeof entry !== 'object') continue;
 		if (entry.status === 'deprecated') continue;
 		if (!isZeroCost(entry.cost)) continue;
-		out.push({ id });
+		out.push(modelProfile(id, entry));
 	}
 	return out.sort((left, right) => left.id.localeCompare(right.id));
 }
-/** Preserve configured metadata for surviving models; new ids get `{ id }`. */
+/**
+ * Keep metadata models.dev cannot answer; its live catalog owns identity,
+ * capacities, modalities, and selectable efforts for this product-managed
+ * route. `compat` remains local because it describes this gateway's wire.
+ */
 function mergeModelEntries(currentValue, selectable) {
 	const current = currentValue?.providers?.opencode?.models;
 	if (!Array.isArray(current)) return selectable;
 	const existing = new Map(current.map((entry) => [entry?.id, entry]));
-	return selectable.map((entry) => existing.get(entry.id) ?? entry);
+	return selectable.map((entry) => {
+		const local = existing.get(entry.id);
+		return {
+			...local?.maxTokens === undefined ? {} : { maxTokens: local.maxTokens },
+			...local?.compat === undefined ? {} : { compat: local.compat },
+			...entry,
+		};
+	});
 }
 /**
  * Keep the opencode default model usable after a refresh drops it.
@@ -128,13 +157,21 @@ async function ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selec
 	}
 	if (current === undefined || current.provider !== 'opencode') return;
 	if (nextIds.includes(current.model)) return;
-	const fallbackId = selectable[0]?.id;
-	if (fallbackId === undefined) return;
+	const fallback = selectable[0];
+	if (fallback === undefined) return;
+	const reasoningEffort = current.reasoningEffort;
+	const next = {
+		provider: 'opencode',
+		model: fallback.id,
+		...(typeof reasoningEffort === 'string' && fallback.reasoningEfforts?.[reasoningEffort] !== undefined
+			? { reasoningEffort }
+			: {}),
+	};
 	try {
-		await defaultModel.saveSelection({ provider: 'opencode', model: fallbackId });
-		logger?.info?.(`default opencode model ${current.model} retired; moved to ${fallbackId}`);
+		await defaultModel.saveSelection(next);
+		logger?.info?.(`default opencode model ${current.model} retired; moved to ${fallback.id}`);
 	} catch (error) {
-		logger?.warn?.(`failed to move default opencode model from ${current.model} to ${fallbackId}: ${error instanceof Error ? error.message : String(error)}`);
+		logger?.warn?.(`failed to move default opencode model from ${current.model} to ${fallback.id}: ${error instanceof Error ? error.message : String(error)}`);
 	}
 }
 /** Per-request bound so a hung gateway cannot leave a refresh pending forever. */
@@ -204,18 +241,25 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 		logger?.warn?.('OpenCode Free catalog refresh found no usable free models; leaving the packaged model list');
 		return undefined;
 	}
+	// The network request may outlive a settings edit. Re-read the authoritative
+	// descriptor immediately before deriving and committing the replacement,
+	// then let the settings revision reject any still-later concurrent change.
+	const descriptor = settings.describe?.().find((entry) => entry.ns === LLM_PI_AI_NAMESPACE);
+	const currentValue = descriptor?.value ?? value;
 	const nextIds = selectable.map((entry) => entry.id);
-	const currentIds = configuredModelIds(value);
-	// Skip the write when the served set and routing already match: a periodic
+	const merged = mergeModelEntries(currentValue, selectable);
+	const currentModels = currentValue?.providers?.opencode?.models;
+	// Skip the write when the live profiles and routing already match: a periodic
 	// refresh must not churn settings.yaml or rebuild the adapter every interval.
-	const unchanged = currentIds !== undefined && routeConfigured(value) && sameModelIds(currentIds, nextIds);
+	const unchanged = Array.isArray(currentModels)
+		&& routeConfigured(currentValue)
+		&& isDeepStrictEqual(currentModels, merged);
 	if (!unchanged) {
-		const merged = mergeModelEntries(value, selectable);
 		await settings.mutate(LLM_PI_AI_NAMESPACE, [
 			{ op: 'set', path: ['providers', 'opencode', 'api'], value: OPENCODE_ROUTE_API },
 			{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: OPENCODE_ROUTE_BASE_URL },
 			{ op: 'set', path: MODELS_PATH, value: merged },
-		]);
+		], descriptor?.revision);
 		logger?.info?.(`OpenCode Free catalog refreshed to ${selectable.length} models`);
 	}
 	// Keep the opencode default usable when the refresh drops it from the set.
@@ -226,11 +270,9 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 }
 
 module.exports = {
-	configuredModelIds,
 	isZeroCost,
 	mergeModelEntries,
 	refreshOpenCodeFreeModels,
-	sameModelIds,
 	selectFreeAndServed,
 	waitForNamespace,
 };

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -88,11 +88,15 @@ function selectFreeAndServed(catalog, servedIds) {
 	}
 	return out.sort((left, right) => left.id.localeCompare(right.id));
 }
-/** Fetch one URL as JSON, honoring cancellation. */
-async function fetchJson(url, fetchImpl, signal) {
+/** Per-request bound so a hung gateway cannot leave a refresh pending forever. */
+const DEFAULT_REQUEST_TIMEOUT_MS = 15000;
+/** Fetch one URL as JSON, honoring cancellation and a bounded deadline. */
+async function fetchJson(url, fetchImpl, signal, requestTimeoutMs) {
+	const deadline = AbortSignal.timeout(requestTimeoutMs);
+	const requestSignal = signal === undefined ? deadline : AbortSignal.any([signal, deadline]);
 	const response = await fetchImpl(url, {
 		headers: { accept: 'application/json' },
-		...(signal === undefined ? {} : { signal }),
+		signal: requestSignal,
 	});
 	if (!response.ok) throw new Error(`${url} answered ${response.status}`);
 	const body = await response.json();
@@ -130,7 +134,7 @@ async function waitForNamespace(describe, timeoutMs, signal) {
  * @param deps - settings service, fetch impl, logger, and an optional abort signal.
  * @returns the selectable model count written, or `undefined` when nothing was written.
  */
-async function refreshOpenCodeFreeModels({ settings, describe, logger, fetchImpl = globalThis.fetch, signal, timeoutMs }) {
+async function refreshOpenCodeFreeModels({ settings, describe, logger, fetchImpl = globalThis.fetch, signal, timeoutMs, requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS }) {
 	const descriptor = await waitForNamespace(describe ?? (() => settings.describe()), timeoutMs, signal);
 	if (descriptor === undefined) {
 		logger?.warn?.('llm-pi-ai settings namespace is not registered; leaving the packaged OpenCode Free model list');
@@ -140,8 +144,8 @@ async function refreshOpenCodeFreeModels({ settings, describe, logger, fetchImpl
 	let gateway;
 	try {
 		[catalog, gateway] = await Promise.all([
-			fetchJson(OPENCODE_MODELS_URL, fetchImpl, signal),
-			fetchJson(OPENCODE_ZEN_MODELS_URL, fetchImpl, signal),
+			fetchJson(OPENCODE_MODELS_URL, fetchImpl, signal, requestTimeoutMs),
+			fetchJson(OPENCODE_ZEN_MODELS_URL, fetchImpl, signal, requestTimeoutMs),
 		]);
 	} catch (error) {
 		logger?.warn?.(`OpenCode Free catalog refresh failed; leaving the packaged model list: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -50,11 +50,22 @@ function sameModelIds(left, right) {
 	const a = new Set(left);
 	return right.every((id) => a.has(id));
 }
-/** A model entry is free when its leading input cost is explicitly zero. */
+/** Billable cost fields that must all be zero for a model to be free. */
+const BILLABLE_COST_FIELDS = ['input', 'output', 'cache_read', 'cache_write'];
+/** A model is free only when every present billable field, in every cost tier, is numeric zero. */
 function isZeroCost(cost) {
 	if (cost === null || typeof cost !== 'object') return false;
-	if (Array.isArray(cost)) return cost.length > 0 && isZeroCost(cost[0]);
-	return Number(cost.input) === 0;
+	const tiers = Array.isArray(cost) ? cost : [cost];
+	if (tiers.length === 0) return false;
+	for (const tier of tiers) {
+		if (tier === null || typeof tier !== 'object') return false;
+		for (const field of BILLABLE_COST_FIELDS) {
+			const value = tier[field];
+			if (value === undefined) continue; // absent field charges nothing
+			if (typeof value !== 'number' || !Number.isFinite(value) || value !== 0) return false;
+		}
+	}
+	return true;
 }
 /**
  * Select the free-and-served opencode models.
@@ -97,11 +108,13 @@ async function fetchJson(url, fetchImpl, signal) {
  * slow adapter from silently dropping the refresh.
  * @param describe - the settings service's `describe()`.
  * @param timeoutMs - upper bound on the wait.
- * @returns the `llm-pi-ai` descriptor, or `undefined` on timeout.
+ * @param signal - cancellation; aborts the wait promptly on shutdown.
+ * @returns the `llm-pi-ai` descriptor, or `undefined` on timeout/cancel.
  */
-async function waitForNamespace(describe, timeoutMs) {
+async function waitForNamespace(describe, timeoutMs, signal) {
 	const deadline = Date.now() + (timeoutMs === undefined ? 10000 : timeoutMs);
 	for (;;) {
+		if (signal?.aborted) return undefined;
 		const descriptor = describe().find((entry) => entry.ns === LLM_PI_AI_NAMESPACE);
 		if (descriptor !== undefined) return descriptor;
 		if (Date.now() >= deadline) return undefined;
@@ -118,7 +131,7 @@ async function waitForNamespace(describe, timeoutMs) {
  * @returns the selectable model count written, or `undefined` when nothing was written.
  */
 async function refreshOpenCodeFreeModels({ settings, describe, logger, fetchImpl = globalThis.fetch, signal, timeoutMs }) {
-	const descriptor = await waitForNamespace(describe ?? (() => settings.describe()), timeoutMs);
+	const descriptor = await waitForNamespace(describe ?? (() => settings.describe()), timeoutMs, signal);
 	if (descriptor === undefined) {
 		logger?.warn?.('llm-pi-ai settings namespace is not registered; leaving the packaged OpenCode Free model list');
 		return undefined;

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -213,16 +213,20 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 	const currentIds = configuredModelIds(value);
 	// Skip the write when the served set and routing already match: a periodic
 	// refresh must not churn settings.yaml or rebuild the adapter every interval.
-	if (currentIds !== undefined && routeConfigured(value) && sameModelIds(currentIds, nextIds)) return selectable.length;
+	const unchanged = currentIds !== undefined && routeConfigured(value) && sameModelIds(currentIds, nextIds);
+	if (!unchanged) {
+		const merged = mergeModelEntries(value, selectable);
+		await settings.mutate(LLM_PI_AI_NAMESPACE, [
+			{ op: 'set', path: ['providers', 'opencode', 'api'], value: OPENCODE_ROUTE_API },
+			{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: OPENCODE_ROUTE_BASE_URL },
+			{ op: 'set', path: MODELS_PATH, value: merged },
+		]);
+		logger?.info?.(`OpenCode Free catalog refreshed to ${selectable.length} models`);
+	}
 	// Keep the opencode default usable when the refresh drops it from the set.
+	// Runs after (or without) a write, and also when the set is unchanged, so a
+	// default pointing outside the configured list is repaired either way.
 	await ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selectable });
-	const merged = mergeModelEntries(value, selectable);
-	await settings.mutate(LLM_PI_AI_NAMESPACE, [
-		{ op: 'set', path: ['providers', 'opencode', 'api'], value: OPENCODE_ROUTE_API },
-		{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: OPENCODE_ROUTE_BASE_URL },
-		{ op: 'set', path: MODELS_PATH, value: merged },
-	]);
-	logger?.info?.(`OpenCode Free catalog refreshed to ${selectable.length} models`);
 	return selectable.length;
 }
 

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -45,8 +45,6 @@ const MODELS_PATH = ['providers', 'opencode', 'models'];
 const OPENCODE_ROUTE_API = 'openai-completions';
 /** Base URL the opencode zen gateway serves. */
 const OPENCODE_ROUTE_BASE_URL = 'https://opencode.ai/zen/v1';
-/** The id the product ships as the default opencode model. */
-const DEFAULT_OPENCODE_MODEL_ID = 'big-pickle';
 
 /** The ids currently configured for opencode, when the resolved value lists them. */
 function configuredModelIds(value) {
@@ -117,9 +115,8 @@ function mergeModelEntries(currentValue, selectable) {
  *
  * The product ships `opencode/big-pickle` as the default; if the refresh stops
  * selecting it (upstream deprecation), new sessions would fail with an unknown
- * model. Prefer the product default when it still survives, else the first
- * selectable id. Only touches an `opencode` default; a user default on another
- * provider is left alone.
+ * model. Move to the first surviving selectable model. Only touches an
+ * `opencode` default; a user default on another provider is left alone.
  */
 async function ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selectable }) {
 	if (defaultModel === undefined) return;
@@ -131,9 +128,7 @@ async function ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selec
 	}
 	if (current === undefined || current.provider !== 'opencode') return;
 	if (nextIds.includes(current.model)) return;
-	const fallbackId = selectable.some((entry) => entry.id === DEFAULT_OPENCODE_MODEL_ID)
-		? DEFAULT_OPENCODE_MODEL_ID
-		: selectable[0]?.id;
+	const fallbackId = selectable[0]?.id;
 	if (fallbackId === undefined) return;
 	try {
 		await defaultModel.saveSelection({ provider: 'opencode', model: fallbackId });
@@ -231,10 +226,6 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 }
 
 module.exports = {
-	LLM_PI_AI_NAMESPACE,
-	OPENCODE_MODELS_URL,
-	OPENCODE_ROUTE_API,
-	OPENCODE_ROUTE_BASE_URL,
 	configuredModelIds,
 	isZeroCost,
 	mergeModelEntries,

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -3,46 +3,62 @@
  * OpenCode Free catalog discovery for PawWork.
  *
  * The shipped "OpenCode Free" model list is a build-time static snapshot (the
- * product patch replaces `llm-pi-ai.providers.opencode.models` with exactly
- * seven ids). Upstream opencode adds and retires free models independently of
+ * product patch replaces `llm-pi-ai.providers.opencode.models` with a fixed
+ * set of ids). Upstream opencode adds and retires free models independently of
  * any PawWork release, so a frozen list both hides new models and keeps dead
- * ones selectable until a 401 surfaces as "API key is invalid".
+ * ones selectable until a request 401s, which the surface mislabels as
+ * "API key is invalid".
  *
  * This module restores the old v1 behavior at runtime: it reads the live
- * opencode catalog for pricing and the gateway's own model listing for
- * serviceability, then writes the intersection into the existing `llm-pi-ai`
- * settings namespace. The `llm-pi-ai` adapter rebuilds from its configured
- * model list on change, so streaming stays with the already-verified pi-ai
- * adapter; this module only supplies the list.
+ * models.dev catalog once, selects the models that are genuinely free and not
+ * deprecated, and writes them into the existing `llm-pi-ai` settings
+ * namespace. The `llm-pi-ai` adapter rebuilds from its configured model list
+ * on change, so streaming stays with the already-verified pi-ai adapter; this
+ * module only supplies the list.
  *
- * Two authorities, one selectable set:
- *  - `models.opencode.ai/api.json` is the pricing/metadata authority.
- *  - `GET /zen/v1/models` (public credential) is the serviceability authority.
- *    A model that only exists in the metadata catalog — or one the gateway no
- *    longer serves — must not be offered as free.
+ * One authority, one predicate:
+ *  - `models.dev/api.json` is the pricing/metadata authority (what opencode
+ *    itself reads). A model is selectable iff its cost has no nonzero numeric
+ *    leaf and it is not marked `deprecated`; the gateway serves a model that
+ *    is neither paid nor deprecated, so no separate serviceability probe is
+ *    needed. (A model priced at zero but `deprecated` — e.g. a promotion that
+ *    has ended — 401s on use and must not be offered as free.)
  *
- * Failure policy: any fetch/parse error, or an intersection of zero usable
- * models, leaves the configured list untouched (the packaged seven-model
- * bootstrap) rather than writing an empty list — DSH interprets an empty
- * configured `models` as "use the entire bundled catalog".
+ * Route wiring: opencode speaks `openai-completions` at
+ * `https://opencode.ai/zen/v1`. The adapter only accepts models it describes,
+ * plus a route-level `api`/`baseURL` for the rest; the write therefore sets
+ * those two keys alongside the model list so the selectable set is servable.
+ *
+ * Failure policy: any fetch/parse error, or a usable set of zero models,
+ * leaves the configured list untouched (the packaged bootstrap) rather than
+ * writing an empty list — DSH interprets an empty configured `models` as "use
+ * the entire bundled catalog".
  */
 
-const path = require('node:path');
-
 /** Live opencode catalog (what the opencode CLI itself reads). */
-const OPENCODE_MODELS_URL = 'https://models.opencode.ai/api.json';
-/** Gateway model listing under the public credential. */
-const OPENCODE_ZEN_MODELS_URL = 'https://opencode.ai/zen/v1/models';
+const OPENCODE_MODELS_URL = 'https://models.dev/api.json';
 /** The settings namespace the pi-ai adapter owns. */
 const LLM_PI_AI_NAMESPACE = 'llm-pi-ai';
 /** Path of the opencode model list inside that namespace. */
 const MODELS_PATH = ['providers', 'opencode', 'models'];
-/** The ids currently configured for opencode, when the descriptor resolves them. */
-function configuredModelIds(descriptor) {
-	const models = descriptor?.value?.providers?.opencode?.models;
+/** Wire protocol every opencode route uses. */
+const OPENCODE_ROUTE_API = 'openai-completions';
+/** Base URL the opencode zen gateway serves. */
+const OPENCODE_ROUTE_BASE_URL = 'https://opencode.ai/zen/v1';
+/** The id the product ships as the default opencode model. */
+const DEFAULT_OPENCODE_MODEL_ID = 'big-pickle';
+
+/** The ids currently configured for opencode, when the resolved value lists them. */
+function configuredModelIds(value) {
+	const models = value?.providers?.opencode?.models;
 	if (!Array.isArray(models)) return undefined;
 	const ids = models.map((entry) => entry?.id).filter((id) => typeof id === 'string');
 	return ids.length === models.length ? ids : undefined;
+}
+/** Whether the opencode route already carries our api/baseURL wiring. */
+function routeConfigured(value) {
+	const provider = value?.providers?.opencode;
+	return provider?.api === OPENCODE_ROUTE_API && provider?.baseURL === OPENCODE_ROUTE_BASE_URL;
 }
 /** Whether two id arrays name the same set, in any order. */
 function sameModelIds(left, right) {
@@ -50,43 +66,81 @@ function sameModelIds(left, right) {
 	const a = new Set(left);
 	return right.every((id) => a.has(id));
 }
-/** Billable cost fields that must all be zero for a model to be free. */
-const BILLABLE_COST_FIELDS = ['input', 'output', 'cache_read', 'cache_write'];
-/** A model is free only when every present billable field, in every cost tier, is numeric zero. */
+/**
+ * A model is free only when its cost metadata has no nonzero numeric leaf.
+ *
+ * Fail-closed: a missing or non-object cost, or a missing `input`/`output`
+ * (the schema's required pricing fields), is NOT free. The `tier` key is
+ * structural metadata (a context-size threshold), not a billable field, so it
+ * is ignored. This covers `cost.tiers[]`, `context_over_200k`, reasoning and
+ * audio fields and any future nested pricing without enumerating them.
+ */
 function isZeroCost(cost) {
 	if (cost === null || typeof cost !== 'object') return false;
-	const tiers = Array.isArray(cost) ? cost : [cost];
-	if (tiers.length === 0) return false;
-	for (const tier of tiers) {
-		if (tier === null || typeof tier !== 'object') return false;
-		for (const field of BILLABLE_COST_FIELDS) {
-			const value = tier[field];
-			if (value === undefined) continue; // absent field charges nothing
-			if (typeof value !== 'number' || !Number.isFinite(value) || value !== 0) return false;
-		}
-	}
-	return true;
+	if (typeof cost.input !== 'number' || typeof cost.output !== 'number') return false;
+	const walk = (node, key) => {
+		if (key === 'tier') return true; // structural metadata, not billable
+		if (typeof node === 'number') return node === 0;
+		if (node === null || typeof node !== 'object') return true; // structural leaves are not prices
+		return Object.entries(node).every(([childKey, child]) => walk(child, childKey));
+	};
+	return Object.keys(cost).length > 0 && walk(cost, 'root');
 }
 /**
- * Select the free-and-served opencode models.
- * @param catalog - the raw `models.opencode.ai/api.json` document.
- * @param servedIds - model ids served by `GET /zen/v1/models`.
+ * Select the free, non-deprecated opencode models.
+ * @param catalog - the raw `models.dev/api.json` document.
  * @returns the selectable ids in sorted order, each shaped as a pi-ai model entry.
  */
-function selectFreeAndServed(catalog, servedIds) {
+function selectFreeAndServed(catalog) {
 	const opencode = catalog?.opencode;
 	if (opencode === null || typeof opencode !== 'object') return [];
 	const models = opencode.models;
 	if (models === null || typeof models !== 'object') return [];
-	const served = new Set(servedIds);
 	const out = [];
 	for (const [id, entry] of Object.entries(models)) {
 		if (entry === null || typeof entry !== 'object') continue;
+		if (entry.status === 'deprecated') continue;
 		if (!isZeroCost(entry.cost)) continue;
-		if (!served.has(id)) continue;
 		out.push({ id });
 	}
 	return out.sort((left, right) => left.id.localeCompare(right.id));
+}
+/** Preserve configured metadata for surviving models; new ids get `{ id }`. */
+function mergeModelEntries(currentValue, selectable) {
+	const current = currentValue?.providers?.opencode?.models;
+	if (!Array.isArray(current)) return selectable;
+	const existing = new Map(current.map((entry) => [entry?.id, entry]));
+	return selectable.map((entry) => existing.get(entry.id) ?? entry);
+}
+/**
+ * Keep the opencode default model usable after a refresh drops it.
+ *
+ * The product ships `opencode/big-pickle` as the default; if the refresh stops
+ * selecting it (upstream deprecation), new sessions would fail with an unknown
+ * model. Prefer the product default when it still survives, else the first
+ * selectable id. Only touches an `opencode` default; a user default on another
+ * provider is left alone.
+ */
+async function ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selectable }) {
+	if (defaultModel === undefined) return;
+	let current;
+	try {
+		current = defaultModel.currentSelection();
+	} catch {
+		return; // default-model service unavailable; leave selection untouched
+	}
+	if (current === undefined || current.provider !== 'opencode') return;
+	if (nextIds.includes(current.model)) return;
+	const fallbackId = selectable.some((entry) => entry.id === DEFAULT_OPENCODE_MODEL_ID)
+		? DEFAULT_OPENCODE_MODEL_ID
+		: selectable[0]?.id;
+	if (fallbackId === undefined) return;
+	try {
+		await defaultModel.saveSelection({ provider: 'opencode', model: fallbackId });
+		logger?.info?.(`default opencode model ${current.model} retired; moved to ${fallbackId}`);
+	} catch (error) {
+		logger?.warn?.(`failed to move default opencode model from ${current.model} to ${fallbackId}: ${error instanceof Error ? error.message : String(error)}`);
+	}
 }
 /** Per-request bound so a hung gateway cannot leave a refresh pending forever. */
 const DEFAULT_REQUEST_TIMEOUT_MS = 15000;
@@ -107,20 +161,20 @@ async function fetchJson(url, fetchImpl, signal, requestTimeoutMs) {
  * Wait until the `llm-pi-ai` settings namespace is registered.
  *
  * DSH activates plugins by service availability, not patch order, so this
- * plugin may apply before `llm-pi-ai` has run `installSettingsSection`; a
+ * plugin may apply before `llm-pi-ai` has registered its section; a
  * `settings.mutate` on an unregistered namespace throws. Bounded wait keeps a
  * slow adapter from silently dropping the refresh.
- * @param describe - the settings service's `describe()`.
+ * @param get - the settings service's `get(ns)` (resolved value, undefined while unregistered).
  * @param timeoutMs - upper bound on the wait.
  * @param signal - cancellation; aborts the wait promptly on shutdown.
- * @returns the `llm-pi-ai` descriptor, or `undefined` on timeout/cancel.
+ * @returns the resolved `llm-pi-ai` value, or `undefined` on timeout/cancel.
  */
-async function waitForNamespace(describe, timeoutMs, signal) {
+async function waitForNamespace(get, timeoutMs, signal) {
 	const deadline = Date.now() + (timeoutMs === undefined ? 10000 : timeoutMs);
 	for (;;) {
 		if (signal?.aborted) return undefined;
-		const descriptor = describe().find((entry) => entry.ns === LLM_PI_AI_NAMESPACE);
-		if (descriptor !== undefined) return descriptor;
+		const value = get(LLM_PI_AI_NAMESPACE);
+		if (value !== undefined) return value;
 		if (Date.now() >= deadline) return undefined;
 		await new Promise((resolve) => setTimeout(resolve, 200));
 	}
@@ -128,41 +182,46 @@ async function waitForNamespace(describe, timeoutMs, signal) {
 /**
  * Refresh the OpenCode Free model list in the `llm-pi-ai` settings namespace.
  *
- * A fetch or parse failure, or an empty usable set, leaves the packaged list
- * untouched. A successful non-empty set replaces `providers.opencode.models`,
- * which triggers the pi-ai adapter to rebuild on the next request.
- * @param deps - settings service, fetch impl, logger, and an optional abort signal.
+ * A fetch/parse failure or an empty usable set leaves the packaged list
+ * untouched. A successful non-empty set replaces `providers.opencode.models`
+ * (plus the route `api`/`baseURL` needed to serve models the bundled catalog
+ * does not yet describe), which triggers the pi-ai adapter to rebuild.
+ * Surviving models keep their configured metadata; when the opencode default
+ * model is dropped, the default selection moves to a surviving model.
+ * @param deps - settings service, optional default-model service, fetch impl, logger, abort signal.
  * @returns the selectable model count written, or `undefined` when nothing was written.
  */
-async function refreshOpenCodeFreeModels({ settings, describe, logger, fetchImpl = globalThis.fetch, signal, timeoutMs, requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS }) {
-	const descriptor = await waitForNamespace(describe ?? (() => settings.describe()), timeoutMs, signal);
-	if (descriptor === undefined) {
+async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetchImpl = globalThis.fetch, signal, timeoutMs, requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS }) {
+	const value = await waitForNamespace((ns) => settings.get(ns), timeoutMs, signal);
+	if (value === undefined) {
 		logger?.warn?.('llm-pi-ai settings namespace is not registered; leaving the packaged OpenCode Free model list');
 		return undefined;
 	}
 	let catalog;
-	let gateway;
 	try {
-		[catalog, gateway] = await Promise.all([
-			fetchJson(OPENCODE_MODELS_URL, fetchImpl, signal, requestTimeoutMs),
-			fetchJson(OPENCODE_ZEN_MODELS_URL, fetchImpl, signal, requestTimeoutMs),
-		]);
+		catalog = await fetchJson(OPENCODE_MODELS_URL, fetchImpl, signal, requestTimeoutMs);
 	} catch (error) {
 		logger?.warn?.(`OpenCode Free catalog refresh failed; leaving the packaged model list: ${error instanceof Error ? error.message : String(error)}`);
 		return undefined;
 	}
-	const servedIds = Array.isArray(gateway?.data) ? gateway.data.map((entry) => entry?.id).filter(Boolean) : [];
-	const selectable = selectFreeAndServed(catalog, servedIds);
+	const selectable = selectFreeAndServed(catalog);
 	if (selectable.length === 0) {
 		logger?.warn?.('OpenCode Free catalog refresh found no usable free models; leaving the packaged model list');
 		return undefined;
 	}
 	const nextIds = selectable.map((entry) => entry.id);
-	const currentIds = configuredModelIds(descriptor);
-	// Skip the write when the served set already matches: a periodic refresh
-	// must not churn settings.yaml or rebuild the adapter every interval.
-	if (currentIds !== undefined && sameModelIds(currentIds, nextIds)) return selectable.length;
-	await settings.mutate(LLM_PI_AI_NAMESPACE, [{ op: 'set', path: MODELS_PATH, value: selectable }], descriptor.revision);
+	const currentIds = configuredModelIds(value);
+	// Skip the write when the served set and routing already match: a periodic
+	// refresh must not churn settings.yaml or rebuild the adapter every interval.
+	if (currentIds !== undefined && routeConfigured(value) && sameModelIds(currentIds, nextIds)) return selectable.length;
+	// Keep the opencode default usable when the refresh drops it from the set.
+	await ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selectable });
+	const merged = mergeModelEntries(value, selectable);
+	await settings.mutate(LLM_PI_AI_NAMESPACE, [
+		{ op: 'set', path: ['providers', 'opencode', 'api'], value: OPENCODE_ROUTE_API },
+		{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: OPENCODE_ROUTE_BASE_URL },
+		{ op: 'set', path: MODELS_PATH, value: merged },
+	]);
 	logger?.info?.(`OpenCode Free catalog refreshed to ${selectable.length} models`);
 	return selectable.length;
 }
@@ -170,9 +229,11 @@ async function refreshOpenCodeFreeModels({ settings, describe, logger, fetchImpl
 module.exports = {
 	LLM_PI_AI_NAMESPACE,
 	OPENCODE_MODELS_URL,
-	OPENCODE_ZEN_MODELS_URL,
+	OPENCODE_ROUTE_API,
+	OPENCODE_ROUTE_BASE_URL,
 	configuredModelIds,
 	isZeroCost,
+	mergeModelEntries,
 	refreshOpenCodeFreeModels,
 	sameModelIds,
 	selectFreeAndServed,

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -161,7 +161,9 @@ test('refresh is bounded by the per-request deadline when a fetch hangs', async 
 	const elapsed = Date.now() - started;
 	assert.equal(count, undefined);
 	assert.equal(writes.length, 0);
-	assert.ok(elapsed < 10000, `refresh took too long: ${elapsed}ms`);
+	// The mock aborts on the 100ms deadline; a regression that restored the 15s
+	// default (or left the fetch hung) would blow past 2s.
+	assert.ok(elapsed < 2000, `refresh took too long: ${elapsed}ms`);
 });
 
 test('refresh never writes while the llm-pi-ai namespace is unregistered', async () => {
@@ -256,6 +258,8 @@ test('refresh moves the opencode default model when it is dropped', async () => 
 	const count = await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
 	assert.equal(count, 1);
 	assert.deepEqual(saves, [{ provider: 'opencode', model: 'hy3-free' }]);
+	assert.equal(writes.length, 1);
+	assert.deepEqual(writes[0].ops[2].value, [{ id: 'hy3-free' }]);
 });
 
 test('refresh leaves a non-opencode default untouched', async () => {

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -18,14 +18,27 @@ function catalogWith(models) {
 	return { opencode: { api: 'https://opencode.ai/zen/v1', models } };
 }
 
-test('isZeroCost treats leading zero input cost as free', () => {
+test('isZeroCost accepts only fully zero-cost models across all tiers', () => {
 	assert.equal(isZeroCost({ input: 0, output: 0, cache_read: 0 }), true);
 	assert.equal(isZeroCost({ input: 0, output: 0, cache_read: 0, cache_write: 0 }), true);
-	assert.equal(isZeroCost({ input: 2, output: 12 }), false);
 	assert.equal(isZeroCost([{ input: 0, output: 0 }]), true);
+	// Any present billable field above zero makes the model paid.
+	assert.equal(isZeroCost({ input: 0, output: 1 }), false);
+	assert.equal(isZeroCost({ input: 0, cache_read: 1 }), false);
+	assert.equal(isZeroCost({ input: 0, cache_write: 1 }), false);
+	assert.equal(isZeroCost({ input: 2, output: 12 }), false);
+	// A later paid tier still makes the whole model paid.
+	assert.equal(isZeroCost([{ input: 0 }, { input: 1 }]), false);
+	// Zero-like but non-numeric values are rejected, not coerced.
+	assert.equal(isZeroCost({ input: null }), false);
+	assert.equal(isZeroCost({ input: '' }), false);
+	assert.equal(isZeroCost({ input: false }), false);
+	assert.equal(isZeroCost({ input: NaN }), false);
+	// Non-object inputs are rejected.
 	assert.equal(isZeroCost(null), false);
 	assert.equal(isZeroCost('0'), false);
 	assert.equal(isZeroCost(undefined), false);
+	assert.equal(isZeroCost([]), false);
 });
 
 test('selectFreeAndServed returns only free AND served models, sorted', () => {
@@ -63,6 +76,14 @@ test('waitForNamespace resolves with the descriptor once registered', async () =
 
 test('waitForNamespace times out without a registered namespace', async () => {
 	const descriptor = await waitForNamespace(() => [], 50);
+	assert.equal(descriptor, undefined);
+});
+
+test('waitForNamespace aborts promptly when the signal fires', async () => {
+	const controller = new AbortController();
+	const pending = waitForNamespace(() => [], 5000, controller.signal);
+	setTimeout(() => controller.abort(), 30);
+	const descriptor = await pending;
 	assert.equal(descriptor, undefined);
 });
 

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -1,8 +1,6 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { pathToFileURL } = require('node:url');
-const path = require('node:path');
 
 const {
 	isZeroCost,
@@ -11,29 +9,37 @@ const {
 	refreshOpenCodeFreeModels,
 	sameModelIds,
 	configuredModelIds,
+	mergeModelEntries,
 } = require('./opencode-free.cjs');
 
-// A catalog shaped like models.opencode.ai/api.json (opencode provider).
+// A catalog shaped like models.dev/api.json (opencode provider).
 function catalogWith(models) {
 	return { opencode: { api: 'https://opencode.ai/zen/v1', models } };
 }
 
-test('isZeroCost accepts only fully zero-cost models across all tiers', () => {
-	assert.equal(isZeroCost({ input: 0, output: 0, cache_read: 0 }), true);
+test('isZeroCost accepts only fully zero-cost models', () => {
 	assert.equal(isZeroCost({ input: 0, output: 0, cache_read: 0, cache_write: 0 }), true);
-	assert.equal(isZeroCost([{ input: 0, output: 0 }]), true);
-	// Any present billable field above zero makes the model paid.
+	assert.equal(isZeroCost({ input: 0, output: 0 }), true);
+	// Any present nonzero billable field makes the model paid.
 	assert.equal(isZeroCost({ input: 0, output: 1 }), false);
 	assert.equal(isZeroCost({ input: 0, cache_read: 1 }), false);
 	assert.equal(isZeroCost({ input: 0, cache_write: 1 }), false);
 	assert.equal(isZeroCost({ input: 2, output: 12 }), false);
-	// A later paid tier still makes the whole model paid.
-	assert.equal(isZeroCost([{ input: 0 }, { input: 1 }]), false);
+	// Nested paid pricing (tiers / context_over_200k / reasoning / audio) is caught.
+	assert.equal(isZeroCost({ input: 0, output: 0, tiers: [{ input: 1, output: 1 }] }), false);
+	assert.equal(isZeroCost({ input: 0, output: 0, context_over_200k: { input: 1, output: 1 } }), false);
+	assert.equal(isZeroCost({ input: 0, output: 0, reasoning: 1 }), false);
+	// The tier descriptor metadata (a context-size threshold, not a price) is ignored.
+	assert.equal(isZeroCost({ input: 0, output: 0, tiers: [{ input: 0, output: 0, tier: { type: 'context', size: 200000 } }] }), true);
+	// Fail closed: missing/optional pricing fields are not free.
+	assert.equal(isZeroCost({ input: 0 }), false);
+	assert.equal(isZeroCost({ output: 0 }), false);
+	assert.equal(isZeroCost({}), false);
 	// Zero-like but non-numeric values are rejected, not coerced.
-	assert.equal(isZeroCost({ input: null }), false);
-	assert.equal(isZeroCost({ input: '' }), false);
-	assert.equal(isZeroCost({ input: false }), false);
-	assert.equal(isZeroCost({ input: NaN }), false);
+	assert.equal(isZeroCost({ input: 0, output: null }), false);
+	assert.equal(isZeroCost({ input: 0, output: '' }), false);
+	assert.equal(isZeroCost({ input: 0, output: false }), false);
+	assert.equal(isZeroCost({ input: 0, output: NaN }), false);
 	// Non-object inputs are rejected.
 	assert.equal(isZeroCost(null), false);
 	assert.equal(isZeroCost('0'), false);
@@ -41,100 +47,87 @@ test('isZeroCost accepts only fully zero-cost models across all tiers', () => {
 	assert.equal(isZeroCost([]), false);
 });
 
-test('selectFreeAndServed returns only free AND served models, sorted', () => {
+test('selectFreeAndServed returns only free AND non-deprecated models, sorted', () => {
 	const catalog = catalogWith({
 		'new-free': { cost: { input: 0, output: 0 } },
-		'free-but-not-served': { cost: { input: 0, output: 0 } },
+		'dead-free': { cost: { input: 0, output: 0 }, status: 'deprecated' },
 		'paid': { cost: { input: 2, output: 12 } },
 		'free-persisted': { cost: { input: 0, output: 0 } },
 	});
-	const served = ['new-free', 'paid', 'free-persisted'];
-	assert.deepEqual(selectFreeAndServed(catalog, served), [
+	assert.deepEqual(selectFreeAndServed(catalog), [
 		{ id: 'free-persisted' },
 		{ id: 'new-free' },
 	]);
 });
 
 test('selectFreeAndServed tolerates missing opencode / models / malformed entries', () => {
-	assert.deepEqual(selectFreeAndServed({}, ['a']), []);
-	assert.deepEqual(selectFreeAndServed({ opencode: {} }, ['a']), []);
-	assert.deepEqual(selectFreeAndServed({ opencode: { models: { a: null } } }, ['a']), []);
-	assert.deepEqual(selectFreeAndServed(null, []), []);
-	assert.deepEqual(selectFreeAndServed(catalogWith({ a: { cost: { input: 0 } } }), []), []);
+	assert.deepEqual(selectFreeAndServed({}), []);
+	assert.deepEqual(selectFreeAndServed({ opencode: {} }), []);
+	assert.deepEqual(selectFreeAndServed({ opencode: { models: { a: null } } }), []);
+	assert.deepEqual(selectFreeAndServed(null), []);
+	assert.deepEqual(selectFreeAndServed(catalogWith({ a: { cost: { input: 0 } } })), []);
 });
 
-test('waitForNamespace resolves with the descriptor once registered', async () => {
-	let registrations = [];
-	const describe = () => registrations;
-	const pending = waitForNamespace(describe, 5000);
+test('waitForNamespace resolves with the registered value', async () => {
+	let stored;
+	const get = (ns) => (ns === 'llm-pi-ai' ? stored : undefined);
+	const pending = waitForNamespace(get, 5000);
 	setTimeout(() => {
-		registrations = [{ ns: 'llm-pi-ai', revision: 7 }];
+		stored = { providers: { opencode: { models: [] } } };
 	}, 30);
-	const descriptor = await pending;
-	assert.deepEqual(descriptor, { ns: 'llm-pi-ai', revision: 7 });
+	const value = await pending;
+	assert.deepEqual(value, { providers: { opencode: { models: [] } } });
 });
 
 test('waitForNamespace times out without a registered namespace', async () => {
-	const descriptor = await waitForNamespace(() => [], 50);
-	assert.equal(descriptor, undefined);
+	const value = await waitForNamespace(() => undefined, 50);
+	assert.equal(value, undefined);
 });
 
 test('waitForNamespace aborts promptly when the signal fires', async () => {
 	const controller = new AbortController();
-	const pending = waitForNamespace(() => [], 5000, controller.signal);
+	const pending = waitForNamespace(() => undefined, 5000, controller.signal);
 	setTimeout(() => controller.abort(), 30);
-	const descriptor = await pending;
-	assert.equal(descriptor, undefined);
+	const value = await pending;
+	assert.equal(value, undefined);
 });
 
-test('refresh writes the free-and-served intersection via settings.mutate', async () => {
+test('refresh writes free non-deprecated models plus route wiring via settings.mutate', async () => {
 	const writes = [];
 	const settings = {
-		describe: () => [{ ns: 'llm-pi-ai', revision: 3 }],
+		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'old' }] } } } : undefined,
 		async mutate(ns, ops, revision) {
 			writes.push({ ns, ops, revision });
 		},
 	};
-	const fetchImpl = async (url) => {
-		if (url.includes('models.opencode.ai')) {
-			return {
-				ok: true,
-				json: async () => catalogWith({
-					'hy3-free': { cost: { input: 0, output: 0 } },
-					'ghost-free': { cost: { input: 0, output: 0 } }, // not served -> excluded
-					'paid': { cost: { input: 2, output: 12 } },
-				}),
-			};
-		}
-		// /zen/v1/models
-		return {
-			ok: true,
-			json: async () => ({ data: [{ id: 'hy3-free' }, { id: 'paid' }] }),
-		};
-	};
-	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	const fetchImpl = async () => ({
+		ok: true,
+		json: async () => catalogWith({
+			'hy3-free': { cost: { input: 0, output: 0 } },
+			'dead-free': { cost: { input: 0, output: 0 }, status: 'deprecated' },
+			'paid': { cost: { input: 2, output: 12 } },
+		}),
+	});
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, 1);
 	assert.equal(writes.length, 1);
 	assert.equal(writes[0].ns, 'llm-pi-ai');
 	assert.deepEqual(writes[0].ops, [
+		{ op: 'set', path: ['providers', 'opencode', 'api'], value: 'openai-completions' },
+		{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: 'https://opencode.ai/zen/v1' },
 		{ op: 'set', path: ['providers', 'opencode', 'models'], value: [{ id: 'hy3-free' }] },
 	]);
-	assert.equal(writes[0].revision, 3);
+	assert.equal(writes[0].revision, undefined);
 });
 
 test('refresh does not write an empty list when nothing is usable', async () => {
 	const writes = [];
 	const settings = {
-		describe: () => [{ ns: 'llm-pi-ai', revision: 1 }],
+		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [] } } } : undefined,
 		mutate: async (ns, ops) => writes.push({ ns, ops }),
 	};
-	const fetchImpl = async (url) => {
-		if (url.includes('models.opencode.ai')) {
-			return { ok: true, json: async () => catalogWith({ 'free-not-served': { cost: { input: 0, output: 0 } } }) };
-		}
-		return { ok: true, json: async () => ({ data: [] }) };
-	};
-	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({ 'dead-free': { cost: { input: 0, output: 0 }, status: 'deprecated' } }) });
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, undefined);
 	assert.equal(writes.length, 0);
 });
@@ -142,11 +135,11 @@ test('refresh does not write an empty list when nothing is usable', async () => 
 test('refresh leaves the list untouched on a fetch failure', async () => {
 	const writes = [];
 	const settings = {
-		describe: () => [{ ns: 'llm-pi-ai', revision: 1 }],
+		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [] } } } : undefined,
 		async mutate(ns, ops) { writes.push({ ns, ops }); },
 	};
 	const fetchImpl = async () => { throw new Error('network down'); };
-	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, undefined);
 	assert.equal(writes.length, 0);
 });
@@ -154,7 +147,7 @@ test('refresh leaves the list untouched on a fetch failure', async () => {
 test('refresh is bounded by the per-request deadline when a fetch hangs', async () => {
 	const writes = [];
 	const settings = {
-		describe: () => [{ ns: 'llm-pi-ai', revision: 1 }],
+		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [] } } } : undefined,
 		async mutate(ns, ops) { writes.push({ ns, ops }); },
 	};
 	// A fetch that never settles would otherwise leave the refresh pending
@@ -164,7 +157,7 @@ test('refresh is bounded by the per-request deadline when a fetch hangs', async 
 		init.signal.addEventListener('abort', () => reject(new Error('aborted')));
 	});
 	const started = Date.now();
-	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe, requestTimeoutMs: 100 });
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, requestTimeoutMs: 100 });
 	const elapsed = Date.now() - started;
 	assert.equal(count, undefined);
 	assert.equal(writes.length, 0);
@@ -174,10 +167,10 @@ test('refresh is bounded by the per-request deadline when a fetch hangs', async 
 test('refresh never writes while the llm-pi-ai namespace is unregistered', async () => {
 	const writes = [];
 	const settings = {
-		describe: () => [],
+		get: (ns) => ns === 'llm-pi-ai' ? undefined : undefined,
 		async mutate(ns, ops) { writes.push({ ns, ops }); },
 	};
-	const count = await refreshOpenCodeFreeModels({ settings, describe: settings.describe, timeoutMs: 30 });
+	const count = await refreshOpenCodeFreeModels({ settings, timeoutMs: 30 });
 	assert.equal(count, undefined);
 	assert.equal(writes.length, 0);
 });
@@ -189,59 +182,96 @@ test('sameModelIds compares id sets regardless of order', () => {
 	assert.equal(sameModelIds([], []), true);
 });
 
-test('configuredModelIds reads ids from a resolved descriptor, tolerating gaps', () => {
-	assert.deepEqual(configuredModelIds({ value: { providers: { opencode: { models: [{ id: 'a' }, { id: 'b' }] } } } }), ['a', 'b']);
-	assert.equal(configuredModelIds({ value: {} }), undefined);
+test('configuredModelIds reads ids from a resolved value, tolerating gaps', () => {
+	assert.deepEqual(configuredModelIds({ providers: { opencode: { models: [{ id: 'a' }, { id: 'b' }] } } }), ['a', 'b']);
+	assert.equal(configuredModelIds({ providers: {} }), undefined);
 	assert.equal(configuredModelIds({}), undefined);
-	assert.equal(configuredModelIds({ value: { providers: { opencode: {} } } }), undefined);
-	assert.equal(configuredModelIds({ value: { providers: { opencode: { models: [{ id: 'a' }, {}] } } } }), undefined);
+	assert.equal(configuredModelIds({ providers: { opencode: {} } }), undefined);
+	assert.equal(configuredModelIds({ providers: { opencode: { models: [{ id: 'a' }, {}] } } }), undefined);
 });
 
-test('refresh skips the write when the served set already matches', async () => {
+test('refresh skips the write when the served set and routing already match', async () => {
 	const writes = [];
 	const settings = {
-		describe: () => [{
-			ns: 'llm-pi-ai',
-			revision: 5,
-			value: { providers: { opencode: { models: [{ id: 'hy3-free' }] } } },
-		}],
+		get: (ns) => ns === 'llm-pi-ai' ? {
+			providers: { opencode: {
+				api: 'openai-completions',
+				baseURL: 'https://opencode.ai/zen/v1',
+				models: [{ id: 'hy3-free' }],
+			} },
+		} : undefined,
 		async mutate(ns, ops) { writes.push({ ns, ops }); },
 	};
-	const fetchImpl = async (url) => {
-		if (url.includes('models.opencode.ai')) {
-			return { ok: true, json: async () => catalogWith({
-				'hy3-free': { cost: { input: 0, output: 0 } },
-				'paid': { cost: { input: 2, output: 12 } },
-			}) };
-		}
-		return { ok: true, json: async () => ({ data: [{ id: 'hy3-free' }, { id: 'paid' }] }) };
-	};
-	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+		'hy3-free': { cost: { input: 0, output: 0 } },
+		'paid': { cost: { input: 2, output: 12 } },
+	}) });
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, 1); // still reports the usable count
 	assert.equal(writes.length, 0); // but nothing was written
 });
 
-test('refresh writes when a new free-and-served model appears', async () => {
+test('refresh writes when a new free model appears', async () => {
 	const writes = [];
 	const settings = {
-		describe: () => [{
-			ns: 'llm-pi-ai',
-			revision: 5,
-			value: { providers: { opencode: { models: [{ id: 'old-model' }] } } },
-		}],
+		get: (ns) => ns === 'llm-pi-ai' ? {
+			providers: { opencode: {
+				api: 'openai-completions',
+				baseURL: 'https://opencode.ai/zen/v1',
+				models: [{ id: 'old-model' }],
+			} },
+		} : undefined,
 		async mutate(ns, ops) { writes.push({ ns, ops }); },
 	};
-	const fetchImpl = async (url) => {
-		if (url.includes('models.opencode.ai')) {
-			return { ok: true, json: async () => catalogWith({
-				'old-model': { cost: { input: 0, output: 0 } },
-				'brand-new-free': { cost: { input: 0, output: 0 } },
-			}) };
-		}
-		return { ok: true, json: async () => ({ data: [{ id: 'old-model' }, { id: 'brand-new-free' }] }) };
-	};
-	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+		'old-model': { cost: { input: 0, output: 0 } },
+		'brand-new-free': { cost: { input: 0, output: 0 } },
+	}) });
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, 2);
 	assert.equal(writes.length, 1);
-	assert.deepEqual(writes[0].ops[0].value, [{ id: 'brand-new-free' }, { id: 'old-model' }]);
+	assert.deepEqual(writes[0].ops[2].value, [{ id: 'brand-new-free' }, { id: 'old-model' }]);
+});
+
+test('mergeModelEntries preserves surviving model metadata', () => {
+	const current = { providers: { opencode: { models: [{ id: 'kept', maxTokens: 1234 }, { id: 'old' }] } } };
+	const merged = mergeModelEntries(current, [{ id: 'kept' }, { id: 'added' }]);
+	assert.deepEqual(merged, [{ id: 'kept', maxTokens: 1234 }, { id: 'added' }]);
+});
+
+test('refresh moves the opencode default model when it is dropped', async () => {
+	const writes = [];
+	const saves = [];
+	const settings = {
+		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'big-pickle' }] } } } : undefined,
+		async mutate(ns, ops) { writes.push({ ns, ops }); },
+	};
+	const defaultModel = {
+		currentSelection: () => ({ provider: 'opencode', model: 'big-pickle' }),
+		async saveSelection(next) { saves.push(next); },
+	};
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+		'hy3-free': { cost: { input: 0, output: 0 } },
+	}) });
+	const count = await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
+	assert.equal(count, 1);
+	assert.deepEqual(saves, [{ provider: 'opencode', model: 'hy3-free' }]);
+});
+
+test('refresh leaves a non-opencode default untouched', async () => {
+	const writes = [];
+	const saves = [];
+	const settings = {
+		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'big-pickle' }] } } } : undefined,
+		async mutate(ns, ops) { writes.push({ ns, ops }); },
+	};
+	const defaultModel = {
+		currentSelection: () => ({ provider: 'deepseek', model: 'deepseek-chat' }),
+		async saveSelection(next) { saves.push(next); },
+	};
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+		'hy3-free': { cost: { input: 0, output: 0 } },
+	}) });
+	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
+	assert.deepEqual(saves, []);
 });

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -1,0 +1,206 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { pathToFileURL } = require('node:url');
+const path = require('node:path');
+
+const {
+	isZeroCost,
+	selectFreeAndServed,
+	waitForNamespace,
+	refreshOpenCodeFreeModels,
+	sameModelIds,
+	configuredModelIds,
+} = require('./opencode-free.cjs');
+
+// A catalog shaped like models.opencode.ai/api.json (opencode provider).
+function catalogWith(models) {
+	return { opencode: { api: 'https://opencode.ai/zen/v1', models } };
+}
+
+test('isZeroCost treats leading zero input cost as free', () => {
+	assert.equal(isZeroCost({ input: 0, output: 0, cache_read: 0 }), true);
+	assert.equal(isZeroCost({ input: 0, output: 0, cache_read: 0, cache_write: 0 }), true);
+	assert.equal(isZeroCost({ input: 2, output: 12 }), false);
+	assert.equal(isZeroCost([{ input: 0, output: 0 }]), true);
+	assert.equal(isZeroCost(null), false);
+	assert.equal(isZeroCost('0'), false);
+	assert.equal(isZeroCost(undefined), false);
+});
+
+test('selectFreeAndServed returns only free AND served models, sorted', () => {
+	const catalog = catalogWith({
+		'new-free': { cost: { input: 0, output: 0 } },
+		'free-but-not-served': { cost: { input: 0, output: 0 } },
+		'paid': { cost: { input: 2, output: 12 } },
+		'free-persisted': { cost: { input: 0, output: 0 } },
+	});
+	const served = ['new-free', 'paid', 'free-persisted'];
+	assert.deepEqual(selectFreeAndServed(catalog, served), [
+		{ id: 'free-persisted' },
+		{ id: 'new-free' },
+	]);
+});
+
+test('selectFreeAndServed tolerates missing opencode / models / malformed entries', () => {
+	assert.deepEqual(selectFreeAndServed({}, ['a']), []);
+	assert.deepEqual(selectFreeAndServed({ opencode: {} }, ['a']), []);
+	assert.deepEqual(selectFreeAndServed({ opencode: { models: { a: null } } }, ['a']), []);
+	assert.deepEqual(selectFreeAndServed(null, []), []);
+	assert.deepEqual(selectFreeAndServed(catalogWith({ a: { cost: { input: 0 } } }), []), []);
+});
+
+test('waitForNamespace resolves with the descriptor once registered', async () => {
+	let registrations = [];
+	const describe = () => registrations;
+	const pending = waitForNamespace(describe, 5000);
+	setTimeout(() => {
+		registrations = [{ ns: 'llm-pi-ai', revision: 7 }];
+	}, 30);
+	const descriptor = await pending;
+	assert.deepEqual(descriptor, { ns: 'llm-pi-ai', revision: 7 });
+});
+
+test('waitForNamespace times out without a registered namespace', async () => {
+	const descriptor = await waitForNamespace(() => [], 50);
+	assert.equal(descriptor, undefined);
+});
+
+test('refresh writes the free-and-served intersection via settings.mutate', async () => {
+	const writes = [];
+	const settings = {
+		describe: () => [{ ns: 'llm-pi-ai', revision: 3 }],
+		async mutate(ns, ops, revision) {
+			writes.push({ ns, ops, revision });
+		},
+	};
+	const fetchImpl = async (url) => {
+		if (url.includes('models.opencode.ai')) {
+			return {
+				ok: true,
+				json: async () => catalogWith({
+					'hy3-free': { cost: { input: 0, output: 0 } },
+					'ghost-free': { cost: { input: 0, output: 0 } }, // not served -> excluded
+					'paid': { cost: { input: 2, output: 12 } },
+				}),
+			};
+		}
+		// /zen/v1/models
+		return {
+			ok: true,
+			json: async () => ({ data: [{ id: 'hy3-free' }, { id: 'paid' }] }),
+		};
+	};
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	assert.equal(count, 1);
+	assert.equal(writes.length, 1);
+	assert.equal(writes[0].ns, 'llm-pi-ai');
+	assert.deepEqual(writes[0].ops, [
+		{ op: 'set', path: ['providers', 'opencode', 'models'], value: [{ id: 'hy3-free' }] },
+	]);
+	assert.equal(writes[0].revision, 3);
+});
+
+test('refresh does not write an empty list when nothing is usable', async () => {
+	const writes = [];
+	const settings = {
+		describe: () => [{ ns: 'llm-pi-ai', revision: 1 }],
+		mutate: async (ns, ops) => writes.push({ ns, ops }),
+	};
+	const fetchImpl = async (url) => {
+		if (url.includes('models.opencode.ai')) {
+			return { ok: true, json: async () => catalogWith({ 'free-not-served': { cost: { input: 0, output: 0 } } }) };
+		}
+		return { ok: true, json: async () => ({ data: [] }) };
+	};
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	assert.equal(count, undefined);
+	assert.equal(writes.length, 0);
+});
+
+test('refresh leaves the list untouched on a fetch failure', async () => {
+	const writes = [];
+	const settings = {
+		describe: () => [{ ns: 'llm-pi-ai', revision: 1 }],
+		async mutate(ns, ops) { writes.push({ ns, ops }); },
+	};
+	const fetchImpl = async () => { throw new Error('network down'); };
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	assert.equal(count, undefined);
+	assert.equal(writes.length, 0);
+});
+
+test('refresh never writes while the llm-pi-ai namespace is unregistered', async () => {
+	const writes = [];
+	const settings = {
+		describe: () => [],
+		async mutate(ns, ops) { writes.push({ ns, ops }); },
+	};
+	const count = await refreshOpenCodeFreeModels({ settings, describe: settings.describe, timeoutMs: 30 });
+	assert.equal(count, undefined);
+	assert.equal(writes.length, 0);
+});
+
+test('sameModelIds compares id sets regardless of order', () => {
+	assert.equal(sameModelIds(['a', 'b'], ['b', 'a']), true);
+	assert.equal(sameModelIds(['a'], ['a']), true);
+	assert.equal(sameModelIds(['a'], ['a', 'b']), false);
+	assert.equal(sameModelIds([], []), true);
+});
+
+test('configuredModelIds reads ids from a resolved descriptor, tolerating gaps', () => {
+	assert.deepEqual(configuredModelIds({ value: { providers: { opencode: { models: [{ id: 'a' }, { id: 'b' }] } } } }), ['a', 'b']);
+	assert.equal(configuredModelIds({ value: {} }), undefined);
+	assert.equal(configuredModelIds({}), undefined);
+	assert.equal(configuredModelIds({ value: { providers: { opencode: {} } } }), undefined);
+	assert.equal(configuredModelIds({ value: { providers: { opencode: { models: [{ id: 'a' }, {}] } } } }), undefined);
+});
+
+test('refresh skips the write when the served set already matches', async () => {
+	const writes = [];
+	const settings = {
+		describe: () => [{
+			ns: 'llm-pi-ai',
+			revision: 5,
+			value: { providers: { opencode: { models: [{ id: 'hy3-free' }] } } },
+		}],
+		async mutate(ns, ops) { writes.push({ ns, ops }); },
+	};
+	const fetchImpl = async (url) => {
+		if (url.includes('models.opencode.ai')) {
+			return { ok: true, json: async () => catalogWith({
+				'hy3-free': { cost: { input: 0, output: 0 } },
+				'paid': { cost: { input: 2, output: 12 } },
+			}) };
+		}
+		return { ok: true, json: async () => ({ data: [{ id: 'hy3-free' }, { id: 'paid' }] }) };
+	};
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	assert.equal(count, 1); // still reports the usable count
+	assert.equal(writes.length, 0); // but nothing was written
+});
+
+test('refresh writes when a new free-and-served model appears', async () => {
+	const writes = [];
+	const settings = {
+		describe: () => [{
+			ns: 'llm-pi-ai',
+			revision: 5,
+			value: { providers: { opencode: { models: [{ id: 'old-model' }] } } },
+		}],
+		async mutate(ns, ops) { writes.push({ ns, ops }); },
+	};
+	const fetchImpl = async (url) => {
+		if (url.includes('models.opencode.ai')) {
+			return { ok: true, json: async () => catalogWith({
+				'old-model': { cost: { input: 0, output: 0 } },
+				'brand-new-free': { cost: { input: 0, output: 0 } },
+			}) };
+		}
+		return { ok: true, json: async () => ({ data: [{ id: 'old-model' }, { id: 'brand-new-free' }] }) };
+	};
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe });
+	assert.equal(count, 2);
+	assert.equal(writes.length, 1);
+	assert.deepEqual(writes[0].ops[0].value, [{ id: 'brand-new-free' }, { id: 'old-model' }]);
+});

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -7,12 +7,29 @@ const {
 	selectFreeAndServed,
 	waitForNamespace,
 	refreshOpenCodeFreeModels,
-	mergeModelEntries,
 } = require('./opencode-free.cjs');
 
 // A catalog shaped like models.dev/api.json (opencode provider).
 function catalogWith(models) {
 	return { opencode: { api: 'https://opencode.ai/zen/v1', models } };
+}
+
+function fetchCatalog(models) {
+	return async () => ({ ok: true, json: async () => catalogWith(models) });
+}
+
+function settingsHarness(value, descriptor) {
+	const writes = [];
+	const settings = {
+		get: (ns) => ns === 'llm-pi-ai' ? value : undefined,
+		async mutate(ns, ops, revision) { writes.push({ ns, ops, revision }); },
+	};
+	if (descriptor !== undefined) settings.describe = () => [descriptor];
+	return { settings, writes };
+}
+
+function writtenModels(write) {
+	return write.ops.find((op) => op.path.at(-1) === 'models')?.value;
 }
 
 test('isZeroCost accepts only fully zero-cost models', () => {
@@ -90,12 +107,7 @@ test('waitForNamespace resolves with the registered value', async () => {
 	assert.deepEqual(value, { providers: { opencode: { models: [] } } });
 });
 
-test('waitForNamespace times out without a registered namespace', async () => {
-	const value = await waitForNamespace(() => undefined, 50);
-	assert.equal(value, undefined);
-});
-
-test('waitForNamespace returns undefined when aborted', async () => {
+test('waitForNamespace returns promptly when aborted', { timeout: 1000 }, async () => {
 	const controller = new AbortController();
 	const pending = waitForNamespace(() => undefined, 5000, controller.signal);
 	setTimeout(() => controller.abort(), 30);
@@ -103,21 +115,12 @@ test('waitForNamespace returns undefined when aborted', async () => {
 	assert.equal(value, undefined);
 });
 
-test('refresh writes free non-deprecated models plus route wiring via settings.mutate', async () => {
-	const writes = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'old' }] } } } : undefined,
-		async mutate(ns, ops, revision) {
-			writes.push({ ns, ops, revision });
-		},
-	};
-	const fetchImpl = async () => ({
-		ok: true,
-		json: async () => catalogWith({
-			'hy3-free': { cost: { input: 0, output: 0 } },
-			'dead-free': { cost: { input: 0, output: 0 }, status: 'deprecated' },
-			'paid': { cost: { input: 2, output: 12 } },
-		}),
+test('refresh writes free non-deprecated models with serviceable route wiring', async () => {
+	const { settings, writes } = settingsHarness({ providers: { opencode: { models: [{ id: 'old' }] } } });
+	const fetchImpl = fetchCatalog({
+		'hy3-free': { cost: { input: 0, output: 0 } },
+		'dead-free': { cost: { input: 0, output: 0 }, status: 'deprecated' },
+		'paid': { cost: { input: 2, output: 12 } },
 	});
 	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, 1);
@@ -131,23 +134,15 @@ test('refresh writes free non-deprecated models plus route wiring via settings.m
 });
 
 test('refresh does not write an empty list when nothing is usable', async () => {
-	const writes = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [] } } } : undefined,
-		mutate: async (ns, ops) => writes.push({ ns, ops }),
-	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({ 'dead-free': { cost: { input: 0, output: 0 }, status: 'deprecated' } }) });
+	const { settings, writes } = settingsHarness({ providers: { opencode: { models: [] } } });
+	const fetchImpl = fetchCatalog({ 'dead-free': { cost: { input: 0, output: 0 }, status: 'deprecated' } });
 	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, undefined);
 	assert.equal(writes.length, 0);
 });
 
 test('refresh leaves the list untouched on a fetch failure', async () => {
-	const writes = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [] } } } : undefined,
-		async mutate(ns, ops) { writes.push({ ns, ops }); },
-	};
+	const { settings, writes } = settingsHarness({ providers: { opencode: { models: [] } } });
 	const fetchImpl = async () => { throw new Error('network down'); };
 	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, undefined);
@@ -155,11 +150,7 @@ test('refresh leaves the list untouched on a fetch failure', async () => {
 });
 
 test('refresh is bounded by the per-request deadline when a fetch hangs', { timeout: 2000 }, async () => {
-	const writes = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [] } } } : undefined,
-		async mutate(ns, ops) { writes.push({ ns, ops }); },
-	};
+	const { settings, writes } = settingsHarness({ providers: { opencode: { models: [] } } });
 	// A fetch that never settles would otherwise leave the refresh pending
 	// forever; fetchJson must pass a combined signal that aborts on the
 	// deadline, which this mock observes and turns into a rejection.
@@ -172,176 +163,96 @@ test('refresh is bounded by the per-request deadline when a fetch hangs', { time
 });
 
 test('refresh never writes while the llm-pi-ai namespace is unregistered', async () => {
-	const writes = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? undefined : undefined,
-		async mutate(ns, ops) { writes.push({ ns, ops }); },
-	};
+	const { settings, writes } = settingsHarness(undefined);
 	const count = await refreshOpenCodeFreeModels({ settings, timeoutMs: 30 });
 	assert.equal(count, undefined);
 	assert.equal(writes.length, 0);
 });
 
 test('refresh skips the write when live profiles and routing already match', async () => {
-	const writes = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? {
-			providers: { opencode: {
-				api: 'openai-completions',
-				baseURL: 'https://opencode.ai/zen/v1',
-				models: [{ id: 'hy3-free' }],
-			} },
-		} : undefined,
-		async mutate(ns, ops) { writes.push({ ns, ops }); },
-	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+	const { settings, writes } = settingsHarness({
+		providers: { opencode: {
+			api: 'openai-completions',
+			baseURL: 'https://opencode.ai/zen/v1',
+			models: [{ id: 'hy3-free' }],
+		} },
+	});
+	const fetchImpl = fetchCatalog({
 		'hy3-free': { cost: { input: 0, output: 0 } },
 		'paid': { cost: { input: 2, output: 12 } },
-	}) });
+	});
 	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(count, 1); // still reports the usable count
 	assert.equal(writes.length, 0); // but nothing was written
 });
 
-test('refresh writes when a new free model appears', async () => {
-	const writes = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? {
-			providers: { opencode: {
-				api: 'openai-completions',
-				baseURL: 'https://opencode.ai/zen/v1',
-				models: [{ id: 'old-model' }],
-			} },
-		} : undefined,
-		async mutate(ns, ops) { writes.push({ ns, ops }); },
-	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
-		'old-model': { cost: { input: 0, output: 0 } },
-		'brand-new-free': { cost: { input: 0, output: 0 } },
-	}) });
-	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
-	assert.equal(count, 2);
-	assert.equal(writes.length, 1);
-	assert.deepEqual(writes[0].ops[2].value, [{ id: 'brand-new-free' }, { id: 'old-model' }]);
-});
-
 test('refresh writes when live metadata changes without an id change', async () => {
-	const writes = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? {
-			providers: { opencode: {
-				api: 'openai-completions',
-				baseURL: 'https://opencode.ai/zen/v1',
-				models: [{ id: 'hy3-free', contextWindow: 262144 }],
-			} },
-		} : undefined,
-		async mutate(ns, ops) { writes.push({ ns, ops }); },
-	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+	const { settings, writes } = settingsHarness({
+		providers: { opencode: { models: [{ id: 'hy3-free', contextWindow: 262144 }] } },
+	});
+	const fetchImpl = fetchCatalog({
 		'hy3-free': { cost: { input: 0, output: 0 }, limit: { context: 190000 } },
-	}) });
+	});
 	await refreshOpenCodeFreeModels({ settings, fetchImpl });
-	assert.deepEqual(writes[0].ops[2].value, [{ id: 'hy3-free', contextWindow: 190000 }]);
+	assert.deepEqual(writtenModels(writes[0]), [{ id: 'hy3-free', contextWindow: 190000 }]);
 });
 
 test('refresh writes against the latest settings revision after the catalog request', async () => {
-	const writes = [];
 	const initial = { providers: { opencode: { models: [{ id: 'old-model' }] } } };
 	const latest = { providers: { opencode: { models: [{ id: 'old-model', compat: { supportsStore: false } }] } } };
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? initial : undefined,
-		describe: () => [{ ns: 'llm-pi-ai', value: latest, revision: 7 }],
-		async mutate(ns, ops, revision) { writes.push({ ns, ops, revision }); },
-	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+	const { settings, writes } = settingsHarness(initial, { ns: 'llm-pi-ai', value: latest, revision: 7 });
+	const fetchImpl = fetchCatalog({
 		'old-model': { cost: { input: 0, output: 0 }, limit: { context: 190000 } },
-	}) });
+	});
 	await refreshOpenCodeFreeModels({ settings, fetchImpl });
 	assert.equal(writes[0].revision, 7);
-	assert.deepEqual(writes[0].ops[2].value, [{ id: 'old-model', contextWindow: 190000, compat: { supportsStore: false } }]);
-});
-
-test('mergeModelEntries keeps local route metadata but refreshes catalog-owned fields', () => {
-	const current = { providers: { opencode: { models: [{ id: 'kept', contextWindow: 1234, compat: { supportsStore: false } }, { id: 'old' }] } } };
-	const merged = mergeModelEntries(current, [{ id: 'kept', contextWindow: 190000 }, { id: 'added' }]);
-	assert.deepEqual(merged, [{ id: 'kept', contextWindow: 190000, compat: { supportsStore: false } }, { id: 'added' }]);
+	assert.deepEqual(writtenModels(writes[0]), [{ id: 'old-model', contextWindow: 190000, compat: { supportsStore: false } }]);
 });
 
 test('refresh moves the opencode default model when it is dropped', async () => {
-	const writes = [];
 	const saves = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'big-pickle' }] } } } : undefined,
-		async mutate(ns, ops) { writes.push({ ns, ops }); },
-	};
+	const { settings, writes } = settingsHarness({ providers: { opencode: { models: [{ id: 'big-pickle' }] } } });
 	const defaultModel = {
 		currentSelection: () => ({ provider: 'opencode', model: 'big-pickle' }),
 		async saveSelection(next) { saves.push(next); },
 	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+	const fetchImpl = fetchCatalog({
 		'hy3-free': { cost: { input: 0, output: 0 } },
-	}) });
+	});
 	const count = await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
 	assert.equal(count, 1);
 	assert.deepEqual(saves, [{ provider: 'opencode', model: 'hy3-free' }]);
 	assert.equal(writes.length, 1);
-	assert.deepEqual(writes[0].ops[2].value, [{ id: 'hy3-free' }]);
+	assert.deepEqual(writtenModels(writes[0]), [{ id: 'hy3-free' }]);
 });
 
-test('refresh preserves a supported reasoning effort when moving the default model', async () => {
+test('refresh clears the previous reasoning effort when moving the default model', async () => {
 	const saves = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'retired' }] } } } : undefined,
-		async mutate() {},
-	};
+	const { settings } = settingsHarness({ providers: { opencode: { models: [{ id: 'retired' }] } } });
 	const defaultModel = {
 		currentSelection: () => ({ provider: 'opencode', model: 'retired', reasoningEffort: 'high' }),
 		async saveSelection(next) { saves.push(next); },
 	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+	const fetchImpl = fetchCatalog({
 		'survivor': {
 			cost: { input: 0, output: 0 },
 			reasoning_options: [{ type: 'effort', values: ['low', 'high'] }],
 		},
-	}) });
-	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
-	assert.deepEqual(saves, [{ provider: 'opencode', model: 'survivor', reasoningEffort: 'high' }]);
-});
-
-test('refresh clears an unsupported reasoning effort when moving the default model', async () => {
-	const saves = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'retired' }] } } } : undefined,
-		async mutate() {},
-	};
-	const defaultModel = {
-		currentSelection: () => ({ provider: 'opencode', model: 'retired', reasoningEffort: 'max' }),
-		async saveSelection(next) { saves.push(next); },
-	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
-		'survivor': {
-			cost: { input: 0, output: 0 },
-			reasoning_options: [{ type: 'effort', values: ['low', 'high'] }],
-		},
-	}) });
+	});
 	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
 	assert.deepEqual(saves, [{ provider: 'opencode', model: 'survivor' }]);
 });
 
 test('refresh leaves a non-opencode default untouched', async () => {
-	const writes = [];
 	const saves = [];
-	const settings = {
-		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'big-pickle' }] } } } : undefined,
-		async mutate(ns, ops) { writes.push({ ns, ops }); },
-	};
+	const { settings } = settingsHarness({ providers: { opencode: { models: [{ id: 'big-pickle' }] } } });
 	const defaultModel = {
 		currentSelection: () => ({ provider: 'deepseek', model: 'deepseek-chat' }),
 		async saveSelection(next) { saves.push(next); },
 	};
-	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+	const fetchImpl = fetchCatalog({
 		'hy3-free': { cost: { input: 0, output: 0 } },
-	}) });
+	});
 	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
 	assert.deepEqual(saves, []);
 });
@@ -381,7 +292,7 @@ test('product lifecycle immediately refreshes the runtime catalog through settin
 		await wrote;
 		assert.equal(writes.length, 1);
 		assert.equal(writes[0].revision, 0);
-		assert.deepEqual(writes[0].ops[2].value, [{ id: 'live-free', contextWindow: 190000, maxTokens: 64000 }]);
+		assert.deepEqual(writtenModels(writes[0]), [{ id: 'live-free', contextWindow: 190000, maxTokens: 64000 }]);
 	} finally {
 		dispose?.();
 		globalThis.fetch = originalFetch;

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -7,8 +7,6 @@ const {
 	selectFreeAndServed,
 	waitForNamespace,
 	refreshOpenCodeFreeModels,
-	sameModelIds,
-	configuredModelIds,
 	mergeModelEntries,
 } = require('./opencode-free.cjs');
 
@@ -49,14 +47,27 @@ test('isZeroCost accepts only fully zero-cost models', () => {
 
 test('selectFreeAndServed returns only free AND non-deprecated models, sorted', () => {
 	const catalog = catalogWith({
-		'new-free': { cost: { input: 0, output: 0 } },
+		'new-free': {
+			name: 'New Free',
+			cost: { input: 0, output: 0 },
+			limit: { context: 190000, output: 64000 },
+			modalities: { input: ['text', 'image', 'video'] },
+			reasoning_options: [{ type: 'toggle' }, { type: 'effort', values: ['low', 'medium', 'high'] }],
+		},
 		'dead-free': { cost: { input: 0, output: 0 }, status: 'deprecated' },
 		'paid': { cost: { input: 2, output: 12 } },
-		'free-persisted': { cost: { input: 0, output: 0 } },
+		'free-persisted': { cost: { input: 0, output: 0 }, reasoning: false },
 	});
 	assert.deepEqual(selectFreeAndServed(catalog), [
-		{ id: 'free-persisted' },
-		{ id: 'new-free' },
+		{ id: 'free-persisted', reasoningEfforts: false },
+		{
+			id: 'new-free',
+			name: 'New Free',
+			contextWindow: 190000,
+			maxTokens: 64000,
+			input: ['text', 'image'],
+			reasoningEfforts: { off: null, low: 'low', medium: 'medium', high: 'high' },
+		},
 	]);
 });
 
@@ -84,7 +95,7 @@ test('waitForNamespace times out without a registered namespace', async () => {
 	assert.equal(value, undefined);
 });
 
-test('waitForNamespace aborts promptly when the signal fires', async () => {
+test('waitForNamespace returns undefined when aborted', async () => {
 	const controller = new AbortController();
 	const pending = waitForNamespace(() => undefined, 5000, controller.signal);
 	setTimeout(() => controller.abort(), 30);
@@ -117,7 +128,6 @@ test('refresh writes free non-deprecated models plus route wiring via settings.m
 		{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: 'https://opencode.ai/zen/v1' },
 		{ op: 'set', path: ['providers', 'opencode', 'models'], value: [{ id: 'hy3-free' }] },
 	]);
-	assert.equal(writes[0].revision, undefined);
 });
 
 test('refresh does not write an empty list when nothing is usable', async () => {
@@ -144,7 +154,7 @@ test('refresh leaves the list untouched on a fetch failure', async () => {
 	assert.equal(writes.length, 0);
 });
 
-test('refresh is bounded by the per-request deadline when a fetch hangs', async () => {
+test('refresh is bounded by the per-request deadline when a fetch hangs', { timeout: 2000 }, async () => {
 	const writes = [];
 	const settings = {
 		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [] } } } : undefined,
@@ -156,14 +166,9 @@ test('refresh is bounded by the per-request deadline when a fetch hangs', async 
 	const fetchImpl = (_url, init) => new Promise((_resolve, reject) => {
 		init.signal.addEventListener('abort', () => reject(new Error('aborted')));
 	});
-	const started = Date.now();
 	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, requestTimeoutMs: 100 });
-	const elapsed = Date.now() - started;
 	assert.equal(count, undefined);
 	assert.equal(writes.length, 0);
-	// The mock aborts on the 100ms deadline; a regression that restored the 15s
-	// default (or left the fetch hung) would blow past 2s.
-	assert.ok(elapsed < 2000, `refresh took too long: ${elapsed}ms`);
 });
 
 test('refresh never writes while the llm-pi-ai namespace is unregistered', async () => {
@@ -177,22 +182,7 @@ test('refresh never writes while the llm-pi-ai namespace is unregistered', async
 	assert.equal(writes.length, 0);
 });
 
-test('sameModelIds compares id sets regardless of order', () => {
-	assert.equal(sameModelIds(['a', 'b'], ['b', 'a']), true);
-	assert.equal(sameModelIds(['a'], ['a']), true);
-	assert.equal(sameModelIds(['a'], ['a', 'b']), false);
-	assert.equal(sameModelIds([], []), true);
-});
-
-test('configuredModelIds reads ids from a resolved value, tolerating gaps', () => {
-	assert.deepEqual(configuredModelIds({ providers: { opencode: { models: [{ id: 'a' }, { id: 'b' }] } } }), ['a', 'b']);
-	assert.equal(configuredModelIds({ providers: {} }), undefined);
-	assert.equal(configuredModelIds({}), undefined);
-	assert.equal(configuredModelIds({ providers: { opencode: {} } }), undefined);
-	assert.equal(configuredModelIds({ providers: { opencode: { models: [{ id: 'a' }, {}] } } }), undefined);
-});
-
-test('refresh skips the write when the served set and routing already match', async () => {
+test('refresh skips the write when live profiles and routing already match', async () => {
 	const writes = [];
 	const settings = {
 		get: (ns) => ns === 'llm-pi-ai' ? {
@@ -235,10 +225,46 @@ test('refresh writes when a new free model appears', async () => {
 	assert.deepEqual(writes[0].ops[2].value, [{ id: 'brand-new-free' }, { id: 'old-model' }]);
 });
 
-test('mergeModelEntries preserves surviving model metadata', () => {
-	const current = { providers: { opencode: { models: [{ id: 'kept', maxTokens: 1234 }, { id: 'old' }] } } };
-	const merged = mergeModelEntries(current, [{ id: 'kept' }, { id: 'added' }]);
-	assert.deepEqual(merged, [{ id: 'kept', maxTokens: 1234 }, { id: 'added' }]);
+test('refresh writes when live metadata changes without an id change', async () => {
+	const writes = [];
+	const settings = {
+		get: (ns) => ns === 'llm-pi-ai' ? {
+			providers: { opencode: {
+				api: 'openai-completions',
+				baseURL: 'https://opencode.ai/zen/v1',
+				models: [{ id: 'hy3-free', contextWindow: 262144 }],
+			} },
+		} : undefined,
+		async mutate(ns, ops) { writes.push({ ns, ops }); },
+	};
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+		'hy3-free': { cost: { input: 0, output: 0 }, limit: { context: 190000 } },
+	}) });
+	await refreshOpenCodeFreeModels({ settings, fetchImpl });
+	assert.deepEqual(writes[0].ops[2].value, [{ id: 'hy3-free', contextWindow: 190000 }]);
+});
+
+test('refresh writes against the latest settings revision after the catalog request', async () => {
+	const writes = [];
+	const initial = { providers: { opencode: { models: [{ id: 'old-model' }] } } };
+	const latest = { providers: { opencode: { models: [{ id: 'old-model', compat: { supportsStore: false } }] } } };
+	const settings = {
+		get: (ns) => ns === 'llm-pi-ai' ? initial : undefined,
+		describe: () => [{ ns: 'llm-pi-ai', value: latest, revision: 7 }],
+		async mutate(ns, ops, revision) { writes.push({ ns, ops, revision }); },
+	};
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+		'old-model': { cost: { input: 0, output: 0 }, limit: { context: 190000 } },
+	}) });
+	await refreshOpenCodeFreeModels({ settings, fetchImpl });
+	assert.equal(writes[0].revision, 7);
+	assert.deepEqual(writes[0].ops[2].value, [{ id: 'old-model', contextWindow: 190000, compat: { supportsStore: false } }]);
+});
+
+test('mergeModelEntries keeps local route metadata but refreshes catalog-owned fields', () => {
+	const current = { providers: { opencode: { models: [{ id: 'kept', contextWindow: 1234, compat: { supportsStore: false } }, { id: 'old' }] } } };
+	const merged = mergeModelEntries(current, [{ id: 'kept', contextWindow: 190000 }, { id: 'added' }]);
+	assert.deepEqual(merged, [{ id: 'kept', contextWindow: 190000, compat: { supportsStore: false } }, { id: 'added' }]);
 });
 
 test('refresh moves the opencode default model when it is dropped', async () => {
@@ -262,6 +288,46 @@ test('refresh moves the opencode default model when it is dropped', async () => 
 	assert.deepEqual(writes[0].ops[2].value, [{ id: 'hy3-free' }]);
 });
 
+test('refresh preserves a supported reasoning effort when moving the default model', async () => {
+	const saves = [];
+	const settings = {
+		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'retired' }] } } } : undefined,
+		async mutate() {},
+	};
+	const defaultModel = {
+		currentSelection: () => ({ provider: 'opencode', model: 'retired', reasoningEffort: 'high' }),
+		async saveSelection(next) { saves.push(next); },
+	};
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+		'survivor': {
+			cost: { input: 0, output: 0 },
+			reasoning_options: [{ type: 'effort', values: ['low', 'high'] }],
+		},
+	}) });
+	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
+	assert.deepEqual(saves, [{ provider: 'opencode', model: 'survivor', reasoningEffort: 'high' }]);
+});
+
+test('refresh clears an unsupported reasoning effort when moving the default model', async () => {
+	const saves = [];
+	const settings = {
+		get: (ns) => ns === 'llm-pi-ai' ? { providers: { opencode: { models: [{ id: 'retired' }] } } } : undefined,
+		async mutate() {},
+	};
+	const defaultModel = {
+		currentSelection: () => ({ provider: 'opencode', model: 'retired', reasoningEffort: 'max' }),
+		async saveSelection(next) { saves.push(next); },
+	};
+	const fetchImpl = async () => ({ ok: true, json: async () => catalogWith({
+		'survivor': {
+			cost: { input: 0, output: 0 },
+			reasoning_options: [{ type: 'effort', values: ['low', 'high'] }],
+		},
+	}) });
+	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
+	assert.deepEqual(saves, [{ provider: 'opencode', model: 'survivor' }]);
+});
+
 test('refresh leaves a non-opencode default untouched', async () => {
 	const writes = [];
 	const saves = [];
@@ -278,4 +344,46 @@ test('refresh leaves a non-opencode default untouched', async () => {
 	}) });
 	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
 	assert.deepEqual(saves, []);
+});
+
+test('product lifecycle immediately refreshes the runtime catalog through settings', { timeout: 2000 }, async () => {
+	const originalFetch = globalThis.fetch;
+	const writes = [];
+	let dispose;
+	let resolveWrite;
+	const wrote = new Promise((resolve) => { resolveWrite = resolve; });
+	globalThis.fetch = async () => ({
+		ok: true,
+		json: async () => catalogWith({
+			'live-free': { cost: { input: 0, output: 0 }, limit: { context: 190000, output: 64000 } },
+		}),
+	});
+	try {
+		const { apply } = await import('./index.js');
+		const value = { providers: { opencode: { models: [{ id: 'packaged-free' }] } } };
+		apply({
+			settings: {
+				get: (ns) => ns === 'llm-pi-ai' ? value : undefined,
+				describe: () => [{ ns: 'llm-pi-ai', value, revision: 0 }],
+				async mutate(ns, ops, revision) {
+					writes.push({ ns, ops, revision });
+					resolveWrite();
+				},
+			},
+			agentDefaultModel: { currentSelection: () => ({ provider: 'opencode', model: 'live-free' }) },
+			logger: { info() {}, warn() {} },
+			interval(callback, milliseconds) {
+				assert.equal(typeof callback, 'function');
+				assert.equal(milliseconds, 60 * 60 * 1000);
+			},
+			effect(register) { dispose = register(); },
+		});
+		await wrote;
+		assert.equal(writes.length, 1);
+		assert.equal(writes[0].revision, 0);
+		assert.deepEqual(writes[0].ops[2].value, [{ id: 'live-free', contextWindow: 190000, maxTokens: 64000 }]);
+	} finally {
+		dispose?.();
+		globalThis.fetch = originalFetch;
+	}
 });

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -151,6 +151,26 @@ test('refresh leaves the list untouched on a fetch failure', async () => {
 	assert.equal(writes.length, 0);
 });
 
+test('refresh is bounded by the per-request deadline when a fetch hangs', async () => {
+	const writes = [];
+	const settings = {
+		describe: () => [{ ns: 'llm-pi-ai', revision: 1 }],
+		async mutate(ns, ops) { writes.push({ ns, ops }); },
+	};
+	// A fetch that never settles would otherwise leave the refresh pending
+	// forever; fetchJson must pass a combined signal that aborts on the
+	// deadline, which this mock observes and turns into a rejection.
+	const fetchImpl = (_url, init) => new Promise((_resolve, reject) => {
+		init.signal.addEventListener('abort', () => reject(new Error('aborted')));
+	});
+	const started = Date.now();
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl, describe: settings.describe, requestTimeoutMs: 100 });
+	const elapsed = Date.now() - started;
+	assert.equal(count, undefined);
+	assert.equal(writes.length, 0);
+	assert.ok(elapsed < 10000, `refresh took too long: ${elapsed}ms`);
+});
+
 test('refresh never writes while the llm-pi-ai namespace is unregistered', async () => {
 	const writes = [];
 	const settings = {

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -231,7 +231,6 @@ describe("ci smoke helpers", () => {
       sidebarExpandedAgain: true,
       platform: "MacIntel",
       freeProviderActive: true,
-      freeModelAvailable: true,
       v1SessionImported: true,
       skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
       sessionId: "session-smoke",
@@ -275,7 +274,6 @@ describe("ci smoke helpers", () => {
     sidebarExpandedAgain: true,
     platform: "MacIntel",
     freeProviderActive: true,
-    freeModelAvailable: true,
     v1SessionImported: true,
     skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
     sessionId: "session-1",
@@ -313,7 +311,6 @@ describe("ci smoke helpers", () => {
     sidebarExpandToggleHasContent: false,
     sidebarExpandedAgain: false,
     freeProviderActive: false,
-    freeModelAvailable: false,
     v1SessionImported: false,
     skillNames: ["office-docx"],
   }

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -461,7 +461,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       sidebarExpandedAgain: !document.querySelector("[data-sidebar-collapsed]"),
       platform: typeof navigator === "undefined" ? "" : navigator.platform,
       freeProviderActive: freeProvider?.active === true && freeProvider?.displayName === "OpenCode Free",
-      freeModelAvailable: freeModels.some((model) => model.id === "big-pickle" && model.name === "Big Pickle"),
+      freeModelAvailable: freeModels.length > 0,
       v1SessionImported,
       skillNames: skills.map((skill) => skill.name).sort(),
       sessionId: session.sessionId,
@@ -627,7 +627,7 @@ export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform:
     snapshot.sidebarExpandToggleHasContent ? null : "collapsed sidebar expand control renders empty",
     snapshot.sidebarExpandedAgain ? null : "DSH expand control did not reopen the sidebar",
     snapshot.freeProviderActive ? null : "OpenCode Free provider is not active",
-    snapshot.freeModelAvailable ? null : "Big Pickle free model is unavailable",
+    snapshot.freeModelAvailable ? null : "No OpenCode Free model is available",
     snapshot.v1SessionImported ? null : "V1 session was not imported into DSH",
     ["office-docx", "office-pdf", "office-pptx", "office-xlsx"].every((name) => snapshot.skillNames.includes(name))
       ? null

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -461,7 +461,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       sidebarExpandedAgain: !document.querySelector("[data-sidebar-collapsed]"),
       platform: typeof navigator === "undefined" ? "" : navigator.platform,
       freeProviderActive: freeProvider?.active === true && freeProvider?.displayName === "OpenCode Free",
-      freeModelAvailable: freeModels.some((model) => model.id === "deepseek-v4-flash-free" && model.name === "DeepSeek V4 Flash Free"),
+      freeModelAvailable: freeModels.some((model) => model.id === "big-pickle" && model.name === "Big Pickle"),
       v1SessionImported,
       skillNames: skills.map((skill) => skill.name).sort(),
       sessionId: session.sessionId,
@@ -627,7 +627,7 @@ export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform:
     snapshot.sidebarExpandToggleHasContent ? null : "collapsed sidebar expand control renders empty",
     snapshot.sidebarExpandedAgain ? null : "DSH expand control did not reopen the sidebar",
     snapshot.freeProviderActive ? null : "OpenCode Free provider is not active",
-    snapshot.freeModelAvailable ? null : "DeepSeek V4 Flash Free is unavailable",
+    snapshot.freeModelAvailable ? null : "Big Pickle free model is unavailable",
     snapshot.v1SessionImported ? null : "V1 session was not imported into DSH",
     ["office-docx", "office-pdf", "office-pptx", "office-xlsx"].every((name) => snapshot.skillNames.includes(name))
       ? null

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -72,7 +72,6 @@ export type CiSmokeProductSnapshot = {
   sidebarExpandedAgain: boolean
   platform: string
   freeProviderActive: boolean
-  freeModelAvailable: boolean
   v1SessionImported: boolean
   skillNames: string[]
   sessionId: string
@@ -423,12 +422,10 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       if (!v1SessionImported) await new Promise((resolve) => setTimeout(resolve, 100))
     }
     const providers = (await call("llm.providers", {})).providers
-    const models = (await call("llm.models", {})).groups
     const session = await call("session.create", { cwd: ${workspace} })
     const skills = (await call("skill.list", { sessionId: session.sessionId })).skills
     const sessionIdsBeforeRestart = (await call("session.list", {})).items.map((item) => item.sessionId)
     const freeProvider = providers.find((provider) => provider.provider === "opencode")
-    const freeModels = models.find((group) => group.id === "opencode")?.models || []
     return JSON.stringify({
       sidebarBrandVisible,
       heroMarkVisible,
@@ -461,7 +458,6 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       sidebarExpandedAgain: !document.querySelector("[data-sidebar-collapsed]"),
       platform: typeof navigator === "undefined" ? "" : navigator.platform,
       freeProviderActive: freeProvider?.active === true && freeProvider?.displayName === "OpenCode Free",
-      freeModelAvailable: freeModels.length > 0,
       v1SessionImported,
       skillNames: skills.map((skill) => skill.name).sort(),
       sessionId: session.sessionId,
@@ -627,7 +623,6 @@ export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform:
     snapshot.sidebarExpandToggleHasContent ? null : "collapsed sidebar expand control renders empty",
     snapshot.sidebarExpandedAgain ? null : "DSH expand control did not reopen the sidebar",
     snapshot.freeProviderActive ? null : "OpenCode Free provider is not active",
-    snapshot.freeModelAvailable ? null : "No OpenCode Free model is available",
     snapshot.v1SessionImported ? null : "V1 session was not imported into DSH",
     ["office-docx", "office-pdf", "office-pptx", "office-xlsx"].every((name) => snapshot.skillNames.includes(name))
       ? null


### PR DESCRIPTION
## Summary

Makes OpenCode Free a runtime-discovered catalog instead of a build-time snapshot. The PawWork product plugin reads `models.dev/api.json` on launch and hourly, keeps only zero-cost non-deprecated models, normalizes their complete capabilities into the existing `llm-pi-ai` route, and repairs a retired OpenCode default.

## Why

OpenCode adds and retires free models independently of PawWork releases. A frozen list hides new models and leaves ended promotions selectable until the gateway rejects them with an error the UI can mislabel as an invalid key.

No issue was opened; this is the runtime-discovery fix for the stale OpenCode Free catalog.

## Human Review Status

`Pending`

## Design

- **One catalog authority:** `models.dev` owns identity, free/deprecated status, name, context/output capacities, supported input modalities, and explicitly selectable reasoning efforts.
- **One existing runtime seam:** the plugin mutates `llm-pi-ai.providers.opencode`; the pi-ai adapter still owns model registration and streaming.
- **Servable dynamic IDs:** OpenCode's bundled catalog spans multiple protocols, so unknown IDs cannot inherit one shared API. The product-managed route therefore pins `openai-completions` and `https://opencode.ai/zen/v1` alongside the discovered models.
- **Fail closed:** missing or malformed pricing, any nonzero numeric cost leaf, and deprecated entries are excluded. Fetch/parse failure or an empty result leaves the packaged fallback untouched.
- **Capability fidelity:** live context and output limits, supported text/image inputs, and advertised reasoning effort values are written for newly discovered models. A reasoning model without advertised effort values uses the provider default instead of inventing wire spellings.
- **Clear ownership:** catalog-owned fields refresh from `models.dev`; local `compat` survives because it describes gateway wire behavior the catalog does not own.
- **Concurrency boundary:** the plugin re-reads the Settings descriptor after the network request and commits with its revision, so a stale refresh cannot overwrite a concurrent edit.
- **Default continuity:** a retired OpenCode default moves to a surviving model. Moving to a different model clears the previous reasoning effort, matching DSH model-selection semantics.
- **No churn:** normalized profiles and route wiring are compared structurally before mutation.

The prior `/zen/v1/models` serviceability check was removed because it duplicated the model set without carrying the pricing/deprecation fact that defines this product route.

## Review Focus

- The models.dev to pi-ai profile mapping and field ownership.
- Settings revision handling across the network await.
- Generic OpenAI-compatible route behavior for both bundled and newly discovered IDs.
- Default-model migration when the selected model retires.

## Risk Notes

- The route-level `api` intentionally uses the adapter's generic OpenAI-compatible provider: the installed OpenCode catalog mixes `anthropic-messages`, `google-generative-ai`, `openai-completions`, and `openai-responses`, so unknown dynamic IDs have no single protocol to inherit.
- `maxTokens` is both the published output capability and the adapter request cap in DSH rc.8; the provider's own `limit.output` is used rather than the 32K unknown-model fallback.
- No externally visible layout change. Deterministic product lifecycle coverage proves `apply -> fetch -> settings.mutate`.

## How To Verify

```text
pnpm --filter @pawwork/desktop test
  Vitest: 31 files, 293 tests passed
  Node integration: 102 tests passed

pnpm --filter @pawwork/desktop typecheck
pnpm exec eslint packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
```

A local Electron/CDP smoke reached and passed the OpenCode provider path, then failed on two unrelated pre-existing sidebar-brand geometry assertions; the full smoke is therefore not reported as green.

## Screenshots or Recordings

Not applicable - no visible UI change.

## Checklist

- [x] Type, routing, and priority labels are applied.
- [x] The change targets `main` and uses Conventional Commit titles.
- [x] The change was reviewed adversarially for correctness and simplification.
- [x] Human review remains pending.
