### PR TITLE
chore(repo): rename the product mainline to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-task.yml
+++ b/.github/ISSUE_TEMPLATE/03-task.yml
@@ -71,6 +71,6 @@ body:
       options:
         - Wait for human approval — the agent must not write code or open a PR until a human leaves an explicit "approved" comment on this issue
         - Investigate and propose a plan first — the agent must post the plan as an issue comment and wait for an explicit "approved" comment before writing code or opening a PR
-        - Implement and open a PR — the agent makes the requested changes on a feature branch and opens a PR following the standard PR template without requiring prior issue-comment approval. The agent must not push directly to dev, and the resulting PR still requires human approval to merge.
+        - Implement and open a PR — the agent makes the requested changes on a feature branch and opens a PR following the standard PR template without requiring prior issue-comment approval. The agent must not push directly to main, and the resulting PR still requires human approval to merge.
     validations:
       required: true

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -4,12 +4,12 @@ Use this checklist for PawWork desktop releases.
 
 ## 1. Prepare
 
-- Confirm the release PR targets `dev` and all required CI checks are green.
-- Confirm the version bump is merged into `dev`.
-- Confirm `dev` is up to date locally:
+- Confirm the release PR targets `main` and all required CI checks are green.
+- Confirm the version bump is merged into `main`.
+- Confirm `main` is up to date locally:
 
 ```bash
-git switch dev
+git switch main
 git pull --ff-only
 ```
 
@@ -71,8 +71,8 @@ Do not rely on the GitHub Assets list as the primary download UI. It mixes user 
 Submit macOS notarization for both architectures:
 
 ```bash
-gh workflow run build.yml --repo Astro-Han/pawwork --ref dev -f phase=submit -f channel=prod -f target=macos -f arch=arm64
-gh workflow run build.yml --repo Astro-Han/pawwork --ref dev -f phase=submit -f channel=prod -f target=macos -f arch=x64
+gh workflow run build.yml --repo Astro-Han/pawwork --ref main -f phase=submit -f channel=prod -f target=macos -f arch=arm64
+gh workflow run build.yml --repo Astro-Han/pawwork --ref main -f phase=submit -f channel=prod -f target=macos -f arch=x64
 ```
 
 Record each submit run's source run ID, source run attempt, source ref, source sha, workflow ref, workflow sha, and Apple submission ID from the workflow summary.
@@ -82,7 +82,7 @@ The submit workflow summary should include values like this:
 ```text
 source_run_id: 123456789
 source_run_attempt: 1
-source_ref: dev
+source_ref: main
 source_sha: 0123456789abcdef0123456789abcdef01234567
 source_workflow_ref: workflow-snapshot-123456789-1-macos-arm64
 source_workflow_sha: 0123456789abcdef0123456789abcdef01234567
@@ -101,10 +101,10 @@ gh workflow run build.yml --repo Astro-Han/pawwork --ref X64_SOURCE_WORKFLOW_REF
 Build and publish the Windows installer:
 
 ```bash
-gh workflow run build.yml --repo Astro-Han/pawwork --ref dev -f phase=full -f channel=prod -f target=windows -f arch=x64
+gh workflow run build.yml --repo Astro-Han/pawwork --ref main -f phase=full -f channel=prod -f target=windows -f arch=x64
 ```
 
-> **All three final targets must be the same build commit.** mac finalize rebuilds from the commit pinned by its submit snapshot tag (`source_sha`), while the Windows `full` build uses the current `dev` HEAD (`github.sha`). If `dev` moves between the macOS submits and the Windows build, the targets disagree and the auto-publisher (Step 4) refuses to publish — by design. Freeze `dev` for the duration of the release, or confirm the Windows build's commit matches the macOS `source_sha` before expecting auto-publish to fire.
+> **All three final targets must be the same build commit.** mac finalize rebuilds from the commit pinned by its submit snapshot tag (`source_sha`), while the Windows `full` build uses the current `main` HEAD (`github.sha`). If `main` moves between the macOS submits and the Windows build, the targets disagree and the auto-publisher (Step 4) refuses to publish — by design. Freeze `main` for the duration of the release, or confirm the Windows build's commit matches the macOS `source_sha` before expecting auto-publish to fire.
 
 ## 4. Publish
 
@@ -138,7 +138,7 @@ On the normal path the auto-publisher (Step 4) dispatches `.github/workflows/mir
 ```bash
 gh run list --workflow mirror-release-to-r2.yml --repo Astro-Han/pawwork --limit 3
 # If no run was triggered for this tag, dispatch it manually:
-gh workflow run mirror-release-to-r2.yml --repo Astro-Han/pawwork --ref dev -f tag=vX.Y.Z
+gh workflow run mirror-release-to-r2.yml --repo Astro-Han/pawwork --ref main -f tag=vX.Y.Z
 ```
 
 Then confirm the landing page points at the new version on R2:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -65,4 +65,4 @@ Required for visible UI changes.
 - [ ] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
 - [ ] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
 - [ ] I reviewed the final diff for unrelated changes and suspicious dependency changes.
