### PR TITLE
fix(desktop): report why DSH failed to start instead of exiting silently

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -4,6 +4,7 @@ import { rm } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
+import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath, pathToFileURL } from "node:url"
 import { app, BrowserWindow, dialog, ipcMain, shell, type Event } from "electron"
 import contextMenu from "electron-context-menu"
@@ -30,6 +31,8 @@ import { launchDshSidecar, type DshSidecar } from "./dsh-sidecar"
 import { initLogging } from "./logging"
 import { detectSystemMenuLocale } from "./menu-labels"
 import { createUpdateFeed, githubFeed, r2Feed, type FeedTarget } from "./update-feed"
+import { reportStartupFailure } from "./startup-failure"
+import { PAWWORK_GITHUB_ISSUE_URL } from "./support-links"
 import { createUpdaterController } from "./updater"
 import { pendingUpdateCacheDir } from "./updater-cache"
 import { updaterDialogLabels } from "./updater-dialog-labels"
@@ -63,6 +66,11 @@ const menuLocale = detectSystemMenuLocale(app.getLocale())
 
 let dshUrl: string | undefined
 let fileInputPreload: string | undefined
+// DSH states the cause and the fix on its own stderr before it exits, and a
+// failure that early has no window to render it in. Keeping the tail costs a few
+// kilobytes and is the only copy the dialog can reach.
+const DSH_OUTPUT_TAIL_CHARS = 4_000
+let dshOutputTail = ""
 let sidecar: DshSidecar | undefined
 let sidecarShutdown: Promise<void> | undefined
 let sidecarStopRequested = false
@@ -169,6 +177,25 @@ function setupApp() {
     .catch(async (error) => {
       logger.error("app initialization failed", error)
       await shutdownSidecar().catch((shutdownError) => logger.error("DSH shutdown failed", shutdownError))
+      // The log already holds all of this, but no window ever opened, so the log
+      // is the one place the user cannot be expected to look. The dialog is also
+      // what keeps the process alive long enough for DSH's last words to reach
+      // the log. Failing to show it must not replace the original failure.
+      if (!CI_SMOKE_ENABLED) {
+        await reportStartupFailure({
+          locale: menuLocale,
+          logPath: logger.transports.file.getFile().path,
+          output: dshOutputTail,
+          showMessageBox: (options) => dialog.showMessageBox(options),
+          openIssue: () => shell.openExternal(PAWWORK_GITHUB_ISSUE_URL),
+          showItemInFolder: async (path) => {
+            shell.showItemInFolder(path)
+            // Windows hands the reveal to a background task and app.exit skips
+            // cleanup, so give the call a moment to land before the process goes.
+            await delay(500)
+          },
+        }).catch((dialogError) => logger.error("startup failure dialog failed", dialogError))
+      }
       app.exit(1)
     })
 }
