### PR TITLE
fix(desktop): show v1 imported sessions in the sidebar without a reload

### DIFF
--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
@@ -37,7 +37,7 @@ function fileDigest(file) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 }
 
-test('persists each v1 session without announcing it on the live session channel', async () => {
+test('retires each persisted v1 session through the paired live lifecycle', async () => {
   const importerModule = require('./import-v1.cjs');
   const settingsModule = require('./import-v1-settings.cjs');
   const automationsModule = require('./import-v1-automations.cjs');
@@ -150,12 +150,11 @@ test('persists each v1 session without announcing it on the live session channel
     assert.equal(missingContinueSessionRejected, true);
     assert.equal(incompleteContinueSessionRejected, true);
     assert.equal(unavailableAutomationCatalogRejected, true);
-    // The importer writes cold sessions: enter/rename/flush/detach is the
-    // persistence path, and attach-workspace is the follow-up that does not
-    // depend on the session staying live. announce used to sit between flush
-    // and detach, but the client list removes a session again on
-    // session/disposed, so every announced import flickered in and out.
-    assert.deepEqual(sessionLifecycle, ['enter', 'rename', 'flush', 'detach', 'attach-workspace']);
+    // DSH rc.8 persistence adopts ownership on session/created and releases it
+    // on the paired session/disposed. Detaching an unannounced session removes
+    // it from the live store without retirement, leaving later load/prepare to
+    // fail with "already has a live persistence owner" until restart.
+    assert.deepEqual(sessionLifecycle, ['enter', 'rename', 'flush', 'announce', 'detach', 'attach-workspace']);
     await stopPlugin();
   } finally {
     importerModule.runV1SessionImport = originalRun;
@@ -166,11 +165,10 @@ test('persists each v1 session without announcing it on the live session channel
   }
 });
 
-// The client only pulls the cold-session list at connect time, which is before
-// this background task finishes, so the sidebar needs a completion signal. The
-// status RPC is that signal: the client polls it, and refreshes the list once
-// the phase leaves "running".
-test('reports migration progress through the loopback status RPC', async () => {
+// The sidebar is the only status consumer, so its barrier belongs to the
+// session stage: once the cold sessions are flushed, later settings and
+// Automation work must not delay the authoritative list refresh.
+test('reports the session import settled while later migration stages continue', async () => {
   const importerModule = require('./import-v1.cjs');
   const settingsModule = require('./import-v1-settings.cjs');
   const automationsModule = require('./import-v1-automations.cjs');
@@ -188,12 +186,36 @@ test('reports migration progress through the loopback status RPC', async () => {
   process.env.DSH_HOME = home;
   process.env.PAWWORK_V1_DATABASE = source;
 
+  let releaseSessions;
+  const sessionsGate = new Promise((resolve) => { releaseSessions = resolve; });
+  let settingsStarted;
+  const settingsStage = new Promise((resolve) => { settingsStarted = resolve; });
+  let releaseSettings;
+  const settingsGate = new Promise((resolve) => { releaseSettings = resolve; });
+  let automationsStarted;
+  const automationsStage = new Promise((resolve) => { automationsStarted = resolve; });
   let releaseAutomations;
   const automationsGate = new Promise((resolve) => { releaseAutomations = resolve; });
-  importerModule.runV1SessionImport = async () => ({ status: 'complete' });
+  let sessionFlushed = false;
+  importerModule.runV1SessionImport = async ({ importSession }) => {
+    await sessionsGate;
+    await importSession({
+      id: 'pawwork-v1-session',
+      images: [],
+      meta: { cwd: root, seedLength: 1 },
+      seed: [{ type: 'pawwork-v1/session', data: { sourceSessionId: 'session' } }],
+      title: 'Imported session',
+    });
+    return { status: 'complete' };
+  };
   settingsModule.createDshSettingImporter = () => async () => 'skipped';
-  settingsModule.runV1SettingsImport = async () => ({ status: 'complete' });
+  settingsModule.runV1SettingsImport = async () => {
+    settingsStarted();
+    await settingsGate;
+    return { status: 'complete' };
+  };
   automationsModule.runV1AutomationImport = async () => {
+    automationsStarted();
     await automationsGate;
     return { status: 'complete' };
   };
@@ -219,9 +241,14 @@ test('reports migration progress through the loopback status RPC', async () => {
       logger: { warn: () => {} },
       agentDefaultModel: { currentSelection: () => ({ provider: 'opencode', model: 'big-pickle' }) },
       pawworkAutomations: { scheduler: { refresh: () => {} }, store: { activateImportedDefinitions: () => {} } },
-      sessionPersistence: { inspect: async () => { throw new Error('no session should be inspected'); } },
+      sessionPersistence: { inspect: async (id) => { throw new Error(`session "${id}" not found`); } },
       sessionTitle: { rename: () => {} },
-      sessions: { enter: () => () => {}, flush: async () => {}, prepare: () => ({}) },
+      sessions: {
+        announce: () => {},
+        enter: () => () => {},
+        flush: async () => { sessionFlushed = true; },
+        prepare: () => ({ id: 'pawwork-v1-session' }),
+      },
       attachments: { saveImage: async () => {} },
       workspaceRegistry: {},
     });
@@ -230,16 +257,28 @@ test('reports migration progress through the loopback status RPC', async () => {
       channel: '/pawwork-import-v1',
       options: { authority: 'loopback' },
     });
-    // The automations stage is gated, so the run is still in flight here no
-    // matter how far the earlier microtasks advanced.
     assert.deepEqual(await status('status', {}), { ok: true, value: { phase: 'running' } });
-    assert.equal((await status('bogus', {})).ok, false);
 
+    releaseSessions();
+    await settingsStage;
+    assert.equal(sessionFlushed, true);
+    assert.deepEqual(await status('status', {}), {
+      ok: true,
+      value: { phase: 'done', sessionId: 'pawwork-v1-session' },
+    });
+
+    releaseSettings();
+    await automationsStage;
+    assert.deepEqual(await status('status', {}), {
+      ok: true,
+      value: { phase: 'done', sessionId: 'pawwork-v1-session' },
+    });
     releaseAutomations();
-    // Disposal awaits the task, so the finally that retires the phase has run.
     await stopPlugin();
-    assert.deepEqual(await status('status', {}), { ok: true, value: { phase: 'done' } });
   } finally {
+    releaseSessions?.();
+    releaseSettings?.();
+    releaseAutomations?.();
     importerModule.runV1SessionImport = originalRun;
     settingsModule.createDshSettingImporter = originalCreateSettingImporter;
     settingsModule.runV1SettingsImport = originalSettingsRun;
@@ -248,6 +287,50 @@ test('reports migration progress through the loopback status RPC', async () => {
     else process.env.DSH_HOME = originalHome;
     if (originalSource === undefined) delete process.env.PAWWORK_V1_DATABASE;
     else process.env.PAWWORK_V1_DATABASE = originalSource;
+  }
+});
+
+test('settles the session status when source discovery fails before import', async () => {
+  const migrationIoModule = require('./migration-io.cjs');
+  const settingsModule = require('./import-v1-settings.cjs');
+  const automationsModule = require('./import-v1-automations.cjs');
+  const originalDiscover = migrationIoModule.discoverV1Database;
+  const originalSettingsRun = settingsModule.runV1SettingsImport;
+  const originalCreateSettingImporter = settingsModule.createDshSettingImporter;
+  const originalAutomationsRun = automationsModule.runV1AutomationImport;
+  migrationIoModule.discoverV1Database = () => { throw new Error('source discovery failed'); };
+  settingsModule.createDshSettingImporter = () => async () => 'skipped';
+  settingsModule.runV1SettingsImport = async () => ({ status: 'complete' });
+  automationsModule.runV1AutomationImport = async () => ({ status: 'complete' });
+  let status;
+  let stopPlugin;
+
+  try {
+    const pluginUrl = `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?discovery-status=${Date.now()}`;
+    const { apply } = await import(pluginUrl);
+    apply({
+      connection: { rpc: { handle: (_channel, handler) => { status = handler; return async () => {}; } } },
+      effect: (setup) => { stopPlugin = setup(); },
+      llm: { listProviders: () => [], listModels: async () => [] },
+      logger: { warn: () => {} },
+      agentDefaultModel: { currentSelection: () => ({ provider: 'opencode', model: 'big-pickle' }) },
+      pawworkAutomations: { scheduler: { refresh: () => {} }, store: { activateImportedDefinitions: () => {} } },
+      sessionPersistence: { inspect: async () => { throw new Error('no session should be inspected'); } },
+      sessionTitle: { rename: () => {} },
+      sessions: { announce: () => {}, enter: () => () => {}, flush: async () => {}, prepare: () => ({}) },
+      attachments: { saveImage: async () => {} },
+      workspaceRegistry: {},
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(await status('status', {}), { ok: true, value: { phase: 'done' } });
+    await stopPlugin();
+  } finally {
+    migrationIoModule.discoverV1Database = originalDiscover;
+    settingsModule.createDshSettingImporter = originalCreateSettingImporter;
+    settingsModule.runV1SettingsImport = originalSettingsRun;
+    automationsModule.runV1AutomationImport = originalAutomationsRun;
+    if (stopPlugin) await stopPlugin().catch(() => {});
   }
 });
 
@@ -521,9 +604,13 @@ test('plugin disposal aborts and awaits the background migration', async () => {
   let started;
   const importStarted = new Promise((resolve) => { started = resolve; });
   let stopPlugin;
+  let releaseStatusRpc;
+  const statusRpcStopped = new Promise((resolve) => { releaseStatusRpc = resolve; });
+  let importSignal;
   let settingsCalls = 0;
   let automationCalls = 0;
   importerModule.runV1SessionImport = async ({ signal }) => {
+    importSignal = signal;
     started();
     await new Promise((resolve) => signal.addEventListener('abort', () => setImmediate(resolve), { once: true }));
     signal.throwIfAborted();
@@ -534,15 +621,19 @@ test('plugin disposal aborts and awaits the background migration', async () => {
     const pluginUrl = `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?dispose=${Date.now()}`;
     const { apply } = await import(pluginUrl);
     apply({
-      connection: { rpc: { handle: () => async () => {} } },
+      connection: { rpc: { handle: () => async () => { await statusRpcStopped; } } },
       effect: (setup) => { stopPlugin = setup(); },
       logger: { warn: () => {} },
     });
     await importStarted;
 
     const stopped = stopPlugin();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(importSignal.aborted, false);
+    releaseStatusRpc();
     await stopped;
 
+    assert.equal(importSignal.aborted, true);
     assert.equal(settingsCalls, 0);
     assert.equal(automationCalls, 0);
   } finally {

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
@@ -37,7 +37,7 @@ function fileDigest(file) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 }
 
-test('announces each imported session without a migration status polling channel', async () => {
+test('persists each v1 session without announcing it on the live session channel', async () => {
   const importerModule = require('./import-v1.cjs');
   const settingsModule = require('./import-v1-settings.cjs');
   const automationsModule = require('./import-v1-automations.cjs');
@@ -100,6 +100,7 @@ test('announces each imported session without a migration status polling channel
     const pluginUrl = `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?status=${Date.now()}`;
     const { apply } = await import(pluginUrl);
     apply({
+      connection: { rpc: { handle: () => async () => {} } },
       effect: (setup) => { stopPlugin = setup(); },
       llm: {
         listProviders: () => [{ id: 'opencode' }],
@@ -149,7 +150,12 @@ test('announces each imported session without a migration status polling channel
     assert.equal(missingContinueSessionRejected, true);
     assert.equal(incompleteContinueSessionRejected, true);
     assert.equal(unavailableAutomationCatalogRejected, true);
-    assert.deepEqual(sessionLifecycle, ['enter', 'rename', 'flush', 'announce', 'detach', 'attach-workspace']);
+    // The importer writes cold sessions: enter/rename/flush/detach is the
+    // persistence path, and attach-workspace is the follow-up that does not
+    // depend on the session staying live. announce used to sit between flush
+    // and detach, but the client list removes a session again on
+    // session/disposed, so every announced import flickered in and out.
+    assert.deepEqual(sessionLifecycle, ['enter', 'rename', 'flush', 'detach', 'attach-workspace']);
     await stopPlugin();
   } finally {
     importerModule.runV1SessionImport = originalRun;
@@ -157,6 +163,91 @@ test('announces each imported session without a migration status polling channel
     settingsModule.createDshSettingImporter = originalCreateSettingImporter;
     settingsModule.runV1SettingsImport = originalSettingsRun;
     automationsModule.runV1AutomationImport = originalAutomationsRun;
+  }
+});
+
+// The client only pulls the cold-session list at connect time, which is before
+// this background task finishes, so the sidebar needs a completion signal. The
+// status RPC is that signal: the client polls it, and refreshes the list once
+// the phase leaves "running".
+test('reports migration progress through the loopback status RPC', async () => {
+  const importerModule = require('./import-v1.cjs');
+  const settingsModule = require('./import-v1-settings.cjs');
+  const automationsModule = require('./import-v1-automations.cjs');
+  const originalRun = importerModule.runV1SessionImport;
+  const originalSettingsRun = settingsModule.runV1SettingsImport;
+  const originalCreateSettingImporter = settingsModule.createDshSettingImporter;
+  const originalAutomationsRun = automationsModule.runV1AutomationImport;
+  const originalHome = process.env.DSH_HOME;
+  const originalSource = process.env.PAWWORK_V1_DATABASE;
+
+  const root = temporaryDirectory();
+  const source = path.join(root, 'pawwork.db');
+  const home = path.join(root, 'v2-home');
+  createV1Fixture(source);
+  process.env.DSH_HOME = home;
+  process.env.PAWWORK_V1_DATABASE = source;
+
+  let releaseAutomations;
+  const automationsGate = new Promise((resolve) => { releaseAutomations = resolve; });
+  importerModule.runV1SessionImport = async () => ({ status: 'complete' });
+  settingsModule.createDshSettingImporter = () => async () => 'skipped';
+  settingsModule.runV1SettingsImport = async () => ({ status: 'complete' });
+  automationsModule.runV1AutomationImport = async () => {
+    await automationsGate;
+    return { status: 'complete' };
+  };
+  let registration;
+  let status;
+  let stopPlugin;
+
+  try {
+    const pluginUrl = `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?status-rpc=${Date.now()}`;
+    const { apply } = await import(pluginUrl);
+    apply({
+      connection: {
+        rpc: {
+          handle: (channel, handler, options) => {
+            registration = { channel, options };
+            status = handler;
+            return async () => {};
+          },
+        },
+      },
+      effect: (setup) => { stopPlugin = setup(); },
+      llm: { listProviders: () => [], listModels: async () => [] },
+      logger: { warn: () => {} },
+      agentDefaultModel: { currentSelection: () => ({ provider: 'opencode', model: 'big-pickle' }) },
+      pawworkAutomations: { scheduler: { refresh: () => {} }, store: { activateImportedDefinitions: () => {} } },
+      sessionPersistence: { inspect: async () => { throw new Error('no session should be inspected'); } },
+      sessionTitle: { rename: () => {} },
+      sessions: { enter: () => () => {}, flush: async () => {}, prepare: () => ({}) },
+      attachments: { saveImage: async () => {} },
+      workspaceRegistry: {},
+    });
+
+    assert.deepEqual(registration, {
+      channel: '/pawwork-import-v1',
+      options: { authority: 'loopback' },
+    });
+    // The automations stage is gated, so the run is still in flight here no
+    // matter how far the earlier microtasks advanced.
+    assert.deepEqual(await status('status', {}), { ok: true, value: { phase: 'running' } });
+    assert.equal((await status('bogus', {})).ok, false);
+
+    releaseAutomations();
+    // Disposal awaits the task, so the finally that retires the phase has run.
+    await stopPlugin();
+    assert.deepEqual(await status('status', {}), { ok: true, value: { phase: 'done' } });
+  } finally {
+    importerModule.runV1SessionImport = originalRun;
+    settingsModule.createDshSettingImporter = originalCreateSettingImporter;
+    settingsModule.runV1SettingsImport = originalSettingsRun;
+    automationsModule.runV1AutomationImport = originalAutomationsRun;
+    if (originalHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = originalHome;
+    if (originalSource === undefined) delete process.env.PAWWORK_V1_DATABASE;
+    else process.env.PAWWORK_V1_DATABASE = originalSource;
   }
 });
 
@@ -443,6 +534,7 @@ test('plugin disposal aborts and awaits the background migration', async () => {
     const pluginUrl = `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?dispose=${Date.now()}`;
     const { apply } = await import(pluginUrl);
     apply({
+      connection: { rpc: { handle: () => async () => {} } },
       effect: (setup) => { stopPlugin = setup(); },
       logger: { warn: () => {} },
     });

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
@@ -10,6 +10,7 @@ export const name = 'pawwork-import-v1';
 export const inject = [
   'agentDefaultModel',
   'attachments',
+  'connection',
   'llm',
   'pawworkAutomations',
   'sessions',
@@ -95,7 +96,12 @@ export function createDshSessionImporter(ctx) {
       try {
         ctx.sessionTitle.rename(session, imported.title);
         await ctx.sessions.flush(session);
-        ctx.sessions.announce(session);
+        // No announce: imported sessions are cold, and the client list removes
+        // a session again on session/disposed, so announcing here only made
+        // each import flicker into the sidebar and back out at detach. Cold
+        // sessions reach the client through its list refresh, which runs at
+        // connect time - before this task finishes - so the status RPC below
+        // tells the client to refresh once the import settles.
       } finally {
         detach();
       }
@@ -106,6 +112,7 @@ export function createDshSessionImporter(ctx) {
 
 export function apply(ctx) {
   const controller = new AbortController();
+  let phase = 'running';
   const importTask = (async () => {
     // The two database-backed stages read one private copy of the v1 database,
     // opened once for the whole run: before, each of them VACUUMed the user's
@@ -122,8 +129,10 @@ export function apply(ctx) {
       }
     }
     try {
-      // Each successful session is announced as it lands; one malformed source
-      // must not hide the rest or require a separate completion channel.
+      // Each stage is caught individually so one malformed source must not
+      // hide the rest; the session stage is the long one, and the client
+      // learns when all of it landed through the status RPC, not through
+      // per-session announce.
       try {
         const importSession = createDshSessionImporter(ctx);
         controller.signal.throwIfAborted();
@@ -188,10 +197,28 @@ export function apply(ctx) {
       } catch (error) {
         ctx.logger.warn(`v1 database snapshot cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
       }
+      // Every settle path passes through here, including the early returns the
+      // abort checks take: the phase is done whether the import completed, was
+      // aborted, or found nothing to do.
+      phase = 'done';
     }
   })();
-  ctx.effect(() => async () => {
-    controller.abort(new Error('PawWork v1 importer stopped'));
-    await importTask;
+  ctx.effect(() => {
+    const stopStatusRpc = ctx.connection.rpc.handle(
+      '/pawwork-import-v1',
+      async (endpoint) => {
+        if (endpoint === 'status') return { ok: true, value: { phase } };
+        return {
+          ok: false,
+          error: { code: 'bad-request', message: `unknown import-v1 endpoint: ${endpoint}`, details: {} },
+        };
+      },
+      { authority: 'loopback' },
+    );
+    return async () => {
+      await stopStatusRpc();
+      controller.abort(new Error('PawWork v1 importer stopped'));
+      await importTask;
+    };
   });
 }

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
@@ -70,7 +70,7 @@ async function hasPersistedV1Session(sessionPersistence, id) {
     && inspection.events.length >= inspection.meta.seedLength;
 }
 
-export function createDshSessionImporter(ctx) {
+export function createDshSessionImporter(ctx, onPersisted = () => {}) {
   return async (imported) => {
     let inspection;
     try {
@@ -96,45 +96,41 @@ export function createDshSessionImporter(ctx) {
       try {
         ctx.sessionTitle.rename(session, imported.title);
         await ctx.sessions.flush(session);
-        // No announce: imported sessions are cold, and the client list removes
-        // a session again on session/disposed, so announcing here only made
-        // each import flicker into the sidebar and back out at detach. Cold
-        // sessions reach the client through its list refresh, which runs at
-        // connect time - before this task finishes - so the status RPC below
-        // tells the client to refresh once the import settles.
+        // DSH persistence adopts the session on session/created and retires
+        // that ownership on the paired session/disposed emitted by detach.
+        // Imported sessions are cold after this lifecycle; the status RPC
+        // below still supplies the later authoritative sidebar refresh.
+        ctx.sessions.announce(session);
       } finally {
         detach();
       }
     }
+    onPersisted(imported.id);
     return await importer.attachDshWorkspace(imported, ctx.workspaceRegistry);
   };
 }
 
 export function apply(ctx) {
   const controller = new AbortController();
-  let phase = 'running';
+  let lastPersistedSessionId;
+  let sessionPhase = 'running';
   const importTask = (async () => {
-    // The two database-backed stages read one private copy of the v1 database,
-    // opened once for the whole run: before, each of them VACUUMed the user's
-    // entire v1 database into a copy of its own. The settings stage reads JSON
-    // files and needs no snapshot; a snapshot that fails to open lets the two
-    // database stages report it as their own failure.
-    const sourceDatabase = migrationIo.discoverV1Database();
+    let sourceDatabase;
     let snapshot;
-    if (sourceDatabase) {
-      try {
-        snapshot = await migrationIo.openV1Snapshot({ home: process.env.DSH_HOME, sourceDatabase });
-      } catch (error) {
-        ctx.logger.warn(`v1 database snapshot failed: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    }
     try {
       // Each stage is caught individually so one malformed source must not
-      // hide the rest; the session stage is the long one, and the client
-      // learns when all of it landed through the status RPC, not through
-      // per-session announce.
+      // hide the rest. The two database-backed stages share one private copy
+      // of the v1 database; settings read independent JSON files.
       try {
-        const importSession = createDshSessionImporter(ctx);
+        sourceDatabase = migrationIo.discoverV1Database();
+        if (sourceDatabase) {
+          try {
+            snapshot = await migrationIo.openV1Snapshot({ home: process.env.DSH_HOME, sourceDatabase });
+          } catch (error) {
+            ctx.logger.warn(`v1 database snapshot failed: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        }
+        const importSession = createDshSessionImporter(ctx, (id) => { lastPersistedSessionId = id; });
         controller.signal.throwIfAborted();
         await importer.runV1SessionImport({
           home: process.env.DSH_HOME,
@@ -147,6 +143,11 @@ export function apply(ctx) {
       } catch (error) {
         if (controller.signal.aborted) return;
         ctx.logger.warn(`v1 session import failed: ${error instanceof Error ? error.message : String(error)}`);
+      } finally {
+        // The sidebar consumes only session persistence. Settings and
+        // Automation continue independently after this barrier and must not
+        // delay the client's cold-session list refresh.
+        sessionPhase = 'done';
       }
       try {
         controller.signal.throwIfAborted();
@@ -197,22 +198,18 @@ export function apply(ctx) {
       } catch (error) {
         ctx.logger.warn(`v1 database snapshot cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
       }
-      // Every settle path passes through here, including the early returns the
-      // abort checks take: the phase is done whether the import completed, was
-      // aborted, or found nothing to do.
-      phase = 'done';
     }
   })();
   ctx.effect(() => {
     const stopStatusRpc = ctx.connection.rpc.handle(
       '/pawwork-import-v1',
-      async (endpoint) => {
-        if (endpoint === 'status') return { ok: true, value: { phase } };
-        return {
-          ok: false,
-          error: { code: 'bad-request', message: `unknown import-v1 endpoint: ${endpoint}`, details: {} },
-        };
-      },
+      async () => ({
+        ok: true,
+        value: {
+          phase: sessionPhase,
+          ...(lastPersistedSessionId === undefined ? {} : { sessionId: lastPersistedSessionId }),
+        },
+      }),
       { authority: 'loopback' },
     );
     return async () => {

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -173,16 +173,12 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
 
     // v1 迁移是后台任务：它把冷会话逐条写进持久化，而客户端只在连接/重连时
     // 拉取一次冷列表，迁移结束的时刻没人再刷新，侧边栏就停在旧列表上。宿主的
-    // import-v1 插件在 /pawwork-import-v1 暴露 phase；这里轮询到它离开 running
-    // 就刷新一次列表。refreshList 单飞且合并有序基线，重复调用无害；传输层连续
-    // 失败（旧后端、宿主重启窗口）重试有限次后放弃，不做兜底刷新——重连路径
-    // 本身就会刷新冷列表。
+    // import-v1 插件在 /pawwork-import-v1 暴露 phase；这里等到它离开 running
+    // 就补一次列表读取，然后停。refreshList 单飞且合并有序基线，重复调用无害。
     const IMPORT_POLL_INTERVAL_MS = 1_000
-    const IMPORT_POLL_MAX_FAILURES = 10
 
     function watchV1Import({ connection, sessions }) {
       let timer = null
-      let failures = 0
       let stopped = false
       const stop = () => {
         stopped = true
@@ -190,23 +186,30 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
       }
       async function poll() {
         if (stopped) return
+        let result
         try {
-          const result = await connection.rpc.call("/pawwork-import-v1", "status", {})
-          if (stopped) return
-          failures = 0
-          if (result.ok && result.value.phase === "running") {
-            timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
-            return
-          }
-          stop()
-          await sessions.refresh()
+          result = await connection.rpc.call("/pawwork-import-v1", "status", {})
         } catch {
+          // 传输层失败不是完成信号（旧后端没有这个通道、宿主重启窗口都只是瞬时
+          // 的），继续等；绝不因为数满几次失败就放弃，否则侧边栏停在旧列表上。
           if (stopped) return
-          failures += 1
-          if (failures < IMPORT_POLL_MAX_FAILURES) timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
+          timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
+          return
         }
+        if (stopped) return
+        if (!result.ok || result.value.phase === "running") {
+          timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
+          return
+        }
+        // 离开 running 即完成。refreshList 单飞复用仍在途的拉取——完成信号出现
+        // 时可能还挂着一条迁移前的旧列表——所以读两次：第一次等在途的 settle，
+        // 第二次才是必然在完成屏障之后发起的权威读取。
+        await sessions.refresh()
+        await sessions.refresh()
+        stop()
       }
       void poll()
+      return stop
     }
 
     function apply(ctx) {
@@ -215,7 +218,9 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
       ctx.slots.inject("conversation.hero.brand.mark", () => ctx.slots.register({ name: "conversation.hero.brand.mark", priority: -100 }, PawGloveMark))
       ctx.slots.inject("settings.onboarding", () => ctx.slots.register({ name: "settings.onboarding", id: "welcome-notice", order: -100, priority: -1 }, CompleteWelcomeNotice))
       ctx.slots.inject("conversation.input.left", () => ctx.slots.register({ name: "conversation.input.left", id: "pawwork-files", order: -100 }, FileAction))
-      watchV1Import(ctx)
+      // 轮询器随插件而止：dispose（HMR / 重新登录）时清掉定时器，不再对已销毁的
+      // fiber 发起 status / refresh 调用。
+      ctx.effect(() => watchV1Import(ctx))
     }
 
     return { inject, apply }

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -173,38 +173,63 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
 
     // v1 迁移是后台任务：它把冷会话逐条写进持久化，而客户端只在连接/重连时
     // 拉取一次冷列表，迁移结束的时刻没人再刷新，侧边栏就停在旧列表上。宿主的
-    // import-v1 插件在 /pawwork-import-v1 暴露 phase；这里等到它离开 running
-    // 就补一次列表读取，然后停。refreshList 单飞且合并有序基线，重复调用无害。
+    // import-v1 插件在 /pawwork-import-v1 暴露 session 阶段与最后一个已持久化
+    // session marker。完成后双读跨过 refreshList 的单飞屏障；只有 marker 已进入
+    // 公开 list 快照才算权威列表安装成功，否则退避后重试。
     const IMPORT_POLL_INTERVAL_MS = 1_000
+    const IMPORT_POLL_MAX_RETRY_MS = 30_000
 
     function watchV1Import({ connection, sessions }) {
+      let retryDelay = IMPORT_POLL_INTERVAL_MS
       let timer = null
       let stopped = false
       const stop = () => {
         stopped = true
         if (timer !== null) clearTimeout(timer)
       }
+      const schedule = (delay) => {
+        timer = setTimeout(() => void poll(), delay)
+      }
+      const retry = () => {
+        const delay = retryDelay
+        retryDelay = Math.min(retryDelay * 2, IMPORT_POLL_MAX_RETRY_MS)
+        schedule(delay)
+      }
       async function poll() {
         if (stopped) return
-        let result = undefined
+        let result
         try {
           result = await connection.rpc.call("/pawwork-import-v1", "status", {})
         } catch {
-          // 传输层失败不是完成信号（旧后端没有这个通道、宿主重启窗口都只是瞬时
-          // 的），落到下面同一个"还没完成就继续等"分支；绝不因为数满几次失败就
-          // 放弃，否则侧边栏停在旧列表上。
+          if (stopped) return
+          retry()
+          return
         }
         if (stopped) return
-        if (result === undefined || !result.ok || result.value.phase === "running") {
-          timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
+        const value = result?.ok === true ? result.value : undefined
+        if (value === null || typeof value !== "object"
+          || (value.phase !== "running" && value.phase !== "done")
+          || (value.sessionId !== undefined && typeof value.sessionId !== "string")) {
+          retry()
+          return
+        }
+        if (value.phase === "running") {
+          retryDelay = IMPORT_POLL_INTERVAL_MS
+          schedule(IMPORT_POLL_INTERVAL_MS)
           return
         }
         // 离开 running 即完成。refreshList 单飞复用仍在途的拉取——完成信号出现
         // 时可能还挂着一条迁移前的旧列表——所以读两次：第一次等在途的 settle，
         // 第二次才是必然在完成屏障之后发起的权威读取。
         await sessions.refresh()
+        if (stopped) return
         await sessions.refresh()
-        stop()
+        if (stopped) return
+        if (value.sessionId === undefined || sessions.list.getSnapshot().ids.includes(value.sessionId)) {
+          stop()
+          return
+        }
+        retry()
       }
       void poll()
       return stop

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -186,18 +186,16 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
       }
       async function poll() {
         if (stopped) return
-        let result
+        let result = undefined
         try {
           result = await connection.rpc.call("/pawwork-import-v1", "status", {})
         } catch {
           // 传输层失败不是完成信号（旧后端没有这个通道、宿主重启窗口都只是瞬时
-          // 的），继续等；绝不因为数满几次失败就放弃，否则侧边栏停在旧列表上。
-          if (stopped) return
-          timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
-          return
+          // 的），落到下面同一个"还没完成就继续等"分支；绝不因为数满几次失败就
+          // 放弃，否则侧边栏停在旧列表上。
         }
         if (stopped) return
-        if (!result.ok || result.value.phase === "running") {
+        if (result === undefined || !result.ok || result.value.phase === "running") {
           timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
           return
         }

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -167,9 +167,47 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
           gloveLayer(BRAND_CREAM, GLOVE_PADS)))
     }
 
-    const inject = ["slots"]
+    const inject = ["slots", "connection", "sessions"]
 
     function BrandName() { return text("爪印", "PawWork") }
+
+    // v1 迁移是后台任务：它把冷会话逐条写进持久化，而客户端只在连接/重连时
+    // 拉取一次冷列表，迁移结束的时刻没人再刷新，侧边栏就停在旧列表上。宿主的
+    // import-v1 插件在 /pawwork-import-v1 暴露 phase；这里轮询到它离开 running
+    // 就刷新一次列表。refreshList 单飞且合并有序基线，重复调用无害；传输层连续
+    // 失败（旧后端、宿主重启窗口）重试有限次后放弃，不做兜底刷新——重连路径
+    // 本身就会刷新冷列表。
+    const IMPORT_POLL_INTERVAL_MS = 1_000
+    const IMPORT_POLL_MAX_FAILURES = 10
+
+    function watchV1Import({ connection, sessions }) {
+      let timer = null
+      let failures = 0
+      let stopped = false
+      const stop = () => {
+        stopped = true
+        if (timer !== null) clearTimeout(timer)
+      }
+      async function poll() {
+        if (stopped) return
+        try {
+          const result = await connection.rpc.call("/pawwork-import-v1", "status", {})
+          if (stopped) return
+          failures = 0
+          if (result.ok && result.value.phase === "running") {
+            timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
+            return
+          }
+          stop()
+          await sessions.refresh()
+        } catch {
+          if (stopped) return
+          failures += 1
+          if (failures < IMPORT_POLL_MAX_FAILURES) timer = setTimeout(() => void poll(), IMPORT_POLL_INTERVAL_MS)
+        }
+      }
+      void poll()
+    }
 
     function apply(ctx) {
       ctx.slots.inject("sidebar.brand.mark", () => ctx.slots.register({ name: "sidebar.brand.mark", priority: -100 }, PawGloveMark))
@@ -177,6 +215,7 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
       ctx.slots.inject("conversation.hero.brand.mark", () => ctx.slots.register({ name: "conversation.hero.brand.mark", priority: -100 }, PawGloveMark))
       ctx.slots.inject("settings.onboarding", () => ctx.slots.register({ name: "settings.onboarding", id: "welcome-notice", order: -100, priority: -1 }, CompleteWelcomeNotice))
       ctx.slots.inject("conversation.input.left", () => ctx.slots.register({ name: "conversation.input.left", id: "pawwork-files", order: -100 }, FileAction))
+      watchV1Import(ctx)
     }
 
     return { inject, apply }

--- a/packages/desktop-electron/scripts/ci-smoke-v1-fixture.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke-v1-fixture.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 })
 
 describe("CI smoke v1 fixture", () => {
-  test("is consumed by the production session and Automation import readers", async () => {
+  test("is consumed by the production session and Automation import readers", { timeout: 20_000 }, async () => {
     const root = mkdtempSync(join(tmpdir(), "pawwork-ci-v1-"))
     roots.push(root)
     const database = join(root, "pawwork.db")

--- a/packages/desktop-electron/scripts/ci-smoke-v1-fixture.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke-v1-fixture.test.ts
@@ -4,7 +4,12 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { CI_SMOKE_V1_AUTOMATION_ID, CI_SMOKE_V1_SESSION_ID, createCiSmokeV1Fixture } from "./ci-smoke-v1-fixture"
+import {
+  CI_SMOKE_V1_AUTOMATION_ID,
+  CI_SMOKE_V1_BULK_SESSION_COUNT,
+  CI_SMOKE_V1_SESSION_ID,
+  createCiSmokeV1Fixture,
+} from "./ci-smoke-v1-fixture"
 
 const require = createRequire(import.meta.url)
 const { readV1Sessions } = require("../resources/dsh/home/plugins/import-v1/import-v1.cjs")
@@ -26,7 +31,13 @@ describe("CI smoke v1 fixture", () => {
     for await (const session of readV1Sessions(database)) sessions.push(session)
     const automations = readV1Automations(database)
 
-    expect(sessions.map((session) => session.id)).toEqual([CI_SMOKE_V1_SESSION_ID])
+    expect(sessions).toHaveLength(CI_SMOKE_V1_BULK_SESSION_COUNT + 1)
+    // The bulk sessions import first; the target lands last, so the sidebar
+    // assertion can prove a post-connect refresh without a reload.
+    expect(sessions.slice(0, CI_SMOKE_V1_BULK_SESSION_COUNT).map((session) => session.id)).toEqual(
+      Array.from({ length: CI_SMOKE_V1_BULK_SESSION_COUNT }, (_, index) => `ci-smoke-bulk-${index}`),
+    )
+    expect(sessions.at(-1)?.id).toBe(CI_SMOKE_V1_SESSION_ID)
     expect(automations.definitions.map((definition: { id: string }) => definition.id)).toEqual([
       CI_SMOKE_V1_AUTOMATION_ID,
     ])

--- a/packages/desktop-electron/scripts/ci-smoke-v1-fixture.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke-v1-fixture.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 })
 
 describe("CI smoke v1 fixture", () => {
-  test("is consumed by the production session and Automation import readers", { timeout: 20_000 }, async () => {
+  test("is consumed by the production session and Automation import readers", async () => {
     const root = mkdtempSync(join(tmpdir(), "pawwork-ci-v1-"))
     roots.push(root)
     const database = join(root, "pawwork.db")

--- a/packages/desktop-electron/scripts/ci-smoke-v1-fixture.ts
+++ b/packages/desktop-electron/scripts/ci-smoke-v1-fixture.ts
@@ -14,7 +14,7 @@ export const CI_SMOKE_IMPORTED_AUTOMATION_ID = `pawwork-v1-${CI_SMOKE_V1_AUTOMAT
 // and lands last - while it is missing, the fix under test (poll
 // /pawwork-import-v1, refresh the list once at completion) is the only path
 // that can surface it in the sidebar without a reload.
-export const CI_SMOKE_V1_BULK_SESSION_COUNT = 200
+export const CI_SMOKE_V1_BULK_SESSION_COUNT = 150
 
 export function createCiSmokeV1Fixture(file: string, workspace: string) {
   mkdirSync(dirname(file), { recursive: true })

--- a/packages/desktop-electron/scripts/ci-smoke-v1-fixture.ts
+++ b/packages/desktop-electron/scripts/ci-smoke-v1-fixture.ts
@@ -7,6 +7,15 @@ export const CI_SMOKE_V1_AUTOMATION_ID = "ci-smoke-automation"
 export const CI_SMOKE_IMPORTED_SESSION_ID = `pawwork-v1-${CI_SMOKE_V1_SESSION_ID}`
 export const CI_SMOKE_IMPORTED_AUTOMATION_ID = `pawwork-v1-${CI_SMOKE_V1_AUTOMATION_ID}`
 
+// The bulk sessions keep the migration in flight after the app window has
+// connected: the client pulls the cold-session list only at connect time, so a
+// one-session fixture finishes importing before that pull and even the pre-fix
+// importer looks correct. The target session carries the largest time_created
+// and lands last - while it is missing, the fix under test (poll
+// /pawwork-import-v1, refresh the list once at completion) is the only path
+// that can surface it in the sidebar without a reload.
+export const CI_SMOKE_V1_BULK_SESSION_COUNT = 200
+
 export function createCiSmokeV1Fixture(file: string, workspace: string) {
   mkdirSync(dirname(file), { recursive: true })
   const database = new DatabaseSync(file)
@@ -21,13 +30,11 @@ export function createCiSmokeV1Fixture(file: string, workspace: string) {
       );
       CREATE TABLE message (
         id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
-        time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
-        data TEXT NOT NULL
+        time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL
       );
       CREATE TABLE part (
         id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL,
-        time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
-        data TEXT NOT NULL
+        time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL
       );
       CREATE TABLE automation_definition (
         id TEXT PRIMARY KEY, project_id TEXT NOT NULL, owner_directory TEXT NOT NULL,
@@ -40,7 +47,50 @@ export function createCiSmokeV1Fixture(file: string, workspace: string) {
       );
     `)
 
-    database.prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(
+    const insertSession = database.prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+    const insertMessage = database.prepare("INSERT INTO message VALUES (?, ?, ?, ?, ?)")
+    const insertPart = database.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)")
+
+    for (let index = 0; index < CI_SMOKE_V1_BULK_SESSION_COUNT; index += 1) {
+      const sessionId = `ci-smoke-bulk-${index}`
+      const created = index * 2 + 2
+      insertSession.run(
+        sessionId,
+        "ci-smoke-project",
+        "ci-smoke-workspace",
+        null,
+        sessionId,
+        workspace,
+        null,
+        `V1 bulk session ${index}`,
+        "1.0.0",
+        created,
+        created + 1,
+        null,
+      )
+      insertMessage.run(
+        `ci-smoke-bulk-message-${index}`,
+        sessionId,
+        created,
+        created,
+        JSON.stringify({
+          role: "user",
+          time: { created },
+          agent: "build",
+          model: { providerID: "opencode", modelID: "deepseek-v4-flash-free" },
+        }),
+      )
+      insertPart.run(
+        `ci-smoke-bulk-part-${index}`,
+        `ci-smoke-bulk-message-${index}`,
+        sessionId,
+        created,
+        created,
+        JSON.stringify({ type: "text", text: "Imported from PawWork V1" }),
+      )
+    }
+
+    insertSession.run(
       CI_SMOKE_V1_SESSION_ID,
       "ci-smoke-project",
       "ci-smoke-workspace",
@@ -54,7 +104,7 @@ export function createCiSmokeV1Fixture(file: string, workspace: string) {
       2_000,
       null,
     )
-    database.prepare("INSERT INTO message VALUES (?, ?, ?, ?, ?)").run(
+    insertMessage.run(
       "ci-smoke-message",
       CI_SMOKE_V1_SESSION_ID,
       1_100,
@@ -66,7 +116,7 @@ export function createCiSmokeV1Fixture(file: string, workspace: string) {
         model: { providerID: "opencode", modelID: "deepseek-v4-flash-free" },
       }),
     )
-    database.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)").run(
+    insertPart.run(
       "ci-smoke-part",
       "ci-smoke-message",
       CI_SMOKE_V1_SESSION_ID,

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -239,7 +239,6 @@ describe("ci smoke helpers", () => {
       platform: "MacIntel",
       freeProviderActive: true,
       v1SessionImported: true,
-      v1SidebarLaggingHost: true,
       v1SessionVisibleInSidebar: true,
       skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
       sessionId: "session-smoke",
@@ -284,7 +283,6 @@ describe("ci smoke helpers", () => {
     platform: "MacIntel",
     freeProviderActive: true,
     v1SessionImported: true,
-    v1SidebarLaggingHost: true,
     v1SessionVisibleInSidebar: true,
     skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
     sessionId: "session-1",
@@ -323,7 +321,6 @@ describe("ci smoke helpers", () => {
     sidebarExpandedAgain: false,
     freeProviderActive: false,
     v1SessionImported: false,
-    v1SidebarLaggingHost: false,
     v1SessionVisibleInSidebar: false,
     skillNames: ["office-docx"],
   }

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -239,6 +239,7 @@ describe("ci smoke helpers", () => {
       platform: "MacIntel",
       freeProviderActive: true,
       v1SessionImported: true,
+      v1SidebarLaggingHost: true,
       v1SessionVisibleInSidebar: true,
       skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
       sessionId: "session-smoke",
@@ -283,6 +284,7 @@ describe("ci smoke helpers", () => {
     platform: "MacIntel",
     freeProviderActive: true,
     v1SessionImported: true,
+    v1SidebarLaggingHost: true,
     v1SessionVisibleInSidebar: true,
     skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
     sessionId: "session-1",
@@ -321,6 +323,7 @@ describe("ci smoke helpers", () => {
     sidebarExpandedAgain: false,
     freeProviderActive: false,
     v1SessionImported: false,
+    v1SidebarLaggingHost: false,
     v1SessionVisibleInSidebar: false,
     skillNames: ["office-docx"],
   }

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -239,6 +239,7 @@ describe("ci smoke helpers", () => {
       platform: "MacIntel",
       freeProviderActive: true,
       v1SessionImported: true,
+      v1SessionVisibleInSidebar: true,
       skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
       sessionId: "session-smoke",
       sessionIdsBeforeRestart: ["session-smoke"],
@@ -282,6 +283,7 @@ describe("ci smoke helpers", () => {
     platform: "MacIntel",
     freeProviderActive: true,
     v1SessionImported: true,
+    v1SessionVisibleInSidebar: true,
     skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
     sessionId: "session-1",
     sessionIdsBeforeRestart: ["session-1"],
@@ -319,6 +321,7 @@ describe("ci smoke helpers", () => {
     sidebarExpandedAgain: false,
     freeProviderActive: false,
     v1SessionImported: false,
+    v1SessionVisibleInSidebar: false,
     skillNames: ["office-docx"],
   }
 

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -74,7 +74,6 @@ export type CiSmokeProductSnapshot = {
   platform: string
   freeProviderActive: boolean
   v1SessionImported: boolean
-  v1SidebarLaggingHost: boolean
   v1SessionVisibleInSidebar: boolean
   skillNames: string[]
   sessionId: string
@@ -433,29 +432,23 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     expandToggles[0]?.click()
     await new Promise((resolve) => setTimeout(resolve, 200))
 
-    // The list the HOST returns is not the list the SIDEBAR shows: the client
-    // pulls cold sessions only at connect, before the migration finishes, so the
-    // imported title only reaches the visible sidebar through the post-completion
-    // refresh. To prove this run actually exercised that path we require the
-    // sidebar to be observed LAGGING the authoritative host list at least once
-    // (host has the session, sidebar does not): if the sidebar never lagged, the
-    // migration finished before the client's connect-time pull and this run could
-    // not have proved the fix. The sidebar sample is repeated after a pause
-    // because a single sample could catch a sub-frame transition.
+    // Assert the real user outcome without a reload. The bulk fixture makes a
+    // post-connect completion likely, but machine speed is not a synchronization
+    // barrier, so a healthy run must not fail merely because its first sample
+    // already contains the imported title. Repeat the visible sample to exclude
+    // the old announce/dispose flicker.
     const sidebarHasV1Session = () => Array.from(document.querySelectorAll("*"))
       .filter((element) => element.childElementCount === 0)
       .some((element) => visible(element) && (element.textContent || "").trim() === "Imported V1 session")
     let v1SessionImported = false
-    let v1SidebarLaggingHost = false
     let v1SessionVisibleInSidebar = false
     // The fixture's target session imports last (bulk sessions keep the run
     // going), so this wait spans the whole migration on a slow runner.
-    const importDeadline = Date.now() + 180_000
+    const importDeadline = Date.now() + 120_000
     while (!v1SessionVisibleInSidebar && Date.now() < importDeadline) {
       const sidebarHas = sidebarHasV1Session()
       const sessions = (await call("session.list", {})).items
       v1SessionImported = sessions.some((item) => item.sessionId === ${expectedSession})
-      if (v1SessionImported && !sidebarHas) v1SidebarLaggingHost = true
       if (sidebarHas) {
         await new Promise((resolve) => setTimeout(resolve, 500))
         v1SessionVisibleInSidebar = sidebarHasV1Session()
@@ -500,7 +493,6 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       platform: typeof navigator === "undefined" ? "" : navigator.platform,
       freeProviderActive: freeProvider?.active === true && freeProvider?.displayName === "OpenCode Free",
       v1SessionImported,
-      v1SidebarLaggingHost,
       v1SessionVisibleInSidebar,
       skillNames: skills.map((skill) => skill.name).sort(),
       sessionId: session.sessionId,
@@ -508,7 +500,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     })
   })()`
 
-  return await evaluateCiSmokeJson(target, expression, 200_000) as CiSmokeProductSnapshot
+  return await evaluateCiSmokeJson(target, expression, 180_000) as CiSmokeProductSnapshot
 }
 
 async function evaluateCiSmokeJson(target: CdpTarget, expression: string, timeoutMs = 20_000) {
@@ -667,11 +659,7 @@ export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform:
     snapshot.sidebarExpandedAgain ? null : "DSH expand control did not reopen the sidebar",
     snapshot.freeProviderActive ? null : "OpenCode Free provider is not active",
     snapshot.v1SessionImported ? null : "V1 session was not imported into DSH",
-    snapshot.v1SessionVisibleInSidebar
-      ? snapshot.v1SidebarLaggingHost
-        ? null
-        : "Imported V1 session appeared in the sidebar, but the sidebar was never observed lagging the host list - this run did not exercise the post-connect refresh and cannot prove the fix"
-      : "Imported V1 session never appeared in the sidebar without a reload",
+    snapshot.v1SessionVisibleInSidebar ? null : "Imported V1 session never appeared in the sidebar without a reload",
     ["office-docx", "office-pdf", "office-pptx", "office-xlsx"].every((name) => snapshot.skillNames.includes(name))
       ? null
       : `bundled Office skills are incomplete: ${snapshot.skillNames.join(", ")}`,

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -435,7 +435,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     let v1SessionImported = false
     // The fixture's target session imports last (bulk sessions keep the run
     // going), so this wait spans the whole migration on a slow runner.
-    const importDeadline = Date.now() + 40_000
+    const importDeadline = Date.now() + 180_000
     while (!v1SessionImported && Date.now() < importDeadline) {
       const sessions = (await call("session.list", {})).items
       v1SessionImported = sessions.some((item) => item.sessionId === ${expectedSession})
@@ -504,7 +504,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     })
   })()`
 
-  return await evaluateCiSmokeJson(target, expression, 75_000) as CiSmokeProductSnapshot
+  return await evaluateCiSmokeJson(target, expression, 200_000) as CiSmokeProductSnapshot
 }
 
 async function evaluateCiSmokeJson(target: CdpTarget, expression: string, timeoutMs = 20_000) {

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -74,6 +74,7 @@ export type CiSmokeProductSnapshot = {
   platform: string
   freeProviderActive: boolean
   v1SessionImported: boolean
+  v1SidebarLaggingHost: boolean
   v1SessionVisibleInSidebar: boolean
   skillNames: string[]
   sessionId: string
@@ -432,28 +433,30 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     expandToggles[0]?.click()
     await new Promise((resolve) => setTimeout(resolve, 200))
 
-    let v1SessionImported = false
-    // The fixture's target session imports last (bulk sessions keep the run
-    // going), so this wait spans the whole migration on a slow runner.
-    const importDeadline = Date.now() + 180_000
-    while (!v1SessionImported && Date.now() < importDeadline) {
-      const sessions = (await call("session.list", {})).items
-      v1SessionImported = sessions.some((item) => item.sessionId === ${expectedSession})
-      if (!v1SessionImported) await new Promise((resolve) => setTimeout(resolve, 250))
-    }
     // The list the HOST returns is not the list the SIDEBAR shows: the client
-    // pulls cold sessions only at connect, which is before the migration
-    // finishes, so what proves the fix is the imported title appearing in the
-    // visible sidebar without a reload. The sample is repeated after a pause
-    // because the pre-fix importer announced each session and detached it in
-    // the same tick - a single sample could catch that sub-frame flicker.
+    // pulls cold sessions only at connect, before the migration finishes, so the
+    // imported title only reaches the visible sidebar through the post-completion
+    // refresh. To prove this run actually exercised that path we require the
+    // sidebar to be observed LAGGING the authoritative host list at least once
+    // (host has the session, sidebar does not): if the sidebar never lagged, the
+    // migration finished before the client's connect-time pull and this run could
+    // not have proved the fix. The sidebar sample is repeated after a pause
+    // because a single sample could catch a sub-frame transition.
     const sidebarHasV1Session = () => Array.from(document.querySelectorAll("*"))
       .filter((element) => element.childElementCount === 0)
       .some((element) => visible(element) && (element.textContent || "").trim() === "Imported V1 session")
+    let v1SessionImported = false
+    let v1SidebarLaggingHost = false
     let v1SessionVisibleInSidebar = false
-    const sidebarDeadline = Date.now() + 25_000
-    while (!v1SessionVisibleInSidebar && Date.now() < sidebarDeadline) {
-      if (sidebarHasV1Session()) {
+    // The fixture's target session imports last (bulk sessions keep the run
+    // going), so this wait spans the whole migration on a slow runner.
+    const importDeadline = Date.now() + 180_000
+    while (!v1SessionVisibleInSidebar && Date.now() < importDeadline) {
+      const sidebarHas = sidebarHasV1Session()
+      const sessions = (await call("session.list", {})).items
+      v1SessionImported = sessions.some((item) => item.sessionId === ${expectedSession})
+      if (v1SessionImported && !sidebarHas) v1SidebarLaggingHost = true
+      if (sidebarHas) {
         await new Promise((resolve) => setTimeout(resolve, 500))
         v1SessionVisibleInSidebar = sidebarHasV1Session()
       }
@@ -497,6 +500,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       platform: typeof navigator === "undefined" ? "" : navigator.platform,
       freeProviderActive: freeProvider?.active === true && freeProvider?.displayName === "OpenCode Free",
       v1SessionImported,
+      v1SidebarLaggingHost,
       v1SessionVisibleInSidebar,
       skillNames: skills.map((skill) => skill.name).sort(),
       sessionId: session.sessionId,
@@ -663,7 +667,11 @@ export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform:
     snapshot.sidebarExpandedAgain ? null : "DSH expand control did not reopen the sidebar",
     snapshot.freeProviderActive ? null : "OpenCode Free provider is not active",
     snapshot.v1SessionImported ? null : "V1 session was not imported into DSH",
-    snapshot.v1SessionVisibleInSidebar ? null : "Imported V1 session never appeared in the sidebar without a reload",
+    snapshot.v1SessionVisibleInSidebar
+      ? snapshot.v1SidebarLaggingHost
+        ? null
+        : "Imported V1 session appeared in the sidebar, but the sidebar was never observed lagging the host list - this run did not exercise the post-connect refresh and cannot prove the fix"
+      : "Imported V1 session never appeared in the sidebar without a reload",
     ["office-docx", "office-pdf", "office-pptx", "office-xlsx"].every((name) => snapshot.skillNames.includes(name))
       ? null
       : `bundled Office skills are incomplete: ${snapshot.skillNames.join(", ")}`,

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -74,6 +74,7 @@ export type CiSmokeProductSnapshot = {
   platform: string
   freeProviderActive: boolean
   v1SessionImported: boolean
+  v1SessionVisibleInSidebar: boolean
   skillNames: string[]
   sessionId: string
   sessionIdsBeforeRestart: string[]
@@ -432,10 +433,31 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     await new Promise((resolve) => setTimeout(resolve, 200))
 
     let v1SessionImported = false
-    for (let attempt = 0; attempt < 100 && !v1SessionImported; attempt += 1) {
+    // The fixture's target session imports last (bulk sessions keep the run
+    // going), so this wait spans the whole migration on a slow runner.
+    const importDeadline = Date.now() + 40_000
+    while (!v1SessionImported && Date.now() < importDeadline) {
       const sessions = (await call("session.list", {})).items
       v1SessionImported = sessions.some((item) => item.sessionId === ${expectedSession})
-      if (!v1SessionImported) await new Promise((resolve) => setTimeout(resolve, 100))
+      if (!v1SessionImported) await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+    // The list the HOST returns is not the list the SIDEBAR shows: the client
+    // pulls cold sessions only at connect, which is before the migration
+    // finishes, so what proves the fix is the imported title appearing in the
+    // visible sidebar without a reload. The sample is repeated after a pause
+    // because the pre-fix importer announced each session and detached it in
+    // the same tick - a single sample could catch that sub-frame flicker.
+    const sidebarHasV1Session = () => Array.from(document.querySelectorAll("*"))
+      .filter((element) => element.childElementCount === 0)
+      .some((element) => visible(element) && (element.textContent || "").trim() === "Imported V1 session")
+    let v1SessionVisibleInSidebar = false
+    const sidebarDeadline = Date.now() + 25_000
+    while (!v1SessionVisibleInSidebar && Date.now() < sidebarDeadline) {
+      if (sidebarHasV1Session()) {
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        v1SessionVisibleInSidebar = sidebarHasV1Session()
+      }
+      if (!v1SessionVisibleInSidebar) await new Promise((resolve) => setTimeout(resolve, 250))
     }
     const providers = (await call("llm.providers", {})).providers
     const session = await call("session.create", { cwd: ${workspace} })
@@ -475,23 +497,24 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       platform: typeof navigator === "undefined" ? "" : navigator.platform,
       freeProviderActive: freeProvider?.active === true && freeProvider?.displayName === "OpenCode Free",
       v1SessionImported,
+      v1SessionVisibleInSidebar,
       skillNames: skills.map((skill) => skill.name).sort(),
       sessionId: session.sessionId,
       sessionIdsBeforeRestart,
     })
   })()`
 
-  return await evaluateCiSmokeJson(target, expression) as CiSmokeProductSnapshot
+  return await evaluateCiSmokeJson(target, expression, 75_000) as CiSmokeProductSnapshot
 }
 
-async function evaluateCiSmokeJson(target: CdpTarget, expression: string) {
+async function evaluateCiSmokeJson(target: CdpTarget, expression: string, timeoutMs = 20_000) {
   if (typeof target.webSocketDebuggerUrl !== "string") {
     throw new Error("DSH CDP target does not expose a WebSocket debugger URL")
   }
 
   const socket = new WebSocket(target.webSocketDebuggerUrl)
   const response = await new Promise<Record<string, unknown>>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Timed out waiting for the DSH product CDP evaluation")), 20_000)
+    const timeout = setTimeout(() => reject(new Error("Timed out waiting for the DSH product CDP evaluation")), timeoutMs)
     socket.addEventListener("error", () => {
       clearTimeout(timeout)
       reject(new Error("Failed to connect to the DSH product CDP target"))
@@ -640,6 +663,7 @@ export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform:
     snapshot.sidebarExpandedAgain ? null : "DSH expand control did not reopen the sidebar",
     snapshot.freeProviderActive ? null : "OpenCode Free provider is not active",
     snapshot.v1SessionImported ? null : "V1 session was not imported into DSH",
+    snapshot.v1SessionVisibleInSidebar ? null : "Imported V1 session never appeared in the sidebar without a reload",
     ["office-docx", "office-pdf", "office-pptx", "office-xlsx"].every((name) => snapshot.skillNames.includes(name))
       ? null
       : `bundled Office skills are incomplete: ${snapshot.skillNames.join(", ")}`,

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -9,7 +9,7 @@ const productRoot = resolve(repositoryRoot, "packages/desktop-electron/resources
 describe("PawWork DSH client product layer", () => {
   // 共享的 watcher 测试脚手架：假定时器驱动轮询节奏，假 context 钉住 rpc/sessions
   // 契约。每个测试只声明自己关心的 call/refresh/effect 行为。
-  function loadPlugin(timers: Array<() => void>) {
+  function loadPlugin(timers: Array<() => void>, delays: number[] = []) {
     const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
       document: {
         title: "DeepSeek Harness",
@@ -18,8 +18,9 @@ describe("PawWork DSH client product layer", () => {
         createElement: () => ({ dataset: {}, textContent: "" }),
         head: { appendChild: () => {} },
       },
-      setTimeout: (callback: () => void) => {
+      setTimeout: (callback: () => void, delay: number) => {
         timers.push(callback)
+        delays.push(delay)
         return timers.length
       },
       clearTimeout: () => {},
@@ -30,15 +31,16 @@ describe("PawWork DSH client product layer", () => {
     })
   }
 
-  function applyWatcher({ call, refresh, dispose }: {
+  function applyWatcher({ call, refresh, sessionIds = () => [], dispose }: {
     call: () => Promise<unknown>
     refresh: () => Promise<void>
+    sessionIds?: () => string[]
     dispose?: (setup: () => unknown) => void
   }) {
     return {
       connection: { rpc: { call } },
       effect: dispose ?? ((fn: () => unknown) => fn()),
-      sessions: { refresh },
+      sessions: { list: { getSnapshot: () => ({ ids: sessionIds() }) }, refresh },
       slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
     }
   }
@@ -217,9 +219,15 @@ describe("PawWork DSH client product layer", () => {
     const timers: Array<() => void> = []
     const plugin = loadPlugin(timers)
     const remainingPhases = ["running", "done"]
-    const call = vi.fn(async () => ({ ok: true, value: { phase: remainingPhases.shift() } }))
-    const refresh = vi.fn(async () => {})
-    plugin.apply(applyWatcher({ call, refresh }))
+    const visibleSessionIds: string[] = []
+    const call = vi.fn(async () => ({
+      ok: true,
+      value: { phase: remainingPhases.shift(), sessionId: "pawwork-v1-session" },
+    }))
+    const refresh = vi.fn(async () => {
+      if (refresh.mock.calls.length === 2) visibleSessionIds.push("pawwork-v1-session")
+    })
+    plugin.apply(applyWatcher({ call, refresh, sessionIds: () => visibleSessionIds }))
 
     await new Promise((resolve) => setImmediate(resolve))
     expect(call).toHaveBeenCalledTimes(1)
@@ -246,10 +254,13 @@ describe("PawWork DSH client product layer", () => {
         failuresLeft -= 1
         throw new Error("status channel unavailable")
       }
-      return { ok: true, value: { phase: "done" } }
+      return { ok: true, value: { phase: "done", sessionId: "pawwork-v1-session" } }
     })
-    const refresh = vi.fn(async () => {})
-    plugin.apply(applyWatcher({ call, refresh }))
+    const visibleSessionIds: string[] = []
+    const refresh = vi.fn(async () => {
+      if (refresh.mock.calls.length === 2) visibleSessionIds.push("pawwork-v1-session")
+    })
+    plugin.apply(applyWatcher({ call, refresh, sessionIds: () => visibleSessionIds }))
 
     await new Promise((resolve) => setImmediate(resolve))
     // 第一次调用即失败：不停止、不刷新，只排下一轮。
@@ -271,6 +282,50 @@ describe("PawWork DSH client product layer", () => {
     expect(timers).toHaveLength(0)
   })
 
+  test("backs off repeated transport failures without giving up", async () => {
+    const timers: Array<() => void> = []
+    const delays: number[] = []
+    const plugin = loadPlugin(timers, delays)
+    const call = vi.fn(async () => { throw new Error("status channel unavailable") })
+    const refresh = vi.fn(async () => {})
+    plugin.apply(applyWatcher({ call, refresh }))
+
+    await new Promise((resolve) => setImmediate(resolve))
+    for (let retry = 0; retry < 20; retry += 1) {
+      timers.shift()!()
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+
+    expect(call).toHaveBeenCalledTimes(21)
+    expect(refresh).not.toHaveBeenCalled()
+    expect(timers).toHaveLength(1)
+    expect(delays.slice(0, 6)).toEqual([1_000, 2_000, 4_000, 8_000, 16_000, 30_000])
+    expect(delays.at(-1)).toBe(30_000)
+  })
+
+  test("retries completion until the imported session is installed in the list", async () => {
+    const timers: Array<() => void> = []
+    const plugin = loadPlugin(timers)
+    const visibleSessionIds: string[] = []
+    const call = vi.fn(async () => ({
+      ok: true,
+      value: { phase: "done", sessionId: "pawwork-v1-session" },
+    }))
+    const refresh = vi.fn(async () => {
+      if (refresh.mock.calls.length === 4) visibleSessionIds.push("pawwork-v1-session")
+    })
+    plugin.apply(applyWatcher({ call, refresh, sessionIds: () => visibleSessionIds }))
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(refresh).toHaveBeenCalledTimes(2)
+    expect(timers).toHaveLength(1)
+
+    timers.shift()!()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(refresh).toHaveBeenCalledTimes(4)
+    expect(timers).toHaveLength(0)
+  })
+
   // refreshList 单飞复用仍在途的拉取，完成信号出现时可能还挂着一条迁移前的旧
   // 拉取；所以要读两次：第一次等在途的 settle，第二次才是必然全新的权威读取。
   test("issues a fresh authoritative read after any in-flight refresh settles", async () => {
@@ -279,34 +334,97 @@ describe("PawWork DSH client product layer", () => {
     // 第一次 refresh 停在在途不 resolve；第二次才开始新的拉取。
     const refresh = vi.fn()
     let firstInFlight: () => void = () => {}
+    const visibleSessionIds: string[] = []
     refresh.mockImplementationOnce(() => new Promise<void>((resolve) => { firstInFlight = resolve }))
-    refresh.mockImplementation(async () => {})
-    const call = vi.fn(async () => ({ ok: true, value: { phase: "done" } }))
-    plugin.apply(applyWatcher({ call, refresh }))
+    refresh.mockImplementation(async () => { visibleSessionIds.push("pawwork-v1-session") })
+    const call = vi.fn(async () => ({
+      ok: true,
+      value: { phase: "done", sessionId: "pawwork-v1-session" },
+    }))
+    plugin.apply(applyWatcher({ call, refresh, sessionIds: () => visibleSessionIds }))
 
     await new Promise((resolve) => setImmediate(resolve))
     expect(call).toHaveBeenCalledTimes(1)
     expect(refresh).toHaveBeenCalledTimes(1)
     // 第一条在途：权威读取必须等它 settle，而不是并发。
-    expect(refresh).toHaveBeenCalledTimes(1)
     firstInFlight()
     await new Promise((resolve) => setImmediate(resolve))
     expect(refresh).toHaveBeenCalledTimes(2)
   })
 
+  test("does not start the authoritative read after disposal", async () => {
+    const timers: Array<() => void> = []
+    const plugin = loadPlugin(timers)
+    let finishFirstRefresh: () => void = () => {}
+    const refresh = vi.fn(() => new Promise<void>((resolve) => { finishFirstRefresh = resolve }))
+    const call = vi.fn(async () => ({
+      ok: true,
+      value: { phase: "done", sessionId: "pawwork-v1-session" },
+    }))
+    let dispose: (() => void) | undefined
+    plugin.apply(applyWatcher({ call, refresh, dispose: (fn) => { dispose = fn() as () => void } }))
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(refresh).toHaveBeenCalledTimes(1)
+    dispose!()
+    finishFirstRefresh()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(timers).toHaveLength(0)
+  })
+
+  test("retries a malformed success response instead of dereferencing it", async () => {
+    const timers: Array<() => void> = []
+    const plugin = loadPlugin(timers)
+    const responses = [
+      { ok: true, value: undefined },
+      { ok: true, value: { phase: "done", sessionId: "pawwork-v1-session" } },
+    ]
+    const call = vi.fn(async () => responses.shift())
+    const refresh = vi.fn(async () => {})
+    plugin.apply(applyWatcher({ call, refresh, sessionIds: () => ["pawwork-v1-session"] }))
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(timers).toHaveLength(1)
+    expect(refresh).not.toHaveBeenCalled()
+    timers.shift()!()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(refresh).toHaveBeenCalledTimes(2)
+    expect(timers).toHaveLength(0)
+  })
+
   // 轮询器随插件而止：dispose 后不再排下一轮、也不再发 status 调用。
-  test("stops polling when the client plugin is disposed", () => {
+  test("stops polling when the client plugin is disposed", async () => {
     const timers: Array<() => void> = []
     const plugin = loadPlugin(timers)
     const call = vi.fn(async () => ({ ok: true, value: { phase: "running" } }))
     const refresh = vi.fn(async () => {})
     let dispose: (() => void) | undefined
     plugin.apply(applyWatcher({ call, refresh, dispose: (fn) => { dispose = fn() as () => void } }))
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(timers).toHaveLength(1)
     expect(dispose).toBeTypeOf("function")
     dispose!()
     const pending = timers.splice(0)
     for (const fire of pending) fire()
     expect(call).toHaveBeenCalledTimes(1)
+    expect(refresh).not.toHaveBeenCalled()
+    expect(timers).toHaveLength(0)
+  })
+
+  test("does not refresh when disposed during an in-flight status call", async () => {
+    const timers: Array<() => void> = []
+    const plugin = loadPlugin(timers)
+    let resolveStatus: (result: unknown) => void = () => {}
+    const call = vi.fn(() => new Promise((resolve) => { resolveStatus = resolve }))
+    const refresh = vi.fn(async () => {})
+    let dispose: (() => void) | undefined
+    plugin.apply(applyWatcher({ call, refresh, dispose: (fn) => { dispose = fn() as () => void } }))
+
+    dispose!()
+    resolveStatus({ ok: true, value: { phase: "done", sessionId: "pawwork-v1-session" } })
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(refresh).not.toHaveBeenCalled()
     expect(timers).toHaveLength(0)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -211,44 +211,13 @@ describe("PawWork DSH client product layer", () => {
     expect(setDraft).toHaveBeenCalledWith('请总结\n\n文件：\n- "/tmp/notes.md"')
   })
 
-  // v1 迁移在后台把冷会话逐条写进持久化，而客户端只在连接/重连时拉取冷列表：
-  // 迁移结束的那一刻侧边栏不会自己更新。宿主的 import-v1 插件在
-  // /pawwork-import-v1 暴露 phase。这里钉住「等到 phase 离开 running，就补一次
-  // 权威列表读取，然后停」的契约——不是「轮询到某个时刻就刷一次」。
-  test("refreshes the session list once the v1 import settles", async () => {
-    const timers: Array<() => void> = []
-    const plugin = loadPlugin(timers)
-    const remainingPhases = ["running", "done"]
-    const visibleSessionIds: string[] = []
-    const call = vi.fn(async () => ({
-      ok: true,
-      value: { phase: remainingPhases.shift(), sessionId: "pawwork-v1-session" },
-    }))
-    const refresh = vi.fn(async () => {
-      if (refresh.mock.calls.length === 2) visibleSessionIds.push("pawwork-v1-session")
-    })
-    plugin.apply(applyWatcher({ call, refresh, sessionIds: () => visibleSessionIds }))
-
-    await new Promise((resolve) => setImmediate(resolve))
-    expect(call).toHaveBeenCalledTimes(1)
-    expect(call).toHaveBeenCalledWith("/pawwork-import-v1", "status", {})
-    expect(refresh).not.toHaveBeenCalled()
-
-    timers.shift()!()
-    await new Promise((resolve) => setImmediate(resolve))
-    expect(call).toHaveBeenCalledTimes(2)
-    // 完成信号出现后必须读一次权威列表，而不是只在途的一次。
-    expect(refresh).toHaveBeenCalledTimes(2)
-    // Completion is terminal: no further poll is scheduled.
-    expect(timers).toHaveLength(0)
-  })
-
   // 传输层失败不是完成信号：旧后端没有这个通道、宿主重启窗口都只是瞬时的，
   // 客户端必须继续等，而不是数满几次失败就放弃、让侧边栏停在旧列表上。
-  test("waits through transport failures until the import settles", async () => {
+  test("backs off repeated transport failures and recovers without giving up", async () => {
     const timers: Array<() => void> = []
-    const plugin = loadPlugin(timers)
-    let failuresLeft = 2
+    const delays: number[] = []
+    const plugin = loadPlugin(timers, delays)
+    let failuresLeft = 20
     const call = vi.fn(async () => {
       if (failuresLeft > 0) {
         failuresLeft -= 1
@@ -263,42 +232,14 @@ describe("PawWork DSH client product layer", () => {
     plugin.apply(applyWatcher({ call, refresh, sessionIds: () => visibleSessionIds }))
 
     await new Promise((resolve) => setImmediate(resolve))
-    // 第一次调用即失败：不停止、不刷新，只排下一轮。
-    expect(call).toHaveBeenCalledTimes(1)
-    expect(refresh).not.toHaveBeenCalled()
-    expect(timers).toHaveLength(1)
-
-    timers.shift()!()
-    await new Promise((resolve) => setImmediate(resolve))
-    expect(call).toHaveBeenCalledTimes(2)
-    expect(refresh).not.toHaveBeenCalled()
-    expect(timers).toHaveLength(1)
-
-    timers.shift()!()
-    await new Promise((resolve) => setImmediate(resolve))
-    expect(call).toHaveBeenCalledTimes(3)
-    // 失败结束后恢复正常：完成信号触发权威刷新，然后停。
-    expect(refresh).toHaveBeenCalledTimes(2)
-    expect(timers).toHaveLength(0)
-  })
-
-  test("backs off repeated transport failures without giving up", async () => {
-    const timers: Array<() => void> = []
-    const delays: number[] = []
-    const plugin = loadPlugin(timers, delays)
-    const call = vi.fn(async () => { throw new Error("status channel unavailable") })
-    const refresh = vi.fn(async () => {})
-    plugin.apply(applyWatcher({ call, refresh }))
-
-    await new Promise((resolve) => setImmediate(resolve))
     for (let retry = 0; retry < 20; retry += 1) {
       timers.shift()!()
       await new Promise((resolve) => setImmediate(resolve))
     }
 
     expect(call).toHaveBeenCalledTimes(21)
-    expect(refresh).not.toHaveBeenCalled()
-    expect(timers).toHaveLength(1)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    expect(timers).toHaveLength(0)
     expect(delays.slice(0, 6)).toEqual([1_000, 2_000, 4_000, 8_000, 16_000, 30_000])
     expect(delays.at(-1)).toBe(30_000)
   })
@@ -326,9 +267,9 @@ describe("PawWork DSH client product layer", () => {
     expect(timers).toHaveLength(0)
   })
 
-  // refreshList 单飞复用仍在途的拉取，完成信号出现时可能还挂着一条迁移前的旧
-  // 拉取；所以要读两次：第一次等在途的 settle，第二次才是必然全新的权威读取。
-  test("issues a fresh authoritative read after any in-flight refresh settles", async () => {
+  // 迁移运行时不读冷列表。完成后 refreshList 可能单飞复用仍在途的旧拉取；
+  // 所以要读两次：第一次等在途的 settle，第二次才是必然全新的权威读取。
+  test("waits for v1 import completion before issuing a fresh authoritative read", async () => {
     const timers: Array<() => void> = []
     const plugin = loadPlugin(timers)
     // 第一次 refresh 停在在途不 resolve；第二次才开始新的拉取。
@@ -337,19 +278,28 @@ describe("PawWork DSH client product layer", () => {
     const visibleSessionIds: string[] = []
     refresh.mockImplementationOnce(() => new Promise<void>((resolve) => { firstInFlight = resolve }))
     refresh.mockImplementation(async () => { visibleSessionIds.push("pawwork-v1-session") })
+    const remainingPhases = ["running", "done"]
     const call = vi.fn(async () => ({
       ok: true,
-      value: { phase: "done", sessionId: "pawwork-v1-session" },
+      value: { phase: remainingPhases.shift(), sessionId: "pawwork-v1-session" },
     }))
     plugin.apply(applyWatcher({ call, refresh, sessionIds: () => visibleSessionIds }))
 
     await new Promise((resolve) => setImmediate(resolve))
     expect(call).toHaveBeenCalledTimes(1)
+    expect(call).toHaveBeenCalledWith("/pawwork-import-v1", "status", {})
+    expect(refresh).not.toHaveBeenCalled()
+    expect(timers).toHaveLength(1)
+
+    timers.shift()!()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(call).toHaveBeenCalledTimes(2)
     expect(refresh).toHaveBeenCalledTimes(1)
     // 第一条在途：权威读取必须等它 settle，而不是并发。
     firstInFlight()
     await new Promise((resolve) => setImmediate(resolve))
     expect(refresh).toHaveBeenCalledTimes(2)
+    expect(timers).toHaveLength(0)
   })
 
   test("does not start the authoritative read after disposal", async () => {

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -7,6 +7,42 @@ const repositoryRoot = resolve(import.meta.dirname, "../../../..")
 const productRoot = resolve(repositoryRoot, "packages/desktop-electron/resources/dsh/product")
 
 describe("PawWork DSH client product layer", () => {
+  // 共享的 watcher 测试脚手架：假定时器驱动轮询节奏，假 context 钉住 rpc/sessions
+  // 契约。每个测试只声明自己关心的 call/refresh/effect 行为。
+  function loadPlugin(timers: Array<() => void>) {
+    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
+      document: {
+        title: "DeepSeek Harness",
+        documentElement: { lang: "zh-CN" },
+        querySelector: () => null,
+        createElement: () => ({ dataset: {}, textContent: "" }),
+        head: { appendChild: () => {} },
+      },
+      setTimeout: (callback: () => void) => {
+        timers.push(callback)
+        return timers.length
+      },
+      clearTimeout: () => {},
+    })
+    return definition.factory((name) => {
+      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
+      throw new Error(`unexpected product client dependency: ${name}`)
+    })
+  }
+
+  function applyWatcher({ call, refresh, dispose }: {
+    call: () => Promise<unknown>
+    refresh: () => Promise<void>
+    dispose?: (setup: () => unknown) => void
+  }) {
+    return {
+      connection: { rpc: { call } },
+      effect: dispose ?? ((fn: () => unknown) => fn()),
+      sessions: { refresh },
+      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
+    }
+  }
+
   test("is a packaged DSH web plugin", () => {
     const productPackage = JSON.parse(readFileSync(resolve(productRoot, "package.json"), "utf8"))
 
@@ -178,35 +214,12 @@ describe("PawWork DSH client product layer", () => {
   // /pawwork-import-v1 暴露 phase。这里钉住「等到 phase 离开 running，就补一次
   // 权威列表读取，然后停」的契约——不是「轮询到某个时刻就刷一次」。
   test("refreshes the session list once the v1 import settles", async () => {
-    const document = {
-      title: "DeepSeek Harness",
-      documentElement: { lang: "zh-CN" },
-      querySelector: () => null,
-      createElement: () => ({ dataset: {}, textContent: "" }),
-      head: { appendChild: () => {} },
-    }
     const timers: Array<() => void> = []
-    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
-      document,
-      setTimeout: (callback: () => void) => {
-        timers.push(callback)
-        return timers.length
-      },
-      clearTimeout: () => {},
-    })
-    const plugin = definition.factory((name) => {
-      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
-      throw new Error(`unexpected product client dependency: ${name}`)
-    })
+    const plugin = loadPlugin(timers)
     const remainingPhases = ["running", "done"]
     const call = vi.fn(async () => ({ ok: true, value: { phase: remainingPhases.shift() } }))
     const refresh = vi.fn(async () => {})
-    plugin.apply({
-      connection: { rpc: { call } },
-      effect: (fn: () => unknown) => fn(),
-      sessions: { refresh },
-      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
-    })
+    plugin.apply(applyWatcher({ call, refresh }))
 
     await new Promise((resolve) => setImmediate(resolve))
     expect(call).toHaveBeenCalledTimes(1)
@@ -225,26 +238,8 @@ describe("PawWork DSH client product layer", () => {
   // 传输层失败不是完成信号：旧后端没有这个通道、宿主重启窗口都只是瞬时的，
   // 客户端必须继续等，而不是数满几次失败就放弃、让侧边栏停在旧列表上。
   test("waits through transport failures until the import settles", async () => {
-    const document = {
-      title: "DeepSeek Harness",
-      documentElement: { lang: "zh-CN" },
-      querySelector: () => null,
-      createElement: () => ({ dataset: {}, textContent: "" }),
-      head: { appendChild: () => {} },
-    }
     const timers: Array<() => void> = []
-    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
-      document,
-      setTimeout: (callback: () => void) => {
-        timers.push(callback)
-        return timers.length
-      },
-      clearTimeout: () => {},
-    })
-    const plugin = definition.factory((name) => {
-      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
-      throw new Error(`unexpected product client dependency: ${name}`)
-    })
+    const plugin = loadPlugin(timers)
     let failuresLeft = 2
     const call = vi.fn(async () => {
       if (failuresLeft > 0) {
@@ -254,12 +249,7 @@ describe("PawWork DSH client product layer", () => {
       return { ok: true, value: { phase: "done" } }
     })
     const refresh = vi.fn(async () => {})
-    plugin.apply({
-      connection: { rpc: { call } },
-      effect: (fn: () => unknown) => fn(),
-      sessions: { refresh },
-      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
-    })
+    plugin.apply(applyWatcher({ call, refresh }))
 
     await new Promise((resolve) => setImmediate(resolve))
     // 第一次调用即失败：不停止、不刷新，只排下一轮。
@@ -284,38 +274,15 @@ describe("PawWork DSH client product layer", () => {
   // refreshList 单飞复用仍在途的拉取，完成信号出现时可能还挂着一条迁移前的旧
   // 拉取；所以要读两次：第一次等在途的 settle，第二次才是必然全新的权威读取。
   test("issues a fresh authoritative read after any in-flight refresh settles", async () => {
-    const document = {
-      title: "DeepSeek Harness",
-      documentElement: { lang: "zh-CN" },
-      querySelector: () => null,
-      createElement: () => ({ dataset: {}, textContent: "" }),
-      head: { appendChild: () => {} },
-    }
     const timers: Array<() => void> = []
-    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
-      document,
-      setTimeout: (callback: () => void) => {
-        timers.push(callback)
-        return timers.length
-      },
-      clearTimeout: () => {},
-    })
-    const plugin = definition.factory((name) => {
-      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
-      throw new Error(`unexpected product client dependency: ${name}`)
-    })
+    const plugin = loadPlugin(timers)
     // 第一次 refresh 停在在途不 resolve；第二次才开始新的拉取。
     const refresh = vi.fn()
     let firstInFlight: () => void = () => {}
     refresh.mockImplementationOnce(() => new Promise<void>((resolve) => { firstInFlight = resolve }))
     refresh.mockImplementation(async () => {})
     const call = vi.fn(async () => ({ ok: true, value: { phase: "done" } }))
-    plugin.apply({
-      connection: { rpc: { call } },
-      effect: (fn: () => unknown) => fn(),
-      sessions: { refresh },
-      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
-    })
+    plugin.apply(applyWatcher({ call, refresh }))
 
     await new Promise((resolve) => setImmediate(resolve))
     expect(call).toHaveBeenCalledTimes(1)
@@ -329,35 +296,12 @@ describe("PawWork DSH client product layer", () => {
 
   // 轮询器随插件而止：dispose 后不再排下一轮、也不再发 status 调用。
   test("stops polling when the client plugin is disposed", () => {
-    const document = {
-      title: "DeepSeek Harness",
-      documentElement: { lang: "zh-CN" },
-      querySelector: () => null,
-      createElement: () => ({ dataset: {}, textContent: "" }),
-      head: { appendChild: () => {} },
-    }
     const timers: Array<() => void> = []
-    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
-      document,
-      setTimeout: (callback: () => void) => {
-        timers.push(callback)
-        return timers.length
-      },
-      clearTimeout: () => {},
-    })
-    const plugin = definition.factory((name) => {
-      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
-      throw new Error(`unexpected product client dependency: ${name}`)
-    })
+    const plugin = loadPlugin(timers)
     const call = vi.fn(async () => ({ ok: true, value: { phase: "running" } }))
     const refresh = vi.fn(async () => {})
     let dispose: (() => void) | undefined
-    plugin.apply({
-      connection: { rpc: { call } },
-      effect: (fn: () => unknown) => { dispose = fn() as () => void },
-      sessions: { refresh },
-      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
-    })
+    plugin.apply(applyWatcher({ call, refresh, dispose: (fn) => { dispose = fn() as () => void } }))
     expect(dispose).toBeTypeOf("function")
     dispose!()
     const pending = timers.splice(0)

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -47,6 +47,7 @@ describe("PawWork DSH client product layer", () => {
     }> = []
     const ctx = {
       connection: { rpc: { call: vi.fn(async () => ({ ok: true, value: { phase: "done" } })) } },
+      effect: (fn: () => unknown) => fn(),
       sessions: { refresh: vi.fn(async () => {}) },
       slots: {
         inject: (_name: string, register: () => void) => register(),
@@ -149,6 +150,7 @@ describe("PawWork DSH client product layer", () => {
     let fileAction: ((props: unknown) => { props: Record<string, unknown> }) | undefined
     const ctx = {
       connection: { rpc: { call: vi.fn(async () => ({ ok: true, value: { phase: "done" } })) } },
+      effect: (fn: () => unknown) => fn(),
       sessions: { refresh: vi.fn(async () => {}) },
       slots: {
         inject: (_name: string, register: () => void) => register(),
@@ -173,8 +175,8 @@ describe("PawWork DSH client product layer", () => {
 
   // v1 迁移在后台把冷会话逐条写进持久化，而客户端只在连接/重连时拉取冷列表：
   // 迁移结束的那一刻侧边栏不会自己更新。宿主的 import-v1 插件在
-  // /pawwork-import-v1 暴露 phase，这里钉住「轮询到离开 running 就刷一次列表、
-  // 然后停」的契约。
+  // /pawwork-import-v1 暴露 phase。这里钉住「等到 phase 离开 running，就补一次
+  // 权威列表读取，然后停」的契约——不是「轮询到某个时刻就刷一次」。
   test("refreshes the session list once the v1 import settles", async () => {
     const document = {
       title: "DeepSeek Harness",
@@ -201,6 +203,7 @@ describe("PawWork DSH client product layer", () => {
     const refresh = vi.fn(async () => {})
     plugin.apply({
       connection: { rpc: { call } },
+      effect: (fn: () => unknown) => fn(),
       sessions: { refresh },
       slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
     })
@@ -213,14 +216,15 @@ describe("PawWork DSH client product layer", () => {
     timers.shift()!()
     await new Promise((resolve) => setImmediate(resolve))
     expect(call).toHaveBeenCalledTimes(2)
-    expect(refresh).toHaveBeenCalledTimes(1)
+    // 完成信号出现后必须读一次权威列表，而不是只在途的一次。
+    expect(refresh).toHaveBeenCalledTimes(2)
     // Completion is terminal: no further poll is scheduled.
     expect(timers).toHaveLength(0)
   })
 
-  // 传输层连续失败（旧后端没有这个通道、宿主重启窗口）只重试有限次；失败分支
-  // 不做兜底刷新——重连路径本身会刷新冷列表。
-  test("stops polling after repeated status failures without refreshing", async () => {
+  // 传输层失败不是完成信号：旧后端没有这个通道、宿主重启窗口都只是瞬时的，
+  // 客户端必须继续等，而不是数满几次失败就放弃、让侧边栏停在旧列表上。
+  test("waits through transport failures until the import settles", async () => {
     const document = {
       title: "DeepSeek Harness",
       documentElement: { lang: "zh-CN" },
@@ -241,24 +245,124 @@ describe("PawWork DSH client product layer", () => {
       if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
       throw new Error(`unexpected product client dependency: ${name}`)
     })
+    let failuresLeft = 2
     const call = vi.fn(async () => {
-      throw new Error("status channel unavailable")
+      if (failuresLeft > 0) {
+        failuresLeft -= 1
+        throw new Error("status channel unavailable")
+      }
+      return { ok: true, value: { phase: "done" } }
     })
     const refresh = vi.fn(async () => {})
     plugin.apply({
       connection: { rpc: { call } },
+      effect: (fn: () => unknown) => fn(),
       sessions: { refresh },
       slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
     })
 
     await new Promise((resolve) => setImmediate(resolve))
-    for (let round = 0; round < 9; round += 1) {
-      timers.shift()!()
-      await new Promise((resolve) => setImmediate(resolve))
-    }
-
-    expect(call).toHaveBeenCalledTimes(10)
+    // 第一次调用即失败：不停止、不刷新，只排下一轮。
+    expect(call).toHaveBeenCalledTimes(1)
     expect(refresh).not.toHaveBeenCalled()
+    expect(timers).toHaveLength(1)
+
+    timers.shift()!()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(call).toHaveBeenCalledTimes(2)
+    expect(refresh).not.toHaveBeenCalled()
+    expect(timers).toHaveLength(1)
+
+    timers.shift()!()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(call).toHaveBeenCalledTimes(3)
+    // 失败结束后恢复正常：完成信号触发权威刷新，然后停。
+    expect(refresh).toHaveBeenCalledTimes(2)
+    expect(timers).toHaveLength(0)
+  })
+
+  // refreshList 单飞复用仍在途的拉取，完成信号出现时可能还挂着一条迁移前的旧
+  // 拉取；所以要读两次：第一次等在途的 settle，第二次才是必然全新的权威读取。
+  test("issues a fresh authoritative read after any in-flight refresh settles", async () => {
+    const document = {
+      title: "DeepSeek Harness",
+      documentElement: { lang: "zh-CN" },
+      querySelector: () => null,
+      createElement: () => ({ dataset: {}, textContent: "" }),
+      head: { appendChild: () => {} },
+    }
+    const timers: Array<() => void> = []
+    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
+      document,
+      setTimeout: (callback: () => void) => {
+        timers.push(callback)
+        return timers.length
+      },
+      clearTimeout: () => {},
+    })
+    const plugin = definition.factory((name) => {
+      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
+      throw new Error(`unexpected product client dependency: ${name}`)
+    })
+    // 第一次 refresh 停在在途不 resolve；第二次才开始新的拉取。
+    const refresh = vi.fn()
+    let firstInFlight: () => void = () => {}
+    refresh.mockImplementationOnce(() => new Promise<void>((resolve) => { firstInFlight = resolve }))
+    refresh.mockImplementation(async () => {})
+    const call = vi.fn(async () => ({ ok: true, value: { phase: "done" } }))
+    plugin.apply({
+      connection: { rpc: { call } },
+      effect: (fn: () => unknown) => fn(),
+      sessions: { refresh },
+      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(call).toHaveBeenCalledTimes(1)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    // 第一条在途：权威读取必须等它 settle，而不是并发。
+    expect(refresh).toHaveBeenCalledTimes(1)
+    firstInFlight()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(refresh).toHaveBeenCalledTimes(2)
+  })
+
+  // 轮询器随插件而止：dispose 后不再排下一轮、也不再发 status 调用。
+  test("stops polling when the client plugin is disposed", () => {
+    const document = {
+      title: "DeepSeek Harness",
+      documentElement: { lang: "zh-CN" },
+      querySelector: () => null,
+      createElement: () => ({ dataset: {}, textContent: "" }),
+      head: { appendChild: () => {} },
+    }
+    const timers: Array<() => void> = []
+    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
+      document,
+      setTimeout: (callback: () => void) => {
+        timers.push(callback)
+        return timers.length
+      },
+      clearTimeout: () => {},
+    })
+    const plugin = definition.factory((name) => {
+      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
+      throw new Error(`unexpected product client dependency: ${name}`)
+    })
+    const call = vi.fn(async () => ({ ok: true, value: { phase: "running" } }))
+    const refresh = vi.fn(async () => {})
+    let dispose: (() => void) | undefined
+    plugin.apply({
+      connection: { rpc: { call } },
+      effect: (fn: () => unknown) => { dispose = fn() as () => void },
+      sessions: { refresh },
+      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
+    })
+    expect(dispose).toBeTypeOf("function")
+    dispose!()
+    const pending = timers.splice(0)
+    for (const fire of pending) fire()
+    expect(call).toHaveBeenCalledTimes(1)
     expect(timers).toHaveLength(0)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -46,6 +46,8 @@ describe("PawWork DSH client product layer", () => {
       component: (props: unknown) => unknown
     }> = []
     const ctx = {
+      connection: { rpc: { call: vi.fn(async () => ({ ok: true, value: { phase: "done" } })) } },
+      sessions: { refresh: vi.fn(async () => {}) },
       slots: {
         inject: (_name: string, register: () => void) => register(),
         register: (options: { id?: string; name?: string; priority?: number }, component: (props: unknown) => unknown) => {
@@ -55,7 +57,7 @@ describe("PawWork DSH client product layer", () => {
     }
 
     plugin.apply(ctx)
-    expect(plugin.inject).toEqual(["slots"])
+    expect(plugin.inject).toEqual(["slots", "connection", "sessions"])
     const welcome = registrations.find((entry) => entry.options.id === "welcome-notice")
     expect(welcome).toBeDefined()
     expect(welcome!.options.priority).toBe(-1)
@@ -146,6 +148,8 @@ describe("PawWork DSH client product layer", () => {
     })
     let fileAction: ((props: unknown) => { props: Record<string, unknown> }) | undefined
     const ctx = {
+      connection: { rpc: { call: vi.fn(async () => ({ ok: true, value: { phase: "done" } })) } },
+      sessions: { refresh: vi.fn(async () => {}) },
       slots: {
         inject: (_name: string, register: () => void) => register(),
         register: (options: { id?: string }, component: typeof fileAction) => {
@@ -165,5 +169,96 @@ describe("PawWork DSH client product layer", () => {
 
     expect(pick).toHaveBeenCalledTimes(1)
     expect(setDraft).toHaveBeenCalledWith('请总结\n\n文件：\n- "/tmp/notes.md"')
+  })
+
+  // v1 迁移在后台把冷会话逐条写进持久化，而客户端只在连接/重连时拉取冷列表：
+  // 迁移结束的那一刻侧边栏不会自己更新。宿主的 import-v1 插件在
+  // /pawwork-import-v1 暴露 phase，这里钉住「轮询到离开 running 就刷一次列表、
+  // 然后停」的契约。
+  test("refreshes the session list once the v1 import settles", async () => {
+    const document = {
+      title: "DeepSeek Harness",
+      documentElement: { lang: "zh-CN" },
+      querySelector: () => null,
+      createElement: () => ({ dataset: {}, textContent: "" }),
+      head: { appendChild: () => {} },
+    }
+    const timers: Array<() => void> = []
+    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
+      document,
+      setTimeout: (callback: () => void) => {
+        timers.push(callback)
+        return timers.length
+      },
+      clearTimeout: () => {},
+    })
+    const plugin = definition.factory((name) => {
+      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
+      throw new Error(`unexpected product client dependency: ${name}`)
+    })
+    const remainingPhases = ["running", "done"]
+    const call = vi.fn(async () => ({ ok: true, value: { phase: remainingPhases.shift() } }))
+    const refresh = vi.fn(async () => {})
+    plugin.apply({
+      connection: { rpc: { call } },
+      sessions: { refresh },
+      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(call).toHaveBeenCalledTimes(1)
+    expect(call).toHaveBeenCalledWith("/pawwork-import-v1", "status", {})
+    expect(refresh).not.toHaveBeenCalled()
+
+    timers.shift()!()
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(call).toHaveBeenCalledTimes(2)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    // Completion is terminal: no further poll is scheduled.
+    expect(timers).toHaveLength(0)
+  })
+
+  // 传输层连续失败（旧后端没有这个通道、宿主重启窗口）只重试有限次；失败分支
+  // 不做兜底刷新——重连路径本身会刷新冷列表。
+  test("stops polling after repeated status failures without refreshing", async () => {
+    const document = {
+      title: "DeepSeek Harness",
+      documentElement: { lang: "zh-CN" },
+      querySelector: () => null,
+      createElement: () => ({ dataset: {}, textContent: "" }),
+      head: { appendChild: () => {} },
+    }
+    const timers: Array<() => void> = []
+    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
+      document,
+      setTimeout: (callback: () => void) => {
+        timers.push(callback)
+        return timers.length
+      },
+      clearTimeout: () => {},
+    })
+    const plugin = definition.factory((name) => {
+      if (name === "react") return { createElement: () => null, useEffect: () => {}, useRef: () => ({ current: null }) }
+      throw new Error(`unexpected product client dependency: ${name}`)
+    })
+    const call = vi.fn(async () => {
+      throw new Error("status channel unavailable")
+    })
+    const refresh = vi.fn(async () => {})
+    plugin.apply({
+      connection: { rpc: { call } },
+      sessions: { refresh },
+      slots: { inject: (_name: string, register: () => void) => register(), register: () => {} },
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    for (let round = 0; round < 9; round += 1) {
+      timers.shift()!()
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+
+    expect(call).toHaveBeenCalledTimes(10)
+    expect(refresh).not.toHaveBeenCalled()
+    expect(timers).toHaveLength(0)
   })
 })


### PR DESCRIPTION
# Show v1 imported sessions in the sidebar without a reload

## Problem

After an upgrade to v2, the migration imports v1 sessions into DSH persistence in the background, but the sidebar can keep the cold session list captured when the client first connected. The imported sessions then appear only after a reload or reconnect.

## Root cause

The importer and client have separate responsibilities:

- DSH session persistence requires the paired `session/created` → `session/disposed` lifecycle to adopt and retire a live persistence owner. Skipping `announce()` leaves imported sessions locked until backend restart, so the importer must announce after flush and detach immediately afterward.
- Those live lifecycle events are not the cold-list authority. The client removes the transient row again on `session/disposed`, while its authoritative `session.list` pull normally runs only at connect/reconnect time — before a long background import has settled.

## Fix

- The importer keeps the required `flush()` → `announce()` → detach lifecycle and exposes a loopback status RPC at `/pawwork-import-v1`.
- Status now represents only the boundary the sidebar consumes: the session import stage. It becomes `done` as soon as session persistence settles, even while settings and Automation migration continue.
- The completion value includes the last persisted session as an observable marker. The client crosses DSH's single-flight list barrier with two `sessions.refresh()` calls and stops only after that marker is present in the public session-list snapshot.
- Transport, malformed response, and not-yet-installed marker paths retry with exponential backoff from 1 second to a 30-second cap. A valid `running` status remains a 1 Hz progress poll. Disposal cancels timers and prevents a second refresh from starting on a destroyed client fiber.
- The unused unknown-endpoint error branch was removed instead of publishing a malformed RPC error schema.

The change stays in PawWork's product/importer layers; no vendored DSH engine code and no second full-migration state were added.

## Verification

- `pnpm test` in `packages/desktop-electron`: 306 Vitest tests and 87 Node tests passed.
- Post-rebase on current `main` with DSH `0.1.1-rc.2`: 73 client/smoke tests and 25 importer tests passed.
- `pnpm run typecheck` passed.
- `pnpm run build` passed.
- Real development desktop smoke (`PAWWORK_CI_SMOKE_CDP=true pnpm run smoke:ci`) passed on macOS: the 150-session fixture plus target session imported, the target title became visible in the sidebar without a reload, and session + Automation persistence survived a clean restart.

## E2E boundary

The 150-session desktop path remains because it is the current real Electron/user-path evidence. Its assertion now checks the durable outcome without requiring a speed-dependent observation of the transient “host has it, sidebar does not” state. There is no existing deterministic migration-pause seam that avoids adding test-only production state; creating one is outside this fix.

## Residual risk

- DSH's public `sessions.refresh()` resolves even when its internal list RPC records an error. The persisted-session marker closes that gap without reaching into DSH internals: a failed or stale read cannot terminate the watcher.
- Full cross-platform packaged smoke remains PR CI's responsibility; local verification covered the real macOS Electron path.