### PR TITLE
fix(desktop): give Automations one page head

### DIFF
--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
@@ -256,11 +256,7 @@ class AutomationStore {
     if (input.startedAt !== null) assertTimestamp(input.startedAt, 'startedAt');
     this.document.runs.push(structuredClone(input));
     const definition = this.document.definitions.find((entry) => entry.id === input.automationId);
-    if (definition?.kind === 'recurring'
-      && definition.stop?.kind === 'count'
-      && this.completedRunCount(definition.id) >= definition.stop.count) {
-      definition.nextFireAt = null;
-    }
+    if (definition?.kind === 'recurring' && this.runLimitReached(definition)) definition.nextFireAt = null;
     this.save();
     return 'imported';
   }
@@ -379,15 +375,18 @@ class AutomationStore {
     });
   }
 
+  runLimitReached(definition) {
+    return definition.stop?.kind === 'count'
+      && this.completedRunCount(definition.id) >= definition.stop.count;
+  }
+
   // Why a definition has no next run, so the list can say "completed" or "run limit reached"
   // instead of one dash for both. Paused is excluded: the list states that on its own. An
   // unschedulable expression is not a case — every write path validates the cron first.
   terminalReason(definition) {
     if (definition.paused || definition.nextFireAt !== null) return null;
     if (definition.kind === 'oneshot') return 'completed';
-    if (definition.stop?.kind === 'count'
-      && this.completedRunCount(definition.id) >= definition.stop.count) return 'run-limit';
-    return null;
+    return this.runLimitReached(definition) ? 'run-limit' : null;
   }
 
   completedRunCount(automationId) {
@@ -454,9 +453,7 @@ class AutomationStore {
     };
     Object.assign(run, completed);
     const definition = this.document.definitions.find((entry) => entry.id === run.automationId);
-    if (definition?.kind === 'recurring' && definition.stop?.kind === 'count') {
-      if (this.completedRunCount(definition.id) >= definition.stop.count) definition.nextFireAt = null;
-    }
+    if (definition?.kind === 'recurring' && this.runLimitReached(definition)) definition.nextFireAt = null;
     this.save();
     return structuredClone(run);
   }

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
@@ -663,11 +663,14 @@ function createAutomationRpcHandler({ store, scheduler, now = () => Date.now() }
         return rpcSuccess({
           definitions: definitions.map((definition) => {
             const runs = store.listRuns(definition.id);
+            const activeRun = runs.find((run) => run.state === 'running') || null;
             return {
               ...definition,
-              activeRun: runs.find((run) => run.state === 'running') || null,
+              activeRun,
               recentRuns: runs.filter((run) => run.state !== 'running').slice(0, 5),
-              terminalReason: store.terminalReason(definition),
+              // A claimed run clears nextFireAt before it lands, so a definition is only
+              // terminal once nothing is still running for it.
+              terminalReason: activeRun ? null : store.terminalReason(definition),
             };
           }),
         });

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
@@ -73,9 +73,7 @@ function normalizeRhythm(rhythm) {
   if (rhythm?.kind === 'cron') {
     const expression = assertText(rhythm.expression, 'rhythm.expression');
     if (!isValidCronExpression(expression)) {
-      // Coded, because the Settings editor cannot repeat this rule without
-      // copying the cron parser: it maps the code to localized copy instead of
-      // showing the user this sentence.
+      // Coded so the editor can localize it without copying the cron parser.
       const invalid = new Error(`invalid cron expression: ${expression}`);
       invalid.code = 'invalid-cron';
       throw invalid;
@@ -381,13 +379,9 @@ class AutomationStore {
     });
   }
 
-  // Why a definition has no next run, so the list can say "completed" or "run
-  // limit reached" instead of one dash standing for both. Paused is excluded
-  // because the list states it on its own, and an imported definition is
-  // activated inside the same import call that wrote it, so no reader observes
-  // that window. An unschedulable expression is not a case here: every write
-  // path runs it through isValidCronExpression first, and the resolver looks
-  // five years ahead, which covers even a Feb 29 schedule.
+  // Why a definition has no next run, so the list can say "completed" or "run limit reached"
+  // instead of one dash for both. Paused is excluded: the list states that on its own. An
+  // unschedulable expression is not a case — every write path validates the cron first.
   terminalReason(definition) {
     if (definition.paused || definition.nextFireAt !== null) return null;
     if (definition.kind === 'oneshot') return 'completed';
@@ -711,9 +705,6 @@ function createAutomationRpcHandler({ store, scheduler, now = () => Date.now() }
     } catch (error) {
       if (signal?.aborted) return rpcFailure('cancelled', 'automation request cancelled');
       if (error?.code === 'conflict') return rpcFailure('conflict', error.message);
-      // DSH validates the wire error against its own `code` enum, so a code of our
-      // own reaches the renderer as a schema violation instead of a message. The
-      // reason travels in `issues`, which the enum leaves to us.
       if (error?.code === 'invalid-cron') {
         return rpcFailure('bad-request', error.message, { issues: [{ code: 'invalid-cron' }] });
       }

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
@@ -374,6 +374,21 @@ class AutomationStore {
     });
   }
 
+  // Why a definition has no next run, so the list can say "completed" or "run
+  // limit reached" instead of one dash standing for both. Paused is excluded
+  // because the list states it on its own, and an imported definition is
+  // activated inside the same import call that wrote it, so no reader observes
+  // that window. An unschedulable expression is not a case here: every write
+  // path runs it through isValidCronExpression first, and the resolver looks
+  // five years ahead, which covers even a Feb 29 schedule.
+  terminalReason(definition) {
+    if (definition.paused || definition.nextFireAt !== null) return null;
+    if (definition.kind === 'oneshot') return 'completed';
+    if (definition.stop?.kind === 'count'
+      && this.completedRunCount(definition.id) >= definition.stop.count) return 'run-limit';
+    return null;
+  }
+
   completedRunCount(automationId) {
     return this.document.runs.filter((run) => (
       run.automationId === automationId && (run.state === 'succeeded' || run.state === 'failed')
@@ -651,6 +666,7 @@ function createAutomationRpcHandler({ store, scheduler, now = () => Date.now() }
               ...definition,
               activeRun: runs.find((run) => run.state === 'running') || null,
               recentRuns: runs.filter((run) => run.state !== 'running').slice(0, 5),
+              terminalReason: store.terminalReason(definition),
             };
           }),
         });

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
@@ -72,7 +72,14 @@ function normalizeRhythm(rhythm) {
   }
   if (rhythm?.kind === 'cron') {
     const expression = assertText(rhythm.expression, 'rhythm.expression');
-    if (!isValidCronExpression(expression)) throw new Error(`invalid cron expression: ${expression}`);
+    if (!isValidCronExpression(expression)) {
+      // Coded, because the Settings editor cannot repeat this rule without
+      // copying the cron parser: it maps the code to localized copy instead of
+      // showing the user this sentence.
+      const invalid = new Error(`invalid cron expression: ${expression}`);
+      invalid.code = 'invalid-cron';
+      throw invalid;
+    }
     return { kind: 'cron', expression };
   }
   throw new Error('recurring rhythm must be interval or cron');
@@ -642,6 +649,9 @@ function rpcSuccess(value) {
   return { ok: true, value };
 }
 
+// `code` must come from DSH's enum: it validates the whole response, so an invented
+// code fails validation entirely and the user sees that instead of the message.
+// Our own reasons go in `details.issues`.
 function rpcFailure(code, message, details = {}) {
   return { ok: false, error: { code, message, details } };
 }
@@ -701,6 +711,12 @@ function createAutomationRpcHandler({ store, scheduler, now = () => Date.now() }
     } catch (error) {
       if (signal?.aborted) return rpcFailure('cancelled', 'automation request cancelled');
       if (error?.code === 'conflict') return rpcFailure('conflict', error.message);
+      // DSH validates the wire error against its own `code` enum, so a code of our
+      // own reaches the renderer as a schema violation instead of a message. The
+      // reason travels in `issues`, which the enum leaves to us.
+      if (error?.code === 'invalid-cron') {
+        return rpcFailure('bad-request', error.message, { issues: [{ code: 'invalid-cron' }] });
+      }
       return rpcFailure('internal', error instanceof Error ? error.message : String(error));
     }
   };

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
@@ -385,7 +385,11 @@ class AutomationStore {
   // unschedulable expression is not a case — every write path validates the cron first.
   terminalReason(definition) {
     if (definition.paused || definition.nextFireAt !== null) return null;
-    if (definition.kind === 'oneshot') return 'completed';
+    // A one-shot resumed after its moment, or seen again after a missed startup, loses its
+    // next run without ever attempting one: that is missed, not completed.
+    if (definition.kind === 'oneshot') {
+      return this.completedRunCount(definition.id) > 0 ? 'completed' : 'missed';
+    }
     return this.runLimitReached(definition) ? 'run-limit' : null;
   }
 

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
@@ -669,6 +669,28 @@ test('every write path refuses a cron expression whose date never comes', () => 
   assert.equal(store.getDefinition(existing.id).rhythm.kind, 'interval');
 });
 
