### PR TITLE
chore(release): prepare 2026.8.6

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.8.4",
+  "version": "2026.8.6",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

- bump the PawWork V2 desktop version from `2026.8.4` to `2026.8.6`
- reserve the next repository-wide CalVer after the V1-only `v2026.8.5` hotfix
- keep `packages/desktop-electron/package.json` as the single version authority consumed by Electron Builder and the release workflow

## Why

`main` has accumulated the next PawWork V2 release since `v2026.8.4`. The repository-wide `v2026.8.5` tag is already owned by the V1 maintenance hotfix, so the next unambiguous version is `v2026.8.6`.

There is no separate issue: this is the release-preparation change for the current `main` head.

## How To Verify

- `node -e 'const assert=require("node:assert/strict"); assert.equal(require("./packages/desktop-electron/package.json").version,"2026.8.6")'` — the desktop package exposes the intended release version
- `pnpm test` — 363 Vitest tests, 107 DSH Node tests, and 10 label-policy tests passed
- `pnpm typecheck` — passed
- `pnpm lint:ci` — passed
- `pnpm --filter @pawwork/desktop build` — the production Electron main bundle built successfully

## Risk

- Release artifacts and updater metadata will identify themselves as `2026.8.6`; the production workflow must build macOS arm64, macOS x64, and Windows x64 from the exact merged release commit.
- DSH `0.1.1-rc.2` migrates `.credentials.yaml` to a format older PawWork builds cannot read. Any rollback must tell affected users to delete `<DSH_HOME>/.credentials.yaml` before launching the older build.
- This PR does not publish a release by itself; production publication remains guarded by the existing single-source release workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application package to version 2026.8.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->