### PR TITLE
docs: rewrite source comments in English

### DIFF
--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -5,14 +5,15 @@ window.__ModuleLoader__.load({
     const h = createElement
 
     const productCss = `
-/* 无边框窗口里没有原生标题栏可抓，这条顶带是窗口唯一的拖拽区；它同时替原生窗口
-   控件（macOS 交通灯、Windows overlay 按钮）占住它们画进内容坐标系的那一行。
-   Windows 由 Chromium 自己把 overlay 的真实几何写进 env(titlebar-area-*)，全屏和
-   DPI 缩放都跟着走；macOS 没有这个原语（titleBarOverlay 在那边不生效），由主进程
-   发布 --pawwork-titlebar-host-height。两个变量角色不同：host 的是宿主给的值，
-   下面这一行把它解析成最终值 —— 用 var() 的回退链而不是靠样式表顺序或选择器权重
-   压过彼此，注入时机和插入位置都不再影响结果。Linux 保留系统标题栏，两边都不给，
-   回退到 0px 自动失效。所有需要让位的规则都读解析后的那一个变量。 */
+/* A frameless window has no native title bar to grab: this strip is the window's only drag region,
+   and it reserves the row the native controls (macOS traffic lights, Windows overlay buttons) paint
+   into the content coordinate system. On Windows Chromium publishes the overlay's real geometry in
+   env(titlebar-area-*), which tracks fullscreen and DPI scaling; macOS has no such primitive
+   (titleBarOverlay does nothing there), so the main process publishes --pawwork-titlebar-host-height.
+   The line below resolves whichever the host supplies through a var() fallback chain instead of
+   stylesheet order or selector weight, so injection timing and insertion point stop mattering. Linux
+   keeps its system title bar and supplies neither, falling back to 0px. Every rule that has to yield
+   space reads the resolved variable. */
 :root { --pawwork-titlebar-height: var(--pawwork-titlebar-host-height, env(titlebar-area-height, 0px)); }
 #root { box-sizing: border-box; padding-top: var(--pawwork-titlebar-height, 0px); }
 .pawwork-titlebar {
@@ -20,9 +21,10 @@ window.__ModuleLoader__.load({
   height: var(--pawwork-titlebar-height, 0px);
   left: 0; position: fixed; right: 0; top: 0;
 }
-/* DSH 的断线重连横幅是 position: fixed; top: 0，不在 #root 的盒子里，padding 推不动
-   它，会整条落进原生控件带下面。同一个变量再用一次即可。选择器锚在 CSS-modules 的
-   前缀上（hash 会随版本变，前缀不会）；代码块横幅同名但不是定位元素，top 对它无效。 */
+/* The DSH reconnect banner is position: fixed; top: 0, outside #root's box, so padding cannot push
+   it and it would sit under the native control row. Reusing the same variable is enough. The selector
+   anchors on the CSS-modules prefix (the hash changes per version, the prefix does not); the code
+   block banner shares that name but is not positioned, so top does nothing to it. */
 [class*="_banner_"] { top: var(--pawwork-titlebar-height, 0px); }
 .pawwork-file-action {
   align-items: center; background: transparent; border: 0; border-radius: 6px;
@@ -32,19 +34,19 @@ window.__ModuleLoader__.load({
 .pawwork-file-action:hover { background: var(--dsw-alias-interactive-bg-hover); color: var(--dsw-alias-label-primary); }
 .pawwork-file-action:focus-visible { outline: 2px solid #fc5c14; outline-offset: 1px; }
 .pawwork-file-action:disabled { cursor: default; opacity: 0.45; }
-/* Hero 的标题与「预览版」角标是 DSH 自带文案。rc.8 的 locale registry 对重复
-   命名空间直接抛错，没有公开覆盖点，所以锚在 SlotOutlet 的 data-slot 上做视觉
-   替换 —— data-slot 是稳定的可寻址属性，不像构建产物的哈希类名会随版本变。
-   line-height 必须一起归零：只清 font-size 会留下 32px 的行高撑大行盒，把
-   整行文字相对 mark 上移 4.5px。 */
+/* The hero headline and the preview badge are DSH's own copy. The rc.8 locale registry throws on a
+   duplicate namespace and exposes no override point, so the replacement is visual and anchored on
+   SlotOutlet's data-slot — a stable addressable attribute, unlike build-hashed class names.
+   line-height has to be zeroed too: clearing font-size alone leaves a 32px line box that lifts the
+   whole line 4.5px relative to the mark. */
 span:has(> [data-slot="conversation.hero.brand.mark"]) + span { font-size: 0; line-height: 0; }
 span:has(> [data-slot="conversation.hero.brand.mark"]) + span::before { content: "What's first today?"; font-size: 26px; line-height: 32px; }
 html[lang^="zh"] span:has(> [data-slot="conversation.hero.brand.mark"]) + span::before { content: "今天从哪件事开始？"; }
 span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: none; }
-/* Hero mark 的悬停摆动。DSH 的 hero-fish-swim 是按鱼调的小幅度（±1px / -5°~3°），
-   爪印是只手套，挥手的左右幅度要大得多才读得出来。同样锚 data-slot，选择器权重
-   0,3,2 高于 DSH 的 0,3,0，直接覆盖 animation 简写。transform-origin 沿用 DSH 的
-   50% 60%，只改幅度不改性格。 */
+/* Hover wiggle for the hero mark. DSH's hero-fish-swim is tuned for a fish and stays small
+   (±1px, -5° to 3°); PawWork's mark is a glove, and a wave needs far more lateral travel to
+   read. Same data-slot anchor; selector weight 0,3,2 beats DSH's 0,3,0 and overrides the animation
+   shorthand outright. transform-origin keeps DSH's 50% 60% — only the amplitude changes. */
 @keyframes pawwork-hero-mark-swim {
   0%, 100% { transform: translate(0) rotate(0deg); }
   35% { transform: translate(-3px, -1.5px) rotate(-13deg); }
@@ -105,10 +107,11 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
         icon(["M21.44 11.05 12.25 20.24a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"]))
     }
 
-    // --- 爪印手套 mark -------------------------------------------------------
-    // 描自品牌应用图标：橙色手套体、米白肉垫与袖口、藏蓝外圈。袖口另画一份上移
-    // 副本，把它从原图的 19% 高度撑到约 29%，否则 24px 侧边栏里手套语义会塌成纯爪。
-    // 路径坐标空间是 0..6270，由 GLOVE_TRANSFORM 映射进 64x64 viewBox。
+    // --- PawWork glove mark --------------------------------------------------
+    // Traced from the brand app icon: orange glove body, cream pads and cuff, navy outline. The cuff
+    // is drawn a second time, shifted up, to grow it from 19% of the source height to roughly 29% —
+    // otherwise the glove collapses into a bare paw in the 24px sidebar. Path coordinates live in a
+    // 0..6270 space that GLOVE_TRANSFORM maps into the 64x64 viewBox.
     const BRAND_ORANGE = "#fc5c14"
     const BRAND_NAVY = "#1a2d5a"
     const BRAND_CREAM = "#faf6f1"
@@ -180,11 +183,12 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
 
     function BrandName() { return text("爪印", "PawWork") }
 
-    // v1 迁移是后台任务：它把冷会话逐条写进持久化，而客户端只在连接/重连时
-    // 拉取一次冷列表，迁移结束的时刻没人再刷新，侧边栏就停在旧列表上。宿主的
-    // import-v1 插件在 /pawwork-import-v1 暴露 session 阶段与最后一个已持久化
-    // session marker。完成后双读跨过 refreshList 的单飞屏障；只有 marker 已进入
-    // 公开 list 快照才算权威列表安装成功，否则退避后重试。
+    // The v1 import is a background job: it writes cold sessions into persistence one at a time,
+    // while the client fetches the cold list only on connect and reconnect. Nothing refreshes when
+    // the import finishes, so the sidebar keeps the old list. The host's import-v1 plugin exposes the
+    // session phase and the last persisted session marker at /pawwork-import-v1. On completion two
+    // reads clear refreshList's single-flight barrier; the authoritative list only counts as
+    // installed once the marker appears in the public list snapshot, otherwise back off and retry.
     const IMPORT_POLL_INTERVAL_MS = 1_000
     const IMPORT_POLL_MAX_RETRY_MS = 30_000
 
@@ -227,9 +231,9 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
           schedule(IMPORT_POLL_INTERVAL_MS)
           return
         }
-        // 离开 running 即完成。refreshList 单飞复用仍在途的拉取——完成信号出现
-        // 时可能还挂着一条迁移前的旧列表——所以读两次：第一次等在途的 settle，
-        // 第二次才是必然在完成屏障之后发起的权威读取。
+        // Leaving running means done. refreshList reuses a still in-flight fetch, which when the
+        // completion signal arrives may still be carrying the pre-import list, so read twice: the
+        // first waits for that fetch to settle, the second is guaranteed to start after the barrier.
         await sessions.refresh()
         if (stopped) return
         await sessions.refresh()
@@ -250,8 +254,8 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
       ctx.slots.inject("conversation.hero.brand.mark", () => ctx.slots.register({ name: "conversation.hero.brand.mark", priority: -100 }, PawGloveMark))
       ctx.slots.inject("settings.onboarding", () => ctx.slots.register({ name: "settings.onboarding", id: "welcome-notice", order: -100, priority: -1 }, CompleteWelcomeNotice))
       ctx.slots.inject("conversation.input.left", () => ctx.slots.register({ name: "conversation.input.left", id: "pawwork-files", order: -100 }, FileAction))
-      // 轮询器随插件而止：dispose（HMR / 重新登录）时清掉定时器，不再对已销毁的
-      // fiber 发起 status / refresh 调用。
+      // The poller stops with the plugin: dispose (HMR, re-login) clears the timer so no status or
+      // refresh call is fired at a destroyed fiber.
       ctx.effect(() => watchV1Import(ctx))
     }
 

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -5,15 +5,12 @@ window.__ModuleLoader__.load({
     const h = createElement
 
     const productCss = `
-/* A frameless window has no native title bar to grab: this strip is the window's only drag region,
-   and it reserves the row the native controls (macOS traffic lights, Windows overlay buttons) paint
-   into the content coordinate system. On Windows Chromium publishes the overlay's real geometry in
-   env(titlebar-area-*), which tracks fullscreen and DPI scaling; macOS has no such primitive
-   (titleBarOverlay does nothing there), so the main process publishes --pawwork-titlebar-host-height.
-   The line below resolves whichever the host supplies through a var() fallback chain instead of
-   stylesheet order or selector weight, so injection timing and insertion point stop mattering. Linux
-   keeps its system title bar and supplies neither, falling back to 0px. Every rule that has to yield
-   space reads the resolved variable. */
+/* A frameless window has nothing to grab, and the native controls paint into the content
+   coordinate system, so this strip is both the only drag region and the reservation for them.
+   Chromium publishes the overlay geometry in env(titlebar-area-*) on Windows; macOS has no such
+   primitive, so the main process publishes --pawwork-titlebar-host-height instead. Resolving them
+   through a var() fallback chain rather than competing rules keeps injection order irrelevant, and
+   Linux, which supplies neither, falls back to 0px. */
 :root { --pawwork-titlebar-height: var(--pawwork-titlebar-host-height, env(titlebar-area-height, 0px)); }
 #root { box-sizing: border-box; padding-top: var(--pawwork-titlebar-height, 0px); }
 .pawwork-titlebar {
@@ -21,10 +18,9 @@ window.__ModuleLoader__.load({
   height: var(--pawwork-titlebar-height, 0px);
   left: 0; position: fixed; right: 0; top: 0;
 }
-/* The DSH reconnect banner is position: fixed; top: 0, outside #root's box, so padding cannot push
-   it and it would sit under the native control row. Reusing the same variable is enough. The selector
-   anchors on the CSS-modules prefix (the hash changes per version, the prefix does not); the code
-   block banner shares that name but is not positioned, so top does nothing to it. */
+/* The DSH reconnect banner is fixed and outside #root, so #root's padding cannot push it clear of
+   the control row. The selector anchors on the CSS-modules prefix because the hash after it changes
+   per version; the code block banner matches too but is not positioned, so top is inert there. */
 [class*="_banner_"] { top: var(--pawwork-titlebar-height, 0px); }
 .pawwork-file-action {
   align-items: center; background: transparent; border: 0; border-radius: 6px;
@@ -34,19 +30,17 @@ window.__ModuleLoader__.load({
 .pawwork-file-action:hover { background: var(--dsw-alias-interactive-bg-hover); color: var(--dsw-alias-label-primary); }
 .pawwork-file-action:focus-visible { outline: 2px solid #fc5c14; outline-offset: 1px; }
 .pawwork-file-action:disabled { cursor: default; opacity: 0.45; }
-/* The hero headline and the preview badge are DSH's own copy. The rc.8 locale registry throws on a
-   duplicate namespace and exposes no override point, so the replacement is visual and anchored on
-   SlotOutlet's data-slot — a stable addressable attribute, unlike build-hashed class names.
-   line-height has to be zeroed too: clearing font-size alone leaves a 32px line box that lifts the
-   whole line 4.5px relative to the mark. */
+/* The rc.8 locale registry throws on a duplicate namespace and offers no override point, so DSH's
+   own headline and preview badge are replaced visually, anchored on data-slot rather than on class
+   names that carry a per-version hash. Zeroing font-size alone leaves a 32px line box that lifts
+   the line 4.5px against the mark, so line-height has to go with it. */
 span:has(> [data-slot="conversation.hero.brand.mark"]) + span { font-size: 0; line-height: 0; }
 span:has(> [data-slot="conversation.hero.brand.mark"]) + span::before { content: "What's first today?"; font-size: 26px; line-height: 32px; }
 html[lang^="zh"] span:has(> [data-slot="conversation.hero.brand.mark"]) + span::before { content: "今天从哪件事开始？"; }
 span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: none; }
-/* Hover wiggle for the hero mark. DSH's hero-fish-swim is tuned for a fish and stays small
-   (±1px, -5° to 3°); PawWork's mark is a glove, and a wave needs far more lateral travel to
-   read. Same data-slot anchor; selector weight 0,3,2 beats DSH's 0,3,0 and overrides the animation
-   shorthand outright. transform-origin keeps DSH's 50% 60% — only the amplitude changes. */
+/* DSH's hero-fish-swim swims a fish in ±1px and -5° to 3°; a glove has to wave, which needs far
+   more travel to read. Selector weight 0,3,2 beats DSH's 0,3,0 and takes the animation shorthand
+   outright, and transform-origin stays at DSH's 50% 60%. */
 @keyframes pawwork-hero-mark-swim {
   0%, 100% { transform: translate(0) rotate(0deg); }
   35% { transform: translate(-3px, -1.5px) rotate(-13deg); }
@@ -108,10 +102,9 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
     }
 
     // --- PawWork glove mark --------------------------------------------------
-    // Traced from the brand app icon: orange glove body, cream pads and cuff, navy outline. The cuff
-    // is drawn a second time, shifted up, to grow it from 19% of the source height to roughly 29% —
-    // otherwise the glove collapses into a bare paw in the 24px sidebar. Path coordinates live in a
-    // 0..6270 space that GLOVE_TRANSFORM maps into the 64x64 viewBox.
+    // Traced from the brand app icon, in a 0..6270 coordinate space GLOVE_TRANSFORM maps into the
+    // 64x64 viewBox. The cuff is drawn twice, the copy shifted up, to grow it from 19% of the source
+    // height to roughly 29% — at 19% the glove collapses into a bare paw in the 24px sidebar.
     const BRAND_ORANGE = "#fc5c14"
     const BRAND_NAVY = "#1a2d5a"
     const BRAND_CREAM = "#faf6f1"
@@ -183,12 +176,11 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
 
     function BrandName() { return text("爪印", "PawWork") }
 
-    // The v1 import is a background job: it writes cold sessions into persistence one at a time,
-    // while the client fetches the cold list only on connect and reconnect. Nothing refreshes when
-    // the import finishes, so the sidebar keeps the old list. The host's import-v1 plugin exposes the
-    // session phase and the last persisted session marker at /pawwork-import-v1. On completion two
-    // reads clear refreshList's single-flight barrier; the authoritative list only counts as
-    // installed once the marker appears in the public list snapshot, otherwise back off and retry.
+    // The client fetches the cold list only on connect and reconnect, while the v1 import writes
+    // into it in the background — nothing refreshes when the import ends, so the sidebar keeps the
+    // pre-import list. The host's import-v1 plugin exposes the phase and the last persisted session
+    // at /pawwork-import-v1; the list only counts as installed once that marker shows up in the
+    // public snapshot.
     const IMPORT_POLL_INTERVAL_MS = 1_000
     const IMPORT_POLL_MAX_RETRY_MS = 30_000
 
@@ -231,9 +223,9 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
           schedule(IMPORT_POLL_INTERVAL_MS)
           return
         }
-        // Leaving running means done. refreshList reuses a still in-flight fetch, which when the
-        // completion signal arrives may still be carrying the pre-import list, so read twice: the
-        // first waits for that fetch to settle, the second is guaranteed to start after the barrier.
+        // refreshList reuses a still in-flight fetch, which at this point may be one that started
+        // before the import finished, so the first read only settles it and the second is the one
+        // guaranteed to begin after the completion barrier.
         await sessions.refresh()
         if (stopped) return
         await sessions.refresh()
@@ -254,8 +246,6 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
       ctx.slots.inject("conversation.hero.brand.mark", () => ctx.slots.register({ name: "conversation.hero.brand.mark", priority: -100 }, PawGloveMark))
       ctx.slots.inject("settings.onboarding", () => ctx.slots.register({ name: "settings.onboarding", id: "welcome-notice", order: -100, priority: -1 }, CompleteWelcomeNotice))
       ctx.slots.inject("conversation.input.left", () => ctx.slots.register({ name: "conversation.input.left", id: "pawwork-files", order: -100 }, FileAction))
-      // The poller stops with the plugin: dispose (HMR, re-login) clears the timer so no status or
-      // refresh call is fired at a destroyed fiber.
       ctx.effect(() => watchV1Import(ctx))
     }
 

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -291,12 +291,12 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     })
     const brandNodes = ["sidebar.brand.mark", "sidebar.brand.name"].flatMap(slotContent).filter(visible)
     const sidebarBrandVisible = brandNodes.length > 0
-    // 空数组时 Math.min 是 Infinity，JSON 化后变成 null，>= 比较会静默通过。
+    // Math.min of an empty array is Infinity, which JSON-serialises to null and lets >= pass silently.
     const sidebarBrandTop = brandNodes.length
       ? Math.min(...brandNodes.map((node) => node.getBoundingClientRect().top))
       : -1
-    // 品牌名槽位渲染的是纯字符串，也就是文本节点 —— slotContent 只选元素后代，
-    // 匹配不到任何东西。单独读文本，否则这条槽位回归 null 也不会红。
+    // The brand-name slot renders a bare string, i.e. a text node, and slotContent only selects
+    // element descendants. Read the text separately or a regression to null here stays green.
     const sidebarBrandName = (document.querySelector('[data-slot="sidebar.brand.name"]')?.textContent || "").trim()
     const titlebarStrip = document.querySelector(".pawwork-titlebar")
     const titlebarStripHeight = titlebarStrip ? titlebarStrip.getBoundingClientRect().height : -1
@@ -304,8 +304,9 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       && getComputedStyle(titlebarStrip).getPropertyValue("-webkit-app-region").trim() === "drag"
     const appRoot = document.getElementById("root")
     const contentInsetHeight = appRoot ? Number.parseFloat(getComputedStyle(appRoot).paddingTop) : -1
-    // Hero 是品牌标识唯一的落点：mark、覆盖后的标题、以及被隐藏的 DSH「预览版」角标。
-    // 只断言覆盖机制是否还在生效，不锁死具体文案 —— rc.7→rc.8 悄悄失效的正是机制。
+    // The hero is the only place the brand lands: mark, overridden headline, and the hidden DSH
+    // preview badge. Assert that the override still fires rather than pinning the copy — the
+    // mechanism is what broke silently between rc.7 and rc.8.
     const heroMark = document.querySelector('[data-slot="conversation.hero.brand.mark"] > svg')
     const heroHeadline = heroMark?.parentElement?.parentElement?.nextElementSibling
     const heroBadge = heroHeadline?.nextElementSibling
@@ -414,9 +415,9 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     await new Promise((resolve) => setTimeout(resolve, 50))
     const collapseToggles = sidebarToggles()
     collapseToggles[0]?.click()
-    // 折叠轨道是重新挂载的，data-sidebar-collapsed 会先于按钮出现；等按钮真正
-    // 就位再量，否则慢一点的机器上量到的是过渡中的空态。空壳按钮仍然有 36×36
-    // 的盒子，所以这个循环不会替真正的缺陷兜底 —— 那条由 hasContent 单独盯。
+    // The collapsed rail remounts, so data-sidebar-collapsed lands before the button does; wait
+    // for the button itself or a slower machine measures the mid-transition empty state. An empty
+    // shell button still has a 36x36 box, so this loop cannot mask the real defect — hasContent does.
     let expandToggles = []
     for (let frame = 0; frame < 60; frame += 1) {
       await new Promise((resolve) => setTimeout(resolve, 16))
@@ -425,8 +426,8 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     }
     const sidebarCollapsed = Boolean(document.querySelector("[data-sidebar-collapsed]"))
     const sidebarExpandToggleUsable = usable(expandToggles[0])
-    // 折叠态下 DSH 把品牌 mark 当作展开按钮的图标，悬停才换成面板图标。品牌槽位
-    // 一旦留空，这颗按钮就是个看不见的空壳 —— 这里盯的就是那种空壳。
+    // Collapsed, DSH uses the brand mark as the expand button's icon and swaps in the panel icon
+    // on hover. An empty brand slot leaves an invisible shell button, which is what this catches.
     const sidebarExpandToggleHasContent = Boolean(expandToggles[0])
       && Array.from(expandToggles[0].querySelectorAll("*")).some(visible)
     expandToggles[0]?.click()
@@ -559,9 +560,9 @@ export async function inspectCiSmokePersistence(target: CdpTarget, sessionId: st
   const restored = await evaluateCiSmokeJson(target, expression) as string[]
   if (restored.includes(sessionId)) return
 
-  // 这条断言只在重启后失败一次就没有第二次机会：进程已经换了一个，现场只剩磁盘。
-  // 所以失败信息要自带现场 —— 重启后实际读回哪些会话，以及 DSH home 里到底躺着
-  // 什么文件。区分「根本没写」和「写了但没读回来」全靠这两样。
+  // This assertion gets one shot: the process that wrote is gone and only the disk is left, so the
+  // message has to carry the scene — which sessions came back, and what sits in the DSH home. Those
+  // two are what separate "never written" from "written but not read back".
   throw new Error([
     `DSH session ${sessionId} did not survive desktop restart`,
     `sessions before restart: ${listedBefore.length ? listedBefore.join(", ") : "(none)"}`,
@@ -616,10 +617,11 @@ function describeDirectory(dir: string, prefix = "  "): string {
 }
 
 export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform: NodeJS.Platform = process.platform) {
-  // 原生窗口控件画在内容坐标系里，顶带是唯一声明这块安全区的地方。断言的是**关系**
-  // 而不是某个数字：数字在 Windows 上由 Chromium 的 env(titlebar-area-height) 决定，
-  // 在 macOS 上由主进程决定，这里再写一遍就又多一个手写权威。frameless 取自
-  // window-options 的无边框决定 —— 它和高度不同源，所以两边发散会红。
+  // Native window controls are painted in the content coordinate system, and the strip is the only
+  // declaration of that safe area. Assert the relationship, not a number: the number comes from
+  // Chromium's env(titlebar-area-height) on Windows and from the main process on macOS, so
+  // restating it here would add a second hand-written authority. frameless comes from the
+  // window-options frameless decision — a different source than the height, so divergence goes red.
   const frameless = "titleBarStyle" in dshTitleBarOptions(platform)
   const failures = [
     snapshot.sidebarBrandVisible ? null : "PawWork sidebar brand is not rendered",
@@ -837,8 +839,8 @@ async function main() {
       product = await inspectCiSmokeProduct(cdpTarget, homeDir)
       assertCiSmokeProduct(product)
       console.log("CI smoke verified DSH product UI, free model, and bundled skills")
-      // 关停前的快照。和失败信息里那张重启后的对照，才能把「会话根本没写成」
-      // 和「写成了但没读回来」分开 —— 只看重启后那一张，两者长得一模一样。
+      // Snapshot before shutdown. Paired with the post-restart one in the failure message it tells
+      // "never written" apart from "written but not read back"; the later snapshot alone cannot.
       await waitForSessionOnDisk(dshHome, product.sessionId)
       console.log(`CI smoke sessions before shutdown: ${product.sessionIdsBeforeRestart.join(", ") || "(none)"}`)
       console.log(`CI smoke session files before shutdown:\n${describeDirectory(join(dshHome, "sessions"))}`)

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -295,8 +295,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     const sidebarBrandTop = brandNodes.length
       ? Math.min(...brandNodes.map((node) => node.getBoundingClientRect().top))
       : -1
-    // The brand-name slot renders a bare string, i.e. a text node, and slotContent only selects
-    // element descendants. Read the text separately or a regression to null here stays green.
+    // The slot renders a bare string, so slotContent — element descendants only — misses it.
     const sidebarBrandName = (document.querySelector('[data-slot="sidebar.brand.name"]')?.textContent || "").trim()
     const titlebarStrip = document.querySelector(".pawwork-titlebar")
     const titlebarStripHeight = titlebarStrip ? titlebarStrip.getBoundingClientRect().height : -1
@@ -304,9 +303,8 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       && getComputedStyle(titlebarStrip).getPropertyValue("-webkit-app-region").trim() === "drag"
     const appRoot = document.getElementById("root")
     const contentInsetHeight = appRoot ? Number.parseFloat(getComputedStyle(appRoot).paddingTop) : -1
-    // The hero is the only place the brand lands: mark, overridden headline, and the hidden DSH
-    // preview badge. Assert that the override still fires rather than pinning the copy — the
-    // mechanism is what broke silently between rc.7 and rc.8.
+    // Assert that the headline override still fires, not the copy it produces: the mechanism is
+    // what broke silently between rc.7 and rc.8.
     const heroMark = document.querySelector('[data-slot="conversation.hero.brand.mark"] > svg')
     const heroHeadline = heroMark?.parentElement?.parentElement?.nextElementSibling
     const heroBadge = heroHeadline?.nextElementSibling
@@ -415,9 +413,9 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     await new Promise((resolve) => setTimeout(resolve, 50))
     const collapseToggles = sidebarToggles()
     collapseToggles[0]?.click()
-    // The collapsed rail remounts, so data-sidebar-collapsed lands before the button does; wait
-    // for the button itself or a slower machine measures the mid-transition empty state. An empty
-    // shell button still has a 36x36 box, so this loop cannot mask the real defect — hasContent does.
+    // The collapsed rail remounts, and data-sidebar-collapsed lands before the button does, so a
+    // slower machine would measure the transition. An empty shell button still has a 36x36 box, so
+    // waiting cannot mask the defect hasContent catches.
     let expandToggles = []
     for (let frame = 0; frame < 60; frame += 1) {
       await new Promise((resolve) => setTimeout(resolve, 16))
@@ -426,8 +424,8 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
     }
     const sidebarCollapsed = Boolean(document.querySelector("[data-sidebar-collapsed]"))
     const sidebarExpandToggleUsable = usable(expandToggles[0])
-    // Collapsed, DSH uses the brand mark as the expand button's icon and swaps in the panel icon
-    // on hover. An empty brand slot leaves an invisible shell button, which is what this catches.
+    // Collapsed, DSH uses the brand mark as the expand button's icon, so an empty brand slot
+    // leaves a button that is present and clickable but invisible.
     const sidebarExpandToggleHasContent = Boolean(expandToggles[0])
       && Array.from(expandToggles[0].querySelectorAll("*")).some(visible)
     expandToggles[0]?.click()
@@ -560,9 +558,9 @@ export async function inspectCiSmokePersistence(target: CdpTarget, sessionId: st
   const restored = await evaluateCiSmokeJson(target, expression) as string[]
   if (restored.includes(sessionId)) return
 
-  // This assertion gets one shot: the process that wrote is gone and only the disk is left, so the
-  // message has to carry the scene — which sessions came back, and what sits in the DSH home. Those
-  // two are what separate "never written" from "written but not read back".
+  // The process that wrote is gone and only the disk is left, so the message has to carry the
+  // scene: it is the sessions plus the home listing that separate "never written" from "not read
+  // back".
   throw new Error([
     `DSH session ${sessionId} did not survive desktop restart`,
     `sessions before restart: ${listedBefore.length ? listedBefore.join(", ") : "(none)"}`,
@@ -617,11 +615,9 @@ function describeDirectory(dir: string, prefix = "  "): string {
 }
 
 export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform: NodeJS.Platform = process.platform) {
-  // Native window controls are painted in the content coordinate system, and the strip is the only
-  // declaration of that safe area. Assert the relationship, not a number: the number comes from
-  // Chromium's env(titlebar-area-height) on Windows and from the main process on macOS, so
-  // restating it here would add a second hand-written authority. frameless comes from the
-  // window-options frameless decision — a different source than the height, so divergence goes red.
+  // Assert relationships, never a height: that number is owned by Chromium on Windows and by the
+  // main process on macOS, and restating it here would add a third authority. frameless is read
+  // from window-options, a different source than the height, so the two diverging goes red.
   const frameless = "titleBarStyle" in dshTitleBarOptions(platform)
   const failures = [
     snapshot.sidebarBrandVisible ? null : "PawWork sidebar brand is not rendered",
@@ -839,8 +835,6 @@ async function main() {
       product = await inspectCiSmokeProduct(cdpTarget, homeDir)
       assertCiSmokeProduct(product)
       console.log("CI smoke verified DSH product UI, free model, and bundled skills")
-      // Snapshot before shutdown. Paired with the post-restart one in the failure message it tells
-      // "never written" apart from "written but not read back"; the later snapshot alone cannot.
       await waitForSessionOnDisk(dshHome, product.sessionId)
       console.log(`CI smoke sessions before shutdown: ${product.sessionIdsBeforeRestart.join(", ") || "(none)"}`)
       console.log(`CI smoke session files before shutdown:\n${describeDirectory(join(dshHome, "sessions"))}`)

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -7,8 +7,8 @@ const repositoryRoot = resolve(import.meta.dirname, "../../../..")
 const productRoot = resolve(repositoryRoot, "packages/desktop-electron/resources/dsh/product")
 
 describe("PawWork DSH client product layer", () => {
-  // 共享的 watcher 测试脚手架：假定时器驱动轮询节奏，假 context 钉住 rpc/sessions
-  // 契约。每个测试只声明自己关心的 call/refresh/effect 行为。
+  // Shared watcher scaffold: fake timers drive the polling cadence and a fake context
+  // pins the rpc/sessions contract, so each test only declares what it cares about.
   function loadPlugin(timers: Array<() => void>, delays: number[] = []) {
     const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
       document: {
@@ -115,8 +115,8 @@ describe("PawWork DSH client product layer", () => {
       "conversation.hero.brand.mark",
     ])
     expect(brandEntries.every((entry) => entry.options.priority === -100)).toBe(true)
-    // 顶带替原生窗口控件占住了左上角，侧边栏品牌不再需要为它们让路：mark 和名字
-    // 在所有平台上一致渲染。
+    // The drag strip already reserves the top-left corner for the native window
+    // controls, so the sidebar brand renders identically on every platform.
     const sidebarMark = brandEntries[0].component({ size: 24 }) as { type: string; props: Record<string, unknown> }
     expect(sidebarMark.type).toBe("svg")
     expect(sidebarMark.props).toMatchObject({ viewBox: "0 0 64 64", width: 24, height: 24 })
@@ -147,10 +147,11 @@ describe("PawWork DSH client product layer", () => {
       throw new Error(`unexpected product client dependency: ${name}`)
     })
 
-    // 顶带必须是真元素：-webkit-app-region 对伪元素无效，拖不动窗口。
+    // The strip must be a real element: -webkit-app-region does nothing on pseudo-elements.
     expect(appended.map((node) => node.className)).toEqual(["pawwork-titlebar"])
-    // 让位的规则全部读同一个变量，没有第二处写死的数字。变量本身只从平台来：
-    // Windows 是 Chromium 的 env(titlebar-area-height)，macOS 由主进程注入覆盖。
+    // Every rule that yields space reads the same variable instead of a second hardcoded
+    // number, and the variable comes only from the platform: Chromium's
+    // env(titlebar-area-height) on Windows, a main-process override on macOS.
     expect(style.textContent).toContain("-webkit-app-region: drag")
     expect(style.textContent).toContain("padding-top: var(--pawwork-titlebar-height, 0px)")
     expect(style.textContent).toContain('[class*="_banner_"] { top: var(--pawwork-titlebar-height, 0px); }')
@@ -217,8 +218,9 @@ describe("PawWork DSH client product layer", () => {
     expect(setDraft).toHaveBeenCalledWith('请总结\n\n文件：\n- "/tmp/notes.md"')
   })
 
-  // 传输层失败不是完成信号：旧后端没有这个通道、宿主重启窗口都只是瞬时的，
-  // 客户端必须继续等，而不是数满几次失败就放弃、让侧边栏停在旧列表上。
+  // A transport failure is not a completion signal — an older backend without this channel
+  // and a host restart are both transient — so the client keeps waiting instead of giving
+  // up after N failures and stranding the sidebar on a stale list.
   test("backs off repeated transport failures and recovers without giving up", async () => {
     const timers: Array<() => void> = []
     const delays: number[] = []
@@ -273,12 +275,13 @@ describe("PawWork DSH client product layer", () => {
     expect(timers).toHaveLength(0)
   })
 
-  // 迁移运行时不读冷列表。完成后 refreshList 可能单飞复用仍在途的旧拉取；
-  // 所以要读两次：第一次等在途的 settle，第二次才是必然全新的权威读取。
+  // The migration runtime never reads the cold list, and after it completes refreshList may
+  // ride along on a still in-flight fetch. Hence two reads: the first waits for that fetch to
+  // settle, the second is the guaranteed-fresh authoritative one.
   test("waits for v1 import completion before issuing a fresh authoritative read", async () => {
     const timers: Array<() => void> = []
     const plugin = loadPlugin(timers)
-    // 第一次 refresh 停在在途不 resolve；第二次才开始新的拉取。
+    // The first refresh stays in flight and never resolves; only the second fetches again.
     const refresh = vi.fn()
     let firstInFlight: () => void = () => {}
     const visibleSessionIds: string[] = []
@@ -301,7 +304,7 @@ describe("PawWork DSH client product layer", () => {
     await new Promise((resolve) => setImmediate(resolve))
     expect(call).toHaveBeenCalledTimes(2)
     expect(refresh).toHaveBeenCalledTimes(1)
-    // 第一条在途：权威读取必须等它 settle，而不是并发。
+    // The first is still in flight: the authoritative read waits for it, it does not race it.
     firstInFlight()
     await new Promise((resolve) => setImmediate(resolve))
     expect(refresh).toHaveBeenCalledTimes(2)
@@ -349,7 +352,6 @@ describe("PawWork DSH client product layer", () => {
     expect(timers).toHaveLength(0)
   })
 
-  // 轮询器随插件而止：dispose 后不再排下一轮、也不再发 status 调用。
   test("stops polling when the client plugin is disposed", async () => {
     const timers: Array<() => void> = []
     const plugin = loadPlugin(timers)

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -7,8 +7,6 @@ const repositoryRoot = resolve(import.meta.dirname, "../../../..")
 const productRoot = resolve(repositoryRoot, "packages/desktop-electron/resources/dsh/product")
 
 describe("PawWork DSH client product layer", () => {
-  // Shared watcher scaffold: fake timers drive the polling cadence and a fake context
-  // pins the rpc/sessions contract, so each test only declares what it cares about.
   function loadPlugin(timers: Array<() => void>, delays: number[] = []) {
     const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
       document: {
@@ -115,8 +113,6 @@ describe("PawWork DSH client product layer", () => {
       "conversation.hero.brand.mark",
     ])
     expect(brandEntries.every((entry) => entry.options.priority === -100)).toBe(true)
-    // The drag strip already reserves the top-left corner for the native window
-    // controls, so the sidebar brand renders identically on every platform.
     const sidebarMark = brandEntries[0].component({ size: 24 }) as { type: string; props: Record<string, unknown> }
     expect(sidebarMark.type).toBe("svg")
     expect(sidebarMark.props).toMatchObject({ viewBox: "0 0 64 64", width: 24, height: 24 })
@@ -149,9 +145,6 @@ describe("PawWork DSH client product layer", () => {
 
     // The strip must be a real element: -webkit-app-region does nothing on pseudo-elements.
     expect(appended.map((node) => node.className)).toEqual(["pawwork-titlebar"])
-    // Every rule that yields space reads the same variable instead of a second hardcoded
-    // number, and the variable comes only from the platform: Chromium's
-    // env(titlebar-area-height) on Windows, a main-process override on macOS.
     expect(style.textContent).toContain("-webkit-app-region: drag")
     expect(style.textContent).toContain("padding-top: var(--pawwork-titlebar-height, 0px)")
     expect(style.textContent).toContain('[class*="_banner_"] { top: var(--pawwork-titlebar-height, 0px); }')
@@ -218,9 +211,8 @@ describe("PawWork DSH client product layer", () => {
     expect(setDraft).toHaveBeenCalledWith('请总结\n\n文件：\n- "/tmp/notes.md"')
   })
 
-  // A transport failure is not a completion signal — an older backend without this channel
-  // and a host restart are both transient — so the client keeps waiting instead of giving
-  // up after N failures and stranding the sidebar on a stale list.
+  // An old backend without this channel and a host restart are both transient, so a transport
+  // failure must not be read as completion.
   test("backs off repeated transport failures and recovers without giving up", async () => {
     const timers: Array<() => void> = []
     const delays: number[] = []
@@ -275,13 +267,9 @@ describe("PawWork DSH client product layer", () => {
     expect(timers).toHaveLength(0)
   })
 
-  // The migration runtime never reads the cold list, and after it completes refreshList may
-  // ride along on a still in-flight fetch. Hence two reads: the first waits for that fetch to
-  // settle, the second is the guaranteed-fresh authoritative one.
   test("waits for v1 import completion before issuing a fresh authoritative read", async () => {
     const timers: Array<() => void> = []
     const plugin = loadPlugin(timers)
-    // The first refresh stays in flight and never resolves; only the second fetches again.
     const refresh = vi.fn()
     let firstInFlight: () => void = () => {}
     const visibleSessionIds: string[] = []
@@ -304,7 +292,6 @@ describe("PawWork DSH client product layer", () => {
     await new Promise((resolve) => setImmediate(resolve))
     expect(call).toHaveBeenCalledTimes(2)
     expect(refresh).toHaveBeenCalledTimes(1)
-    // The first is still in flight: the authoritative read waits for it, it does not race it.
     firstInFlight()
     await new Promise((resolve) => setImmediate(resolve))
     expect(refresh).toHaveBeenCalledTimes(2)

--- a/packages/desktop-electron/src/main/dsh-product-home.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.ts
@@ -1,9 +1,9 @@
 import { cpSync, existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { isAbsolute, join } from "node:path"
 
-// DSH 的凭据文档自 dsh 0.1.1-rc.1 起是版本化的：`refs:` 存引用名到值的映射，
-// `records:` 存登录态。旧的扁平映射仍会在 boot 时被就地迁移，但种子直接写成
-// 目标格式，新建的 product home 就不必走一次迁移。
+// DSH credential documents are versioned since dsh 0.1.1-rc.1: `refs:` maps ref
+// names to values, `records:` holds login state. Boot still migrates the old flat
+// map in place, but seeding the target format skips that migration entirely.
 const PUBLIC_CREDENTIAL = 'version: 1\nrefs:\n  OPENCODE_API_KEY: "public"\n'
 const DROPPED_MODEL_ENVIRONMENT = [
   "OPENCODE_API_KEY",

--- a/packages/desktop-electron/src/main/dsh-product-home.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.ts
@@ -1,9 +1,8 @@
 import { cpSync, existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { isAbsolute, join } from "node:path"
 
-// DSH credential documents are versioned since dsh 0.1.1-rc.1: `refs:` maps ref
-// names to values, `records:` holds login state. Boot still migrates the old flat
-// map in place, but seeding the target format skips that migration entirely.
+// Boot migrates a pre-0.1.1-rc.1 flat credential map into `version: 1` in place, so seeding the
+// versioned form directly is what keeps a fresh product home out of that migration.
 const PUBLIC_CREDENTIAL = 'version: 1\nrefs:\n  OPENCODE_API_KEY: "public"\n'
 const DROPPED_MODEL_ENVIRONMENT = [
   "OPENCODE_API_KEY",


### PR DESCRIPTION
## Summary

Rewrites the remaining Chinese block comments in `packages/desktop-electron` as English, and deletes the ones that only restated the code below them. Net effect is 22 fewer lines of comment than `main` carried in Chinese.

What survives is the part a reader cannot get from the code: `-webkit-app-region` not applying to pseudo-elements, `Math.min([])` serialising to `null`, the rc.8 locale registry throwing on a duplicate namespace, DSH's selector weight 0,3,0 that the hero animation has to beat, the 19%→29% cuff correction that keeps the glove from reading as a paw at 24px, and why the v1-import watcher reads twice.

Files touched: `resources/dsh/product/lib/client.js`, `scripts/ci-smoke.ts`, `src/main/dsh-product-client.test.ts`, `src/main/dsh-product-home.ts`.

Five files that grep as "containing Chinese" are false positives and unchanged — `app-identity.ts`, `scripts/ci-smoke.test.ts`, `electron-builder-nsis-shortcut.test.ts`, `electron-builder-app-update.test.ts` and `resources/dsh/automations/lib/client.js` hold Simplified Chinese product copy or assertions against it, with comments already in English.

## Why

Source comments are English by convention. A comment that repeats the line under it is worse than no comment, and the Chinese blocks were also the longest comments in the package.

## How To Verify

- `pnpm run lint` — clean.
- `pnpm --filter @pawwork/desktop typecheck` — clean.
- `pnpm --filter @pawwork/desktop test` — 340 vitest tests in 35 files pass, 104 node tests pass. No test moved.
- `pnpm run dev:desktop`, then inspected the running DSH surface: the product stylesheet parses to the same 14 rules, the drag strip mounts, and the sidebar brand and hero override render as before.
- Mechanical check that the shipped CSS is unchanged: extracting `productCss` from `origin/main` and from this branch and stripping comments yields byte-identical stylesheets. Outside `client.js`, every changed line is a comment line.

## Risk

None. Comments only — no code, no shipped CSS, no product copy.