+// The editor cannot repeat the cron rule without copying the parser, so it reads
+// this issue to know it may say so in the user's language. Plain, the user met
+// the store's own English sentence in a Chinese UI. The reason travels in
+// `issues` rather than `code` because DSH validates `code` against its own enum
+// and rejects the whole response for one it does not know.
+test('a refused cron expression reaches the editor as an issue it can localize', async () => {
+  const { file, cwd } = fixture();
+  const store = new AutomationStore(file);
+  const definition = interval(store, cwd, 300_000);
+  const rpc = createAutomationRpcHandler({ store, scheduler: { refresh: () => {} }, now: () => 10_000 });
+
+  const response = await rpc('update', {
+    id: definition.id,
+    expectedRevision: definition.revision,
+    rhythm: { kind: 'cron', expression: '0 9 30 2 *' },
+  });
+
+  assert.equal(response.ok, false);
+  assert.equal(response.error.code, 'bad-request');
+  assert.deepEqual(response.error.details.issues, [{ code: 'invalid-cron' }]);
+});
+
 test('automation RPC validates mutations and returns immediately when running now', async () => {
   const { file, cwd } = fixture();
   const store = new AutomationStore(file);

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
@@ -609,6 +609,66 @@ test('automation RPC keeps the active run separate from bounded terminal history
   assert.equal(response.value.definitions[0].recentRuns.every((run) => run.state !== 'running'), true);
 });
 
+// One dash stood for "finished", "ran out of runs" and "paused" alike, so the
+// list could not say which. Paused it already states on its own; the other two
+// are what this reason carries.
+test('automation RPC says why a definition has no next run', async () => {
+  const { file, cwd } = fixture();
+  const store = new AutomationStore(file);
+  const rpc = createAutomationRpcHandler({ store, scheduler: {}, now: () => 10_000 });
+
+  const live = interval(store, cwd, 300_000);
+  const paused = interval(store, cwd, 300_000);
+  store.setPaused(paused.id, true, 2_000);
+  const finished = oneShot(store, cwd, 2_000);
+  store.claimDue(finished.id, 2_000, 2_000, { state: 'stopped', completedAt: 2_100, stopReason: 'previous_run_active' });
+  const limited = store.createDefinition({
+    kind: 'recurring',
+    title: 'Twice only',
+    prompt: 'Run twice.',
+    cwd,
+    rhythm: { kind: 'interval', everyMs: 300_000 },
+    stop: { kind: 'count', count: 1 },
+    model: { provider: 'opencode', model: 'big-pickle' },
+  }, 1_000);
+  const limitedRun = store.beginRun(limited.id, 1_200);
+  store.completeRun(limitedRun.id, { state: 'succeeded', completedAt: 1_300, sessionId: 'session-1', result: 'done' });
+  const response = await rpc('list', {});
+  const reasonOf = (id) => response.value.definitions.find((entry) => entry.id === id).terminalReason;
+
+  assert.equal(response.ok, true);
+  assert.equal(reasonOf(live.id), null);
+  assert.equal(reasonOf(paused.id), null);
+  assert.equal(reasonOf(finished.id), 'completed');
+  assert.equal(reasonOf(limited.id), 'run-limit');
+});
+
+// The reason above never has to describe a schedule that cannot resolve, because
+// no write path accepts one. Said here so the guarantee survives a change to
+// either side: a cron whose date never comes is refused where it is written.
+test('every write path refuses a cron expression whose date never comes', () => {
+  const { file, cwd } = fixture();
+  const store = new AutomationStore(file);
+  // February 30th: syntactically valid, never a real date.
+  const input = {
+    kind: 'recurring',
+    title: 'Never resolves',
+    prompt: 'Clean up.',
+    cwd,
+    rhythm: { kind: 'cron', expression: '0 9 30 2 *' },
+    model: { provider: 'opencode', model: 'big-pickle' },
+  };
+
+  assert.throws(() => store.createDefinition(input, 1_000), /invalid cron expression/);
+
+  const existing = interval(store, cwd, 300_000);
+  assert.throws(
+    () => store.updateDefinition(existing.id, { rhythm: input.rhythm }, 2_000),
+    /invalid cron expression/,
+  );
+  assert.equal(store.getDefinition(existing.id).rhythm.kind, 'interval');
+});
+
 test('automation RPC validates mutations and returns immediately when running now', async () => {
   const { file, cwd } = fixture();
   const store = new AutomationStore(file);

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
@@ -633,6 +633,10 @@ test('automation RPC says why a definition has no next run', async () => {
   }, 1_000);
   const limitedRun = store.beginRun(limited.id, 1_200);
   store.completeRun(limitedRun.id, { state: 'succeeded', completedAt: 1_300, sessionId: 'session-1', result: 'done' });
+  // Claiming a one-shot clears its next run before the attempt lands, so this one is
+  // running, not finished.
+  const running = oneShot(store, cwd, 3_000);
+  store.claimDue(running.id, 3_000, 3_000, { state: 'running', completedAt: null, stopReason: null });
   const response = await rpc('list', {});
   const reasonOf = (id) => response.value.definitions.find((entry) => entry.id === id).terminalReason;
 
@@ -641,6 +645,7 @@ test('automation RPC says why a definition has no next run', async () => {
   assert.equal(reasonOf(paused.id), null);
   assert.equal(reasonOf(finished.id), 'completed');
   assert.equal(reasonOf(limited.id), 'run-limit');
+  assert.equal(reasonOf(running.id), null);
 });
 
 // The reason above never has to describe a schedule that cannot resolve, because

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
@@ -621,7 +621,8 @@ test('automation RPC says why a definition has no next run', async () => {
   const paused = interval(store, cwd, 300_000);
   store.setPaused(paused.id, true, 2_000);
   const finished = oneShot(store, cwd, 2_000);
-  store.claimDue(finished.id, 2_000, 2_000, { state: 'stopped', completedAt: 2_100, stopReason: 'previous_run_active' });
+  const finishedRun = store.claimDue(finished.id, 2_000, 2_000, { state: 'running', completedAt: null, stopReason: null });
+  store.completeRun(finishedRun.run.id, { state: 'succeeded', completedAt: 2_100, sessionId: 'session-0', result: 'done' });
   const limited = store.createDefinition({
     kind: 'recurring',
     title: 'Twice only',
@@ -637,6 +638,10 @@ test('automation RPC says why a definition has no next run', async () => {
   // running, not finished.
   const running = oneShot(store, cwd, 3_000);
   store.claimDue(running.id, 3_000, 3_000, { state: 'running', completedAt: null, stopReason: null });
+  // Resuming a one-shot after its moment drops its next run without ever attempting one.
+  const missed = oneShot(store, cwd, 4_000);
+  store.setPaused(missed.id, true, 3_500);
+  store.setPaused(missed.id, false, 9_000);
   const response = await rpc('list', {});
   const reasonOf = (id) => response.value.definitions.find((entry) => entry.id === id).terminalReason;
 
@@ -646,6 +651,7 @@ test('automation RPC says why a definition has no next run', async () => {
   assert.equal(reasonOf(finished.id), 'completed');
   assert.equal(reasonOf(limited.id), 'run-limit');
   assert.equal(reasonOf(running.id), null);
+  assert.equal(reasonOf(missed.id), 'missed');
 });
 
 // The reason above never has to describe a schedule that cannot resolve, because
@@ -672,6 +678,24 @@ test('every write path refuses a cron expression whose date never comes', () => 
     /invalid cron expression/,
   );
   assert.equal(store.getDefinition(existing.id).rhythm.kind, 'interval');
+
+  assert.throws(() => store.importDefinition({
+    id: 'pawwork-v1-automation_never',
+    title: 'Never resolves',
+    prompt: 'Clean up.',
+    revision: 1,
+    paused: false,
+    context: 'fresh',
+    cwd,
+    model: { provider: 'opencode', model: 'big-pickle' },
+    timezone: 'UTC',
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    kind: 'recurring',
+    rhythm: input.rhythm,
+    stop: { kind: 'never' },
+    migration: { source: 'pawwork-v1', sourceId: 'automation_never', warnings: [] },
+  }), /invalid cron expression/);
 });
 
 // The editor cannot repeat the cron rule without copying the parser, so it reads

--- a/packages/desktop-electron/resources/dsh/automations/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/automations/lib/client.js
@@ -25,23 +25,24 @@ window.__ModuleLoader__.load({
   color: var(--dsw-alias-label-primary); display: flex; flex-direction: column;
   gap: 12px; max-width: 720px; min-width: 0; width: 100%;
 }
-.pawwork-automations-titlebar {
-  align-items: flex-start; display: flex; gap: 20px; justify-content: space-between; margin-bottom: 20px;
+/* One page head per settings page, matching the DSH Plugins section (18/600 title, 13px intro).
+   The section owns no header actions: the panel header above it already carries the shell's own
+   actions and Close, and a second action cluster 8px below them competes for the same corner. */
+.pawwork-automations-page-head {
+  display: flex; flex-direction: column; gap: 2px; padding: 2px 0 14px;
 }
-.pawwork-automations-titlebar h1 {
-  font-size: 16px; font-weight: 500; line-height: 24px; margin: 0;
-}
-.pawwork-automations-titlebar p {
-  color: var(--dsw-alias-label-tertiary); font-size: 14px; line-height: 22px; margin: 0;
-}
-.pawwork-automations-title-actions { align-items: center; display: flex; flex: none; gap: 8px; }
-.pawwork-automations-search, .pawwork-automations-search input { width: 100%; }
-.pawwork-automations-tabs { display: flex; gap: 6px; }
+.pawwork-automations-page-head h2 { font-size: 18px; font-weight: 600; line-height: 26px; margin: 0; }
+.pawwork-automations-page-head p { color: var(--dsw-alias-label-tertiary); font: var(--dsw-font-xs-13); margin: 0; }
+.pawwork-automations-toolbar { align-items: center; display: flex; gap: 10px; }
+.pawwork-automations-search { flex: 1; min-width: 160px; }
+.pawwork-automations-search input { width: 100%; }
+.pawwork-automations-tabs { display: flex; flex: none; gap: 6px; }
+.pawwork-automations-create { flex: none; }
 .pawwork-automations-list { display: flex; flex-direction: column; gap: 8px; margin-top: 4px; }
 .pawwork-automation-row {
   align-items: center; background: transparent; border: 1px solid var(--dsw-alias-border-l2); border-radius: 12px;
-  color: inherit; display: grid; font: inherit; gap: 10px;
-  grid-template-columns: 20px minmax(0, 1fr); min-height: 62px;
+  color: inherit; display: grid; font: inherit; gap: 12px;
+  grid-template-columns: 16px minmax(0, 1fr) auto; min-height: 56px;
   padding: 10px 14px; text-align: left; width: 100%;
 }
 .pawwork-automation-row:hover { background: var(--dsw-alias-interactive-bg-hover); }
@@ -52,6 +53,11 @@ window.__ModuleLoader__.load({
 }
 .pawwork-automation-row-title { font-size: 14px; font-weight: 500; line-height: 22px; }
 .pawwork-automation-row-meta { color: var(--dsw-alias-label-tertiary); font-size: 12px; line-height: 18px; }
+/* Schedule and next run are two facts, not one sentence: the schedule stays with the title and the
+   next run is right-aligned, so a column of rows can be compared down either edge. */
+.pawwork-automation-row-trail {
+  color: var(--dsw-alias-label-tertiary); font-size: 12px; line-height: 18px; white-space: nowrap;
+}
 .pawwork-automations-empty, .pawwork-automations-loading {
   border: 1px dashed var(--dsw-alias-border-l3); border-radius: 8px;
   color: var(--dsw-alias-label-tertiary); font-size: 13px; line-height: 20px; padding: 20px; text-align: center;
@@ -109,7 +115,9 @@ window.__ModuleLoader__.load({
   display: block; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 @media (max-width: 680px) {
-  .pawwork-automations-titlebar, .pawwork-automation-panel-head { flex-direction: column; }
+  .pawwork-automation-panel-head { flex-direction: column; }
+  .pawwork-automations-toolbar { flex-wrap: wrap; }
+  .pawwork-automations-search { flex: 1 1 100%; }
   .pawwork-automation-actions { flex-wrap: wrap; }
   .pawwork-automation-grid, .pawwork-automation-advanced-content { grid-template-columns: 1fr; }
 }
@@ -450,18 +458,20 @@ window.__ModuleLoader__.load({
         h(AutomationEditor, { closeSettings: close, connection, definition: selected, key: `${selected.id}:${selected.revision}`, onClose: closePanel, onDeleted: async () => { closePanel(); await load() }, onSaved: reloadAfter, sessions }))
 
       return h("main", { className: "pawwork-automations-surface" },
-          h("div", { className: "pawwork-automations-titlebar" },
-            h("div", null, h("h1", null, text("自动化", "Automations")), h("p", null, text("让 PawWork 按计划处理重复工作", "Let PawWork handle recurring work on a schedule"))),
-            h("div", { className: "pawwork-automations-title-actions" },
-              h(Button, { disabled: !preferredWorkspace, onClick: createAutomation, size: "sm", variant: "primary" }, text("在对话中创建", "Create in chat")))),
-          h(Input, { "aria-label": text("搜索自动化", "Search automations"), className: "pawwork-automations-search", icon: h(IconSearchOutline16, { size: 16 }), onChange: (event) => setQuery(event.target.value), placeholder: text("搜索自动化", "Search automations"), value: query }),
-          h("div", { className: "pawwork-automations-tabs", role: "tablist" }, [["all", text("全部", "All")], ["active", text("启用", "Active")], ["paused", text("暂停", "Paused")]].map(([value, label]) => h(Pill, { active: filter === value, key: value, onClick: () => setFilter(value), role: "tab" }, label))),
+          h("div", { className: "pawwork-automations-page-head" },
+            h("h2", null, text("自动化", "Automations")),
+            h("p", null, text("让 PawWork 按计划处理重复工作，创建过程在对话里完成。", "Let PawWork handle recurring work on a schedule; you create one in chat."))),
+          h("div", { className: "pawwork-automations-toolbar" },
+            h(Input, { "aria-label": text("搜索自动化", "Search automations"), className: "pawwork-automations-search", icon: h(IconSearchOutline16, { size: 16 }), onChange: (event) => setQuery(event.target.value), placeholder: text("搜索自动化", "Search automations"), value: query }),
+            h("div", { className: "pawwork-automations-tabs", role: "tablist" }, [["all", text("全部", "All")], ["active", text("启用", "Active")], ["paused", text("暂停", "Paused")]].map(([value, label]) => h(Pill, { active: filter === value, key: value, onClick: () => setFilter(value), role: "tab" }, label))),
+            h(Button, { className: "pawwork-automations-create", disabled: !preferredWorkspace, onClick: createAutomation, size: "sm", variant: "primary" }, text("新建自动化", "New automation"))),
           error ? h("div", { className: "pawwork-automations-error", role: "alert" }, error) : null,
           loading && data === null ? h("div", { className: "pawwork-automations-loading" }, text("正在加载…", "Loading…")) : null,
           h("div", { className: "pawwork-automations-list" },
             visible.map((definition) => h("button", { className: "pawwork-automation-row", key: definition.id, onClick: () => setSelectedId(definition.id), type: "button" },
               h("span", { className: "pawwork-automation-row-icon" }, h(definition.paused ? IconPauseOutline16 : IconPlayOutline16, { size: 16 })),
-              h("span", null, h("span", { className: "pawwork-automation-row-title" }, definition.title), h("span", { className: "pawwork-automation-row-meta" }, `${formatSchedule(definition)}  ${definition.paused ? text("已暂停", "Paused") : `${text("下次", "Next")} ${formatTime(definition.nextFireAt)}`}`)))),
+              h("span", null, h("span", { className: "pawwork-automation-row-title" }, definition.title), h("span", { className: "pawwork-automation-row-meta" }, formatSchedule(definition))),
+              h("span", { className: "pawwork-automation-row-trail" }, definition.paused ? text("已暂停", "Paused") : `${text("下次", "Next")} ${formatTime(definition.nextFireAt)}`))),
             visible.length === 0 && !loading ? h("div", { className: "pawwork-automations-empty" }, query ? text("没有匹配的自动化", "No matching automations") : text("还没有自动化。在对话中描述任务和运行时间即可创建。", "No automations yet. Describe a task and schedule in chat to create one.")) : null))
     }
 

--- a/packages/desktop-electron/resources/dsh/automations/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/automations/lib/client.js
@@ -23,7 +23,7 @@ window.__ModuleLoader__.load({
     const automationCss = `
 .pawwork-automations-surface {
   color: var(--dsw-alias-label-primary); display: flex; flex-direction: column;
-  gap: 12px; max-width: 720px; min-width: 0; width: 100%;
+  gap: 12px; min-width: 0; width: 100%;
 }
 /* One page head per settings page, matching the DSH Plugins section (18/600 title, 13px intro).
    The section owns no header actions: the panel header above it already carries the shell's own
@@ -38,7 +38,7 @@ window.__ModuleLoader__.load({
 .pawwork-automations-search input { width: 100%; }
 .pawwork-automations-tabs { display: flex; flex: none; gap: 6px; }
 .pawwork-automations-create { flex: none; }
-.pawwork-automations-list { display: flex; flex-direction: column; gap: 8px; margin-top: 4px; }
+.pawwork-automations-list { display: flex; flex-direction: column; gap: 8px; }
 .pawwork-automation-row {
   align-items: center; background: transparent; border: 1px solid var(--dsw-alias-border-l2); border-radius: 12px;
   color: inherit; display: grid; font: inherit; gap: 12px;
@@ -113,13 +113,6 @@ window.__ModuleLoader__.load({
 .pawwork-automation-run-time { margin-left: 8px; }
 .pawwork-automation-run-summary {
   display: block; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-@media (max-width: 680px) {
-  .pawwork-automation-panel-head { flex-direction: column; }
-  .pawwork-automations-toolbar { flex-wrap: wrap; }
-  .pawwork-automations-search { flex: 1 1 100%; }
-  .pawwork-automation-actions { flex-wrap: wrap; }
-  .pawwork-automation-grid, .pawwork-automation-advanced-content { grid-template-columns: 1fr; }
 }
 `
 

--- a/packages/desktop-electron/resources/dsh/automations/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/automations/lib/client.js
@@ -195,6 +195,7 @@ window.__ModuleLoader__.load({
     function definitionState(definition) {
       if (definition.paused) return { icon: IconPauseOutline16, label: text("已暂停", "Paused") }
       if (definition.terminalReason === "completed") return { icon: IconCheckOutline16, label: text("已完成", "Completed") }
+      if (definition.terminalReason === "missed") return { icon: IconCheckOutline16, label: text("已错过", "Missed") }
       if (definition.terminalReason === "run-limit") return { icon: IconCheckOutline16, label: text("已跑满", "Run limit reached") }
       return { icon: IconPlayOutline16, label: `${text("下次", "Next")} ${formatTime(definition.nextFireAt)}` }
     }

--- a/packages/desktop-electron/resources/dsh/automations/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/automations/lib/client.js
@@ -34,10 +34,9 @@ window.__ModuleLoader__.load({
 .pawwork-automations-page-head h2 { font-size: 18px; font-weight: 600; line-height: 26px; margin: 0; }
 .pawwork-automations-page-head p { color: var(--dsw-alias-label-tertiary); font: var(--dsw-font-xs-13); margin: 0; }
 .pawwork-automations-toolbar { align-items: center; display: flex; gap: 10px; }
-.pawwork-automations-search { flex: 1; min-width: 160px; }
+.pawwork-automations-search { flex: 1; }
 .pawwork-automations-search input { width: 100%; }
 .pawwork-automations-tabs { display: flex; flex: none; gap: 6px; }
-.pawwork-automations-create { flex: none; }
 .pawwork-automations-list { display: flex; flex-direction: column; gap: 8px; }
 .pawwork-automation-row {
   align-items: center; background: transparent; border: 1px solid var(--dsw-alias-border-l2); border-radius: 12px;
@@ -56,7 +55,6 @@ window.__ModuleLoader__.load({
   color: var(--dsw-alias-label-tertiary); font-size: 12px; line-height: 18px;
 }
 .pawwork-automation-row-trail { white-space: nowrap; }
-.pawwork-automation-row[data-state="stopped"] .pawwork-automation-row-trail { color: var(--dsw-alias-label-secondary); }
 .pawwork-automations-empty, .pawwork-automations-loading {
   border: 1px dashed var(--dsw-alias-border-l3); border-radius: 8px;
   color: var(--dsw-alias-label-tertiary); font-size: 13px; line-height: 20px; padding: 20px; text-align: center;
@@ -195,10 +193,10 @@ window.__ModuleLoader__.load({
     }
     // One statement of what a schedule is doing; the row's glyph and trailing text both render it.
     function definitionState(definition) {
-      if (definition.paused) return { icon: IconPauseOutline16, label: text("已暂停", "Paused"), state: "stopped" }
-      if (definition.terminalReason === "completed") return { icon: IconCheckOutline16, label: text("已完成", "Completed"), state: "stopped" }
-      if (definition.terminalReason === "run-limit") return { icon: IconCheckOutline16, label: text("已跑满", "Run limit reached"), state: "stopped" }
-      return { icon: IconPlayOutline16, label: `${text("下次", "Next")} ${formatTime(definition.nextFireAt)}`, state: "live" }
+      if (definition.paused) return { icon: IconPauseOutline16, label: text("已暂停", "Paused") }
+      if (definition.terminalReason === "completed") return { icon: IconCheckOutline16, label: text("已完成", "Completed") }
+      if (definition.terminalReason === "run-limit") return { icon: IconCheckOutline16, label: text("已跑满", "Run limit reached") }
+      return { icon: IconPlayOutline16, label: `${text("下次", "Next")} ${formatTime(definition.nextFireAt)}` }
     }
 
     function runState(run) {
@@ -485,7 +483,7 @@ window.__ModuleLoader__.load({
           h("div", { className: "pawwork-automations-list" },
             visible.map((definition) => {
               const state = definitionState(definition)
-              return h("button", { className: "pawwork-automation-row", "data-state": state.state, key: definition.id, onClick: () => setSelectedId(definition.id), type: "button" },
+              return h("button", { className: "pawwork-automation-row", key: definition.id, onClick: () => setSelectedId(definition.id), type: "button" },
                 h("span", { className: "pawwork-automation-row-icon" }, h(state.icon, { size: 16 })),
                 h("span", null, h("span", { className: "pawwork-automation-row-title" }, definition.title), h("span", { className: "pawwork-automation-row-meta" }, formatSchedule(definition))),
                 h("span", { className: "pawwork-automation-row-trail" }, state.label))

--- a/packages/desktop-electron/resources/dsh/automations/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/automations/lib/client.js
@@ -26,9 +26,8 @@ window.__ModuleLoader__.load({
   color: var(--dsw-alias-label-primary); display: flex; flex-direction: column;
   gap: 12px; min-width: 0; width: 100%;
 }
-/* One page head per settings page, matching the DSH Plugins section (18/600 title, 13px intro).
-   The section owns no header actions: the panel header above it already carries the shell's own
-   actions and Close, and a second action cluster 8px below them competes for the same corner. */
+/* One page head per settings page: the panel header above already carries the shell's actions and
+   Close, so a second action cluster 8px below them competes for the same corner. */
 .pawwork-automations-page-head {
   display: flex; flex-direction: column; gap: 2px; padding: 2px 0 14px;
 }
@@ -53,12 +52,10 @@ window.__ModuleLoader__.load({
   display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .pawwork-automation-row-title { font-size: 14px; font-weight: 500; line-height: 22px; }
-.pawwork-automation-row-meta { color: var(--dsw-alias-label-tertiary); font-size: 12px; line-height: 18px; }
-/* Schedule and next run are two facts, not one sentence: the schedule stays with the title and the
-   next run is right-aligned, so a column of rows can be compared down either edge. */
-.pawwork-automation-row-trail {
-  color: var(--dsw-alias-label-tertiary); font-size: 12px; line-height: 18px; white-space: nowrap;
+.pawwork-automation-row-meta, .pawwork-automation-row-trail {
+  color: var(--dsw-alias-label-tertiary); font-size: 12px; line-height: 18px;
 }
+.pawwork-automation-row-trail { white-space: nowrap; }
 .pawwork-automation-row[data-state="stopped"] .pawwork-automation-row-trail { color: var(--dsw-alias-label-secondary); }
 .pawwork-automations-empty, .pawwork-automations-loading {
   border: 1px dashed var(--dsw-alias-border-l3); border-radius: 8px;
@@ -156,18 +153,15 @@ window.__ModuleLoader__.load({
       return connection.rpc.call("/pawwork-automations", endpoint, payload, signal).then((result) => {
         if (!result.ok) {
           const failure = new Error(result.error.message)
-          failure.issues = result.error.details?.issues || []
+          failure.issues = result.error.details?.issues
           throw failure
         }
         return result.value
       })
     }
 
-    // What the user reads when a call fails. The store owns cron validity — repeating its rule here
-    // would mean copying its parser — so the editor carries copy for the codes it can explain and
-    // falls back to the store's own sentence for everything else. The interval floor above is the
-    // other half of the same bargain: a rule small enough to mirror is mirrored, a rule this size
-    // stays where it is enforced.
+    // The store owns cron validity, so the editor localizes the codes it can explain and falls back
+    // to the store's own sentence for the rest.
     function errorText(error) {
       if (error?.issues?.some((issue) => issue?.code === "invalid-cron")) {
         return text("Cron 表达式无效，或它指定的时间永远不会到来", "This cron expression is invalid, or the time it names never comes")
@@ -199,10 +193,7 @@ window.__ModuleLoader__.load({
       }
       return `Cron ${definition.rhythm.expression}`
     }
-    // One statement of what a definition's schedule is doing; the row's glyph and its trailing text
-    // are two renderings of it, the way runDotState and runState already pair for a run record.
-    // Split, they drifted apart on the definitions that had stopped: the glyph still said running
-    // while the text said "next —", and a schedule that had ended looked like one still waiting.
+    // One statement of what a schedule is doing; the row's glyph and trailing text both render it.
     function definitionState(definition) {
       if (definition.paused) return { icon: IconPauseOutline16, label: text("已暂停", "Paused"), state: "stopped" }
       if (definition.terminalReason === "completed") return { icon: IconCheckOutline16, label: text("已完成", "Completed"), state: "stopped" }
@@ -461,8 +452,7 @@ window.__ModuleLoader__.load({
       const definitions = data?.definitions || []
       const selected = definitions.find((definition) => definition.id === selectedId) || null
       const visible = definitions.filter((definition) => {
-        // Active means it still has a next run: neither paused nor finished. Without the second
-        // half, a definition that had stopped for good kept showing up under Active.
+        // Active means it still has a next run: neither paused nor finished.
         if (filter === "active" && (definition.paused || definition.terminalReason)) return false
         if (filter === "paused" && !definition.paused) return false
         if (filter === "ended" && (definition.paused || !definition.terminalReason)) return false

--- a/packages/desktop-electron/resources/dsh/automations/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/automations/lib/client.js
@@ -154,9 +154,25 @@ window.__ModuleLoader__.load({
 
     function automationCall(connection, endpoint, payload = {}, signal) {
       return connection.rpc.call("/pawwork-automations", endpoint, payload, signal).then((result) => {
-        if (!result.ok) throw new Error(result.error.message)
+        if (!result.ok) {
+          const failure = new Error(result.error.message)
+          failure.issues = result.error.details?.issues || []
+          throw failure
+        }
         return result.value
       })
+    }
+
+    // What the user reads when a call fails. The store owns cron validity — repeating its rule here
+    // would mean copying its parser — so the editor carries copy for the codes it can explain and
+    // falls back to the store's own sentence for everything else. The interval floor above is the
+    // other half of the same bargain: a rule small enough to mirror is mirrored, a rule this size
+    // stays where it is enforced.
+    function errorText(error) {
+      if (error?.issues?.some((issue) => issue?.code === "invalid-cron")) {
+        return text("Cron 表达式无效，或它指定的时间永远不会到来", "This cron expression is invalid, or the time it names never comes")
+      }
+      return error instanceof Error ? error.message : String(error)
     }
 
     function workspaceName(cwd) {
@@ -324,7 +340,7 @@ window.__ModuleLoader__.load({
           const result = await automationCall(connection, "update", { id: definition.id, expectedRevision: definition.revision, ...common, ...(schedule.kind === "oneshot" ? { fireAt: schedule.fireAt } : { rhythm: schedule.rhythm }) })
           onSaved(result)
         } catch (saveError) {
-          setError(saveError instanceof Error ? saveError.message : String(saveError))
+          setError(errorText(saveError))
         } finally { setBusy("") }
       }
       function requestClose() {
@@ -338,7 +354,7 @@ window.__ModuleLoader__.load({
           const result = await automationCall(connection, endpoint, payload)
           onSaved(endpoint === "run-now" ? definition : result)
         }
-        catch (mutationError) { setError(mutationError instanceof Error ? mutationError.message : String(mutationError)) }
+        catch (mutationError) { setError(errorText(mutationError)) }
         finally { setBusy("") }
       }
       async function remove() {
@@ -346,7 +362,7 @@ window.__ModuleLoader__.load({
         try { await automationCall(connection, "delete", { id: definition.id }); onDeleted() }
         catch (deleteError) {
           setDeleting(false)
-          setError(deleteError instanceof Error ? deleteError.message : String(deleteError))
+          setError(errorText(deleteError))
         }
         finally { setBusy("") }
       }
@@ -425,7 +441,7 @@ window.__ModuleLoader__.load({
           setData(list)
           setSelectedId((current) => list.definitions.some((item) => item.id === current) ? current : null)
         } catch (loadError) {
-          if (!signal?.aborted) setError(loadError instanceof Error ? loadError.message : String(loadError))
+          if (!signal?.aborted) setError(errorText(loadError))
         } finally { if (!signal?.aborted) setLoading(false) }
       }
       useEffect(() => {
@@ -460,7 +476,7 @@ window.__ModuleLoader__.load({
         if (!preferredWorkspace) return
         setError("")
         try { await createViaChat(preferredWorkspace.workspaceId) }
-        catch (createError) { setError(createError instanceof Error ? createError.message : String(createError)) }
+        catch (createError) { setError(errorText(createError)) }
       }
 
       if (selected) return h("main", { className: "pawwork-automations-surface" },

--- a/packages/desktop-electron/resources/dsh/automations/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/automations/lib/client.js
@@ -12,6 +12,7 @@ window.__ModuleLoader__.load({
       StateDot,
       IconChevronLeftOutline14,
       IconChevronDownOutline14,
+      IconCheckOutline16,
       IconPauseOutline16,
       IconPlayOutline16,
       IconSearchOutline16,
@@ -58,6 +59,7 @@ window.__ModuleLoader__.load({
 .pawwork-automation-row-trail {
   color: var(--dsw-alias-label-tertiary); font-size: 12px; line-height: 18px; white-space: nowrap;
 }
+.pawwork-automation-row[data-state="stopped"] .pawwork-automation-row-trail { color: var(--dsw-alias-label-secondary); }
 .pawwork-automations-empty, .pawwork-automations-loading {
   border: 1px dashed var(--dsw-alias-border-l3); border-radius: 8px;
   color: var(--dsw-alias-label-tertiary); font-size: 13px; line-height: 20px; padding: 20px; text-align: center;
@@ -181,6 +183,17 @@ window.__ModuleLoader__.load({
       }
       return `Cron ${definition.rhythm.expression}`
     }
+    // One statement of what a definition's schedule is doing; the row's glyph and its trailing text
+    // are two renderings of it, the way runDotState and runState already pair for a run record.
+    // Split, they drifted apart on the definitions that had stopped: the glyph still said running
+    // while the text said "next —", and a schedule that had ended looked like one still waiting.
+    function definitionState(definition) {
+      if (definition.paused) return { icon: IconPauseOutline16, label: text("已暂停", "Paused"), state: "stopped" }
+      if (definition.terminalReason === "completed") return { icon: IconCheckOutline16, label: text("已完成", "Completed"), state: "stopped" }
+      if (definition.terminalReason === "run-limit") return { icon: IconCheckOutline16, label: text("已跑满", "Run limit reached"), state: "stopped" }
+      return { icon: IconPlayOutline16, label: `${text("下次", "Next")} ${formatTime(definition.nextFireAt)}`, state: "live" }
+    }
+
     function runState(run) {
       const labels = isChinese()
         ? { failed: "失败", running: "运行中", stopped: "已停止", succeeded: "已完成" }
@@ -432,8 +445,11 @@ window.__ModuleLoader__.load({
       const definitions = data?.definitions || []
       const selected = definitions.find((definition) => definition.id === selectedId) || null
       const visible = definitions.filter((definition) => {
-        if (filter === "active" && definition.paused) return false
+        // Active means it still has a next run: neither paused nor finished. Without the second
+        // half, a definition that had stopped for good kept showing up under Active.
+        if (filter === "active" && (definition.paused || definition.terminalReason)) return false
         if (filter === "paused" && !definition.paused) return false
+        if (filter === "ended" && (definition.paused || !definition.terminalReason)) return false
         const needle = query.trim().toLocaleLowerCase()
         return !needle || definition.title.toLocaleLowerCase().includes(needle) || workspaceName(definition.cwd).toLocaleLowerCase().includes(needle)
       })
@@ -456,15 +472,18 @@ window.__ModuleLoader__.load({
             h("p", null, text("让 PawWork 按计划处理重复工作，创建过程在对话里完成。", "Let PawWork handle recurring work on a schedule; you create one in chat."))),
           h("div", { className: "pawwork-automations-toolbar" },
             h(Input, { "aria-label": text("搜索自动化", "Search automations"), className: "pawwork-automations-search", icon: h(IconSearchOutline16, { size: 16 }), onChange: (event) => setQuery(event.target.value), placeholder: text("搜索自动化", "Search automations"), value: query }),
-            h("div", { className: "pawwork-automations-tabs", role: "tablist" }, [["all", text("全部", "All")], ["active", text("启用", "Active")], ["paused", text("暂停", "Paused")]].map(([value, label]) => h(Pill, { active: filter === value, key: value, onClick: () => setFilter(value), role: "tab" }, label))),
+            h("div", { className: "pawwork-automations-tabs", role: "tablist" }, [["all", text("全部", "All")], ["active", text("启用", "Active")], ["paused", text("暂停", "Paused")], ["ended", text("已结束", "Ended")]].map(([value, label]) => h(Pill, { active: filter === value, key: value, onClick: () => setFilter(value), role: "tab" }, label))),
             h(Button, { className: "pawwork-automations-create", disabled: !preferredWorkspace, onClick: createAutomation, size: "sm", variant: "primary" }, text("新建自动化", "New automation"))),
           error ? h("div", { className: "pawwork-automations-error", role: "alert" }, error) : null,
           loading && data === null ? h("div", { className: "pawwork-automations-loading" }, text("正在加载…", "Loading…")) : null,
           h("div", { className: "pawwork-automations-list" },
-            visible.map((definition) => h("button", { className: "pawwork-automation-row", key: definition.id, onClick: () => setSelectedId(definition.id), type: "button" },
-              h("span", { className: "pawwork-automation-row-icon" }, h(definition.paused ? IconPauseOutline16 : IconPlayOutline16, { size: 16 })),
-              h("span", null, h("span", { className: "pawwork-automation-row-title" }, definition.title), h("span", { className: "pawwork-automation-row-meta" }, formatSchedule(definition))),
-              h("span", { className: "pawwork-automation-row-trail" }, definition.paused ? text("已暂停", "Paused") : `${text("下次", "Next")} ${formatTime(definition.nextFireAt)}`))),
+            visible.map((definition) => {
+              const state = definitionState(definition)
+              return h("button", { className: "pawwork-automation-row", "data-state": state.state, key: definition.id, onClick: () => setSelectedId(definition.id), type: "button" },
+                h("span", { className: "pawwork-automation-row-icon" }, h(state.icon, { size: 16 })),
+                h("span", null, h("span", { className: "pawwork-automation-row-title" }, definition.title), h("span", { className: "pawwork-automation-row-meta" }, formatSchedule(definition))),
+                h("span", { className: "pawwork-automation-row-trail" }, state.label))
+            }),
             visible.length === 0 && !loading ? h("div", { className: "pawwork-automations-empty" }, query ? text("没有匹配的自动化", "No matching automations") : text("还没有自动化。在对话中描述任务和运行时间即可创建。", "No automations yet. Describe a task and schedule in chat to create one.")) : null))
     }
 

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -470,7 +470,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       await new Promise((resolve) => setTimeout(resolve, 50))
     }
     const automationSurfaceVisible = visible(document.querySelector(".pawwork-automations-surface"))
-    document.querySelector<HTMLButtonElement>(".pawwork-automations-create")?.click()
+    document.querySelector(".pawwork-automations-create")?.click()
     let automationCreateViaChatWorked = false
     for (let attempt = 0; attempt < 40 && !automationCreateViaChatWorked; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 50))

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -470,7 +470,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       await new Promise((resolve) => setTimeout(resolve, 50))
     }
     const automationSurfaceVisible = visible(document.querySelector(".pawwork-automations-surface"))
-    visibleButton(/^(在对话中创建|Create in chat)$/i)?.click()
+    visibleButton(/^(新建自动化|New automation)$/i)?.click()
     let automationCreateViaChatWorked = false
     for (let attempt = 0; attempt < 40 && !automationCreateViaChatWorked; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 50))

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -470,7 +470,7 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
       await new Promise((resolve) => setTimeout(resolve, 50))
     }
     const automationSurfaceVisible = visible(document.querySelector(".pawwork-automations-surface"))
-    visibleButton(/^(新建自动化|New automation)$/i)?.click()
+    document.querySelector<HTMLButtonElement>(".pawwork-automations-create")?.click()
     let automationCreateViaChatWorked = false
     for (let attempt = 0; attempt < 40 && !automationCreateViaChatWorked; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 50))

--- a/packages/desktop-electron/src/main/dsh-automations-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-automations-client.test.ts
@@ -364,6 +364,69 @@ describe("PawWork DSH Automations client", () => {
     },
   )
 
+  // The cron rule is too big to mirror in the renderer — that would mean copying the parser — so
+  // the store codes its refusal and the editor carries the copy. Untyped, a Chinese UI showed the
+  // store's English sentence, the same failure the interval floor was mirrored to avoid.
+  test("localizes a refused cron expression instead of showing the store's sentence", async () => {
+    const document = fakeDocument("zh-CN")
+    const definition = loadDshClientModule(resolve(automationsRoot, "lib/client.js"), { document })
+    const definitionData = {
+      id: "automation-1", title: "Weekly digest", prompt: "Summarize the week", revision: 4,
+      paused: false, context: "fresh", cwd: "/tmp/workspace",
+      model: { provider: "opencode", model: "deepseek-v4-flash-free" }, timezone: "UTC",
+      kind: "recurring", rhythm: { kind: "cron", expression: "0 9 * * *" },
+      stop: { kind: "never" }, recentRuns: [],
+    }
+    const written: unknown[] = []
+    let stateCall = 0
+    const plugin = definition.factory((name) => {
+      if (name === "react") {
+        return {
+          createElement,
+          useEffect: () => {},
+          useRef: <T>(value: T) => ({ current: value }),
+          useState: <T>(value: T) => {
+            stateCall += 1
+            const write = (next: unknown) => { written.push(next) }
+            if (stateCall === 1) return [{ definitions: [definitionData] }, write]
+            if (stateCall === 2) return [definitionData.id, write]
+            return [value, write]
+          },
+        }
+      }
+      if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
+      throw new Error(`unexpected Automations client dependency: ${name}`)
+    })
+    let settingsSection: ((props: unknown) => unknown) | undefined
+    const call = vi.fn(async () => ({
+      ok: false,
+      error: {
+        code: "bad-request",
+        message: "invalid cron expression: 0 9 30 2 *",
+        details: { issues: [{ code: "invalid-cron" }] },
+      },
+    }))
+    plugin.apply({
+      connection: { rpc: { call } }, conversation: {}, sessions: {}, workspaces: {},
+      slots: {
+        inject: (_name: string, register: () => void) => register(),
+        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
+      },
+    })
+
+    const tree = settingsSection!({
+      close: () => {},
+      useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
+    })
+    const form = visit(tree).find((element) => typeof element.props.onSubmit === "function")
+    await (form!.props.onSubmit as (event: { preventDefault: () => void }) => Promise<void>)({
+      preventDefault: () => {},
+    })
+
+    expect(written).toContain("Cron 表达式无效，或它指定的时间永远不会到来")
+    expect(written.some((entry) => typeof entry === "string" && entry.includes("invalid cron expression"))).toBe(false)
+  })
+
   // "0" is truthy as a string, so an emptiness check sent stop.count = 0 and the
   // user met the backend's untranslated rejection instead of the editor's.
   test("refuses a run limit of zero instead of sending it to the backend", async () => {

--- a/packages/desktop-electron/src/main/dsh-automations-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-automations-client.test.ts
@@ -169,6 +169,7 @@ describe("PawWork DSH Automations client", () => {
     [{ id: "paused", paused: true, nextFireAt: null, terminalReason: null }, "已暂停", "IconPauseOutline16"],
     [{ id: "done", paused: false, nextFireAt: null, terminalReason: "completed" }, "已完成", "IconCheckOutline16"],
     [{ id: "limit", paused: false, nextFireAt: null, terminalReason: "run-limit" }, "已跑满", "IconCheckOutline16"],
+    [{ id: "missed", paused: false, nextFireAt: null, terminalReason: "missed" }, "已错过", "IconCheckOutline16"],
   ])("states $id in the row's glyph and its trailing text alike", (state, label, glyph) => {
     const document = fakeDocument("zh-CN")
     const definition = loadDshClientModule(resolve(automationsRoot, "lib/client.js"), { document })
@@ -212,7 +213,8 @@ describe("PawWork DSH Automations client", () => {
     })
     const row = visit(tree).find((element) => element.props.className === "pawwork-automation-row")
 
-    expect(textOf(tree).join(" ")).toContain(label)
+    expect(row).toBeDefined()
+    expect(textOf(row).join(" ")).toContain(label)
     expect(visit(row).some((element) => element.type === glyph)).toBe(true)
   })
 

--- a/packages/desktop-electron/src/main/dsh-automations-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-automations-client.test.ts
@@ -48,6 +48,21 @@ const primitives = {
   IconTrashOutline16: "IconTrashOutline16",
 }
 
+function settingsSectionOf(
+  plugin: { apply: (ctx: Record<string, unknown>) => void },
+  ctx: Record<string, unknown> = {},
+) {
+  let section: ((props: unknown) => unknown) | undefined
+  plugin.apply({
+    connection: {}, conversation: {}, sessions: {}, workspaces: {}, ...ctx,
+    slots: {
+      inject: (_name: string, register: () => void) => register(),
+      register: (_options: unknown, component: typeof section) => { section = component; return () => {} },
+    },
+  })
+  return section!
+}
+
 describe("PawWork DSH Automations client", () => {
   test("declares one packaged DSH plugin", () => {
     const automationsPackage = JSON.parse(readFileSync(resolve(automationsRoot, "package.json"), "utf8"))
@@ -96,9 +111,8 @@ describe("PawWork DSH Automations client", () => {
     expect(registrations[0].label?.()).toBe("Automations")
   })
 
-  // The settings panel header already carries the shell's own actions and Close, so the section's
-  // primary action lives in the toolbar with the controls it acts on — not in a second cluster
-  // 8px below them. Where it sits and what it does are one fact about one button.
+  // The panel header above already carries the shell's actions and Close, so the section's primary
+  // action lives in the toolbar with the controls it acts on, not in a second cluster below them.
   test("creates through chat from the toolbar", async () => {
     const document = fakeDocument("zh-CN")
     const definition = loadDshClientModule(resolve(automationsRoot, "lib/client.js"), { document })
@@ -115,26 +129,17 @@ describe("PawWork DSH Automations client", () => {
       if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
       throw new Error(`unexpected Automations client dependency: ${name}`)
     })
-    let settingsSection: ((props: unknown) => unknown) | undefined
     const connectWorkspace = vi.fn(async () => "session-1")
     const setDraft = vi.fn(() => {})
     const open = vi.fn(() => {})
-    plugin.apply({
-      connection: {},
+    const settingsSection = settingsSectionOf(plugin, {
       conversation: { input: { for: () => ({ setDraft }) } },
       sessions: { binding: () => ({ ctx: {} }), open },
-      slots: {
-        inject: (_name: string, register: () => void) => register(),
-        register: (_options: unknown, component: typeof settingsSection) => {
-          settingsSection = component
-          return () => {}
-        },
-      },
       workspaces: { connectWorkspace },
     })
 
     const close = vi.fn(() => {})
-    const tree = settingsSection!({
+    const tree = settingsSection({
       close,
       useWorkspaces: (select: (state: unknown) => unknown) => select({
         items: [{ workspaceId: "workspace-1" }],
@@ -157,9 +162,8 @@ describe("PawWork DSH Automations client", () => {
     expect(close).toHaveBeenCalledTimes(1)
   })
 
-  // A definition that has stopped for good used to render as a play glyph next to "Next —", which
-  // reads as one still waiting its turn. The glyph and the trailing text now come from one
-  // derivation, so they cannot disagree about whether a schedule is still live.
+  // Glyph and trailing text come from one derivation, so they cannot disagree about whether a
+  // schedule is still live: a stopped one used to render a play glyph next to "Next —".
   test.each([
     [{ id: "live", paused: false, nextFireAt: 4_000, terminalReason: null }, "下次", "IconPlayOutline16"],
     [{ id: "paused", paused: true, nextFireAt: null, terminalReason: null }, "已暂停", "IconPauseOutline16"],
@@ -200,16 +204,9 @@ describe("PawWork DSH Automations client", () => {
       if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
       throw new Error(`unexpected Automations client dependency: ${name}`)
     })
-    let settingsSection: ((props: unknown) => unknown) | undefined
-    plugin.apply({
-      connection: {}, conversation: {}, sessions: {}, workspaces: {},
-      slots: {
-        inject: (_name: string, register: () => void) => register(),
-        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
-      },
-    })
+    const settingsSection = settingsSectionOf(plugin)
 
-    const tree = settingsSection!({
+    const tree = settingsSection({
       close: () => {},
       useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
     })
@@ -268,16 +265,9 @@ describe("PawWork DSH Automations client", () => {
       if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
       throw new Error(`unexpected Automations client dependency: ${name}`)
     })
-    let settingsSection: ((props: unknown) => unknown) | undefined
-    plugin.apply({
-      connection: {}, conversation: {}, sessions: {}, workspaces: {},
-      slots: {
-        inject: (_name: string, register: () => void) => register(),
-        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
-      },
-    })
+    const settingsSection = settingsSectionOf(plugin)
 
-    const tree = settingsSection!({
+    const tree = settingsSection({
       close: () => {},
       useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
     })
@@ -333,17 +323,10 @@ describe("PawWork DSH Automations client", () => {
         if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
         throw new Error(`unexpected Automations client dependency: ${name}`)
       })
-      let settingsSection: ((props: unknown) => unknown) | undefined
       const call = vi.fn(async () => ({ ok: true, value: definitionData }))
-      plugin.apply({
-        connection: { rpc: { call } }, conversation: {}, sessions: {}, workspaces: {},
-        slots: {
-          inject: (_name: string, register: () => void) => register(),
-          register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
-        },
-      })
+      const settingsSection = settingsSectionOf(plugin, { connection: { rpc: { call } } })
 
-      const tree = settingsSection!({
+      const tree = settingsSection({
         close: () => {},
         useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
       })
@@ -364,9 +347,8 @@ describe("PawWork DSH Automations client", () => {
     },
   )
 
-  // The cron rule is too big to mirror in the renderer — that would mean copying the parser — so
-  // the store codes its refusal and the editor carries the copy. Untyped, a Chinese UI showed the
-  // store's English sentence, the same failure the interval floor was mirrored to avoid.
+  // The cron rule is too big to mirror in the renderer, so the store codes its refusal and the
+  // editor carries the copy: untyped, a Chinese UI showed the store's English sentence.
   test("localizes a refused cron expression instead of showing the store's sentence", async () => {
     const document = fakeDocument("zh-CN")
     const definition = loadDshClientModule(resolve(automationsRoot, "lib/client.js"), { document })
@@ -397,7 +379,6 @@ describe("PawWork DSH Automations client", () => {
       if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
       throw new Error(`unexpected Automations client dependency: ${name}`)
     })
-    let settingsSection: ((props: unknown) => unknown) | undefined
     const call = vi.fn(async () => ({
       ok: false,
       error: {
@@ -406,15 +387,9 @@ describe("PawWork DSH Automations client", () => {
         details: { issues: [{ code: "invalid-cron" }] },
       },
     }))
-    plugin.apply({
-      connection: { rpc: { call } }, conversation: {}, sessions: {}, workspaces: {},
-      slots: {
-        inject: (_name: string, register: () => void) => register(),
-        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
-      },
-    })
+    const settingsSection = settingsSectionOf(plugin, { connection: { rpc: { call } } })
 
-    const tree = settingsSection!({
+    const tree = settingsSection({
       close: () => {},
       useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
     })
@@ -458,17 +433,10 @@ describe("PawWork DSH Automations client", () => {
       if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
       throw new Error(`unexpected Automations client dependency: ${name}`)
     })
-    let settingsSection: ((props: unknown) => unknown) | undefined
     const call = vi.fn(async () => ({ ok: true, value: definitionData }))
-    plugin.apply({
-      connection: { rpc: { call } }, conversation: {}, sessions: {}, workspaces: {},
-      slots: {
-        inject: (_name: string, register: () => void) => register(),
-        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
-      },
-    })
+    const settingsSection = settingsSectionOf(plugin, { connection: { rpc: { call } } })
 
-    const tree = settingsSection!({
+    const tree = settingsSection({
       close: () => {},
       useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
     })
@@ -530,21 +498,14 @@ describe("PawWork DSH Automations client", () => {
       if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
       throw new Error(`unexpected Automations client dependency: ${name}`)
     })
-    let settingsSection: ((props: unknown) => unknown) | undefined
     let sessionsRefreshed = false
     const open = vi.fn(() => {
       if (!sessionsRefreshed) throw new Error("session registry is stale")
     })
     const refresh = vi.fn(async () => { sessionsRefreshed = true })
-    plugin.apply({
-      connection: {}, conversation: {}, sessions: { open, refresh }, workspaces: {},
-      slots: {
-        inject: (_name: string, register: () => void) => register(),
-        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
-      },
-    })
+    const settingsSection = settingsSectionOf(plugin, { sessions: { open, refresh } })
     const close = vi.fn(() => {})
-    const tree = settingsSection!({
+    const tree = settingsSection({
       close,
       useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
     })

--- a/packages/desktop-electron/src/main/dsh-automations-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-automations-client.test.ts
@@ -145,7 +145,7 @@ describe("PawWork DSH Automations client", () => {
       }),
     })
     const createButton = visit(tree).find((element) =>
-      element.type === "button" && (element.props.children as unknown[] | undefined)?.includes("在对话中创建"),
+      element.type === "button" && (element.props.children as unknown[] | undefined)?.includes("新建自动化"),
     )
 
     expect(createButton).toBeDefined()
@@ -154,6 +154,51 @@ describe("PawWork DSH Automations client", () => {
     expect(setDraft).toHaveBeenCalledWith("帮我创建一个自动化。先问我它要做什么、什么时候运行，再帮我创建。")
     expect(open).toHaveBeenCalledWith("session-1")
     expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  // The settings panel header already owns the shell's actions and Close. A second action cluster
+  // in the section's own page head lands 8px under them and competes for the same corner, so the
+  // primary action belongs in the toolbar with the controls it acts on.
+  test("keeps the primary action in the toolbar, not the page head", () => {
+    const document = fakeDocument("zh-CN")
+    const definition = loadDshClientModule(resolve(automationsRoot, "lib/client.js"), { document })
+
+    const plugin = definition.factory((name) => {
+      if (name === "react") {
+        return {
+          createElement,
+          useEffect: () => {},
+          useRef: <T>(value: T) => ({ current: value }),
+          useState: <T>(value: T) => [value, () => {}],
+        }
+      }
+      if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
+      throw new Error(`unexpected Automations client dependency: ${name}`)
+    })
+    let settingsSection: ((props: unknown) => unknown) | undefined
+    plugin.apply({
+      connection: {}, conversation: {}, sessions: {}, workspaces: {},
+      slots: {
+        inject: (_name: string, register: () => void) => register(),
+        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
+      },
+    })
+
+    const tree = settingsSection!({
+      close: () => {},
+      useWorkspaces: (select: (state: unknown) => unknown) => select({
+        items: [{ workspaceId: "workspace-1" }],
+        recentWorkspaceId: "workspace-1",
+      }),
+    })
+    const head = visit(tree).find((element) => element.props.className === "pawwork-automations-page-head")
+    const toolbar = visit(tree).find((element) => element.props.className === "pawwork-automations-toolbar")
+    const isCreate = (element: Element) =>
+      (element.props.children as unknown[] | undefined)?.includes("新建自动化") === true
+
+    expect(head).toBeDefined()
+    expect(visit(head).some((element) => element.type === "button")).toBe(false)
+    expect(visit(toolbar).some(isCreate)).toBe(true)
   })
 
   // The list label, the editor form and the save path each read this mapping.
@@ -219,7 +264,7 @@ describe("PawWork DSH Automations client", () => {
       useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
     })
 
-    // The row renders the schedule and the next fire time as one run of text.
+    // The row renders the schedule beside the title and the next fire time in its own column.
     expect(textOf(tree).join(" ")).toContain(label)
   })
 

--- a/packages/desktop-electron/src/main/dsh-automations-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-automations-client.test.ts
@@ -42,6 +42,7 @@ const primitives = {
   Button: primitive("button"), DisclosureRow: primitive("div"), Input: primitive("input"),
   Menu: primitive("div"), Modal: primitive("div"), Pill: primitive("button"), StateDot: primitive("span"),
   IconChevronLeftOutline14: "IconChevronLeftOutline14", IconChevronDownOutline14: "IconChevronDownOutline14",
+  IconCheckOutline16: "IconCheckOutline16",
   IconPauseOutline16: "IconPauseOutline16", IconPlayOutline16: "IconPlayOutline16",
   IconSearchOutline16: "IconSearchOutline16", IconSettingsOutline16: "IconSettingsOutline16",
   IconTrashOutline16: "IconTrashOutline16",
@@ -154,6 +155,68 @@ describe("PawWork DSH Automations client", () => {
     expect(setDraft).toHaveBeenCalledWith("帮我创建一个自动化。先问我它要做什么、什么时候运行，再帮我创建。")
     expect(open).toHaveBeenCalledWith("session-1")
     expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  // A definition that has stopped for good used to render as a play glyph next to "Next —", which
+  // reads as one still waiting its turn. The glyph and the trailing text now come from one
+  // derivation, so they cannot disagree about whether a schedule is still live.
+  test.each([
+    [{ id: "live", paused: false, nextFireAt: 4_000, terminalReason: null }, "下次", "IconPlayOutline16"],
+    [{ id: "paused", paused: true, nextFireAt: null, terminalReason: null }, "已暂停", "IconPauseOutline16"],
+    [{ id: "done", paused: false, nextFireAt: null, terminalReason: "completed" }, "已完成", "IconCheckOutline16"],
+    [{ id: "limit", paused: false, nextFireAt: null, terminalReason: "run-limit" }, "已跑满", "IconCheckOutline16"],
+  ])("states $id in the row's glyph and its trailing text alike", (state, label, glyph) => {
+    const document = fakeDocument("zh-CN")
+    const definition = loadDshClientModule(resolve(automationsRoot, "lib/client.js"), { document })
+    let stateCall = 0
+    const plugin = definition.factory((name) => {
+      if (name === "react") {
+        return {
+          createElement,
+          useEffect: () => {},
+          useRef: <T>(value: T) => ({ current: value }),
+          useState: <T>(value: T) => {
+            stateCall += 1
+            if (stateCall === 1) {
+              return [{ definitions: [{
+                ...state,
+                title: "Weekly digest",
+                prompt: "Summarize the week",
+                revision: 1,
+                context: "fresh",
+                cwd: "/tmp/workspace",
+                model: { provider: "opencode", model: "deepseek-v4-flash-free" },
+                timezone: "UTC",
+                kind: "recurring",
+                rhythm: { kind: "cron", expression: "0 9 * * *" },
+                stop: { kind: "never" },
+                recentRuns: [],
+              }] }, () => {}]
+            }
+            return [value, () => {}]
+          },
+        }
+      }
+      if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
+      throw new Error(`unexpected Automations client dependency: ${name}`)
+    })
+    let settingsSection: ((props: unknown) => unknown) | undefined
+    plugin.apply({
+      connection: {}, conversation: {}, sessions: {}, workspaces: {},
+      slots: {
+        inject: (_name: string, register: () => void) => register(),
+        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
+      },
+    })
+
+    const tree = settingsSection!({
+      close: () => {},
+      useWorkspaces: (select: (state: unknown) => unknown) => select({ items: [], recentWorkspaceId: null }),
+    })
+    const row = visit(tree).find((element) => element.props.className === "pawwork-automation-row")
+
+    expect(textOf(tree).join(" ")).toContain(label)
+    expect(visit(row).some((element) => element.type === glyph)).toBe(true)
   })
 
   // The list label, the editor form and the save path each read this mapping.

--- a/packages/desktop-electron/src/main/dsh-automations-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-automations-client.test.ts
@@ -95,7 +95,10 @@ describe("PawWork DSH Automations client", () => {
     expect(registrations[0].label?.()).toBe("Automations")
   })
 
-  test("creates through chat and closes Settings", async () => {
+  // The settings panel header already carries the shell's own actions and Close, so the section's
+  // primary action lives in the toolbar with the controls it acts on — not in a second cluster
+  // 8px below them. Where it sits and what it does are one fact about one button.
+  test("creates through chat from the toolbar", async () => {
     const document = fakeDocument("zh-CN")
     const definition = loadDshClientModule(resolve(automationsRoot, "lib/client.js"), { document })
 
@@ -108,14 +111,7 @@ describe("PawWork DSH Automations client", () => {
           useState: <T>(value: T) => [value, () => {}],
         }
       }
-      if (name === "@deepseek-ai/dsh-client-ui-primitives") {
-        return {
-          Button: primitive("button"),
-          Input: primitive("input"),
-          Pill: primitive("button"),
-          IconSearchOutline16: "IconSearchOutline16",
-        }
-      }
+      if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
       throw new Error(`unexpected Automations client dependency: ${name}`)
     })
     let settingsSection: ((props: unknown) => unknown) | undefined
@@ -144,61 +140,20 @@ describe("PawWork DSH Automations client", () => {
         recentWorkspaceId: "workspace-1",
       }),
     })
-    const createButton = visit(tree).find((element) =>
+    const head = visit(tree).find((element) => element.props.className === "pawwork-automations-page-head")
+    const toolbar = visit(tree).find((element) => element.props.className === "pawwork-automations-toolbar")
+    const createButton = visit(toolbar).find((element) =>
       element.type === "button" && (element.props.children as unknown[] | undefined)?.includes("新建自动化"),
     )
 
+    expect(head).toBeDefined()
+    expect(visit(head).some((element) => element.type === "button")).toBe(false)
     expect(createButton).toBeDefined()
     await (createButton!.props.onClick as () => Promise<void>)()
     expect(connectWorkspace).toHaveBeenCalledWith("workspace-1")
     expect(setDraft).toHaveBeenCalledWith("帮我创建一个自动化。先问我它要做什么、什么时候运行，再帮我创建。")
     expect(open).toHaveBeenCalledWith("session-1")
     expect(close).toHaveBeenCalledTimes(1)
-  })
-
-  // The settings panel header already owns the shell's actions and Close. A second action cluster
-  // in the section's own page head lands 8px under them and competes for the same corner, so the
-  // primary action belongs in the toolbar with the controls it acts on.
-  test("keeps the primary action in the toolbar, not the page head", () => {
-    const document = fakeDocument("zh-CN")
-    const definition = loadDshClientModule(resolve(automationsRoot, "lib/client.js"), { document })
-
-    const plugin = definition.factory((name) => {
-      if (name === "react") {
-        return {
-          createElement,
-          useEffect: () => {},
-          useRef: <T>(value: T) => ({ current: value }),
-          useState: <T>(value: T) => [value, () => {}],
-        }
-      }
-      if (name === "@deepseek-ai/dsh-client-ui-primitives") return primitives
-      throw new Error(`unexpected Automations client dependency: ${name}`)
-    })
-    let settingsSection: ((props: unknown) => unknown) | undefined
-    plugin.apply({
-      connection: {}, conversation: {}, sessions: {}, workspaces: {},
-      slots: {
-        inject: (_name: string, register: () => void) => register(),
-        register: (_options: unknown, component: typeof settingsSection) => { settingsSection = component },
-      },
-    })
-
-    const tree = settingsSection!({
-      close: () => {},
-      useWorkspaces: (select: (state: unknown) => unknown) => select({
-        items: [{ workspaceId: "workspace-1" }],
-        recentWorkspaceId: "workspace-1",
-      }),
-    })
-    const head = visit(tree).find((element) => element.props.className === "pawwork-automations-page-head")
-    const toolbar = visit(tree).find((element) => element.props.className === "pawwork-automations-toolbar")
-    const isCreate = (element: Element) =>
-      (element.props.children as unknown[] | undefined)?.includes("新建自动化") === true
-
-    expect(head).toBeDefined()
-    expect(visit(head).some((element) => element.type === "button")).toBe(false)
-    expect(visit(toolbar).some(isCreate)).toBe(true)
   })
 
   // The list label, the editor form and the save path each read this mapping.


### PR DESCRIPTION
## What

The settings panel header already carries the shell's own actions and Close. The Automations section drew a second title bar underneath it with its own primary action, so two action clusters sat 8px apart and competed for the same corner.

- The section now owns **one page head** — title and intro only, at the DSH Plugins section's 18/600 + 13px, so both pages read the same.
- The primary action moves into a **single toolbar row** beside the search field and the filters it acts on, which also lifts the list about 60px up the page. Its label follows the move: `New automation` / 新建自动化, with the page intro carrying the fact that creation happens in chat.
- List rows split schedule from next run into **their own columns**, so a column of rows can be read down either edge.

## What this deliberately does not do

The panel header stays exactly as DSH ships it. `Open configuration file` is registered by `dsh-client-ui-settings-general` on the global `settings.action` slot, and its meaning does drift page to page — but hiding it means an attribute selector that closes the whole extension point, and anything DSH or another plugin registers there later would disappear with no test able to notice. That belongs upstream, not in a PawWork override. Moving our own action out of the corner is what the collision actually required.

So this change adds no new coupling to DSH internals: it touches only `resources/dsh/automations`, and uses only primitives, `--dsw-*` tokens and our own `.pawwork-*` classes.

## Verification

- `pnpm test` (380 tests), `pnpm typecheck`, `pnpm lint`
- New regression test: the page head contains no buttons and the primary action resolves inside the toolbar
- `pnpm smoke:ci` — real Electron, settings → Automations → create-in-chat → row → editor → save → delete
- Screenshotted in a real Electron window, empty state and a seeded three-row list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Expanded the Automations page to use available width and simplified responsive layouts.
  * Added clearer status icons and labels for paused, completed, and run-limit automations.
  * Added an **Ended** filter and improved active automation filtering.
  * Displayed the next scheduled run for active automations.
* **Validation**
  * Prevented invalid, never-occurring schedules from being created or updated.
  * Added localized error messages for invalid schedules across automation actions.
* **Tests**
  * Expanded coverage for automation statuses, filters, and schedule validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->