### PR TITLE
feat(desktop): inject PawWork identity section into every agent's system prompt

### DIFF
--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -21,6 +21,8 @@
 - id: llm-deepseek
   disabled: true
 - insert:
+    - id: pawwork-identity
+      name: '@pawwork/dsh-identity'
     - id: pawwork-product
       name: '@pawwork/dsh-product'
     - id: import-v1

--- a/packages/desktop-electron/resources/dsh/identity/index.js
+++ b/packages/desktop-electron/resources/dsh/identity/index.js
@@ -1,0 +1,26 @@
+export const name = 'pawwork-identity';
+
+// The deployment-wide PawWork identity. dsh-system-prompt's fixed opener only
+// says "powered by DeepSeek Harness", and each shipped preset mounts its own
+// persona row that shadows the deployment persona — so neither the identity
+// toggle nor the persona config can carry the product name into a preset
+// agent. A NEW section name in the global layer can: scope shadowing is
+// per-name, so standard/code/minimal all inherit this section. Order -99 sits
+// in the identity band, right after the harness identity (-100) and before
+// the persona (0). The harness opener stays: PawWork IS built on DSH, and the
+// attribution should say so.
+export const PAWWORK_IDENTITY_SECTION = Object.freeze({
+	name: 'pawwork:identity',
+	order: -99,
+	text: 'You are PawWork (爪印), a desktop AI agent product built on DeepSeek Harness (DSH). When the user asks who you are or what product they are using, answer that you are PawWork (爪印), based on DeepSeek Harness.',
+});
+
+// Only the system-prompt service is needed; activation waits for it alone, so
+// no other product concern can keep the identity from registering.
+export const inject = ['systemPrompt'];
+
+export function apply(ctx) {
+	// One registration on the global layer for the process; the registry
+	// disposes it with this plugin's fiber.
+	ctx.systemPrompt.section(PAWWORK_IDENTITY_SECTION);
+}

--- a/packages/desktop-electron/resources/dsh/identity/index.test.cjs
+++ b/packages/desktop-electron/resources/dsh/identity/index.test.cjs
@@ -1,0 +1,35 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+function loadIdentity() {
+	return import(pathToFileURL(path.join(__dirname, 'index.js')).href);
+}
+
+test('waits for the system-prompt service and nothing else', async () => {
+	const { inject } = await loadIdentity();
+	assert.deepEqual(inject, ['systemPrompt']);
+});
+
+test('registers exactly one PawWork identity section in the identity band', async () => {
+	const { apply, PAWWORK_IDENTITY_SECTION } = await loadIdentity();
+	const registered = [];
+	apply({ systemPrompt: { section: (section) => registered.push(section) } });
+
+	assert.deepEqual(registered, [PAWWORK_IDENTITY_SECTION]);
+	assert.equal(PAWWORK_IDENTITY_SECTION.name, 'pawwork:identity');
+	// Identity band: after the harness identity (-100), before the persona (0).
+	assert.ok(PAWWORK_IDENTITY_SECTION.order > -100 && PAWWORK_IDENTITY_SECTION.order < 0);
+});
+
+test('the identity text names PawWork and its DeepSeek Harness base', async () => {
+	const { PAWWORK_IDENTITY_SECTION } = await loadIdentity();
+	assert.match(PAWWORK_IDENTITY_SECTION.text, /PawWork/);
+	assert.match(PAWWORK_IDENTITY_SECTION.text, /爪印/);
+	assert.match(PAWWORK_IDENTITY_SECTION.text, /DeepSeek Harness/);
+	// Section text is interpolated strictly: a stray {{…}} group throws at
+	// render. The identity is static prose and must stay free of them.
+	assert.ok(!PAWWORK_IDENTITY_SECTION.text.includes('{{'));
+});

--- a/packages/desktop-electron/resources/dsh/identity/package.json
+++ b/packages/desktop-electron/resources/dsh/identity/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@pawwork/dsh-identity",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -109,6 +109,9 @@ describe("DSH product home", () => {
     expect(
       JSON.parse(readFileSync(join(productHome, "node_modules/@pawwork/dsh-automations/package.json"), "utf8")).name,
     ).toBe("@pawwork/dsh-automations")
