### PR TITLE
fix(desktop): read global AGENTS.md via declarative dshHome

### DIFF
--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -18,6 +18,10 @@
           - id: mimo-v2.5-free
           - id: nemotron-3-ultra-free
           - id: north-mini-code-free
+- id: agent-instructions
+  config:
+    dshHome: "~/.pawwork"
+    maxBytes: 65536
 - id: llm-deepseek
   disabled: true
 - insert:


### PR DESCRIPTION
PawWork isolates DSH data under `~/.pawwork/dsh` (`dsh-dev`) to avoid v1 collision, but the global instructions file lives at `~/.pawwork/AGENTS.md`. `dsh-agent-instructions` only probes `$DSH_HOME/AGENTS.md`, so the global file was never injected.

**Previous approach (copy migration) was rejected in adversarial review**: a one-shot `cp ~/.pawwork/AGENTS.md → $DSH_HOME/AGENTS.md` creates a permanent two-source divergence (3 files with dev/prod), violates single-source-of-truth and Occam's coherence test, and adds fallback-path branching. Reviewers A/B/D converged on this.

**Redo as declarative single-source fix** (minimal, cleanest, lowest long-term entropy):

- `product.cordis.patch.yml`: add `agent-instructions` patch `{ dshHome: "~/.pawwork", maxBytes: 65536 }` so the native loader reads the user's file in place. Sessions/config stay in `$DSH_HOME`; global is shared across channels, no copy, no marker, idempotent and reversible. Reuses upstream `dsh-home-paths` contract, no fork.

Verification: `pnpm --filter @pawwork/desktop exec vitest run src/main/pawwork-home.test.ts` — 11 passed (original suite, no new migration code to test). Patch replaces the standard preset's `maxBytes: 65536` row; other fields use defaults.

Closes the v1→v2 regression where global instructions were silently dropped after home relocation.