-- [ ] I am targeting `dev`, and my PR title and commit messages use Conventional Commits in English.
+- [ ] I am targeting `main`, and my PR title and commit messages use Conventional Commits in English.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,24 @@ jobs:
       target: ${{ steps.select.outputs.target }}
       arch: ${{ steps.select.outputs.arch }}
     steps:
+      - name: Validate release source branch
+        run: |
+          set -euo pipefail
+
+          if [ "$PHASE" = "finalize" ]; then
+            if [ "$SOURCE_REF" != "$EXPECTED_SOURCE_REF" ]; then
+              echo "Finalize source must be $EXPECTED_SOURCE_REF, got ${SOURCE_REF:-<empty>}"
+              exit 1
+            fi
+          elif [ "$GITHUB_REF" != "refs/heads/$EXPECTED_SOURCE_REF" ]; then
+            echo "Releases must start from $EXPECTED_SOURCE_REF, got $GITHUB_REF"
+            exit 1
+          fi
+        env:
+          EXPECTED_SOURCE_REF: main
+          PHASE: ${{ inputs.phase || 'submit' }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+
       - id: select
         run: |
           set -euo pipefail
@@ -857,7 +875,7 @@ jobs:
           # Identify this target so it can upload its own provenance marker.
           RELEASE_OS: ${{ runner.os == 'macOS' && 'mac' || 'win' }}
           RELEASE_ARCH: ${{ matrix.arch_label }}
-          MIRROR_REF: dev
+          MIRROR_REF: main
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ runner.os == 'macOS' && (inputs.phase == 'finalize' || inputs.phase == 'full') && inputs.arch == matrix.arch_label }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: ci
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
   pull_request:
-    branches: [dev]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: codeql
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
   pull_request:
-    branches: [dev]
+    branches: [main]
   schedule:
     - cron: "0 2 * * 1"
 
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: codeql-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   analyze-js-ts:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: dependency-review
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [main]
 
 concurrency:
   group: dependency-review-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -2,7 +2,7 @@ name: deploy-site
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
     paths:
       - "site/**"
 
@@ -41,13 +41,13 @@ jobs:
 
       - run: pnpm --filter @pawwork/site build
 
-      # Deploy only when on dev (push to dev or manual dispatch from dev). PRs and
+      # Deploy only when on main (push to main or manual dispatch from main). PRs and
       # manual runs from other branches stop after the build-check steps above, so
-      # the fixed --branch=dev below can never publish non-dev content.
+      # the fixed --branch=main below can never publish non-main content.
       - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        if: github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/main'
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: "3.90.0"
-          command: pages deploy site/dist --project-name=pawwork --branch=dev
+          command: pages deploy site/dist --project-name=pawwork --branch=main

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,14 +1,14 @@
 # Advisory check: lint PR titles against Conventional Commits. Catches
 # drift early so PR titles read consistently in listings and serve as a
 # well-formed subject when a PR is squash-merged. Not required in the
-# `dev` ruleset -- failures flag the PR but do not block merge. Draft
+# `main` ruleset -- failures flag the PR but do not block merge. Draft
 # PRs with `WIP:` prefix are skipped. (#68)
 name: pr-title-lint
 
 on:
   pull_request_target:
     types: [opened, edited, reopened, ready_for_review]