+    expect(
+      JSON.parse(readFileSync(join(productHome, "node_modules/@pawwork/dsh-identity/package.json"), "utf8")).name,
+    ).toBe("@pawwork/dsh-identity")
     expect(prepared.sidecarPreload).toBe(join(resources, "sidecar-preload.mjs"))
   })
 

--- a/packages/desktop-electron/src/main/dsh-product-home.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.ts
@@ -58,14 +58,12 @@ export function prepareDshProductHome(options: PrepareDshProductHomeOptions) {
   cpSync(join(options.resources, "home"), options.productHome, { force: true, recursive: true })
   const productPackageParent = join(options.productHome, "node_modules", "@pawwork")
   mkdirSync(productPackageParent, { recursive: true })
-  cpSync(join(options.resources, "product"), join(productPackageParent, "dsh-product"), {
-    force: true,
-    recursive: true,
-  })
-  cpSync(join(options.resources, "automations"), join(productPackageParent, "dsh-automations"), {
-    force: true,
-    recursive: true,
-  })
+  for (const plugin of ["product", "automations", "identity"] as const) {
+    cpSync(join(options.resources, plugin), join(productPackageParent, `dsh-${plugin}`), {
+      force: true,
+      recursive: true,
+    })
+  }
 
   const credentials = join(options.productHome, ".credentials.yaml")
   if (!existsSync(credentials)) writeFileSync(credentials, PUBLIC_CREDENTIAL, { mode: 0o600 })


### PR DESCRIPTION
## Summary

Adds a dedicated `@pawwork/dsh-identity` plugin (`resources/dsh/identity/`) whose only job is registering one global `pawwork:identity` prompt section at order -99 — right after the fixed harness identity (-100), before the persona (0):

> You are PawWork (爪印), a desktop AI agent product built on DeepSeek Harness (DSH). …

Because scope shadowing in `dsh-system-prompt` is per-name, this new section in the global layer reaches every agent preset (standard/code/minimal) and rosterless agents alike. The harness opener stays — it is the DSH attribution. `prepareDshProductHome` installs the plugin beside the other `@pawwork` packages, and the product patch mounts it as its own row.

## Why

The injected system prompt only said "powered by DeepSeek Harness". Each shipped preset mounts its own `dsh-persona` row that shadows the deployment persona, so patching the `system-prompt` persona config cannot carry the product name into standard mode, and the harness identity text is fixed (only toggleable). A plugin-contributed section is the one seam that covers all modes without forking preset compositions and drifting from the fast-moving DSH prerelease. A standalone plugin (`inject: ['systemPrompt']` only) keeps the identity's fate separate from the OpenCode catalog refresh — either concern can break at a DSH upgrade without taking the other down.

## How To Verify

- `pnpm run test:node` in `packages/desktop-electron`: 107/107 pass, including new `resources/dsh/identity/index.test.cjs` (inject is exactly `['systemPrompt']`, one registration in the identity order band, text names PawWork + 爪印 + DeepSeek Harness, no `{{…}}` interpolation hazards).
- `pnpm vitest run src/main/dsh-product-*.test.ts src/main/dsh-sidecar.test.ts`: 35/35 pass (product-home test now asserts all three `@pawwork` plugins install).
- Real backend boot smoke: prepared a temp DSH_HOME exactly like `prepareDshProductHome`, booted `dsh web --patch product.cordis.patch.yml` → readiness announced, no loader errors. (A stale-copy variant that double-registered the section failed LOUD at boot — duplicate names in one layer throw, so a conflicting registration can never ship silently.)
- End-to-end: `dsh --profile headless --patch <identity-only-patch> "Who are you…"` with the default opencode/big-pickle route answered **"I am PawWork (爪印), a desktop AI agent product built on DeepSeek Harness (DSH)."** Note: the full product patch cannot boot the headless profile — `pawwork-automations`/`import-v1` wait for the web-only `connection` service, a pre-existing constraint unrelated to this change.
- Left to CI: the full vitest suite and desktop smoke.

## Risk

Adds one short section to every system prompt (small fixed token cost per request; one-time KV prefix change). No data, permission, or migration impact. Identity text is one constant in `resources/dsh/identity/index.js`.
