### PR TITLE
fix(desktop): give the shell the native arrow cursor

### DIFF
--- a/packages/desktop-electron/resources/dsh/automations/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/automations/lib/client.js
@@ -40,7 +40,7 @@ window.__ModuleLoader__.load({
 .pawwork-automations-list { display: flex; flex-direction: column; gap: 8px; margin-top: 4px; }
 .pawwork-automation-row {
   align-items: center; background: transparent; border: 1px solid var(--dsw-alias-border-l2); border-radius: 12px;
-  color: inherit; cursor: pointer; display: grid; font: inherit; gap: 10px;
+  color: inherit; display: grid; font: inherit; gap: 10px;
   grid-template-columns: 20px minmax(0, 1fr); min-height: 62px;
   padding: 10px 14px; text-align: left; width: 100%;
 }

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -22,14 +22,25 @@ window.__ModuleLoader__.load({
    the control row. The selector anchors on the CSS-modules prefix because the hash after it changes
    per version; the code block banner matches too but is not positioned, so top is inert there. */
 [class*="_banner_"] { top: var(--pawwork-titlebar-height, 0px); }
+/* The shell keeps the hand cursor for links and gives DSH's buttons, rows and tabs the arrow.
+   PawWork's preference, not a platform rule, so it stays in the shell instead of going upstream.
+   :not(:disabled) is a specificity lever rather than a filter: it beats DSH's [data-expandable]
+   rules at (0,2,0) behind tool cards, skill cards and trajectory rows, which the hero page cannot
+   reveal. Known gap: trajectory's collapsed-summary row is a bare <tr> with no role to match. */
+html body :is(button, [role="button"], [role="treeitem"], [role="tab"], [role="menuitem"], [role="menuitemradio"], [role="option"], [aria-haspopup], label, summary, select):not(a[href]):not(:disabled) { cursor: default; }
+/* Taking the hand away leaves nothing behind on controls DSH ships without a hover state (sidebar
+   brand row, copyable card, search-result file header). :where() drops this below DSH's own
+   .cls:hover at (0,2,0), making it a fallback rather than an override. Background only: a shared
+   border-radius would replace each control's own for as long as the hover lasts. */
+html body :where(button, [role="button"], [role="treeitem"]):where(:not(:disabled)):hover { background-color: var(--dsw-alias-interactive-bg-hover); }
 .pawwork-file-action {
   align-items: center; background: transparent; border: 0; border-radius: 6px;
-  color: var(--dsw-alias-label-secondary); cursor: pointer; display: inline-flex;
+  color: var(--dsw-alias-label-secondary); display: inline-flex;
   height: 28px; justify-content: center; padding: 0; width: 28px;
 }
 .pawwork-file-action:hover { background: var(--dsw-alias-interactive-bg-hover); color: var(--dsw-alias-label-primary); }
 .pawwork-file-action:focus-visible { outline: 2px solid #fc5c14; outline-offset: 1px; }
-.pawwork-file-action:disabled { cursor: default; opacity: 0.45; }
+.pawwork-file-action:disabled { opacity: 0.45; }
 /* The rc.8 locale registry throws on a duplicate namespace and offers no override point, so DSH's
    own headline and preview badge are replaced visually, anchored on data-slot rather than on class
    names that carry a per-version hash. Zeroing font-size alone leaves a 32px line box that lifts

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -205,47 +205,6 @@ describe("ci smoke helpers", () => {
     ).rejects.toThrow("CDP endpoint never came up on port 48291")
   })
 
-  test("assertCiSmokeProduct accepts the shipped DSH product contract", () => {
-    expect(() => assertCiSmokeProduct({
-      sidebarBrandVisible: true,
-      heroMarkVisible: true,
-      heroHeadlineOverridden: true,
-      heroPreviewBadgeHidden: true,
-      heroMarkHeadlineOffset: 0,
-      automationSettingsEntryVisible: true,
-      automationSidebarEntryAbsent: true,
-      automationSurfaceVisible: true,
-      automationCreateViaChatWorked: true,
-      automationEditorVisible: true,
-      automationEditorUsesFullWidth: true,
-      automationAdvancedVisible: true,
-      automationBackNavigationWorks: true,
-      automationEditorHeaderFits: true,
-      automationSaveWorks: true,
-      automationDeleteDialogWorks: true,
-      automationDirtyPauseBlocked: true,
-      automationMetadataPlain: true,
-      titlebarStripHeight: 32,
-      titlebarStripDraggable: true,
-      contentInsetHeight: 32,
-      sidebarBrandName: "爪印",
-      sidebarBrandTop: 46,
-      sidebarToggleCount: 1,
-      sidebarCollapsed: true,
-      sidebarExpandToggleCount: 1,
-      sidebarExpandToggleUsable: true,
-      sidebarExpandToggleHasContent: true,
-      sidebarExpandedAgain: true,
-      platform: "MacIntel",
-      freeProviderActive: true,
-      v1SessionImported: true,
-      v1SessionVisibleInSidebar: true,
-      skillNames: ["office-docx", "office-pdf", "office-pptx", "office-xlsx"],
-      sessionId: "session-smoke",
-      sessionIdsBeforeRestart: ["session-smoke"],
-    }, "darwin")).not.toThrow()
-  })
-
   // A healthy snapshot, and one broken value per field. Asserting on the joined
   // failure prose meant rewording any one message turned the test red while a
   // clause that stopped being evaluated stayed green. What matters is that every
@@ -271,6 +230,8 @@ describe("ci smoke helpers", () => {
     automationDeleteDialogWorks: true,
     automationDirtyPauseBlocked: true,
     automationMetadataPlain: true,
+    cursorMismatches: [],
+    cursorProbeCaught: ["a.pawwork-cursor-probe", "button.pawwork-cursor-probe"],
     titlebarStripHeight: 32,
     titlebarStripDraggable: true,
     contentInsetHeight: 32,
@@ -310,6 +271,8 @@ describe("ci smoke helpers", () => {
     automationDeleteDialogWorks: false,
     automationDirtyPauseBlocked: false,
     automationMetadataPlain: false,
+    cursorMismatches: ["div.CY-8Ka_root"],
+    cursorProbeCaught: [],
     titlebarStripHeight: 0,
     titlebarStripDraggable: false,
     contentInsetHeight: 8,

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -60,6 +60,8 @@ export type CiSmokeProductSnapshot = {
   automationDeleteDialogWorks: boolean
   automationDirtyPauseBlocked: boolean
   automationMetadataPlain: boolean
+  cursorMismatches: string[]
+  cursorProbeCaught: string[]
   titlebarStripHeight: number
   titlebarStripDraggable: boolean
   contentInsetHeight: number
@@ -270,6 +272,43 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       const label = (button.getAttribute("aria-label") || button.textContent || "").trim()
       return visible(button) && pattern.test(label)
     })
+    // The arrow rule's own selector, read back from the live stylesheet rather than copied here, so the
+    // probe cannot drift from the rule it checks. A missing rule reports itself instead of passing.
+    const arrowSelector = () => Array.from(document.styleSheets)
+      .flatMap((sheet) => { try { return Array.from(sheet.cssRules) } catch { return [] } })
+      .find((rule) => rule.style?.cursor === "default" && rule.selectorText?.includes("[aria-haspopup]"))?.selectorText
+    // Two directions, both scanned document-wide: a link that lost the hand fails as loudly as a
+    // control the rule claims and did not win. Elements outside the rule's reach — DSH's clickable
+    // bare divs, which carry no role to match on — are out of contract and deliberately not asserted.
+    const cursorMismatches = () => {
+      const selector = arrowSelector()
+      if (!selector) return ["<arrow cursor rule missing from the document>"]
+      return Array.from(new Set(Array.from(document.querySelectorAll("*"))
+        .filter((element) => {
+          const pointer = getComputedStyle(element).cursor === "pointer"
+          return element.matches("a[href]") ? !pointer : pointer && element.matches(selector)
+        })
+        // classList rather than splitting className: a regex literal loses its backslash on the way
+        // into Runtime.evaluate, so /\s+/ arrived as /s+/ and cut class names at every letter s.
+        .map((element) => element.tagName.toLowerCase() + (element.classList[0] ? "." + element.classList[0] : ""))))
+    }
+    // A probe that quietly stops reporting is worse than no probe, and this one is easy to break: it
+    // depends on a selector read back at runtime. So plant one failure in each direction, confirm both
+    // come back, and take them away again.
+    const cursorProbeDetects = () => {
+      const plant = (tag, cursor) => {
+        const element = document.createElement(tag)
+        element.className = "pawwork-cursor-probe"
+        if (tag === "a") element.href = "https://example.com"
+        element.style.setProperty("cursor", cursor, "important")
+        document.body.appendChild(element)
+        return element
+      }
+      const planted = [plant("a", "default"), plant("button", "pointer")]
+      const caught = cursorMismatches().filter((id) => id.endsWith(".pawwork-cursor-probe"))
+      planted.forEach((element) => element.remove())
+      return caught
+    }
     const call = async (method, payload) => {
       const request = { type: "client-request", rpcId: crypto.randomUUID(), method, payload }
       const response = await fetch("/api/" + method, {
@@ -301,6 +340,8 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     const titlebarStripHeight = titlebarStrip ? titlebarStrip.getBoundingClientRect().height : -1
     const titlebarStripDraggable = Boolean(titlebarStrip)
       && getComputedStyle(titlebarStrip).getPropertyValue("-webkit-app-region").trim() === "drag"
+    const cursorProbeCaught = cursorProbeDetects()
+    const heroCursorMismatches = cursorMismatches()
     const appRoot = document.getElementById("root")
     const contentInsetHeight = appRoot ? Number.parseFloat(getComputedStyle(appRoot).paddingTop) : -1
     // Assert that the headline override still fires, not the copy it produces: the mechanism is
@@ -411,6 +452,9 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     })
     settingsClose?.click()
     await new Promise((resolve) => setTimeout(resolve, 50))
+    // Sample again here: the hero page carries no [data-expandable] rows, so measuring only the
+    // first screen would miss the conversation surface entirely.
+    const settledCursorMismatches = cursorMismatches()
     const collapseToggles = sidebarToggles()
     collapseToggles[0]?.click()
     // The collapsed rail remounts, and data-sidebar-collapsed lands before the button does, so a
@@ -478,6 +522,8 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       automationDeleteDialogWorks,
       automationDirtyPauseBlocked,
       automationMetadataPlain,
+      cursorMismatches: Array.from(new Set([...heroCursorMismatches, ...settledCursorMismatches])),
+      cursorProbeCaught,
       titlebarStripHeight,
       titlebarStripDraggable,
       contentInsetHeight,
@@ -632,6 +678,12 @@ export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform:
     snapshot.sidebarBrandTop >= snapshot.titlebarStripHeight
       ? null
       : `sidebar brand starts at ${snapshot.sidebarBrandTop}px, inside the native window controls`,
+    snapshot.cursorProbeCaught.length === 2
+      ? null
+      : `the cursor probe caught ${snapshot.cursorProbeCaught.length}/2 planted mismatches (${snapshot.cursorProbeCaught.join(", ") || "nothing"}) and cannot be trusted`,
+    snapshot.cursorMismatches.length === 0
+      ? null
+      : `cursor does not match link status on: ${snapshot.cursorMismatches.join(", ")}`,
     snapshot.heroMarkVisible ? null : "PawWork hero brand mark is not rendered",
     snapshot.heroHeadlineOverridden ? null : "hero headline fell back to DSH copy",
     snapshot.heroPreviewBadgeHidden ? null : "DSH preview badge is still visible on the hero",


### PR DESCRIPTION
## Summary

Give the desktop shell the arrow cursor on controls that are not links, and make sure every control that loses the hand still has something to show on hover.

Three changes to the injected stylesheet, one net rule fewer than before:

- One `cursor: default` rule over DSH's buttons, list rows, tabs and menu items, weighted via `:not(:disabled)` and excluding `a[href]`.
- One `:where()` hover fallback at (0,1,2), below DSH's own `.cls:hover` at (0,2,0), so it only reaches controls DSH left without feedback.
- The `a[href^="http"]` rule is gone, along with two of our own `cursor: pointer` declarations that the new weight had made dead.

## Why

The first version of this PR claimed macOS and Windows reserve the hand cursor for hyperlinks. They do not. The only document that ever said so is Microsoft's Windows 7 desktop guide, which Microsoft marks as not updated for newer versions and does not follow on its own site; the CSSWG resolved in 2018 to spell out that authors "may use [pointer] on other interactive elements", and Apple's HIG has never contained a prohibition. Most major design systems — GOV.UK, Bootstrap, MUI, Primer, Polaris, Atlassian — ship the hand on buttons.

So this is PawWork's preference for its desktop shell, not a platform requirement, and the code comment now says that rather than borrowing authority it does not have. It stays in the desktop plugin: DSH is right to ship pointer because it also runs in a browser, and the remote-access path would inherit the mistake if this moved upstream.

The override also has to survive contact with DSH. Exhausting every `cursor: pointer` rule DSH ships — 146 of them, none `!important` — turns up five at or above (0,1,2), and three of those are the `[data-expandable]` disclosure rows behind tool cards, skill cards and trajectory. The previous weight lost all three, which meant the rule did nothing in the surface users actually spend their time in. `:not(:disabled)` lifts it to (0,2,2), wins all five, and unlike `!important` leaves `wait` and `not-allowed` intact on genuinely disabled controls.

Taking the hand away costs a control its last affordance when it has no hover state of its own, and DSH has at least three of those: the sidebar brand row, the copyable card, the file header in search results. Rather than a curated list of hashed class names, the fallback is pinned below DSH's own hover rules — controls that already respond keep their styling, the rest land on the fallback, and future ones are covered without anyone maintaining a list. It sets background only, so each control's own border-radius clips it; a shared radius here would swap out their real one for the duration of the hover.

## How To Verify

`pnpm --filter @pawwork/desktop test` — 338 passed. `typecheck` and `pnpm run lint` clean.

Static exhaustion of DSH's rules (grep across `@deepseek-ai/dsh-*`, specificity computed per selector): 146 pointer selectors, 0 `!important`, histogram `(0,1,0)×135  (0,1,1)×6  (0,2,0)×4  (0,2,2)×1`. The new rule at (0,2,2) beats every one it matches.

`pnpm run dev:desktop` with a CDP port attached:

- Document-wide two-way invariant over the rule's own reach: **0 mismatches**, and the probe's own self-test passes.
- The self-test was broken three ways to confirm it fails loudly: with the rule unreadable it reports `<arrow cursor rule missing from the document>`; with the predicate neutered to `return false` it returns false; on a healthy surface it returns true and leaves no planted element behind.
- `<a href role="button">` computes `pointer`, which is what `:not(a[href])` buys. A bare clickable div in DSH's shape is correctly ignored as out of contract.
- Text inputs keep `text`; the one disabled control on the surface keeps `default`.
- Hover verified through `CSS.forcePseudoState` rather than synthetic mouse events, which produce false negatives here because `.pawwork-titlebar` is a drag region and swallows `mousemove`. The brand row goes `rgba(0,0,0,0)` → `rgba(38,49,72,0.06)` on the fallback; `.hHd-Xa_newSession` goes `rgb(255,255,255)` → `rgb(241,243,245)` on its own rule, confirming the fallback sits below DSH's and does not displace it.

Not run locally: `smoke:ci` end to end, and any Windows or Linux pass. The new assertion runs inside the existing smoke, so CI covers it.

## Risk

The rule reaches semantic controls, so DSH's clickable elements that carry no role keep the hand: trajectory's collapsed-summary `<tr>`, and the composer card in its workspace-trigger state along with the descendants that inherit from it. Left open deliberately — a clickable element without a role is an accessibility defect upstream, and reaching it here would mean anchoring on hashed class names that change with every release candidate. If DSH gives them roles, this rule covers them with no change on our side.

The assertion is the rule's two-way invariant over the elements the rule claims: pointer if and only if link. It reads the rule's selector back off the live stylesheet rather than restating it, so probe and rule cannot drift, and a rule that never injected reports itself instead of passing. It also plants one failure in each direction before sampling and requires both back, so a predicate that stops reporting fails the run rather than passing it. It used to restate the CSS — it enumerated the same selectors the rule does, so a DSH restructure would desync both at once and still report zero. It is now the rule's complement, sampled on the hero surface and again after the automation flow, since the hero has no disclosure rows at all. That collapsed two snapshot fields into one and let the redundant inline fixture (branch-identical to `healthy`) go, so the per-field maintenance cost dropped from three fixtures to two.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor behavior across interactive controls, including disabled elements and additional interactive roles.
  * Ensured links display the appropriate pointer cursor while non-link elements no longer show misleading pointer cursors.
  * Removed misleading pointer cursors from automation list rows.
  * Added consistent hover backgrounds for buttons and supported interactive controls.
  * Improved validation of cursor behavior across key product states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