-    branches: [dev]
+    branches: [main]
 
 concurrency:
   group: pr-title-lint-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -3,7 +3,7 @@ name: pr-triage
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches: [dev]
+    branches: [main]
 
 concurrency:
   group: pr-triage-${{ github.event.pull_request.number }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ pnpm dev:desktop
 
 ## Branches and Commits
 
-- Open pull requests against `dev`
+- Open pull requests against `main`
 - Use small, reversible commits
 - Use Conventional Commits in English, such as `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -375,7 +375,7 @@ async function main() {
   const buildSha = requireEnv("BUILD_SHA")
   const os = requireEnv("RELEASE_OS")
   const arch = requireEnv("RELEASE_ARCH")
-  const mirrorRef = process.env.MIRROR_REF ?? "dev"
+  const mirrorRef = requireEnv("MIRROR_REF")
 
   const version = tag.replace(/^v/, "")
   const expectedProvenance = releaseProvenanceAssetNames(version)

--- a/packages/desktop-electron/scripts/release-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-workflow-contract.test.ts
@@ -22,6 +22,15 @@ function indexOfStep(name: string) {
 }
 
 describe("release workflow", () => {
+  test("accepts releases only from the main product branch", () => {
+    const validate = steps[indexOfStep("Validate release source branch")]
+
+    expect(validate).toBeDefined()
+    expect(validate.body).toMatch(/EXPECTED_SOURCE_REF: main/)
+    expect(validate.body).toMatch(/refs\/heads\/\$EXPECTED_SOURCE_REF/)
+    expect(validate.body).toMatch(/SOURCE_REF.*EXPECTED_SOURCE_REF/)
+  })
+
   test("bundles uv before anything packages the app", () => {
     const packaging = stepsRunning(/electron-builder .*(--mac|\$\{\{ matrix\.platform_flag \}\})/)
     // submit packs the signed directory, finalize repacks it into dmg/zip, and

--- a/packages/desktop-electron/scripts/release-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-workflow-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest"
+import { spawnSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 
@@ -7,6 +8,7 @@ import { join } from "node:path"
 // ordered correctly. These read the workflow as steps rather than as text, so a
 // reformat inside a step does not fail them and a deleted step does.
 const workflow = readFileSync(join(import.meta.dirname, "..", "..", "..", ".github", "workflows", "build.yml"), "utf8")
+const publisher = readFileSync(join(import.meta.dirname, "publish-when-complete.ts"), "utf8")
 
 const steps = workflow
   .split(/\n {6}- name: /)
@@ -21,14 +23,38 @@ function indexOfStep(name: string) {
   return steps.findIndex((step) => step.name === name)
 }
 
-describe("release workflow", () => {
-  test("accepts releases only from the main product branch", () => {
-    const validate = steps[indexOfStep("Validate release source branch")]
+function runSourceValidation(phase: string, githubRef: string, sourceRef = "") {
+  const match = workflow.match(
+    /- name: Validate release source branch\n\s+run: \|\n(?<script>(?: {10}.*\n|\n)+?)\s+env:/,
+  )
+  if (!match?.groups?.script) throw new Error("release source validation step is missing")
 
-    expect(validate).toBeDefined()
-    expect(validate.body).toMatch(/EXPECTED_SOURCE_REF: main/)
-    expect(validate.body).toMatch(/refs\/heads\/\$EXPECTED_SOURCE_REF/)
-    expect(validate.body).toMatch(/SOURCE_REF.*EXPECTED_SOURCE_REF/)
+  return spawnSync("bash", ["-c", match.groups.script.replace(/^ {10}/gm, "")], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      EXPECTED_SOURCE_REF: "main",
+      GITHUB_REF: githubRef,
+      PHASE: phase,
+      SOURCE_REF: sourceRef,
+    },
+  })
+}
+
+describe("release workflow", () => {
+  test("accepts main branch submit and finalize sources", () => {
+    expect(runSourceValidation("submit", "refs/heads/main").status).toBe(0)
+    expect(runSourceValidation("finalize", "refs/tags/workflow-snapshot-1", "main").status).toBe(0)
+  })
+
+  test("rejects release sources outside main", () => {
+    expect(runSourceValidation("submit", "refs/heads/dev").status).toBe(1)
+    expect(runSourceValidation("finalize", "refs/tags/workflow-snapshot-1", "dev").status).toBe(1)
+  })
+
+  test("requires the workflow to name the mirror branch explicitly", () => {
+    expect(publisher).toContain('const mirrorRef = requireEnv("MIRROR_REF")')
+    expect(publisher).not.toMatch(/MIRROR_REF.*\?\?/)
   })
 
   test("bundles uv before anything packages the app", () => {

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -10,8 +10,8 @@ Last updated: 2026-08-20
 - [Source code](https://github.com/Astro-Han/pawwork): GitHub repository (Apache-2.0).
 - [Download](https://github.com/Astro-Han/pawwork/releases/latest): Latest macOS and Windows builds.
 - [English README](https://github.com/Astro-Han/pawwork#readme): Full feature overview and FAQ.
-- [Chinese README](https://github.com/Astro-Han/pawwork/blob/dev/README_CN.md): 中文说明.
-- [License](https://github.com/Astro-Han/pawwork/blob/dev/LICENSE): Apache-2.0.
+- [Chinese README](https://github.com/Astro-Han/pawwork/blob/main/README_CN.md): 中文说明.
+- [License](https://github.com/Astro-Han/pawwork/blob/main/LICENSE): Apache-2.0.
 
 ## About
 

--- a/site/src/components/Home.astro
+++ b/site/src/components/Home.astro
@@ -14,8 +14,8 @@ interface Props {
 const { lang } = Astro.props;
 const t = I18N[lang];
 const otherHref = lang === "cn" ? "/" : "/zh-CN/";
-const README_URL = lang === "cn" ? `${REPO_URL}/blob/dev/README_CN.md` : `${REPO_URL}#readme`;
-const LICENSE_URL = `${REPO_URL}/blob/dev/LICENSE`;
+const README_URL = lang === "cn" ? `${REPO_URL}/blob/main/README_CN.md` : `${REPO_URL}#readme`;
+const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
 ---
 
 <svg width="0" height="0" style="position:absolute"

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -62,7 +62,7 @@ const cnUrl = new URL("/zh-CN/", Astro.site).href;
       "description": description,
       "url": "https://pawwork.ai",
       "downloadUrl": "https://github.com/Astro-Han/pawwork/releases/latest",
-      "license": "https://github.com/Astro-Han/pawwork/blob/dev/LICENSE",
+      "license": "https://github.com/Astro-Han/pawwork/blob/main/LICENSE",
       "author": { "@type": "Organization", "name": "Astro-Han", "url": "https://github.com/Astro-Han" },
       "sameAs": ["https://github.com/Astro-Han/pawwork"],
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },


### PR DESCRIPTION
## Summary

- prepare the current V2 product line for the `dev` to `main` branch rename
- retarget CI, CodeQL, dependency review, PR automation, site deployment, and contributor links to `main`
- reject release runs that do not originate from `main`, while preserving the `latest-v2` updater feed

## Why

`dev` currently names both the default Git branch and a local build channel. Making the product line `main` removes that ambiguity without changing product or updater channels.

## Verification

- `actionlint -shellcheck=`
- `pnpm run lint`
- `pnpm --filter @pawwork/desktop test` (295 Vitest tests and 85 Node tests)
- release workflow contract test observed RED before the source-branch guard and GREEN after it

## Risk

This PR intentionally points repository contracts at the future branch name and must be followed immediately by the GitHub branch rename. Existing updater feeds and release artifact names are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Standardized development, pull request, CI, release, and deployment workflows on the `main` branch.
  * Added validation to ensure releases use the correct source branch and matching commit across build targets.
  * Updated release checklists and contribution guidance.

* **Documentation**
  * Updated website links, README references, and license metadata to use the `main` branch.

* **Tests**
  * Added coverage confirming releases are accepted only from the approved branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->