### PR TITLE
chore(release): prepare V1 2026.8.5 hotfix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -947,7 +947,7 @@ jobs:
           # Identify this target so it can upload its own provenance marker.
           RELEASE_OS: ${{ runner.os == 'macOS' && 'mac' || 'win' }}
           RELEASE_ARCH: ${{ matrix.arch_label }}
-          MIRROR_REF: dev
+          MIRROR_REF: v1
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ runner.os == 'macOS' && (inputs.phase == 'finalize' || inputs.phase == 'full') && inputs.arch == matrix.arch_label }}

--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "2026.8.3",
+      "version": "2026.8.5",
       "dependencies": {
         "@opencode-ai/remote-bridge": "workspace:*",
         "@opencode-ai/util": "workspace:*",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "2026.8.3",
+  "version": "2026.8.5",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",

--- a/packages/desktop-electron/scripts/mirror-release-to-r2.test.ts
+++ b/packages/desktop-electron/scripts/mirror-release-to-r2.test.ts
@@ -3,37 +3,14 @@ import { readFileSync } from "node:fs"
 import { join } from "node:path"
 
 import { releaseAssetNames } from "./verify-release.ts"
-import {
-  buildManifest,
-  missingPointerReferences,
-  pointerReferencedAssets,
-  uploadPlan,
-} from "./mirror-release-to-r2.ts"
-
-describe("buildManifest", () => {
-  test("locks the manifest shape and per-platform installer URLs", () => {
-    expect(buildManifest("2026.5.29", "https://dl.pawwork.ai")).toEqual({
-      version: "2026.5.29",
-      macArm64: "https://dl.pawwork.ai/pawwork-mac-arm64-2026.5.29.dmg",
-      macX64: "https://dl.pawwork.ai/pawwork-mac-x64-2026.5.29.dmg",
-      winX64: "https://dl.pawwork.ai/pawwork-win-x64-2026.5.29.exe",
-    })
-  })
-
-  test("normalizes a trailing slash in the public base", () => {
-    expect(buildManifest("2026.5.29", "https://dl.pawwork.ai/").macArm64).toBe(
-      "https://dl.pawwork.ai/pawwork-mac-arm64-2026.5.29.dmg",
-    )
-  })
-})
+import { missingPointerReferences, pointerReferencedAssets, uploadPlan } from "./mirror-release-to-r2.ts"
 
 describe("uploadPlan", () => {
   const plan = uploadPlan(releaseAssetNames("2026.5.29"))
   const names = plan.map((step) => step.name)
 
-  test("ends with the landing-page manifest as the single live switch", () => {
-    expect(names.at(-1)).toBe("latest.json")
-    expect(plan.at(-1)).toMatchObject({ manifest: true, cacheControl: "no-cache, must-revalidate" })
+  test("does not move the V2 landing-page manifest", () => {
+    expect(names).not.toContain("latest.json")
   })
 
   test("orders immutable versioned artifacts before the mutable updater pointers", () => {
@@ -44,7 +21,6 @@ describe("uploadPlan", () => {
     )
     const firstPointer = Math.min(names.indexOf("latest.yml"), names.indexOf("latest-mac.yml"))
     expect(lastVersioned).toBeLessThan(firstPointer)
-    expect(firstPointer).toBeLessThan(names.indexOf("latest.json"))
   })
 
   test("marks versioned artifacts immutable and pointers no-cache", () => {
@@ -54,9 +30,9 @@ describe("uploadPlan", () => {
     expect(cacheOf("latest-mac.yml")).toBe("no-cache, must-revalidate")
   })
 
-  test("uploads every released asset exactly once plus the manifest", () => {
+  test("uploads every V1 release asset exactly once", () => {
     const assets = releaseAssetNames("2026.5.29")
-    expect(names.slice(0, -1).sort()).toEqual([...assets].sort())
+    expect(names.sort()).toEqual([...assets].sort())
     expect(new Set(names).size).toBe(names.length)
   })
 })

--- a/packages/desktop-electron/scripts/mirror-release-to-r2.ts
+++ b/packages/desktop-electron/scripts/mirror-release-to-r2.ts
@@ -1,12 +1,12 @@
 // Mirror a published GitHub Release's installers to Cloudflare R2 so the China
-// landing page (site/) can serve fast, CDN-cached direct downloads.
+// V1 updater can serve fast, CDN-cached downloads without changing the V2
+// landing-page release.
 //
 // Ordering matters (see PR discussion): versioned installer objects are
 // immutable and uploaded first; the mutable pointers — the electron-updater
-// latest*.yml and finally the landing page's latest.json — are written last,
-// so a failure leaves the site pointing at the previous good release rather
-// than a half-mirrored one. Run AFTER verify-release.ts has confirmed the
-// release is complete.
+// latest*.yml — are written last. V1 must not write latest.json because that
+// manifest now belongs to the V2 product release. Run AFTER verify-release.ts
+// has confirmed the release is complete.
 //
 // Usage: bun packages/desktop-electron/scripts/mirror-release-to-r2.ts <tag> [owner/repo]
 // Env:
@@ -27,26 +27,12 @@ const POINTER_YMLS = ["latest.yml", "latest-mac.yml"] as const
 const MUTABLE_POINTERS = new Set(["latest.yml", "latest-mac.yml"])
 const IMMUTABLE_CACHE = "public, max-age=31536000, immutable"
 const POINTER_CACHE = "no-cache, must-revalidate"
-const MANIFEST_NAME = "latest.json"
 
-export type UploadStep = { name: string; cacheControl: string; manifest?: boolean }
+export type UploadStep = { name: string; cacheControl: string }
 
-// Pointer object the landing page reads to swap download buttons to R2 links.
-// Keys match the data-dl attributes on the buttons in site/src/pages/index.astro.
-export function buildManifest(version: string, publicBase: string) {
-  const base = publicBase.replace(/\/$/, "")
-  return {
-    version,
-    macArm64: `${base}/pawwork-mac-arm64-${version}.dmg`,
-    macX64: `${base}/pawwork-mac-x64-${version}.dmg`,
-    winX64: `${base}/pawwork-win-x64-${version}.exe`,
-  }
-}
-
-// Ordered upload plan: immutable versioned artifacts first, then the mutable
-// electron-updater pointers, then the landing-page manifest LAST — the single
-// switch that makes a release live. The order is load-bearing (a half-mirror
-// must never point the site at incomplete artifacts); locked by the test.
+// Ordered upload plan: immutable versioned artifacts first, then the mutable V1
+// electron-updater pointers. The order is load-bearing: a half-mirror must not
+// advertise artifacts that have not landed yet.
 export function uploadPlan(assets: string[]): UploadStep[] {
   const versioned = assets
     .filter((name) => !MUTABLE_POINTERS.has(name))
@@ -54,7 +40,7 @@ export function uploadPlan(assets: string[]): UploadStep[] {
   const pointers = assets
     .filter((name) => MUTABLE_POINTERS.has(name))
     .map((name) => ({ name, cacheControl: POINTER_CACHE }))
-  return [...versioned, ...pointers, { name: MANIFEST_NAME, cacheControl: POINTER_CACHE, manifest: true }]
+  return [...versioned, ...pointers]
 }
 
 // The bare asset names a latest*.yml points electron-updater at. The generic R2
@@ -119,7 +105,7 @@ async function main() {
 
   const dir = await mkdtemp(join(tmpdir(), "pawwork-r2-"))
   try {
-    await mirror({ assets, tag, repo, dir, bucket, endpoint, publicBase, version })
+    await mirror({ assets, tag, repo, dir, bucket, endpoint, publicBase })
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
@@ -133,10 +119,9 @@ type MirrorArgs = {
   bucket: string
   endpoint: string
   publicBase: string
-  version: string
 }
 
-async function mirror({ assets, tag, repo, dir, bucket, endpoint, publicBase, version }: MirrorArgs) {
+async function mirror({ assets, tag, repo, dir, bucket, endpoint, publicBase }: MirrorArgs) {
   console.log(`Downloading ${assets.length} assets of ${tag} from ${repo} ...`)
   for (const name of assets) {
     await run(["gh", "release", "download", tag, "--repo", repo, "--pattern", name, "--dir", dir])
@@ -175,16 +160,12 @@ async function mirror({ assets, tag, repo, dir, bucket, endpoint, publicBase, ve
     console.log(`  ✓ ${name} (${localSize} bytes)`)
   }
 
-  // Upload in the load-bearing order (versioned -> updater pointers -> manifest
-  // last). The manifest is generated just before its upload.
+  // Upload in the load-bearing order (versioned -> updater pointers).
   for (const step of uploadPlan(assets)) {
-    if (step.manifest) {
-      await Bun.write(join(dir, step.name), JSON.stringify(buildManifest(version, publicBase), null, 2))
-    }
     await upload(step.name, step.cacheControl)
   }
 
-  console.log(`Mirrored ${tag} to ${publicBase} (latest.json -> ${version}).`)
+  console.log(`Mirrored ${tag} V1 artifacts to ${publicBase}; latest.json remains on V2.`)
 }
 
 if (import.meta.main) {

--- a/packages/desktop-electron/scripts/release-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-workflow-contract.test.ts
@@ -51,6 +51,10 @@ describe("release workflow app-update verification", () => {
     expectBefore(workflow, "Prepare uv", "npx electron-builder ${{ matrix.platform_flag }}")
     expect(workflow).toContain('uv_platform="win32"')
   })
+
+  test("dispatches the release mirror with the V1 contract", () => {
+    expect(workflow).toContain("MIRROR_REF: v1")
+  })
 })
 
 const checklist = readFileSync(join(import.meta.dir, "..", "..", "..", ".github", "RELEASE_CHECKLIST.md"), "utf8")


### PR DESCRIPTION
## Summary

Prepare PawWork V1 `2026.8.5` for the OpenCode Free catalog hotfix merged in #1577. No separate issue was opened because this is the release boundary for that maintainer-requested P1 fix.

The release also makes the post-V2 feed boundary explicit: V1 mirrors its versioned artifacts plus `latest.yml` and `latest-mac.yml` from the `v1` workflow, but no longer writes the V2 landing-page `latest.json` manifest.

## Why

V1 `2026.8.3` cannot discover and refresh the current OpenCode free model catalog correctly. #1577 fixes the runtime behavior, but users need a uniquely versioned, signed, notarized cross-platform release to receive it.

After the V2 cutover, dispatching the V1 mirror on `dev` would run V2's `latest-v2` release contract against V1 assets. Running the legacy mirror unchanged would also replace the public V2 download manifest with V1 installers. The release must therefore keep the two updater pointer sets independent while leaving V2 as the download-page product.

## Related Issue

None — release preparation for #1577.

## Human Review Status

Pending

## Review Focus

- The version advances to the globally unused `2026.8.5`; `2026.8.4` remains the current V2 release.
- V1 release jobs dispatch the mirror workflow from `v1`, where the V1 asset contract lives.
- The V1 mirror continues uploading immutable V1 artifacts before its mutable updater pointers.
- V1 never writes `latest.json`, which remains owned by the V2 product release.

## Risk Notes

- This intentionally targets `v1`, not `dev`.
- Release artifacts still require signed/notarized macOS arm64 and x64 builds plus the Windows x64 build from one merged commit.
- Publishing a newer GitHub release changes GitHub's single Latest release. The release operation will preserve the current V2 channel assets in the new release before publication so both `latest` and `latest-v2` GitHub fallback feeds remain resolvable.
- No application UI, runtime dependency, permission, credential, signing, or installer behavior changes in this PR.

## How To Verify

```text
TDD: V1 mirror-ref contract failed before the workflow change and passed after it
Release contracts: 76 passed, 0 failed
Release TypeScript check: passed
Lint: passed
Frozen install: passed with no lockfile drift
Diff check: passed
```

## Screenshots or Recordings

Not applicable; there is no visible UI or copy change.

## Checklist

> **How to use this checklist:**
>
> - Tick a box by replacing `[ ]` with `[x]`. Do not edit, add, or remove items.
> - The bot-applied label items can only be honestly ticked AFTER the PR is opened and the labeler / priority-triage bots have run — return to the PR description and tick them then.
> - Most items are required. The few that are conditional are explicitly marked **(conditional)**; for those, leave unticked if they truly do not apply and explain why in Risk Notes. All other items must be ticked before requesting human review.

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [ ] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
