### PR TITLE
fix(ci): deploy site with locked Wrangler

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -6,8 +6,6 @@ on:
     paths:
       - ".github/workflows/deploy-site.yml"
       - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
       - "site/**"
 
   # Build-check the site on PRs that touch it; deploy step is skipped (see below)
@@ -15,8 +13,6 @@ on:
     paths:
       - ".github/workflows/deploy-site.yml"
       - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
       - "site/**"
 
   # Allow manual trigger for first deploy or re-deploy without code change
@@ -57,5 +53,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "4.124.0"
           command: pages deploy site/dist --project-name=pawwork --branch=main

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -5,14 +5,12 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/deploy-site.yml"
-      - "package.json"
       - "site/**"
 
   # Build-check the site on PRs that touch it; deploy step is skipped (see below)
   pull_request:
     paths:
       - ".github/workflows/deploy-site.yml"
-      - "package.json"
       - "site/**"
 
   # Allow manual trigger for first deploy or re-deploy without code change
@@ -48,9 +46,9 @@ jobs:
       # Deploy only when on main (push to main or manual dispatch from main). PRs and
       # manual runs from other branches stop after the build-check steps above, so
       # the fixed --branch=main below can never publish non-main content.
-      - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+      - name: Deploy site
         if: github.ref == 'refs/heads/main'
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy site/dist --project-name=pawwork --branch=main
+        run: pnpm exec wrangler pages deploy site/dist --project-name=pawwork --branch=main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/workflows/deploy-site.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - "site/**"
 
   # Build-check the site on PRs that touch it; deploy step is skipped (see below)
   pull_request:
     paths:
+      - ".github/workflows/deploy-site.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - "site/**"
 
   # Allow manual trigger for first deploy or re-deploy without code change
@@ -49,5 +57,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: "3.90.0"
+          wranglerVersion: "4.124.0"
           command: pages deploy site/dist --project-name=pawwork --branch=main

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/deploy-site.yml"
+      - "package.json"
       - "site/**"
 
   # Build-check the site on PRs that touch it; deploy step is skipped (see below)
   pull_request:
     paths:
       - ".github/workflows/deploy-site.yml"
+      - "package.json"
       - "site/**"
 
   # Allow manual trigger for first deploy or re-deploy without code change

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "eslint": "^9.39.4",
-    "typescript-eslint": "8.59.3"
+    "typescript-eslint": "8.59.3",
+    "wrangler": "4.124.0"
   },
   "repository": {
     "type": "git",

--- a/packages/desktop-electron/scripts/site-deploy-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/site-deploy-workflow-contract.test.ts
@@ -23,24 +23,21 @@ const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
 }
 
 describe("site deploy workflow", () => {
-  test("preinstalls the requested Wrangler version before the deploy action", () => {
+  test("uses the workspace's preinstalled Wrangler before the deploy action", () => {
     const steps = workflow.jobs["build-and-deploy"].steps
     const install = steps.findIndex((step) => step.run === "pnpm install --frozen-lockfile")
     const deploy = steps.findIndex((step) => step.uses?.startsWith("cloudflare/wrangler-action@"))
-    const wranglerVersion = steps[deploy]?.with?.wranglerVersion
 
     expect(install).toBeGreaterThanOrEqual(0)
     expect(deploy).toBeGreaterThan(install)
-    expect(wranglerVersion).toMatch(/^\d+\.\d+\.\d+$/)
-    expect(packageJson.devDependencies?.wrangler).toBe(wranglerVersion)
+    expect(packageJson.devDependencies?.wrangler).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(steps[deploy]?.with?.wranglerVersion).toBeUndefined()
   })
 
   test("build-checks every file that controls the site deployment", () => {
     const deploymentInputs = [
       ".github/workflows/deploy-site.yml",
       "package.json",
-      "pnpm-lock.yaml",
-      "pnpm-workspace.yaml",
       "site/**",
     ]
 

--- a/packages/desktop-electron/scripts/site-deploy-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/site-deploy-workflow-contract.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { JSON_SCHEMA, load } from "js-yaml"
+import { describe, expect, test } from "vitest"
+
+const root = join(import.meta.dirname, "..", "..", "..")
+const workflow = load(
+  readFileSync(join(root, ".github", "workflows", "deploy-site.yml"), "utf8"),
+  { schema: JSON_SCHEMA },
+) as {
+  on: {
+    push: { paths: string[] }
+    pull_request: { paths: string[] }
+  }
+  jobs: {
+    "build-and-deploy": {
+      steps: Array<{ run?: string; uses?: string; with?: { wranglerVersion?: string } }>
+    }
+  }
+}
+const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+  devDependencies?: Record<string, string>
+}
+
+describe("site deploy workflow", () => {
+  test("preinstalls the requested Wrangler version before the deploy action", () => {
+    const steps = workflow.jobs["build-and-deploy"].steps
+    const install = steps.findIndex((step) => step.run === "pnpm install --frozen-lockfile")
+    const deploy = steps.findIndex((step) => step.uses?.startsWith("cloudflare/wrangler-action@"))
+    const wranglerVersion = steps[deploy]?.with?.wranglerVersion
+
+    expect(install).toBeGreaterThanOrEqual(0)
+    expect(deploy).toBeGreaterThan(install)
+    expect(wranglerVersion).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(packageJson.devDependencies?.wrangler).toBe(wranglerVersion)
+  })
+
+  test("build-checks every file that controls the site deployment", () => {
+    const deploymentInputs = [
+      ".github/workflows/deploy-site.yml",
+      "package.json",
+      "pnpm-lock.yaml",
+      "pnpm-workspace.yaml",
+      "site/**",
+    ]
+
+    expect(workflow.on.push.paths).toEqual(deploymentInputs)
+    expect(workflow.on.pull_request.paths).toEqual(deploymentInputs)
+  })
+})

--- a/packages/desktop-electron/scripts/site-deploy-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/site-deploy-workflow-contract.test.ts
@@ -7,6 +7,10 @@ const root = join(import.meta.dirname, "..", "..", "..")
 const workflow = load(
   readFileSync(join(root, ".github", "workflows", "deploy-site.yml"), "utf8"),
 ) as {
+  on: {
+    push: { paths: string[] }
+    pull_request: { paths: string[] }
+  }
   jobs: {
     "build-and-deploy": {
       steps: Array<{ run?: string; uses?: string; if?: string; env?: Record<string, string> }>
@@ -36,5 +40,7 @@ describe("site deploy workflow", () => {
       },
     })
     expect(steps.some((step) => step.uses?.startsWith("cloudflare/wrangler-action@"))).toBe(false)
+    expect(workflow.on.push.paths).toContain("package.json")
+    expect(workflow.on.pull_request.paths).toContain("package.json")
   })
 })

--- a/packages/desktop-electron/scripts/site-deploy-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/site-deploy-workflow-contract.test.ts
@@ -1,20 +1,15 @@
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
-import { JSON_SCHEMA, load } from "js-yaml"
+import { load } from "js-yaml"
 import { describe, expect, test } from "vitest"
 
 const root = join(import.meta.dirname, "..", "..", "..")
 const workflow = load(
   readFileSync(join(root, ".github", "workflows", "deploy-site.yml"), "utf8"),
-  { schema: JSON_SCHEMA },
 ) as {
-  on: {
-    push: { paths: string[] }
-    pull_request: { paths: string[] }
-  }
   jobs: {
     "build-and-deploy": {
-      steps: Array<{ run?: string; uses?: string; with?: { wranglerVersion?: string } }>
+      steps: Array<{ run?: string; uses?: string; if?: string; env?: Record<string, string> }>
     }
   }
 }
@@ -23,25 +18,23 @@ const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
 }
 
 describe("site deploy workflow", () => {
-  test("uses the workspace's preinstalled Wrangler before the deploy action", () => {
+  test("deploys with the locked workspace Wrangler only from main", () => {
     const steps = workflow.jobs["build-and-deploy"].steps
     const install = steps.findIndex((step) => step.run === "pnpm install --frozen-lockfile")
-    const deploy = steps.findIndex((step) => step.uses?.startsWith("cloudflare/wrangler-action@"))
+    const deploy = steps.findIndex(
+      (step) => step.run === "pnpm exec wrangler pages deploy site/dist --project-name=pawwork --branch=main",
+    )
 
     expect(install).toBeGreaterThanOrEqual(0)
     expect(deploy).toBeGreaterThan(install)
     expect(packageJson.devDependencies?.wrangler).toMatch(/^\d+\.\d+\.\d+$/)
-    expect(steps[deploy]?.with?.wranglerVersion).toBeUndefined()
-  })
-
-  test("build-checks every file that controls the site deployment", () => {
-    const deploymentInputs = [
-      ".github/workflows/deploy-site.yml",
-      "package.json",
-      "site/**",
-    ]
-
-    expect(workflow.on.push.paths).toEqual(deploymentInputs)
-    expect(workflow.on.pull_request.paths).toEqual(deploymentInputs)
+    expect(steps[deploy]).toMatchObject({
+      if: "github.ref == 'refs/heads/main'",
+      env: {
+        CLOUDFLARE_API_TOKEN: "${{ secrets.CLOUDFLARE_API_TOKEN }}",
+        CLOUDFLARE_ACCOUNT_ID: "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}",
+      },
+    })
+    expect(steps.some((step) => step.uses?.startsWith("cloudflare/wrangler-action@"))).toBe(false)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       typescript-eslint:
         specifier: 8.59.3
         version: 8.59.3(eslint@9.39.5(jiti@2.7.0))(typescript@5.6.3)
+      wrangler:
+        specifier: 4.124.0
+        version: 4.124.0
 
   packages/desktop-electron:
     dependencies:
@@ -408,6 +411,53 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260815.1':
+    resolution: {integrity: sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260815.1':
+    resolution: {integrity: sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260815.1':
+    resolution: {integrity: sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260815.1':
+    resolution: {integrity: sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260815.1':
+    resolution: {integrity: sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@deepseek-ai/cordis-plugin-group@1.0.1':
     resolution: {integrity: sha512-E1NThkFB3jn3TCqa6Oc++1zQHqLejF3W2wDwv2BlL3UEmgtBXL1K1j1koc+j676RuiOXtJkUJlPcOntRGKLWBQ==}
@@ -2861,6 +2911,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@koromix/koffi-darwin-arm64@3.1.5':
     resolution: {integrity: sha512-IpqITl2fJi3QN9bTtNnygWPdK7ScSjw3xtGu8e6feYGvimCysu+spgI5KyeslY2jTnqxGS9xr8pLAbLhGJ8edA==}
     cpu: [arm64]
@@ -3073,6 +3126,15 @@ packages:
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
 
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -3282,6 +3344,10 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@smithy/core@3.33.2':
     resolution: {integrity: sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==}
     engines: {node: '>=18.0.0'}
@@ -3321,6 +3387,9 @@ packages:
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@speed-highlight/core@1.2.24':
+    resolution: {integrity: sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3756,6 +3825,9 @@ packages:
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
@@ -4229,6 +4301,9 @@ packages:
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -4294,6 +4369,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5081,6 +5157,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  miniflare@5.20260815.0-alpha:
+    resolution: {integrity: sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==}
+    engines: {node: '>=22.0.0'}
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
@@ -5369,6 +5449,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -5822,6 +5905,10 @@ packages:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5972,6 +6059,9 @@ packages:
   undici@8.10.0:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -6349,6 +6439,21 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260815.1:
+    resolution: {integrity: sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.124.0:
+    resolution: {integrity: sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260815.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -6434,6 +6539,12 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -6896,6 +7007,33 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260815.1
+
+  '@cloudflare/workerd-darwin-64@1.20260815.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260815.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260815.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260815.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260815.1':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@deepseek-ai/cordis-plugin-group@1.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)':
     dependencies:
@@ -9674,6 +9812,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@koromix/koffi-darwin-arm64@3.1.5':
     optional: true
 
@@ -9877,6 +10020,18 @@ snapshots:
       tslib: 2.8.1
       webcrypto-core: 1.9.2
 
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -10022,6 +10177,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@smithy/core@3.33.2':
     dependencies:
       '@smithy/types': 4.17.2
@@ -10074,6 +10231,8 @@ snapshots:
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
+
+  '@speed-highlight/core@1.2.24': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -10652,6 +10811,8 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  blake3-wasm@2.1.5: {}
+
   bluebird@3.7.2: {}
 
   body-parser@2.3.0:
@@ -11150,6 +11311,8 @@ snapshots:
   env-paths@3.0.0: {}
 
   err-code@2.0.3: {}
+
+  error-stack-parser-es@1.0.5: {}
 
   es-define-property@1.0.1: {}
 
@@ -12307,6 +12470,19 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  miniflare@5.20260815.0-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.3(@types/node@24.13.3)
+      undici: 7.29.0
+      workerd: 1.20260815.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9(patch_hash=ef72a243d0bee0990f9a97f527cdcbbb43bc8677f6337ac800e6d1df6ecb5a8b)
@@ -12571,6 +12747,8 @@ snapshots:
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
 
@@ -13138,6 +13316,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -13271,10 +13451,13 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.29.0:
-    optional: true
+  undici@7.29.0: {}
 
   undici@8.10.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unified@11.0.5:
     dependencies:
@@ -13585,6 +13768,31 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260815.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260815.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260815.1
+      '@cloudflare/workerd-linux-64': 1.20260815.1
+      '@cloudflare/workerd-linux-arm64': 1.20260815.1
+      '@cloudflare/workerd-windows-64': 1.20260815.1
+
+  wrangler@4.124.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260815.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260815.0-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260815.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -13663,6 +13871,19 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.24
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ allowBuilds:
   node-pty: true
   protobufjs: false
   sharp: true
+  workerd: false
 
 minimumReleaseAgeExclude:
   - '@deepseek-ai/*'


### PR DESCRIPTION
## Summary

- lock the audited Wrangler CLI at the pnpm workspace root and run it directly after the existing frozen install
- remove `cloudflare/wrangler-action`, including its package-manager detection and runtime installation fallback
- upgrade the deploy CLI from vulnerable `3.90.0` to audited `4.124.0` and explicitly disable the unused `workerd` install script under the existing pnpm supply-chain policy
- add one focused workflow contract test and make workflow changes trigger the site build check

## Root cause

[Run 32459239085](https://github.com/Astro-Han/pawwork/actions/runs/32459239085) failed because `wrangler-action` inferred pnpm from the root lockfile, could not find Wrangler, then ran `pnpm add wrangler@3.90.0` at the workspace root. pnpm correctly rejected that undeclared root mutation with `ERR_PNPM_ADDING_TO_ROOT`.

The workflow now executes the exact lockfile-installed CLI with `pnpm exec wrangler pages deploy`. A missing dependency fails closed instead of falling back to a runtime install.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec wrangler --version` (`4.124.0`)
- `pnpm --filter @pawwork/site check`
- `pnpm --filter @pawwork/site build`
- `pnpm run test` (393 tests)
- `pnpm run typecheck`
- `pnpm run lint:ci`
- `actionlint .github/workflows/deploy-site.yml`
- `pnpm audit --audit-level high` (passes; 1 low and 2 moderate remain)

The PR workflow intentionally stops after the build check. Production deployment remains protected to `main` and will be verified from the post-merge run.