@@ -204,7 +231,10 @@ async function startDsh() {
     timeoutMs: 30_000,
     spawn: (executable, args, options) => spawn(executable, args, options),
     onStdout: (chunk) => logger.log("DSH stdout", { chunk: chunk.trimEnd() }),
-    onStderr: (chunk) => logger.error("DSH stderr", chunk.trimEnd()),
+    onStderr: (chunk) => {
+      dshOutputTail = (dshOutputTail + chunk).slice(-DSH_OUTPUT_TAIL_CHARS)
+      logger.error("DSH stderr", chunk.trimEnd())
+    },
   })
   dshUrl = sidecar.url
   void sidecar.exited.then((code) => {

--- a/packages/desktop-electron/src/main/startup-failure.test.ts
+++ b/packages/desktop-electron/src/main/startup-failure.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest"
+import { reportStartupFailure } from "./startup-failure"
+
+const LOG_PATH = "/Users/pat/Library/Logs/PawWork/main.log"
+
+// Reproduced from a real DSH exit: the sentence that says what to do is at the
+// top, buried in frames, and repeated down the `[cause]` chain.
+const CRASH_DUMP = `file:///app/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:299
+      throw new Error(\`failed to load plugin\`, { cause })
+      ^
+
+Error: failed to load plugin
+    at updateError (file:///app/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:299:9)
+    at Entry._init (file:///app/node_modules/@deepseek-ai/cordis/lib/index.js:519:10) {
+  [cause]: Error: credentials-local: /Users/pat/.credentials.yaml is readable beyond its owner (mode 644); run "chmod 600 /Users/pat/.credentials.yaml" before starting again
+      at assertOwnerOnly (file:///app/node_modules/@deepseek-ai/dsh-credentials-local/lib/index.js:104:8)
+}
+
+Node.js v26.7.0`
+
+function report(output: string, response = 0, locale: "en" | "zh" = "zh") {
+  const seen: Array<Parameters<Parameters<typeof reportStartupFailure>[0]["showMessageBox"]>[0]> = []
+  const opened: string[] = []
+  const revealed: string[] = []
+  const done = reportStartupFailure({
+    locale,
+    logPath: LOG_PATH,
+    output,
+    showMessageBox: async (options) => {
+      seen.push(options)
+      return { response }
+    },
+    openIssue: () => {
+      opened.push("issue")
+    },
+    showItemInFolder: (path) => {
+      revealed.push(path)
+    },
+  })
+  return { done, content: () => seen[0], opened, revealed }
+}
+
+describe("DSH startup failure report", () => {
+  // The dialog's whole job is to hand back the runtime's own words. Anything the
+  // user cannot act on — the throw site, the frames, the Node version — is noise
+  // that pushes the one actionable sentence off the screen.
+  test("shows the innermost cause of a stack dump and nothing else from it", async () => {
+    const { done, content } = report(CRASH_DUMP)
+    await done
+
+    expect(content().detail).toBe(
+      `credentials-local: /Users/pat/.credentials.yaml is readable beyond its owner (mode 644); run "chmod 600 /Users/pat/.credentials.yaml" before starting again\n\n完整日志位于：\n${LOG_PATH}`,
+    )
+  })
+
+  // Node labels its own failures with a code, and a plugin package that failed
+  // to resolve is one of the failures most worth naming.
+  test("reads through the bracketed code Node puts on its own errors", async () => {
+    const { done, content } = report(
+      [
+        "node:internal/modules/esm/resolve:275",
+        "  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base))",
+        "",
+        "Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@pawwork/dsh-product' imported from /Users/pat/.pawwork/",
+        "    at packageResolve (node:internal/modules/esm/resolve:275:9)",
+      ].join("\n"),
+    )
+    await done
+
+    expect(content().detail.split("\n\n")[0]).toBe(
+      "Cannot find package '@pawwork/dsh-product' imported from /Users/pat/.pawwork/",
+    )
+  })
+
+  test("still points at the log when the runtime said nothing recognisable", async () => {
+    const { done, content } = report("dsh: starting\ndsh: loading plugins\n")
+    await done
+
+    expect(content().detail).toBe(`完整日志位于：\n${LOG_PATH}`)
+  })
+
+  // Return and Escape both resolve to this button, and it is the only one whose
+  // meaning must survive a reorder: the other two act on the user's machine.
+  test("defaults and cancels to quitting", async () => {
+    const { done, content } = report("")
+    await done
+
+    expect(content().buttons[content().defaultId]).toBe("退出")
+    expect(content().buttons[content().cancelId]).toBe("退出")
+  })
+
+  test("opens the issue tracker or reveals the log, matching the button pressed", async () => {
+    const quit = report(CRASH_DUMP, 0)
+    await quit.done
+    expect([quit.opened, quit.revealed]).toEqual([[], []])
+    expect(quit.content().buttons).toEqual(["退出", "反馈问题", "显示日志"])
+
+    const issue = report(CRASH_DUMP, 1)
+    await issue.done
+    expect([issue.opened, issue.revealed]).toEqual([["issue"], []])
+
+    const log = report(CRASH_DUMP, 2)
+    await log.done
+    expect([log.opened, log.revealed]).toEqual([[], [LOG_PATH]])
+  })
+
+  // The two locales are separate literals, so a swap inside one of them cannot
+  // be caught by testing the other.
+  test("keeps the button order in both locales", async () => {
+    const en = report("", 0, "en")
+    await en.done
+
+    expect(en.content().buttons).toEqual(["Quit", "Report a Problem", "Show Log"])
+    expect(en.content().detail).toBe(`The full log is at:\n${LOG_PATH}`)
+  })
+
+  test("truncates a runtime that puts a whole document on one line", async () => {
+    const { done, content } = report(`Error: ${"x".repeat(900)}`)
+    await done
+
+    const [diagnosis] = content().detail.split("\n\n")
+    expect(diagnosis).toHaveLength(401)
+    expect(diagnosis.endsWith("…")).toBe(true)
+  })
+})

--- a/packages/desktop-electron/src/main/startup-failure.ts
+++ b/packages/desktop-electron/src/main/startup-failure.ts
@@ -1,0 +1,91 @@
+import type { MenuLocale } from "./menu-labels"
+
+type Labels = {
+  title: string
+  message: string
+  hint: (logPath: string) => string
+  buttons: { quit: string; reportIssue: string; showLog: string }
+}
+
+const labels: Record<MenuLocale, Labels> = {
+  en: {
+    title: "PawWork Could Not Start",
+    message: "PawWork's agent runtime did not start, so the app is closing.",
+    hint: (logPath) => `The full log is at:\n${logPath}`,
+    buttons: { quit: "Quit", reportIssue: "Report a Problem", showLog: "Show Log" },
+  },
+  zh: {
+    title: "爪印无法启动",
+    message: "爪印的智能体运行时未能启动，应用即将退出。",
+    hint: (logPath) => `完整日志位于：\n${logPath}`,
+    buttons: { quit: "退出", reportIssue: "反馈问题", showLog: "显示日志" },
+  },
+}
+
+// A sentence, not a stack: long enough for the runtime's own wording, short
+// enough that the dialog stays one screenful.
+const MAX_DIAGNOSIS_CHARS = 400
+
+/**
+ * The one sentence worth showing out of a runtime's dying output.
+ *
+ * A runtime that fails loud prints a stack dump: the sentence naming the cause
+ * and the fix sits at the top, wrapped in frames, and repeats down the `[cause]`
+ * chain as each layer rethrows. The innermost repetition is the most specific,
+ * so the last match wins, and the frames are noise nobody can act on.
+ *
+ * The bracket is optional because Node labels its own failures with a code —
+ * `Error [ERR_MODULE_NOT_FOUND]: ...` is what a missing plugin package looks
+ * like, and that is one of the failures most worth naming.
+ * @param output - whatever the runtime wrote before exiting.
+ * @returns the innermost error sentence, or "" if there is none.
+ */
+function diagnose(output: string) {
+  let found = ""
+  for (const line of output.split(/\r?\n/)) {
+    const match = /[A-Za-z]*Error(?: \[[^\]]+\])?: (.+)$/.exec(line.trim())
+    if (match) found = match[1].trim()
+  }
+  return found.length > MAX_DIAGNOSIS_CHARS ? `${found.slice(0, MAX_DIAGNOSIS_CHARS)}…` : found
+}
+
+function startupFailureDialog(locale: MenuLocale, logPath: string, output: string) {
+  const copy = labels[locale]
+
+  return {
+    type: "error" as const,
+    title: copy.title,
+    message: copy.message,
+    detail: [diagnose(output), copy.hint(logPath)].filter(Boolean).join("\n\n"),
+    // Quit leads: it is what the app is about to do anyway, and it is the safe
+    // landing spot for Return and Escape alike.
+    buttons: [copy.buttons.quit, copy.buttons.reportIssue, copy.buttons.showLog],
+    defaultId: 0,
+    cancelId: 0,
+  }
+}
+
+type ReportStartupFailureOptions = {
+  locale: MenuLocale
+  logPath: string
+  output: string
+  showMessageBox: (options: ReturnType<typeof startupFailureDialog>) => Promise<{ response: number }>
+  openIssue: () => void | Promise<void>
+  showItemInFolder: (path: string) => void | Promise<void>
+}
+
+/**
+ * Tell the user why the app is closing, and offer the two ways out.
+ *
+ * Reporting comes before the log because the log is a dead end on its own: a
+ * `.log` file has no owning app on a fresh machine, and the user who cannot fix
+ * the runtime needs somewhere to hand the failure to. The menu that normally
+ * carries that link is never built when the start fails this early.
+ * @param options - locale, log path, the runtime's output, and the host calls.
+ */
+export async function reportStartupFailure(options: ReportStartupFailureOptions) {
+  const content = startupFailureDialog(options.locale, options.logPath, options.output)
+  const { response } = await options.showMessageBox(content)
+  if (response === 1) await options.openIssue()
+  if (response === 2) await options.showItemInFolder(options.logPath)
+}


### PR DESCRIPTION
## Goal

When the DSH sidecar never reaches readiness, the app logged the failure and called `app.exit(1)`. No window had opened yet, so the user saw the Dock icon bounce once and nothing else — no way to tell a broken install from a crash, and no reason to look in a log file they do not know exists.

## Change

Show a localized dialog before exiting, carrying the runtime's own diagnosis and three ways out: quit, report the problem, or reveal the log. Reporting is offered because the log is a dead end on its own — a `.log` file has no owning app on a fresh machine, and the Help menu that normally carries the issue link is never built when the start fails this early.

The diagnosis is the innermost `Error:` sentence from DSH's stderr, **not a tail of it**. A runtime that fails loud prints a Node stack dump: the sentence naming the cause and the fix sits at the top, wrapped in frames, and repeats down the `[cause]` chain. A tail would hand the user stack frames and `Node.js v26.7.0`.

Two things this deliberately does **not** do:

- **It adds nothing to `dsh-sidecar.ts`.** The stderr tail is kept where it was already being consumed — the `onStderr` callback that has always written it to the log. The sidecar keeps its one job of owning the child process.
- **It does not drain the child before reporting.** The modal is itself what holds the process open long enough for the runtime's last lines to reach the log; a human takes far longer to read and click than the stdio takes to flush.

Skipped under `PAWWORK_CI_SMOKE` so a failing smoke run still fails fast instead of blocking on a dialog nobody will click.

## Non-goals

- A sidecar that crashes **after** readiness still calls `app.quit()` silently (`index.ts`). Same user-visible symptom, different path; it needs somewhere to render, which is the follow-up below.
- `spawn` itself failing (EACCES/ENOENT) still raises an uncaught exception before this `.catch` can run. Pre-existing, not a regression.

Both are worth fixing by opening the window **before** `startDsh()` and rendering startup, failure, and mid-session crash in-window — which also gets a Retry button and selectable text. That is a separate PR.

## Verification

- `pnpm typecheck`, `pnpm lint`
- 33 vitest files / 305 tests, node suites
- `pnpm run build` then `pnpm run smoke:ci` on the packaged app
- The six dialog tests were checked against eight mutations — first-vs-innermost match, dropped truncation, altered `defaultId`/`cancelId`, swapped button order, swapped English labels, shifted response branch, dropped log hint. All eight were caught.

Ships with #1582; the two together are one release.

## Checklist

- [x] **Type label** added (`bug`)
- [x] **Routing labels** added (`platform`)
- [x] **Priority label** added (`P2`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized startup-failure dialog in English and Chinese.
  * Startup errors now show actionable details, including the log location and runtime output.
  * Added options to quit, report a problem, or open the log location.
  * Captured recent startup diagnostics to improve troubleshooting.

* **Bug Fixes**
  * Startup failures are now surfaced clearly instead of failing silently.

* **Tests**
  * Added coverage for error details, localization, truncation, and dialog actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->