### PR TITLE
feat(desktop): keep DSH data in a home dotdir

### DIFF
--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -8,7 +8,6 @@ import {
   allocateCiSmokeCdpPort,
   appIdForSmoke,
   dshHomeForSmoke,
-  legacyDshHomeForSmoke,
   assertCiSmokeProduct,
   buildSmokeEnv,
   isCiSmokeDshTarget,
@@ -55,18 +54,9 @@ describe("ci smoke helpers", () => {
     expect(appIdForSmoke("prod", "packaged")).toBe("ai.pawwork.desktop")
   })
 
-  test("dshHomeForSmoke points at the dotdir home inside the smoke home", () => {
+  test("dshHomeForSmoke hangs the DSH home off the smoke home, not off its app data directory", () => {
     expect(dshHomeForSmoke("/tmp/smoke", { mode: "raw", channel: "prod" })).toBe(
       path.join("/tmp/smoke", ".pawwork", "dsh-dev"),
-    )
-    expect(
-      dshHomeForSmoke("/tmp/smoke", { mode: "packaged", channel: "prod", executablePath: "/app" }),
-    ).toBe(path.join("/tmp/smoke", ".pawwork", "dsh"))
-  })
-
-  test("legacyDshHomeForSmoke points at the pre-dotdir location the app migrates from", () => {
-    expect(legacyDshHomeForSmoke("/tmp/smoke", { mode: "raw", channel: "prod" })).toBe(
-      path.join("/tmp/smoke", "ai.pawwork.desktop.dev", "dsh"),
     )
   })
 

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -7,6 +7,7 @@ import process from "node:process"
 import {
   allocateCiSmokeCdpPort,
   appIdForSmoke,
+  dshHomeForSmoke,
   assertCiSmokeProduct,
   buildSmokeEnv,
   isCiSmokeDshTarget,
@@ -51,6 +52,15 @@ describe("ci smoke helpers", () => {
     expect(appIdForSmoke("prod", "raw")).toBe("ai.pawwork.desktop.dev")
     expect(appIdForSmoke("dev", "packaged")).toBe("ai.pawwork.desktop.dev")
     expect(appIdForSmoke("prod", "packaged")).toBe("ai.pawwork.desktop")
+  })
+
+  test("dshHomeForSmoke points at the dotdir home inside the smoke home", () => {
+    expect(dshHomeForSmoke("/tmp/smoke", { mode: "raw", channel: "prod" })).toBe(
+      path.join("/tmp/smoke", ".pawwork", "dsh-dev"),
+    )
+    expect(
+      dshHomeForSmoke("/tmp/smoke", { mode: "packaged", channel: "prod", executablePath: "/app" }),
+    ).toBe(path.join("/tmp/smoke", ".pawwork", "dsh"))
   })
 
   test("resolveCiSmokeReadyFile follows packaged channel app IDs", () => {

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -8,6 +8,7 @@ import {
   allocateCiSmokeCdpPort,
   appIdForSmoke,
   dshHomeForSmoke,
+  legacyDshHomeForSmoke,
   assertCiSmokeProduct,
   buildSmokeEnv,
   isCiSmokeDshTarget,
@@ -61,6 +62,12 @@ describe("ci smoke helpers", () => {
     expect(
       dshHomeForSmoke("/tmp/smoke", { mode: "packaged", channel: "prod", executablePath: "/app" }),
     ).toBe(path.join("/tmp/smoke", ".pawwork", "dsh"))
+  })
+
+  test("legacyDshHomeForSmoke points at the pre-dotdir location the app migrates from", () => {
+    expect(legacyDshHomeForSmoke("/tmp/smoke", { mode: "raw", channel: "prod" })).toBe(
+      path.join("/tmp/smoke", "ai.pawwork.desktop.dev", "dsh"),
+    )
   })
 
   test("resolveCiSmokeReadyFile follows packaged channel app IDs", () => {

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -119,6 +119,16 @@ export function dshHomeForSmoke(homeDir: string, target: SmokeTarget) {
   return resolveDshHome({ channel: channelForSmoke(target.channel, target.mode), homeRoot: homeDir })
 }
 
+// Seeded into the legacy home and asserted in the new one, so it is only ever
+// present because the one-time migration ran.
+export const CI_SMOKE_MIGRATED_AUTOMATION_ID = "automation-smoke"
+
+// Where the app kept DSH before the dotdir. The smoke run seeds here so every
+// pass exercises the one-time migration on its way to dshHomeForSmoke.
+export function legacyDshHomeForSmoke(homeDir: string, target: SmokeTarget) {
+  return join(homeDir, appIdForSmoke(target.channel, target.mode), "dsh")
+}
+
 export function parseSmokeArgs(argv: string[]): SmokeTarget {
   const mode = argv[0] as SmokeMode | undefined
   if (mode === undefined || mode === "raw") {
@@ -774,15 +784,19 @@ async function main() {
   const target = parseSmokeArgs(process.argv.slice(2))
   const homeDir = mkdtempSync(join(tmpdir(), "pawwork-ci-smoke-"))
   const dshHome = dshHomeForSmoke(homeDir, target)
+  // Seeded in the legacy home, asserted in the new one: the automation below has
+  // to survive the migration to reach the assertions after the restart, so a
+  // migration that stopped running would fail the smoke rather than pass quietly.
+  const legacyDshHome = legacyDshHomeForSmoke(homeDir, target)
   const v1Database = join(homeDir, "v1", "pawwork.db")
   createCiSmokeV1Fixture(v1Database, homeDir)
-  mkdirSync(dshHome, { recursive: true })
-  writeFileSync(join(dshHome, "automations.json"), `${JSON.stringify({
+  mkdirSync(legacyDshHome, { recursive: true })
+  writeFileSync(join(legacyDshHome, "automations.json"), `${JSON.stringify({
     schema: 1,
     nextDefinition: 2,
     nextRun: 1,
     definitions: [{
-      id: "automation-smoke",
+      id: CI_SMOKE_MIGRATED_AUTOMATION_ID,
       title: "AutomationTitleWithoutBreaksAutomationTitleWithoutBreaksAutomationTitleWithoutBreaksAutomationTitleWithoutBreaks",
       prompt: "Verify the Automation editor.",
       revision: 1,
@@ -848,6 +862,11 @@ async function main() {
     }
     if (!automationDocument.definitions?.some((definition) => definition.id === CI_SMOKE_IMPORTED_AUTOMATION_ID)) {
       throw new Error(`V1 Automation ${CI_SMOKE_IMPORTED_AUTOMATION_ID} did not survive desktop restart`)
+    }
+    // Seeded in the legacy home, read back from the dotdir home: the only way
+    // it got here is the migration, so dropping the migration fails the smoke.
+    if (!automationDocument.definitions?.some((definition) => definition.id === CI_SMOKE_MIGRATED_AUTOMATION_ID)) {
+      throw new Error(`Automation ${CI_SMOKE_MIGRATED_AUTOMATION_ID} seeded in ${legacyDshHome} did not reach ${dshHome}`)
     }
     console.log("CI smoke verified V1 session and Automation migration after restart")
   }

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -10,6 +10,7 @@ import process from "node:process"
 import readline from "node:readline"
 import { PAWWORK_APP, type PawWorkChannel, isPawWorkChannel } from "../src/main/app-identity.ts"
 import { parseCdpPort } from "../src/main/ci-smoke-cdp.ts"
+import { resolveDshHome } from "../src/main/pawwork-home.ts"
 import { dshTitleBarOptions } from "../src/main/window-options.ts"
 import { packagedAppEnv } from "./packaged-app-env.ts"
 import {
@@ -103,8 +104,19 @@ function parseChannel(raw: string | undefined): PawWorkChannel {
   return raw
 }
 
+// A raw run is an unpackaged app, and index.ts pins those to dev the same way.
+export function channelForSmoke(channel: PawWorkChannel, mode: SmokeMode): PawWorkChannel {
+  return mode === "raw" ? "dev" : channel
+}
+
 export function appIdForSmoke(channel: PawWorkChannel, mode: SmokeMode) {
-  return PAWWORK_APP[mode === "raw" ? "dev" : channel].id
+  return PAWWORK_APP[channelForSmoke(channel, mode)].id
+}
+
+// PAWWORK_CI_SMOKE_HOME, not HOME: buildSmokeEnv cannot redirect os.homedir()
+// on Windows, where it reads USERPROFILE.
+export function dshHomeForSmoke(homeDir: string, target: SmokeTarget) {
+  return resolveDshHome({ channel: channelForSmoke(target.channel, target.mode), homeRoot: homeDir })
 }
 
 export function parseSmokeArgs(argv: string[]): SmokeTarget {
@@ -761,7 +773,7 @@ async function stopChild(child: SmokeChild, closeWindow?: () => Promise<void>) {
 async function main() {
   const target = parseSmokeArgs(process.argv.slice(2))
   const homeDir = mkdtempSync(join(tmpdir(), "pawwork-ci-smoke-"))
-  const dshHome = join(homeDir, appIdForSmoke(target.channel, target.mode), "dsh")
+  const dshHome = dshHomeForSmoke(homeDir, target)
   const v1Database = join(homeDir, "v1", "pawwork.db")
   createCiSmokeV1Fixture(v1Database, homeDir)
   mkdirSync(dshHome, { recursive: true })

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -105,7 +105,7 @@ function parseChannel(raw: string | undefined): PawWorkChannel {
 }
 
 // A raw run is an unpackaged app, and index.ts pins those to dev the same way.
-export function channelForSmoke(channel: PawWorkChannel, mode: SmokeMode): PawWorkChannel {
+function channelForSmoke(channel: PawWorkChannel, mode: SmokeMode): PawWorkChannel {
   return mode === "raw" ? "dev" : channel
 }
 
@@ -122,12 +122,6 @@ export function dshHomeForSmoke(homeDir: string, target: SmokeTarget) {
 // Seeded into the legacy home and asserted in the new one, so it is only ever
 // present because the one-time migration ran.
 export const CI_SMOKE_MIGRATED_AUTOMATION_ID = "automation-smoke"
-
-// Where the app kept DSH before the dotdir. The smoke run seeds here so every
-// pass exercises the one-time migration on its way to dshHomeForSmoke.
-export function legacyDshHomeForSmoke(homeDir: string, target: SmokeTarget) {
-  return join(homeDir, appIdForSmoke(target.channel, target.mode), "dsh")
-}
 
 export function parseSmokeArgs(argv: string[]): SmokeTarget {
   const mode = argv[0] as SmokeMode | undefined
@@ -787,7 +781,7 @@ async function main() {
   // Seeded in the legacy home, asserted in the new one: the automation below has
   // to survive the migration to reach the assertions after the restart, so a
   // migration that stopped running would fail the smoke rather than pass quietly.
-  const legacyDshHome = legacyDshHomeForSmoke(homeDir, target)
+  const legacyDshHome = join(homeDir, appIdForSmoke(target.channel, target.mode), "dsh")
   const v1Database = join(homeDir, "v1", "pawwork.db")
   createCiSmokeV1Fixture(v1Database, homeDir)
   mkdirSync(legacyDshHome, { recursive: true })

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -28,7 +28,7 @@ import {
   resolveProductResources,
 } from "./dsh-product-home"
 import { launchDshSidecar, type DshSidecar } from "./dsh-sidecar"
-import { migrateDshHome, resolveDshHome, resolvePawWorkHomeRoot } from "./pawwork-home"
+import { migrateDshHome, resolveDshHome } from "./pawwork-home"
 import { initLogging } from "./logging"
 import { detectSystemMenuLocale } from "./menu-labels"
 import { createUpdateFeed, githubFeed, r2Feed, type FeedTarget } from "./update-feed"
@@ -209,16 +209,19 @@ async function startDsh() {
     isPackaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
   })
-  // Runs before the overlay is prepared: prepareDshProductHome would create and
-  // populate the dotdir home, and the migration would then read it as a home a
-  // newer build had already written and leave the real data behind in userData.
-  const migration = migrateDshHome({
-    home: resolveDshHome({ channel: appChannel, homeRoot: resolvePawWorkHomeRoot() }),
-    legacyHome: join(app.getPath("userData"), "dsh"),
-    onEvent: (message, detail) => logger.log(message, detail),
-  })
+  // The migration is the argument rather than a preceding statement, so it
+  // cannot be reordered: prepareDshProductHome creates and populates whatever
+  // home it is handed, and a migration running after it would read that overlay
+  // as a home a newer build had written and leave the real data in userData.
   const product = prepareDshProductHome({
-    productHome: migration.home,
+    // CI_SMOKE_HOME, not just homedir(): buildSmokeEnv can only set HOME, and
+    // homedir() reads USERPROFILE on Windows, where a smoke run would then
+    // migrate the real user profile.
+    productHome: migrateDshHome({
+      home: resolveDshHome({ channel: appChannel, homeRoot: CI_SMOKE_HOME ?? homedir() }),
+      legacyHome: join(app.getPath("userData"), "dsh"),
+      onEvent: (message, detail) => logger.log(message, detail),
+    }),
     resources: resources.dsh,
   })
   fileInputPreload = product.fileInputPreload

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -28,6 +28,7 @@ import {
   resolveProductResources,
 } from "./dsh-product-home"
 import { launchDshSidecar, type DshSidecar } from "./dsh-sidecar"
+import { migrateDshHome, resolveDshHome, resolvePawWorkHomeRoot } from "./pawwork-home"
 import { initLogging } from "./logging"
 import { detectSystemMenuLocale } from "./menu-labels"
 import { createUpdateFeed, githubFeed, r2Feed, type FeedTarget } from "./update-feed"
@@ -53,7 +54,8 @@ const UPDATE_CHANNEL_FILE = process.platform === "win32" ? `${UPDATE_CHANNEL}.ym
 const LATEST_RELEASE_URL = `https://github.com/${UPDATE_GITHUB_OWNER}/${UPDATE_GITHUB_REPO}/releases/latest`
 
 const userDataRoot = CI_SMOKE_HOME ?? app.getPath("appData")
-const appIdentity = PAWWORK_APP[app.isPackaged ? CHANNEL : "dev"]
+const appChannel = app.isPackaged ? CHANNEL : "dev"
+const appIdentity = PAWWORK_APP[appChannel]
 app.setName(appIdentity.name)
 if (CI_SMOKE_HOME) app.setPath("appData", CI_SMOKE_HOME)
 app.setPath("userData", join(userDataRoot, appIdentity.id))
@@ -207,8 +209,16 @@ async function startDsh() {
     isPackaged: app.isPackaged,
     resourcesPath: process.resourcesPath,
   })
+  // Runs before the overlay is prepared: prepareDshProductHome would create and
+  // populate the dotdir home, and the migration would then read it as a home a
+  // newer build had already written and leave the real data behind in userData.
+  const migration = migrateDshHome({
+    home: resolveDshHome({ channel: appChannel, homeRoot: resolvePawWorkHomeRoot() }),
+    legacyHome: join(app.getPath("userData"), "dsh"),
+    onEvent: (message, detail) => logger.log(message, detail),
+  })
   const product = prepareDshProductHome({
-    productHome: join(app.getPath("userData"), "dsh"),
+    productHome: migration.home,
     resources: resources.dsh,
   })
   fileInputPreload = product.fileInputPreload

--- a/packages/desktop-electron/src/main/pawwork-home.test.ts
+++ b/packages/desktop-electron/src/main/pawwork-home.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  DSH_MOVED_MARKER_NAME,
+  migrateDshHome,
+  resolveDshHome,
+  resolvePawWorkHomeRoot,
+} from "./pawwork-home"
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { force: true, recursive: true })
+})
+
+function temporaryDirectory() {
+  const directory = mkdtempSync(join(tmpdir(), "pawwork-home-"))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+// A DSH home the way the app leaves it: sessions, settings, the private
+// credential file, and the two directories PawWork owns itself.
+function seedLegacyHome(legacyHome: string) {
+  mkdirSync(join(legacyHome, "sessions"), { recursive: true })
+  mkdirSync(join(legacyHome, "import-v1"), { recursive: true })
+  writeFileSync(join(legacyHome, "sessions", "session-1.json"), '{"id":"session-1"}')
+  writeFileSync(join(legacyHome, "settings.yaml"), "theme: dark\n")
+  writeFileSync(join(legacyHome, ".credentials.yaml"), 'OPENCODE_API_KEY: "public"\n', { mode: 0o600 })
+  writeFileSync(join(legacyHome, "automations.json"), '{"schema":1}')
+  writeFileSync(join(legacyHome, "import-v1", "ledger.json"), '{"schema":1}')
+}
+
+function readMovedMarker(legacyHome: string) {
+  return JSON.parse(readFileSync(join(legacyHome, "..", DSH_MOVED_MARKER_NAME), "utf8")) as {
+    schema: number
+    movedAt: string
+    from: string
+    to: string
+  }
+}
+
+function crossDeviceRename() {
+  return () => {
+    const error = new Error("cross-device link not permitted") as NodeJS.ErrnoException
+    error.code = "EXDEV"
+    throw error
+  }
+}
+
+describe("PawWork home", () => {
+  test("resolves the DSH home per channel under the home dotdir", () => {
+    expect(resolveDshHome({ channel: "prod", homeRoot: "/Users/pawwork" })).toBe(
+      join("/Users/pawwork", ".pawwork", "dsh"),
+    )
+    expect(resolveDshHome({ channel: "dev", homeRoot: "/Users/pawwork" })).toBe(
+      join("/Users/pawwork", ".pawwork", "dsh-dev"),
+    )
+  })
+
+  test("prefers the CI smoke home over the real user home", () => {
+    // Windows resolves os.homedir() from USERPROFILE, which buildSmokeEnv does
+    // not set, so a smoke run that fell through to homedir() would write into
+    // the real user profile.
+    expect(resolvePawWorkHomeRoot({ PAWWORK_CI_SMOKE_HOME: "/tmp/smoke" })).toBe("/tmp/smoke")
+    expect(resolvePawWorkHomeRoot({ PAWWORK_CI_SMOKE_HOME: "" })).toBe(homedir())
+    expect(resolvePawWorkHomeRoot({})).toBe(homedir())
+  })
+
+  test("renames the legacy home and leaves a marker behind", () => {
+    const root = temporaryDirectory()
+    const legacyHome = join(root, "userData", "dsh")
+    const home = join(root, ".pawwork", "dsh")
+    seedLegacyHome(legacyHome)
+
+    const events: string[] = []
+    const migration = migrateDshHome({
+      home,
+      legacyHome,
+      now: () => new Date("2026-08-21T00:00:00.000Z"),
+      onEvent: (message) => events.push(message),
+    })
+
+    expect(migration).toEqual({ home, status: "renamed" })
+    expect(existsSync(legacyHome)).toBe(false)
+    expect(readFileSync(join(home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(readFileSync(join(home, "sessions", "session-1.json"), "utf8")).toBe('{"id":"session-1"}')
+    expect(readFileSync(join(home, "import-v1", "ledger.json"), "utf8")).toBe('{"schema":1}')
+    expect(readMovedMarker(legacyHome)).toEqual({
+      schema: 1,
+      movedAt: "2026-08-21T00:00:00.000Z",
+      from: legacyHome,
+      to: home,
+    })
+    expect(events).toEqual(["DSH home migrated"])
+  })
+
+  test("copies and verifies before deleting when the homes are on different filesystems", () => {
+    const root = temporaryDirectory()
+    const legacyHome = join(root, "userData", "dsh")
+    const home = join(root, ".pawwork", "dsh")
+    seedLegacyHome(legacyHome)
+
+    const migration = migrateDshHome({ home, legacyHome, rename: crossDeviceRename() })
+
+    expect(migration).toEqual({ home, status: "copied" })
+    expect(existsSync(legacyHome)).toBe(false)
+    expect(readdirSync(home).sort()).toEqual([
+      ".credentials.yaml",
+      "automations.json",
+      "import-v1",
+      "sessions",
+      "settings.yaml",
+    ])
+    expect(readFileSync(join(home, "import-v1", "ledger.json"), "utf8")).toBe('{"schema":1}')
+    expect(existsSync(join(root, "userData", DSH_MOVED_MARKER_NAME))).toBe(true)
+  })
+
+  test("does nothing on the second start", () => {
+    const root = temporaryDirectory()
+    const legacyHome = join(root, "userData", "dsh")
+    const home = join(root, ".pawwork", "dsh")
+    seedLegacyHome(legacyHome)
+
+    migrateDshHome({ home, legacyHome })
+    writeFileSync(join(home, "settings.yaml"), "theme: light\n")
+    const second = migrateDshHome({ home, legacyHome })
+
+    expect(second).toEqual({ home, status: "no-legacy-home" })
+    expect(readFileSync(join(home, "settings.yaml"), "utf8")).toBe("theme: light\n")
+  })
+
+  test("keeps a populated home and leaves the legacy directory untouched", () => {
+    const root = temporaryDirectory()
+    const legacyHome = join(root, "userData", "dsh")
+    const home = join(root, ".pawwork", "dsh")
+    seedLegacyHome(legacyHome)
+    mkdirSync(home, { recursive: true })
+    writeFileSync(join(home, "settings.yaml"), "theme: light\n")
+
+    const migration = migrateDshHome({ home, legacyHome })
+
+    expect(migration).toEqual({ home, status: "home-already-populated" })
+    expect(readFileSync(join(home, "settings.yaml"), "utf8")).toBe("theme: light\n")
+    expect(readFileSync(join(legacyHome, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(existsSync(join(root, "userData", DSH_MOVED_MARKER_NAME))).toBe(false)
+  })
+
+  test("migrates into an empty home directory", () => {
+    const root = temporaryDirectory()
+    const legacyHome = join(root, "userData", "dsh")
+    const home = join(root, ".pawwork", "dsh")
+    seedLegacyHome(legacyHome)
+    mkdirSync(home, { recursive: true })
+
+    expect(migrateDshHome({ home, legacyHome })).toEqual({ home, status: "renamed" })
+    expect(readFileSync(join(home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+  })
+
+  test("falls back to the legacy home and clears a half-written home when the move fails", () => {
+    const root = temporaryDirectory()
+    const legacyHome = join(root, "userData", "dsh")
+    const home = join(root, ".pawwork", "dsh")
+    seedLegacyHome(legacyHome)
+
+    const events: string[] = []
+    const migration = migrateDshHome({
+      home,
+      legacyHome,
+      onEvent: (message) => events.push(message),
+      rename: (_from, to) => {
+        mkdirSync(to, { recursive: true })
+        writeFileSync(join(to, "settings.yaml"), "theme: dark\n")
+        throw new Error("disk is full")
+      },
+    })
+
+    expect(migration.status).toBe("failed")
+    expect(migration.home).toBe(legacyHome)
+    expect(migration.error?.message).toBe("disk is full")
+    // The partial copy is gone, so the next start migrates again instead of
+    // reading it as a home a newer build had already written.
+    expect(existsSync(home)).toBe(false)
+    expect(readFileSync(join(legacyHome, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(existsSync(join(root, "userData", DSH_MOVED_MARKER_NAME))).toBe(false)
+    expect(events).toEqual(["DSH home migration failed, staying in the legacy home"])
+  })
+
+  test("does nothing when there is no legacy home", () => {
+    const root = temporaryDirectory()
+    const home = join(root, ".pawwork", "dsh")
+
+    expect(migrateDshHome({ home, legacyHome: join(root, "userData", "dsh") })).toEqual({
+      home,
+      status: "no-legacy-home",
+    })
+    expect(existsSync(home)).toBe(false)
+  })
+})

--- a/packages/desktop-electron/src/main/pawwork-home.test.ts
+++ b/packages/desktop-electron/src/main/pawwork-home.test.ts
@@ -13,14 +13,9 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs"
-import { homedir, tmpdir } from "node:os"
+import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
-import {
-  DSH_MOVED_MARKER_NAME,
-  migrateDshHome,
-  resolveDshHome,
-  resolvePawWorkHomeRoot,
-} from "./pawwork-home"
+import { migrateDshHome, resolveDshHome } from "./pawwork-home"
 
 const temporaryDirectories: string[] = []
 
@@ -54,7 +49,7 @@ function seedHomes(): Homes {
 }
 
 function markerPath({ legacyHome }: Homes) {
-  return join(dirname(legacyHome), DSH_MOVED_MARKER_NAME)
+  return join(dirname(legacyHome), "dsh-moved.json")
 }
 
 function readMovedMarker(homes: Homes) {
@@ -88,14 +83,6 @@ describe("PawWork home", () => {
     )
   })
 
-  test("prefers the CI smoke home over the real user home", () => {
-    // Windows resolves os.homedir() from USERPROFILE, which buildSmokeEnv does
-    // not set, so a smoke run that fell through to homedir() would write into
-    // the real user profile.
-    expect(resolvePawWorkHomeRoot({ PAWWORK_CI_SMOKE_HOME: "/tmp/smoke" })).toBe("/tmp/smoke")
-    expect(resolvePawWorkHomeRoot({})).toBe(homedir())
-  })
-
   test("renames the legacy home and leaves a marker behind", () => {
     const homes = seedHomes()
     const { events, onEvent } = collectEvents()
@@ -106,7 +93,7 @@ describe("PawWork home", () => {
       onEvent,
     })
 
-    expect(migration).toEqual({ home: homes.home, status: "renamed" })
+    expect(migration).toBe(homes.home)
     expect(existsSync(homes.legacyHome)).toBe(false)
     expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
     expect(readFileSync(join(homes.home, "sessions", "session-1.json"), "utf8")).toBe('{"id":"session-1"}')
@@ -136,7 +123,7 @@ describe("PawWork home", () => {
 
     const migration = migrateDshHome({ ...homes, rename: crossDeviceRename() })
 
-    expect(migration).toEqual({ home: homes.home, status: "copied" })
+    expect(migration).toBe(homes.home)
     expect(existsSync(homes.legacyHome)).toBe(false)
     expect(existsSync(`${homes.home}.migrating`)).toBe(false)
     expect(readdirSync(homes.home).sort()).toEqual([
@@ -172,7 +159,7 @@ describe("PawWork home", () => {
 
     // The copy was verified before the delete was attempted, so the move stands
     // and the undeleted legacy home is just litter.
-    expect(migration).toEqual({ home: homes.home, status: "copied" })
+    expect(migration).toBe(homes.home)
     expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
     expect(events.map((event) => event.message)).toEqual([
       "DSH legacy home left behind",
@@ -195,7 +182,7 @@ describe("PawWork home", () => {
 
     // The rename already committed: answering the legacy home here would start
     // DSH on a path that no longer exists.
-    expect(migration).toEqual({ home: homes.home, status: "renamed" })
+    expect(migration).toBe(homes.home)
     expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
     expect(existsSync(markerPath(homes))).toBe(false)
     expect(events.map((event) => event.message)).toEqual([
@@ -211,7 +198,7 @@ describe("PawWork home", () => {
     writeFileSync(join(homes.home, "settings.yaml"), "theme: light\n")
     const second = migrateDshHome(homes)
 
-    expect(second).toEqual({ home: homes.home, status: "no-legacy-home" })
+    expect(second).toBe(homes.home)
     expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: light\n")
   })
 
@@ -222,7 +209,7 @@ describe("PawWork home", () => {
 
     const migration = migrateDshHome(homes)
 
-    expect(migration).toEqual({ home: homes.home, status: "home-already-populated" })
+    expect(migration).toBe(homes.home)
     expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: light\n")
     expect(readFileSync(join(homes.legacyHome, "settings.yaml"), "utf8")).toBe("theme: dark\n")
     expect(existsSync(markerPath(homes))).toBe(false)
@@ -232,7 +219,7 @@ describe("PawWork home", () => {
     const homes = seedHomes()
     mkdirSync(homes.home, { recursive: true })
 
-    expect(migrateDshHome(homes)).toEqual({ home: homes.home, status: "renamed" })
+    expect(migrateDshHome(homes)).toBe(homes.home)
     expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
   })
 
@@ -250,17 +237,21 @@ describe("PawWork home", () => {
       },
     })
 
-    expect(migration.status).toBe("failed")
-    expect(migration.home).toBe(homes.legacyHome)
-    expect(migration.error?.message).toBe("disk is full")
+    expect(migration).toBe(homes.legacyHome)
     // Nothing committed, so the leftovers go: the next start has to migrate
     // again rather than read them as a home a newer build had written.
     expect(existsSync(homes.home)).toBe(false)
     expect(existsSync(`${homes.home}.migrating`)).toBe(false)
     expect(readFileSync(join(homes.legacyHome, "settings.yaml"), "utf8")).toBe("theme: dark\n")
     expect(existsSync(markerPath(homes))).toBe(false)
-    expect(events.map((event) => event.message)).toEqual([
-      "DSH home migration failed, staying in the legacy home",
+    // The cause only survives in the log now, so the log has to carry it.
+    expect(events).toEqual([
+      {
+        message: "DSH home migration failed, staying in the legacy home",
+        home: homes.home,
+        legacyHome: homes.legacyHome,
+        error: "disk is full",
+      },
     ])
   })
 
@@ -268,10 +259,7 @@ describe("PawWork home", () => {
     const root = temporaryDirectory()
     const home = join(root, ".pawwork", "dsh")
 
-    expect(migrateDshHome({ home, legacyHome: join(root, "userData", "dsh") })).toEqual({
-      home,
-      status: "no-legacy-home",
-    })
+    expect(migrateDshHome({ home, legacyHome: join(root, "userData", "dsh") })).toBe(home)
     expect(existsSync(home)).toBe(false)
   })
 })

--- a/packages/desktop-electron/src/main/pawwork-home.test.ts
+++ b/packages/desktop-electron/src/main/pawwork-home.test.ts
@@ -1,7 +1,20 @@
 import { afterEach, describe, expect, test } from "vitest"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
 import { homedir, tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import {
   DSH_MOVED_MARKER_NAME,
   migrateDshHome,
@@ -21,9 +34,14 @@ function temporaryDirectory() {
   return directory
 }
 
+type Homes = { root: string; legacyHome: string; home: string }
+
 // A DSH home the way the app leaves it: sessions, settings, the private
-// credential file, and the two directories PawWork owns itself.
-function seedLegacyHome(legacyHome: string) {
+// credential file, the two directories PawWork owns itself, and one of the
+// symlinks the product overlay points at the install directory.
+function seedHomes(): Homes {
+  const root = temporaryDirectory()
+  const legacyHome = join(root, "userData", "dsh")
   mkdirSync(join(legacyHome, "sessions"), { recursive: true })
   mkdirSync(join(legacyHome, "import-v1"), { recursive: true })
   writeFileSync(join(legacyHome, "sessions", "session-1.json"), '{"id":"session-1"}')
@@ -31,22 +49,32 @@ function seedLegacyHome(legacyHome: string) {
   writeFileSync(join(legacyHome, ".credentials.yaml"), 'OPENCODE_API_KEY: "public"\n', { mode: 0o600 })
   writeFileSync(join(legacyHome, "automations.json"), '{"schema":1}')
   writeFileSync(join(legacyHome, "import-v1", "ledger.json"), '{"schema":1}')
+  symlinkSync("/Applications/PawWork.app/Contents/Resources/dsh", join(legacyHome, "installed"))
+  return { root, legacyHome, home: join(root, ".pawwork", "dsh") }
 }
 
-function readMovedMarker(legacyHome: string) {
-  return JSON.parse(readFileSync(join(legacyHome, "..", DSH_MOVED_MARKER_NAME), "utf8")) as {
-    schema: number
-    movedAt: string
-    from: string
-    to: string
-  }
+function markerPath({ legacyHome }: Homes) {
+  return join(dirname(legacyHome), DSH_MOVED_MARKER_NAME)
 }
 
+function readMovedMarker(homes: Homes) {
+  return JSON.parse(readFileSync(markerPath(homes), "utf8")) as Record<string, unknown>
+}
+
+// The only failure renameSync can report that the migration recovers from.
 function crossDeviceRename() {
   return () => {
     const error = new Error("cross-device link not permitted") as NodeJS.ErrnoException
     error.code = "EXDEV"
     throw error
+  }
+}
+
+function collectEvents() {
+  const events: Record<string, unknown>[] = []
+  return {
+    events,
+    onEvent: (message: string, detail: Record<string, unknown>) => events.push({ message, ...detail }),
   }
 }
 
@@ -65,111 +93,156 @@ describe("PawWork home", () => {
     // not set, so a smoke run that fell through to homedir() would write into
     // the real user profile.
     expect(resolvePawWorkHomeRoot({ PAWWORK_CI_SMOKE_HOME: "/tmp/smoke" })).toBe("/tmp/smoke")
-    expect(resolvePawWorkHomeRoot({ PAWWORK_CI_SMOKE_HOME: "" })).toBe(homedir())
     expect(resolvePawWorkHomeRoot({})).toBe(homedir())
   })
 
   test("renames the legacy home and leaves a marker behind", () => {
-    const root = temporaryDirectory()
-    const legacyHome = join(root, "userData", "dsh")
-    const home = join(root, ".pawwork", "dsh")
-    seedLegacyHome(legacyHome)
+    const homes = seedHomes()
+    const { events, onEvent } = collectEvents()
 
-    const events: string[] = []
     const migration = migrateDshHome({
-      home,
-      legacyHome,
+      ...homes,
       now: () => new Date("2026-08-21T00:00:00.000Z"),
-      onEvent: (message) => events.push(message),
+      onEvent,
     })
 
-    expect(migration).toEqual({ home, status: "renamed" })
-    expect(existsSync(legacyHome)).toBe(false)
-    expect(readFileSync(join(home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
-    expect(readFileSync(join(home, "sessions", "session-1.json"), "utf8")).toBe('{"id":"session-1"}')
-    expect(readFileSync(join(home, "import-v1", "ledger.json"), "utf8")).toBe('{"schema":1}')
-    expect(readMovedMarker(legacyHome)).toEqual({
-      schema: 1,
+    expect(migration).toEqual({ home: homes.home, status: "renamed" })
+    expect(existsSync(homes.legacyHome)).toBe(false)
+    expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(readFileSync(join(homes.home, "sessions", "session-1.json"), "utf8")).toBe('{"id":"session-1"}')
+    expect(readFileSync(join(homes.home, "import-v1", "ledger.json"), "utf8")).toBe('{"schema":1}')
+    expect(readMovedMarker(homes)).toMatchObject({
       movedAt: "2026-08-21T00:00:00.000Z",
-      from: legacyHome,
-      to: home,
+      from: homes.legacyHome,
+      to: homes.home,
     })
-    expect(events).toEqual(["DSH home migrated"])
+    expect(events).toEqual([
+      { message: "DSH home migrated", home: homes.home, legacyHome: homes.legacyHome, status: "renamed" },
+    ])
   })
 
-  test("copies and verifies before deleting when the homes are on different filesystems", () => {
-    const root = temporaryDirectory()
-    const legacyHome = join(root, "userData", "dsh")
-    const home = join(root, ".pawwork", "dsh")
-    seedLegacyHome(legacyHome)
+  test("creates the dotdir private to the user", () => {
+    // ~/Library is 0700 and used to protect the sessions inside it. The home
+    // directory is not, so the dotdir has to ask for it.
+    const homes = seedHomes()
 
-    const migration = migrateDshHome({ home, legacyHome, rename: crossDeviceRename() })
+    migrateDshHome(homes)
 
-    expect(migration).toEqual({ home, status: "copied" })
-    expect(existsSync(legacyHome)).toBe(false)
-    expect(readdirSync(home).sort()).toEqual([
+    expect(statSync(dirname(homes.home)).mode & 0o777).toBe(0o700)
+  })
+
+  test("copies through a staging directory when the homes are on different filesystems", () => {
+    const homes = seedHomes()
+
+    const migration = migrateDshHome({ ...homes, rename: crossDeviceRename() })
+
+    expect(migration).toEqual({ home: homes.home, status: "copied" })
+    expect(existsSync(homes.legacyHome)).toBe(false)
+    expect(existsSync(`${homes.home}.migrating`)).toBe(false)
+    expect(readdirSync(homes.home).sort()).toEqual([
       ".credentials.yaml",
       "automations.json",
       "import-v1",
+      "installed",
       "sessions",
       "settings.yaml",
     ])
-    expect(readFileSync(join(home, "import-v1", "ledger.json"), "utf8")).toBe('{"schema":1}')
-    expect(existsSync(join(root, "userData", DSH_MOVED_MARKER_NAME))).toBe(true)
+    expect(readFileSync(join(homes.home, "import-v1", "ledger.json"), "utf8")).toBe('{"schema":1}')
+    // The credential file is the one thing in here that must not widen.
+    expect(statSync(join(homes.home, ".credentials.yaml")).mode & 0o777).toBe(0o600)
+    // Overlay symlinks point at the install directory; following them would
+    // copy the installed product into the user's home.
+    expect(lstatSync(join(homes.home, "installed")).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(join(homes.home, "installed"))).toBe(
+      "/Applications/PawWork.app/Contents/Resources/dsh",
+    )
+    expect(existsSync(markerPath(homes))).toBe(true)
+  })
+
+  test("keeps the migrated home when the legacy home cannot be deleted afterwards", () => {
+    if (process.getuid?.() === 0) return // root deletes regardless of the mode below
+    const homes = seedHomes()
+    const { events, onEvent } = collectEvents()
+    // A read-only parent is the portable stand-in for the real cause: a file in
+    // the legacy home held open on Windows.
+    chmodSync(dirname(homes.legacyHome), 0o555)
+
+    const migration = migrateDshHome({ ...homes, onEvent, rename: crossDeviceRename() })
+    chmodSync(dirname(homes.legacyHome), 0o755)
+
+    // The copy was verified before the delete was attempted, so the move stands
+    // and the undeleted legacy home is just litter.
+    expect(migration).toEqual({ home: homes.home, status: "copied" })
+    expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(events.map((event) => event.message)).toEqual([
+      "DSH legacy home left behind",
+      "DSH moved marker not written",
+      "DSH home migrated",
+    ])
+  })
+
+  test("keeps the migrated home when the marker cannot be written", () => {
+    const homes = seedHomes()
+    const { events, onEvent } = collectEvents()
+
+    const migration = migrateDshHome({
+      ...homes,
+      onEvent,
+      now: () => {
+        throw new Error("no space left on device")
+      },
+    })
+
+    // The rename already committed: answering the legacy home here would start
+    // DSH on a path that no longer exists.
+    expect(migration).toEqual({ home: homes.home, status: "renamed" })
+    expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(existsSync(markerPath(homes))).toBe(false)
+    expect(events.map((event) => event.message)).toEqual([
+      "DSH moved marker not written",
+      "DSH home migrated",
+    ])
   })
 
   test("does nothing on the second start", () => {
-    const root = temporaryDirectory()
-    const legacyHome = join(root, "userData", "dsh")
-    const home = join(root, ".pawwork", "dsh")
-    seedLegacyHome(legacyHome)
+    const homes = seedHomes()
 
-    migrateDshHome({ home, legacyHome })
-    writeFileSync(join(home, "settings.yaml"), "theme: light\n")
-    const second = migrateDshHome({ home, legacyHome })
+    migrateDshHome(homes)
+    writeFileSync(join(homes.home, "settings.yaml"), "theme: light\n")
+    const second = migrateDshHome(homes)
 
-    expect(second).toEqual({ home, status: "no-legacy-home" })
-    expect(readFileSync(join(home, "settings.yaml"), "utf8")).toBe("theme: light\n")
+    expect(second).toEqual({ home: homes.home, status: "no-legacy-home" })
+    expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: light\n")
   })
 
   test("keeps a populated home and leaves the legacy directory untouched", () => {
-    const root = temporaryDirectory()
-    const legacyHome = join(root, "userData", "dsh")
-    const home = join(root, ".pawwork", "dsh")
-    seedLegacyHome(legacyHome)
-    mkdirSync(home, { recursive: true })
-    writeFileSync(join(home, "settings.yaml"), "theme: light\n")
+    const homes = seedHomes()
+    mkdirSync(homes.home, { recursive: true })
+    writeFileSync(join(homes.home, "settings.yaml"), "theme: light\n")
 
-    const migration = migrateDshHome({ home, legacyHome })
+    const migration = migrateDshHome(homes)
 
-    expect(migration).toEqual({ home, status: "home-already-populated" })
-    expect(readFileSync(join(home, "settings.yaml"), "utf8")).toBe("theme: light\n")
-    expect(readFileSync(join(legacyHome, "settings.yaml"), "utf8")).toBe("theme: dark\n")
-    expect(existsSync(join(root, "userData", DSH_MOVED_MARKER_NAME))).toBe(false)
+    expect(migration).toEqual({ home: homes.home, status: "home-already-populated" })
+    expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: light\n")
+    expect(readFileSync(join(homes.legacyHome, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(existsSync(markerPath(homes))).toBe(false)
   })
 
   test("migrates into an empty home directory", () => {
-    const root = temporaryDirectory()
-    const legacyHome = join(root, "userData", "dsh")
-    const home = join(root, ".pawwork", "dsh")
-    seedLegacyHome(legacyHome)
-    mkdirSync(home, { recursive: true })
+    const homes = seedHomes()
+    mkdirSync(homes.home, { recursive: true })
 
-    expect(migrateDshHome({ home, legacyHome })).toEqual({ home, status: "renamed" })
-    expect(readFileSync(join(home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(migrateDshHome(homes)).toEqual({ home: homes.home, status: "renamed" })
+    expect(readFileSync(join(homes.home, "settings.yaml"), "utf8")).toBe("theme: dark\n")
   })
 
-  test("falls back to the legacy home and clears a half-written home when the move fails", () => {
-    const root = temporaryDirectory()
-    const legacyHome = join(root, "userData", "dsh")
-    const home = join(root, ".pawwork", "dsh")
-    seedLegacyHome(legacyHome)
+  test("falls back to the legacy home and clears the leftovers when the move fails", () => {
+    const homes = seedHomes()
+    const { events, onEvent } = collectEvents()
 
-    const events: string[] = []
     const migration = migrateDshHome({
-      home,
-      legacyHome,
-      onEvent: (message) => events.push(message),
+      ...homes,
+      onEvent,
       rename: (_from, to) => {
         mkdirSync(to, { recursive: true })
         writeFileSync(join(to, "settings.yaml"), "theme: dark\n")
@@ -178,14 +251,17 @@ describe("PawWork home", () => {
     })
 
     expect(migration.status).toBe("failed")
-    expect(migration.home).toBe(legacyHome)
+    expect(migration.home).toBe(homes.legacyHome)
     expect(migration.error?.message).toBe("disk is full")
-    // The partial copy is gone, so the next start migrates again instead of
-    // reading it as a home a newer build had already written.
-    expect(existsSync(home)).toBe(false)
-    expect(readFileSync(join(legacyHome, "settings.yaml"), "utf8")).toBe("theme: dark\n")
-    expect(existsSync(join(root, "userData", DSH_MOVED_MARKER_NAME))).toBe(false)
-    expect(events).toEqual(["DSH home migration failed, staying in the legacy home"])
+    // Nothing committed, so the leftovers go: the next start has to migrate
+    // again rather than read them as a home a newer build had written.
+    expect(existsSync(homes.home)).toBe(false)
+    expect(existsSync(`${homes.home}.migrating`)).toBe(false)
+    expect(readFileSync(join(homes.legacyHome, "settings.yaml"), "utf8")).toBe("theme: dark\n")
+    expect(existsSync(markerPath(homes))).toBe(false)
+    expect(events.map((event) => event.message)).toEqual([
+      "DSH home migration failed, staying in the legacy home",
+    ])
   })
 
   test("does nothing when there is no legacy home", () => {

--- a/packages/desktop-electron/src/main/pawwork-home.ts
+++ b/packages/desktop-electron/src/main/pawwork-home.ts
@@ -1,5 +1,4 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs"
-import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import type { PawWorkChannel } from "./app-identity"
 
@@ -15,33 +14,10 @@ const PAWWORK_HOME_DIR_NAME = ".pawwork"
 // retired its files can move into ~/.pawwork/legacy/ without touching this.
 const DSH_HOME_DIR_NAME: Record<PawWorkChannel, string> = { dev: "dsh-dev", prod: "dsh" }
 
-export const DSH_MOVED_MARKER_NAME = "dsh-moved.json"
-
-// CI smoke pins the home root explicitly because buildSmokeEnv can only set HOME,
-// and os.homedir() reads USERPROFILE on Windows — a smoke run resolving through
-// homedir() there would write into the real user profile.
-export function resolvePawWorkHomeRoot(env: NodeJS.ProcessEnv = process.env) {
-  return env.PAWWORK_CI_SMOKE_HOME ?? homedir()
-}
+const DSH_MOVED_MARKER_NAME = "dsh-moved.json"
 
 export function resolveDshHome(options: { channel: PawWorkChannel; homeRoot: string }) {
   return join(options.homeRoot, PAWWORK_HOME_DIR_NAME, DSH_HOME_DIR_NAME[options.channel])
-}
-
-export type DshHomeMigrationStatus =
-  | "no-legacy-home"
-  | "home-already-populated"
-  | "renamed"
-  | "copied"
-  | "failed"
-
-export type DshHomeMigration = {
-  // Where DSH should actually be started from. Everything but a failure answers
-  // the new home; a failure answers the legacy one so a botched migration
-  // degrades to the old location instead of an app that cannot start.
-  home: string
-  status: DshHomeMigrationStatus
-  error?: Error
 }
 
 type MigrateDshHomeOptions = {
@@ -123,10 +99,14 @@ function commitDshHome(legacyHome: string, home: string, rename: (from: string, 
 
 /**
  * Moves `<userData>/dsh` to the dotdir home the first time a build that knows
- * about the dotdir starts. Must run before the product overlay is prepared,
- * which would otherwise populate the new home and make it look already migrated.
+ * about the dotdir starts, and answers where DSH should actually be started
+ * from: the new home, or the legacy one when the move failed, so a botched
+ * migration degrades to the old location instead of an app that cannot start.
+ *
+ * Must run before the product overlay is prepared, which would otherwise
+ * populate the new home and make it look already migrated.
  */
-export function migrateDshHome(options: MigrateDshHomeOptions): DshHomeMigration {
+export function migrateDshHome(options: MigrateDshHomeOptions): string {
   const { home, legacyHome } = options
   const rename = options.rename ?? renameSync
   const now = options.now ?? (() => new Date())
@@ -134,12 +114,12 @@ export function migrateDshHome(options: MigrateDshHomeOptions): DshHomeMigration
 
   let status: "renamed" | "copied"
   try {
-    if (!isDirectory(legacyHome)) return { home, status: "no-legacy-home" }
+    if (!isDirectory(legacyHome)) return home
     // The new home wins whenever it holds anything: a newer build already wrote
     // there, and the legacy directory is a stale copy from a downgrade.
     if (isDirectory(home) && !isEmptyDirectory(home)) {
       onEvent("DSH home migration skipped, destination already populated", { home, legacyHome })
-      return { home, status: "home-already-populated" }
+      return home
     }
 
     // ~/Library is 0700 and used to protect the sessions inside it; the home
@@ -157,13 +137,12 @@ export function migrateDshHome(options: MigrateDshHomeOptions): DshHomeMigration
     // migrated home.
     rmSync(home, { force: true, recursive: true })
     rmSync(stagingHome(home), { force: true, recursive: true })
-    const failure = describe(error)
     onEvent("DSH home migration failed, staying in the legacy home", {
       home,
       legacyHome,
-      error: failure.message,
+      error: describe(error).message,
     })
-    return { home: legacyHome, status: "failed", error: failure }
+    return legacyHome
   }
 
   // Past the commit the new home is authoritative, so the rest is best-effort:
@@ -171,15 +150,16 @@ export function migrateDshHome(options: MigrateDshHomeOptions): DshHomeMigration
   discardLegacyHome(legacyHome, onEvent)
   writeMovedMarker(legacyHome, home, now, onEvent)
   onEvent("DSH home migrated", { home, legacyHome, status })
-  return { home, status }
+  return home
 }
 
 // Left over only after a cross-device copy. Keeping it costs a stale directory
 // the next start walks past; deleting the migrated home to "undo" would cost the
 // data, so a lock or a permission problem here just gets logged.
 function discardLegacyHome(legacyHome: string, onEvent: NonNullable<MigrateDshHomeOptions["onEvent"]>) {
-  if (!isDirectory(legacyHome)) return
   try {
+    // force swallows ENOENT, so the rename path — where there is nothing left
+    // to discard — passes straight through.
     rmSync(legacyHome, { force: true, maxRetries: 3, recursive: true })
   } catch (error) {
     onEvent("DSH legacy home left behind", { legacyHome, error: describe(error).message })

--- a/packages/desktop-electron/src/main/pawwork-home.ts
+++ b/packages/desktop-electron/src/main/pawwork-home.ts
@@ -1,0 +1,155 @@
+import { cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import type { PawWorkChannel } from "./app-identity"
+
+// PawWork keeps its agent data in a dotdir under the user's home, the way Claude
+// Code and Codex do, instead of leaving it in Electron's userData directory.
+// Chromium's own state (Cache, Cookies, Local Storage, Preferences, window
+// state, logs, updater cache) stays in userData — only DSH data lives here.
+export const PAWWORK_HOME_DIR_NAME = ".pawwork"
+
+// One level down rather than ~/.pawwork itself: v1 is still maintained on
+// maint/v1 and owns ~/.pawwork directly, including a node_modules/ that would
+// collide with the product plugin overlay v2 writes into DSH_HOME. When v1 is
+// retired its files can move into ~/.pawwork/legacy/ without touching this.
+const DSH_HOME_DIR_NAME: Record<PawWorkChannel, string> = { dev: "dsh-dev", prod: "dsh" }
+
+export const DSH_MOVED_MARKER_NAME = "dsh-moved.json"
+
+// CI smoke pins the home root explicitly because buildSmokeEnv can only set HOME,
+// and os.homedir() reads USERPROFILE on Windows — a smoke run resolving through
+// homedir() there would write into the real user profile.
+export function resolvePawWorkHomeRoot(env: NodeJS.ProcessEnv = process.env) {
+  const smokeHome = env.PAWWORK_CI_SMOKE_HOME
+  return smokeHome !== undefined && smokeHome !== "" ? smokeHome : homedir()
+}
+
+export function resolveDshHome(options: { channel: PawWorkChannel; homeRoot: string }) {
+  return join(options.homeRoot, PAWWORK_HOME_DIR_NAME, DSH_HOME_DIR_NAME[options.channel])
+}
+
+export type DshHomeMigrationStatus =
+  | "no-legacy-home"
+  | "home-already-populated"
+  | "renamed"
+  | "copied"
+  | "failed"
+
+export type DshHomeMigration = {
+  // Where DSH should actually be started from. Everything but a failure answers
+  // the new home; a failure answers the legacy one so a botched migration
+  // degrades to the old location instead of an app that cannot start.
+  home: string
+  status: DshHomeMigrationStatus
+  error?: Error
+}
+
+type MigrateDshHomeOptions = {
+  home: string
+  legacyHome: string
+  now?: () => Date
+  // Injected so the cross-device fallback can be exercised: a test cannot make
+  // two temporary directories live on different filesystems.
+  rename?: (from: string, to: string) => void
+  onEvent?: (message: string, detail: Record<string, unknown>) => void
+}
+
+function isDirectory(path: string) {
+  try {
+    return statSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function isEmptyDirectory(path: string) {
+  return readdirSync(path).length === 0
+}
+
+function isCrossDeviceError(error: unknown) {
+  return (error as NodeJS.ErrnoException | undefined)?.code === "EXDEV"
+}
+
+// Every path under the source, relative and with separators normalized, so the
+// copy can be checked before the source is deleted. Names alone are enough: cp
+// preserves contents, and a partial copy shows up as a missing entry.
+function listEntries(root: string, prefix = ""): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const relativePath = prefix === "" ? entry.name : `${prefix}/${entry.name}`
+    return entry.isDirectory()
+      ? [relativePath, ...listEntries(join(root, entry.name), relativePath)]
+      : [relativePath]
+  })
+}
+
+function copyAcrossDevices(legacyHome: string, home: string) {
+  cpSync(legacyHome, home, { recursive: true, verbatimSymlinks: true })
+  const copied = new Set(listEntries(home))
+  const missing = listEntries(legacyHome).filter((entry) => !copied.has(entry))
+  if (missing.length) {
+    throw new Error(`DSH home copy is incomplete: ${missing.slice(0, 5).join(", ")}`)
+  }
+  rmSync(legacyHome, { force: true, recursive: true })
+}
+
+function writeMovedMarker(legacyHome: string, home: string, movedAt: Date) {
+  const marker = join(dirname(legacyHome), DSH_MOVED_MARKER_NAME)
+  const document = { schema: 1, movedAt: movedAt.toISOString(), from: legacyHome, to: home }
+  writeFileSync(marker, `${JSON.stringify(document, null, 2)}\n`, "utf8")
+}
+
+/**
+ * Moves `<userData>/dsh` to the dotdir home the first time a build that knows
+ * about the dotdir starts. Must run before the product overlay is prepared,
+ * which would otherwise populate the new home and make it look already migrated.
+ */
+export function migrateDshHome(options: MigrateDshHomeOptions): DshHomeMigration {
+  const { home, legacyHome } = options
+  const rename = options.rename ?? renameSync
+  const now = options.now ?? (() => new Date())
+  const onEvent = options.onEvent ?? (() => {})
+
+  if (home === legacyHome || !isDirectory(legacyHome)) {
+    return { home, status: "no-legacy-home" }
+  }
+  // The new home wins whenever it holds anything: a newer build already wrote
+  // there, and the legacy directory is a stale copy from a downgrade.
+  if (isDirectory(home) && !isEmptyDirectory(home)) {
+    onEvent("DSH home migration skipped, destination already populated", { home, legacyHome })
+    return { home, status: "home-already-populated" }
+  }
+
+  try {
+    mkdirSync(dirname(home), { recursive: true })
+    // rename onto an existing directory is fine on POSIX and fails on Windows,
+    // so the empty placeholder goes first either way.
+    if (existsSync(home)) rmSync(home, { recursive: true })
+
+    let status: DshHomeMigrationStatus
+    try {
+      rename(legacyHome, home)
+      status = "renamed"
+    } catch (error) {
+      if (!isCrossDeviceError(error)) throw error
+      copyAcrossDevices(legacyHome, home)
+      status = "copied"
+    }
+
+    writeMovedMarker(legacyHome, home, now())
+    onEvent("DSH home migrated", { home, legacyHome, status })
+    return { home, status }
+  } catch (error) {
+    // A half-finished copy would read as an already-migrated home on the next
+    // start, so it is removed and this run keeps using the legacy directory.
+    if (existsSync(home) && isDirectory(legacyHome)) rmSync(home, { force: true, recursive: true })
+    const failure = error instanceof Error ? error : new Error(String(error))
+    onEvent("DSH home migration failed, staying in the legacy home", {
+      home,
+      legacyHome,
+      error: failure.message,
+    })
+    return { home: legacyHome, status: "failed", error: failure }
+  }
+}
+

--- a/packages/desktop-electron/src/main/pawwork-home.ts
+++ b/packages/desktop-electron/src/main/pawwork-home.ts
@@ -7,7 +7,7 @@ import type { PawWorkChannel } from "./app-identity"
 // Code and Codex do, instead of leaving it in Electron's userData directory.
 // Chromium's own state (Cache, Cookies, Local Storage, Preferences, window
 // state, logs, updater cache) stays in userData — only DSH data lives here.
-export const PAWWORK_HOME_DIR_NAME = ".pawwork"
+const PAWWORK_HOME_DIR_NAME = ".pawwork"
 
 // One level down rather than ~/.pawwork itself: v1 is still maintained on
 // maint/v1 and owns ~/.pawwork directly, including a node_modules/ that would
@@ -21,8 +21,7 @@ export const DSH_MOVED_MARKER_NAME = "dsh-moved.json"
 // and os.homedir() reads USERPROFILE on Windows — a smoke run resolving through
 // homedir() there would write into the real user profile.
 export function resolvePawWorkHomeRoot(env: NodeJS.ProcessEnv = process.env) {
-  const smokeHome = env.PAWWORK_CI_SMOKE_HOME
-  return smokeHome !== undefined && smokeHome !== "" ? smokeHome : homedir()
+  return env.PAWWORK_CI_SMOKE_HOME ?? homedir()
 }
 
 export function resolveDshHome(options: { channel: PawWorkChannel; homeRoot: string }) {
@@ -49,8 +48,8 @@ type MigrateDshHomeOptions = {
   home: string
   legacyHome: string
   now?: () => Date
-  // Injected so the cross-device fallback can be exercised: a test cannot make
-  // two temporary directories live on different filesystems.
+  // Injected so the cross-device path can be exercised: a test cannot make two
+  // temporary directories live on different filesystems.
   rename?: (from: string, to: string) => void
   onEvent?: (message: string, detail: Record<string, unknown>) => void
 }
@@ -71,9 +70,19 @@ function isCrossDeviceError(error: unknown) {
   return (error as NodeJS.ErrnoException | undefined)?.code === "EXDEV"
 }
 
-// Every path under the source, relative and with separators normalized, so the
-// copy can be checked before the source is deleted. Names alone are enough: cp
-// preserves contents, and a partial copy shows up as a missing entry.
+function describe(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+// Where a cross-device copy is assembled before it becomes the home. A sibling
+// of the home so the final rename stays on one filesystem.
+function stagingHome(home: string) {
+  return `${home}.migrating`
+}
+
+// Every path under the root, relative and separator-normalized, so a copy can be
+// checked against its source. Names alone are enough: cp preserves contents, and
+// an interrupted copy shows up as a missing entry.
 function listEntries(root: string, prefix = ""): string[] {
   return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
     const relativePath = prefix === "" ? entry.name : `${prefix}/${entry.name}`
@@ -83,20 +92,33 @@ function listEntries(root: string, prefix = ""): string[] {
   })
 }
 
-function copyAcrossDevices(legacyHome: string, home: string) {
-  cpSync(legacyHome, home, { recursive: true, verbatimSymlinks: true })
-  const copied = new Set(listEntries(home))
-  const missing = listEntries(legacyHome).filter((entry) => !copied.has(entry))
-  if (missing.length) {
-    throw new Error(`DSH home copy is incomplete: ${missing.slice(0, 5).join(", ")}`)
+/**
+ * Moves the legacy home onto the new path and returns how it got there. This is
+ * the commit point: it either throws with the legacy home still authoritative,
+ * or returns with the new home holding the data.
+ */
+function commitDshHome(legacyHome: string, home: string, rename: (from: string, to: string) => void) {
+  try {
+    rename(legacyHome, home)
+    return "renamed" as const
+  } catch (error) {
+    if (!isCrossDeviceError(error)) throw error
+    // A cross-device move has no rename to lean on, so the atomicity is built
+    // by hand: copy into a sibling staging directory, verify it, and only then
+    // rename it into place. A copy interrupted by a crash leaves the staging
+    // directory behind rather than a half-written home that the next start
+    // would read as already migrated.
+    const staging = stagingHome(home)
+    rmSync(staging, { force: true, recursive: true })
+    cpSync(legacyHome, staging, { recursive: true, verbatimSymlinks: true })
+    // cpSync throws rather than skipping entries, so this is a backstop, not
+    // the primary guard: nothing gets deleted until the copy has been read back.
+    const copied = new Set(listEntries(staging))
+    const missing = listEntries(legacyHome).filter((entry) => !copied.has(entry))
+    if (missing.length) throw new Error(`DSH home copy is incomplete: ${missing.slice(0, 5).join(", ")}`)
+    renameSync(staging, home)
+    return "copied" as const
   }
-  rmSync(legacyHome, { force: true, recursive: true })
-}
-
-function writeMovedMarker(legacyHome: string, home: string, movedAt: Date) {
-  const marker = join(dirname(legacyHome), DSH_MOVED_MARKER_NAME)
-  const document = { schema: 1, movedAt: movedAt.toISOString(), from: legacyHome, to: home }
-  writeFileSync(marker, `${JSON.stringify(document, null, 2)}\n`, "utf8")
 }
 
 /**
@@ -110,40 +132,32 @@ export function migrateDshHome(options: MigrateDshHomeOptions): DshHomeMigration
   const now = options.now ?? (() => new Date())
   const onEvent = options.onEvent ?? (() => {})
 
-  if (home === legacyHome || !isDirectory(legacyHome)) {
-    return { home, status: "no-legacy-home" }
-  }
-  // The new home wins whenever it holds anything: a newer build already wrote
-  // there, and the legacy directory is a stale copy from a downgrade.
-  if (isDirectory(home) && !isEmptyDirectory(home)) {
-    onEvent("DSH home migration skipped, destination already populated", { home, legacyHome })
-    return { home, status: "home-already-populated" }
-  }
-
+  let status: "renamed" | "copied"
   try {
-    mkdirSync(dirname(home), { recursive: true })
+    if (!isDirectory(legacyHome)) return { home, status: "no-legacy-home" }
+    // The new home wins whenever it holds anything: a newer build already wrote
+    // there, and the legacy directory is a stale copy from a downgrade.
+    if (isDirectory(home) && !isEmptyDirectory(home)) {
+      onEvent("DSH home migration skipped, destination already populated", { home, legacyHome })
+      return { home, status: "home-already-populated" }
+    }
+
+    // ~/Library is 0700 and used to protect the sessions inside it; the home
+    // directory is not, so the dotdir has to ask. An existing ~/.pawwork — v1
+    // owns one — keeps whatever mode it already has.
+    mkdirSync(dirname(home), { mode: 0o700, recursive: true })
     // rename onto an existing directory is fine on POSIX and fails on Windows,
     // so the empty placeholder goes first either way.
     if (existsSync(home)) rmSync(home, { recursive: true })
 
-    let status: DshHomeMigrationStatus
-    try {
-      rename(legacyHome, home)
-      status = "renamed"
-    } catch (error) {
-      if (!isCrossDeviceError(error)) throw error
-      copyAcrossDevices(legacyHome, home)
-      status = "copied"
-    }
-
-    writeMovedMarker(legacyHome, home, now())
-    onEvent("DSH home migrated", { home, legacyHome, status })
-    return { home, status }
+    status = commitDshHome(legacyHome, home, rename)
   } catch (error) {
-    // A half-finished copy would read as an already-migrated home on the next
-    // start, so it is removed and this run keeps using the legacy directory.
-    if (existsSync(home) && isDirectory(legacyHome)) rmSync(home, { force: true, recursive: true })
-    const failure = error instanceof Error ? error : new Error(String(error))
+    // Only reachable before the commit, so the legacy home is still intact and
+    // anything at the new path is a leftover the next start would misread as a
+    // migrated home.
+    rmSync(home, { force: true, recursive: true })
+    rmSync(stagingHome(home), { force: true, recursive: true })
+    const failure = describe(error)
     onEvent("DSH home migration failed, staying in the legacy home", {
       home,
       legacyHome,
@@ -151,5 +165,40 @@ export function migrateDshHome(options: MigrateDshHomeOptions): DshHomeMigration
     })
     return { home: legacyHome, status: "failed", error: failure }
   }
+
+  // Past the commit the new home is authoritative, so the rest is best-effort:
+  // failing to tidy up must not undo a move that already succeeded.
+  discardLegacyHome(legacyHome, onEvent)
+  writeMovedMarker(legacyHome, home, now, onEvent)
+  onEvent("DSH home migrated", { home, legacyHome, status })
+  return { home, status }
 }
 
+// Left over only after a cross-device copy. Keeping it costs a stale directory
+// the next start walks past; deleting the migrated home to "undo" would cost the
+// data, so a lock or a permission problem here just gets logged.
+function discardLegacyHome(legacyHome: string, onEvent: NonNullable<MigrateDshHomeOptions["onEvent"]>) {
+  if (!isDirectory(legacyHome)) return
+  try {
+    rmSync(legacyHome, { force: true, maxRetries: 3, recursive: true })
+  } catch (error) {
+    onEvent("DSH legacy home left behind", { legacyHome, error: describe(error).message })
+  }
+}
+
+// A signpost for whoever goes looking in the old location. Nothing reads it, so
+// a write failure is worth a log line and nothing more.
+function writeMovedMarker(
+  legacyHome: string,
+  home: string,
+  now: () => Date,
+  onEvent: NonNullable<MigrateDshHomeOptions["onEvent"]>,
+) {
+  const marker = join(dirname(legacyHome), DSH_MOVED_MARKER_NAME)
+  try {
+    const document = { schema: 1, movedAt: now().toISOString(), from: legacyHome, to: home }
+    writeFileSync(marker, `${JSON.stringify(document, null, 2)}\n`, "utf8")
+  } catch (error) {
+    onEvent("DSH moved marker not written", { marker, error: describe(error).message })
+  }
+}


### PR DESCRIPTION
## Summary

DSH now runs out of a home dotdir instead of Electron's userData directory:

- prod: `~/.pawwork/dsh` — dev: `~/.pawwork/dsh-dev`
- new `src/main/pawwork-home.ts` resolves the home and performs a one-time migration of `<userData>/dsh`, run in `startDsh()` before the product overlay is prepared
- the migration answers the home path DSH should start from, and is modelled around its commit point: same-filesystem moves ride `rename`, cross-device moves build the same atomicity by hand (copy into a sibling staging directory → verify → rename into place), and everything after the commit is best-effort
- `scripts/ci-smoke.ts` resolves the same path, from `PAWWORK_CI_SMOKE_HOME` rather than `os.homedir()`

Only DSH data moves — `sessions/`, `settings.yaml`, `.credentials.yaml`, `attachments/`, `storages/`, `profiles/`, `plugins/`, the `node_modules/@pawwork/*` overlay, plus PawWork's own `automations.json` and `import-v1/`. Chromium's state (Cache, Cookies, Local Storage, Preferences, window state, logs, updater cache) stays in userData, matching what Claude and Codex do on the desktop.

## Why

`<userData>/dsh` put the user's agent data — sessions, settings, credentials, automations — inside `~/Library/Application Support/ai.pawwork.desktop/` and `%APPDATA%\ai.pawwork.desktop\`, among Chromium's caches. That is not where anyone looks for it, and it is not where comparable agent products keep it.

**Why `~/.pawwork/dsh` and not `~/.pawwork` itself.** v1 is still maintained on `maint/v1` and still shipping, and its home *is* `~/.pawwork`: it owns `pawwork.json`, `MEMORY.md`, `memory/` and — the blocker — a `node_modules/` of its own, which would collide with the `node_modules/@pawwork/*` overlay v2 rewrites into DSH_HOME on every start. One level down avoids the collision outright, and when v1 is retired its files can move into `~/.pawwork/legacy/` without moving v2's.

## Related Issue

No issue — follow-up to the v2 storage layout, filed straight as a PR.

## Human Review Status

Approved by @Astro-Han

## Review Focus

- **The commit point.** A move is not a rollback-able transaction: once the new location holds the data, the old cleanup logic is wrong. `migrateDshHome` now has exactly one commit point (`commitDshHome`), the cleanup branch is reachable only before it, and deleting the source / writing the marker happen after it and can fail without undoing anything. This is the part worth reading closely.
- **Ordering:** the migration must run before `prepareDshProductHome()`, which would otherwise create and populate the new home and make the migration read it as a home a newer build had already written. It is now that call's argument, so evaluation order holds the constraint rather than a comment, and the smoke pins it end to end — the fixture is seeded in the legacy home and asserted in the dotdir home, so removing the migrate call fails the smoke (verified by mutation, see below).
- **Smoke isolation:** `buildSmokeEnv` can only set `HOME`, and `os.homedir()` reads `USERPROFILE` on Windows, so the home root resolves from `PAWWORK_CI_SMOKE_HOME` first. Without that, a Windows smoke run would write into the real user profile.

## How To Verify

Rebased onto `main` after #1582 (DSH 0.1.1-rc.1) landed; everything below was run on the rebased branch, after an adversarial review pass reshaped the migration around its commit point.

```text
pnpm --filter @pawwork/desktop typecheck: clean (tsgo -b)
pnpm --filter @pawwork/desktop test: vitest 311/311 in 33 files, node --test 85/85
  src/main/pawwork-home.test.ts covers: per-channel resolution, smoke-home
  precedence, rename, cross-device copy through staging (0600 preserved,
  overlay symlinks not followed, staging cleaned up), 0700 dotdir, source
  delete failing after the commit (migration stands), marker write failing
  after the commit (migration stands), idempotent second start, populated
  home not overwritten, empty home migrated into, pre-commit failure
  falling back with every leftover removed
pnpm --filter @pawwork/desktop build && PAWWORK_CI_SMOKE_CDP=true smoke:ci: passed
Mutation check on the smoke, re-run after the simplification pass: dropping the
  migrateDshHome() call from startDsh()
  fails the run — "Automation automation-smoke seeded in <smoke>/ai.pawwork.
  desktop.dev/dsh did not reach <smoke>/.pawwork/dsh-dev" — and passes again
  once restored. Before this PR's smoke change the same mutation passed green.
Real dev run (pnpm run dev:desktop, dev channel, data moved back to the legacy
  location first so the migration ran for real, backed up beforehand):
  "DSH home migrated { home: ~/.pawwork/dsh-dev, legacyHome: <userData>/dsh,
  status: renamed }"; ~/.pawwork and the home are both drwx------; 33 sessions
  and their workspaces in the sidebar; Settings and the Automations panel
  intact; import-v1/ledger.json moved with the home, no re-import; marker
  written at <userData>/dsh-moved.json
```

## Screenshots or Recordings

No visible UI change — the migration is silent and the app looks identical. Verified by hand that the sidebar, Settings and Automations still show the migrated data (see How To Verify).

## Checklist

- [x] **Type label** — this PR carries exactly one of `bug`, `enhancement`, `task`, `documentation`. Type labels are author-added; the labeler bot does NOT assign them. Add the label in the GitHub UI, then tick this.
- [x] **Routing labels** — this PR carries at least one of `app`, `ui`, `platform`, `harness`, `ci`. The labeler bot assigns these on PR open based on changed paths. Confirm the bot's choice (or override if wrong), then tick this.
- [x] **Priority label** — this PR carries exactly one of `P0`, `P1`, `P2`, `P3`. The priority-triage bot suggests one on PR open. Confirm or override, then tick this.
- [x] Human Review Status above is set to `Pending`, `Approved by @<reviewer>`, or `Not required: <reason>` (default is `Pending`; "not required" is restricted to bot-authored low-risk PRs).
- [x] I linked the related issue, or stated in Summary why there is no issue.
- [x] I described the review focus and any meaningful risks.
- [x] I replaced the example block in How To Verify with the real verification steps and the key result for each.
- [x] I did not introduce unrelated refactors, dependencies, generated files, or file changes beyond the stated scope.
- [ ] **(conditional)** I manually checked visible UI or copy changes when needed, with screenshots or recordings. Leave unticked only if no visible UI or copy changed.
- [x] **(conditional)** I considered macOS and Windows impact for platform, packaging, updater, signing, paths, shell, or permissions changes. Leave unticked only if no platform/packaging surface was touched.
- [x] **(conditional)** I called out docs, release notes, dependencies, permissions, credentials, deletion behavior, generated content, or local file changes when relevant. Leave unticked only if none of those surfaces was touched.
- [x] I reviewed the final diff for unrelated changes and suspicious dependency changes.
- [x] I am targeting `main`, and my PR title and commit messages use Conventional Commits in English.
