### PR TITLE
fix(desktop): recover from an unresolvable profile bundle

### DIFF
--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -296,7 +296,7 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
               : text("社区市场已停用。重新启动后台服务后生效。", "Community market disabled. Restart the background service to apply it.")
             : text(`社区市场 ${state.market.version ?? ""} 已启用。`, `Community market ${state.market.version ?? ""} is enabled.`)),
           h("div", { className: "pawwork-market-actions" },
-            h(Button, { onClick: () => api?.restart(), size: "sm" }, text("重新启动后台服务", "Restart Background Service")),
+            h(Button, { disabled: busy || !api, onClick: () => api?.restart(), size: "sm" }, text("重新启动后台服务", "Restart Background Service")),
             state.market.enabled ? h(Button, {
               disabled: busy || !api, onClick: () => run(() => api.disable()), size: "sm",
             }, text(busy ? "正在停用…" : "停用社区市场", busy ? "Disabling…" : "Disable community market")) : null))

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -176,7 +176,10 @@ html body :is(button, [role="button"], [role="treeitem"], [role="tab"], [role="m
   align-items: center; background: var(--dsw-alias-bg-module-platform); border-radius: 8px;
   display: flex; gap: 12px; justify-content: space-between; padding: 10px 12px;
 }
-.pawwork-market-status p { color: var(--dsw-alias-label-secondary); font-size: 12px; line-height: 19px; }
+.pawwork-market-status p { color: var(--dsw-alias-label-secondary); flex: 1; font-size: 12px; line-height: 19px; }
+/* The buttons share the row with a sentence that grows in every locale; without
+   a group of their own the flex line divides evenly and wraps their labels. */
+.pawwork-market-actions { display: flex; flex-shrink: 0; gap: 8px; white-space: nowrap; }
 .pawwork-market-action { align-self: flex-start; }
 .pawwork-market-error { color: var(--dsw-alias-state-error-primary); font-size: 12px; line-height: 19px; }
 /* The rc.8 locale registry throws on a duplicate namespace and offers no override point, so DSH's
@@ -268,11 +271,11 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
         return () => { current = false }
       }, [api])
 
-      async function enable() {
+      async function run(operation) {
         if (!api || busy) return
         setState((current) => ({ ...current, status: "working", error: "" }))
         try {
-          const market = await api.enable()
+          const market = await operation()
           setState({ status: "ready", market, error: "" })
         } catch (error) {
           setState((current) => ({ ...current, status: "ready", error: error instanceof Error ? error.message : String(error) }))
@@ -288,11 +291,17 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
         state.status === "loading" ? h("p", { className: "pawwork-market-copy" }, text("正在检查社区市场…", "Checking community market…")) : null,
         state.market.enabled || state.market.restartRequired ? h("div", { className: "pawwork-market-status", role: "status" },
           h("p", null, state.market.restartRequired
-            ? text("社区市场已安装。重新启动 DSH 后即可在设置中使用。", "Community market installed. Restart DSH to use it in Settings.")
+            ? state.market.enabled
+              ? text("社区市场已安装。重新启动后台服务后即可在设置中使用。", "Community market installed. Restart the background service to use it in Settings.")
+              : text("社区市场已停用。重新启动后台服务后生效。", "Community market disabled. Restart the background service to apply it.")
             : text(`社区市场 ${state.market.version ?? ""} 已启用。`, `Community market ${state.market.version ?? ""} is enabled.`)),
-          h(Button, { onClick: () => api?.restart(), size: "sm" }, text("重新启动 DSH", "Restart DSH")))
+          h("div", { className: "pawwork-market-actions" },
+            h(Button, { onClick: () => api?.restart(), size: "sm" }, text("重新启动后台服务", "Restart Background Service")),
+            state.market.enabled ? h(Button, {
+              disabled: busy || !api, onClick: () => run(() => api.disable()), size: "sm",
+            }, text(busy ? "正在停用…" : "停用社区市场", busy ? "Disabling…" : "Disable community market")) : null))
           : state.status !== "loading" ? h(Button, {
-            className: "pawwork-market-action", disabled: busy || !api, onClick: enable, size: "sm", variant: "primary",
+            className: "pawwork-market-action", disabled: busy || !api, onClick: () => run(() => api.enable()), size: "sm", variant: "primary",
           }, text(busy ? "正在启用…" : "启用社区市场", busy ? "Enabling…" : "Enable community market")) : null)
     }
 

--- a/packages/desktop-electron/resources/dsh/product/lib/desktop-host.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/desktop-host.cjs
@@ -141,6 +141,22 @@ function createDesktopHost(options) {
         || (current.enabled && current.version !== bootMarket.version),
     };
   };
+  const runMarketPlugin = async (args, failureLabel) => {
+    const operation = pnpm.service.runPlugin(
+      args,
+      profileDir,
+      AbortSignal.timeout(options.operationTimeoutMs ?? MARKET_OPERATION_TIMEOUT_MS),
+    );
+    let stderr = '';
+    operation.stdout.on('data', () => {});
+    operation.stderr.on('data', (chunk) => {
+      stderr = (stderr + chunk.toString()).slice(-64 * 1024);
+    });
+    const outcome = await operation.done;
+    if (outcome.exitCode !== 0 || outcome.signal !== null) {
+      throw new Error(stderr.trim() || `${failureLabel} failed with code ${String(outcome.exitCode)}`);
+    }
+  };
   return {
     desktopProfiles: createDesktopProfiles(profileDir),
     desktopPnpm: pnpm.service,
@@ -149,23 +165,25 @@ function createDesktopHost(options) {
       async enable() {
         const current = await status();
         if (current.enabled) return current;
-        const operation = pnpm.service.runPlugin(
-          ['add', MARKET_TARGET, '--save-exact'],
-          profileDir,
-          AbortSignal.timeout(options.operationTimeoutMs ?? MARKET_OPERATION_TIMEOUT_MS),
-        );
-        let stderr = '';
-        operation.stdout.on('data', () => {});
-        operation.stderr.on('data', (chunk) => {
-          stderr = (stderr + chunk.toString()).slice(-64 * 1024);
-        });
-        const outcome = await operation.done;
-        if (outcome.exitCode !== 0 || outcome.signal !== null) {
-          throw new Error(stderr.trim() || `DSH plugin install failed with code ${String(outcome.exitCode)}`);
-        }
+        await runMarketPlugin(['add', MARKET_TARGET, '--save-exact'], 'DSH plugin install');
         const installed = await status();
         if (!installed.enabled) throw new Error('DSH did not activate a compatible community market');
         return installed;
+      },
+      async disable() {
+        const current = await status();
+        if (!current.enabled && !readProfile(profileDir).dsh?.profile?.bundles?.includes(MARKET_NAME)) return current;
+        await runMarketPlugin(['remove', MARKET_NAME], 'DSH plugin removal');
+        // A bundle left declared but not installed is what stops DSH from
+        // booting at all, so turning the market off must not be able to leave
+        // one behind — the removal is only complete once the row is gone too.
+        const manifest = readProfile(profileDir);
+        const bundles = manifest.dsh?.profile?.bundles;
+        if (Array.isArray(bundles) && bundles.includes(MARKET_NAME)) {
+          manifest.dsh.profile.bundles = bundles.filter((bundle) => bundle !== MARKET_NAME);
+          fs.writeFileSync(path.join(profileDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+        }
+        return status();
       },
     },
     dispose: pnpm.dispose,
@@ -181,6 +199,7 @@ function registerCommunityMarketRoutes(webServer, market, hostToken) {
   const routes = [
     { path: '/pawwork/community-market/status', method: 'GET', invoke: () => market.status() },
     { path: '/pawwork/community-market/enable', method: 'POST', invoke: () => market.enable() },
+    { path: '/pawwork/community-market/disable', method: 'POST', invoke: () => market.disable() },
   ];
   const dispose = routes.map((route) => webServer.register({
     kind: 'exact',

--- a/packages/desktop-electron/resources/dsh/product/lib/desktop-host.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/desktop-host.test.cjs
@@ -302,3 +302,52 @@ test('rejects market mutations that do not carry the per-launch host token', asy
   assert.deepEqual(JSON.parse(response.body), { error: 'PawWork host authorization failed' });
   assert.equal(enables, 0);
 })
+
+test('finishes a removal DSH left half-done, without touching the rest of the profile', async () => {
+  const { home, profileDir } = profileHome('1.21.0');
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    dependencies: { dshmarket: '1.21.0', 'dsh-notifier': '^2.0.0' },
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket', 'dsh-notifier'] } },
+  }));
+  const managed = managedSubprocess();
+  const host = createDesktopHost({
+    dshBin: '/app/dsh/bin.js',
+    home,
+    nodeExecutable: '/app/PawWork',
+    subprocess: managed.subprocess,
+  });
+
+  const disabling = host.communityMarket.disable();
+  await Promise.resolve();
+  assert.deepEqual(managed.spawns[0].argv.slice(-2), ['remove', 'dshmarket']);
+  // What DSH leaves behind when the remove aborts after unlinking the package:
+  // the dependency is gone, the bundle row is not — and that row alone is what
+  // stops the next boot.
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    dependencies: { 'dsh-notifier': '^2.0.0' },
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket', 'dsh-notifier'] } },
+  }));
+  fs.rmSync(path.join(profileDir, 'node_modules', 'dshmarket'), { recursive: true });
+  managed.settle({ exitCode: 0, signal: null });
+
+  assert.deepEqual(await disabling, { enabled: false, restartRequired: true, version: null });
+  const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+  assert.deepEqual(manifest.dsh.profile.bundles, ['@deepseek-ai/dsh-base', 'dsh-notifier']);
+  assert.deepEqual(manifest.dependencies, { 'dsh-notifier': '^2.0.0' });
+})
+
+test('does not spawn a removal when the market is already gone from both lists', async () => {
+  const { home } = profileHome();
+  const host = createDesktopHost({
+    dshBin: '/app/dsh/bin.js',
+    home,
+    nodeExecutable: '/app/PawWork',
+    subprocess: fakeSubprocess(),
+  });
+
+  assert.deepEqual(await host.communityMarket.disable(), {
+    enabled: false,
+    restartRequired: false,
+    version: null,
+  });
+})

--- a/packages/desktop-electron/resources/dsh/product/preload.cjs
+++ b/packages/desktop-electron/resources/dsh/product/preload.cjs
@@ -65,5 +65,6 @@ contextBridge.exposeInMainWorld("pawworkFiles", {
 contextBridge.exposeInMainWorld("pawworkCommunityMarket", {
   status: () => ipcRenderer.invoke("pawwork:dsh-community-market:status"),
   enable: () => ipcRenderer.invoke("pawwork:dsh-community-market:enable"),
+  disable: () => ipcRenderer.invoke("pawwork:dsh-community-market:disable"),
   restart: () => ipcRenderer.send("pawwork:dsh-restart"),
 })

--- a/packages/desktop-electron/src/main/dsh-menu.ts
+++ b/packages/desktop-electron/src/main/dsh-menu.ts
@@ -1,7 +1,7 @@
 import { localizedPawWorkName } from "./app-identity"
 import { app, BrowserWindow, Menu, shell } from "electron"
 import log from "electron-log/main.js"
-import { detectSystemMenuLocale, menuLabel, menuRoleLabel, type MenuLocale } from "./menu-labels"
+import { menuLabel, menuRoleLabel, type MenuLocale } from "./menu-labels"
 import { PAWWORK_GITHUB_ISSUE_URL, PAWWORK_GITHUB_URL } from "./support-links"
 
 type DshMenuOptions = {
@@ -10,7 +10,7 @@ type DshMenuOptions = {
   relaunch: () => void
 }
 
-export function createDshMenu(options: DshMenuOptions, locale: MenuLocale = detectSystemMenuLocale(app.getLocale())) {
+export function createDshMenu(options: DshMenuOptions, locale: MenuLocale) {
   if (process.platform !== "darwin" && process.platform !== "win32") return
 
   const appName = locale === "zh" ? localizedPawWorkName(app.getName()) : app.getName()

--- a/packages/desktop-electron/src/main/dsh-plugins.ts
+++ b/packages/desktop-electron/src/main/dsh-plugins.ts
@@ -1,6 +1,6 @@
 import { decideDshNavigation } from "./window-navigation"
 
-type CommunityMarketAction = "enable" | "status"
+type CommunityMarketAction = "disable" | "enable" | "status"
 
 type RequestDshCommunityMarketOptions = {
   action: CommunityMarketAction

--- a/packages/desktop-electron/src/main/dsh-product-preload.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-preload.test.ts
@@ -177,13 +177,15 @@ describe("PawWork DSH product preload", () => {
     })
 
     const api = exposed.get("pawworkCommunityMarket")!
-    expect(Object.keys(api)).toEqual(["status", "enable", "restart"])
+    expect(Object.keys(api)).toEqual(["status", "enable", "disable", "restart"])
     await api.status()
     await api.enable()
+    await api.disable()
     api.restart()
     expect(invoke.mock.calls).toEqual([
       ["pawwork:dsh-community-market:status"],
       ["pawwork:dsh-community-market:enable"],
+      ["pawwork:dsh-community-market:disable"],
     ])
     expect(send).toHaveBeenCalledWith("pawwork:dsh-restart")
   })

--- a/packages/desktop-electron/src/main/dsh-profile-repair.test.ts
+++ b/packages/desktop-electron/src/main/dsh-profile-repair.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest"
+import { join } from "node:path"
+import { removeProfileBundle, unresolvedProfileBundle } from "./dsh-profile-repair"
+
+// The exact shape DSH dies with when a market install left a bundle behind.
+const FAILURE_OUTPUT = [
+  "file:///app/node_modules/@deepseek-ai/dsh-app-boot/lib/index.js:523",
+  "\tthrow new Error(`${binName}: cannot resolve profile bundle ${JSON.stringify(packageName)} from the dsh installation`);",
+  "",
+  "Error: dsh: cannot resolve profile bundle \"dsh-lark-bot\" from the dsh installation or /home/u/.pawwork/dsh/profiles/web;"
+    + " run 'dsh plugin --profile web install' if its dependency is not installed",
+  "    at resolveBundleDir (file:///app/node_modules/@deepseek-ai/dsh-app-boot/lib/index.js:523:8)",
+].join("\n")
+
+function manifest(bundles: string[]) {
+  return JSON.stringify({
+    name: "dsh-profile-web",
+    dependencies: { dshmarket: "1.21.0" },
+    dsh: { profile: { bundles } },
+  })
+}
+
+describe("unresolvedProfileBundle", () => {
+  test("names the bundle DSH could not resolve", () => {
+    expect(unresolvedProfileBundle(FAILURE_OUTPUT)).toBe("dsh-lark-bot")
+  })
+
+  test("reads the name from the error line, not the source echo above it", () => {
+    // The thrown-source echo carries the uninterpolated template, so a greedy
+    // pattern could match `${JSON.stringify(packageName)}` instead.
+    expect(unresolvedProfileBundle(FAILURE_OUTPUT)).not.toContain("JSON")
+  })
+
+  test("returns undefined for unrelated failures", () => {
+    expect(unresolvedProfileBundle("Error: listen EADDRINUSE: address already in use")).toBeUndefined()
+    expect(unresolvedProfileBundle("")).toBeUndefined()
+  })
+})
+
+describe("removeProfileBundle", () => {
+  test("drops the named bundle and reports the change", () => {
+    const written = new Map<string, string>()
+    const changed = removeProfileBundle({
+      profileDir: "/home/u/.pawwork/dsh/profiles/web",
+      bundle: "dsh-lark-bot",
+      read: () => manifest(["@deepseek-ai/dsh-base", "dsh-lark-bot", "dshmarket"]),
+      write: (path, contents) => void written.set(path, contents),
+    })
+
+    expect(changed).toBe(true)
+    const contents = written.get(join("/home/u/.pawwork/dsh/profiles/web", "package.json"))
+    expect(contents).toBeDefined()
+    expect(JSON.parse(contents!).dsh.profile.bundles).toEqual(["@deepseek-ai/dsh-base", "dshmarket"])
+  })
+
+  test("leaves the dependency entry alone", () => {
+    let contents = ""
+    removeProfileBundle({
+      profileDir: "/profile",
+      bundle: "dsh-lark-bot",
+      read: () => manifest(["dsh-lark-bot"]),
+      write: (_path, value) => void (contents = value),
+    })
+
+    expect(JSON.parse(contents).dependencies).toEqual({ dshmarket: "1.21.0" })
+  })
+
+  test("does not write when the bundle is absent", () => {
+    let wrote = false
+    const changed = removeProfileBundle({
+      profileDir: "/profile",
+      bundle: "dsh-lark-bot",
+      read: () => manifest(["@deepseek-ai/dsh-base"]),
+      write: () => void (wrote = true),
+    })
+
+    expect(changed).toBe(false)
+    expect(wrote).toBe(false)
+  })
+
+  test("does not write when the manifest declares no bundles", () => {
+    let wrote = false
+    const changed = removeProfileBundle({
+      profileDir: "/profile",
+      bundle: "dsh-lark-bot",
+      read: () => JSON.stringify({ name: "dsh-profile-web" }),
+      write: () => void (wrote = true),
+    })
+
+    expect(changed).toBe(false)
+    expect(wrote).toBe(false)
+  })
+})

--- a/packages/desktop-electron/src/main/dsh-profile-repair.test.ts
+++ b/packages/desktop-electron/src/main/dsh-profile-repair.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "vitest"
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { removeProfileBundle, unresolvedProfileBundle } from "./dsh-profile-repair"
 
@@ -12,23 +14,22 @@ const FAILURE_OUTPUT = [
   "    at resolveBundleDir (file:///app/node_modules/@deepseek-ai/dsh-app-boot/lib/index.js:523:8)",
 ].join("\n")
 
-function manifest(bundles: string[]) {
-  return JSON.stringify({
-    name: "dsh-profile-web",
-    dependencies: { dshmarket: "1.21.0" },
-    dsh: { profile: { bundles } },
-  })
+function profileDirWith(manifest: unknown) {
+  const profileDir = mkdtempSync(join(tmpdir(), "pawwork-profile-repair-"))
+  writeFileSync(join(profileDir, "package.json"), JSON.stringify(manifest), "utf8")
+  return profileDir
+}
+
+function manifestOf(profileDir: string) {
+  return JSON.parse(readFileSync(join(profileDir, "package.json"), "utf8")) as {
+    dependencies?: Record<string, string>
+    dsh?: { profile?: { bundles?: string[] } }
+  }
 }
 
 describe("unresolvedProfileBundle", () => {
   test("names the bundle DSH could not resolve", () => {
     expect(unresolvedProfileBundle(FAILURE_OUTPUT)).toBe("dsh-lark-bot")
-  })
-
-  test("reads the name from the error line, not the source echo above it", () => {
-    // The thrown-source echo carries the uninterpolated template, so a greedy
-    // pattern could match `${JSON.stringify(packageName)}` instead.
-    expect(unresolvedProfileBundle(FAILURE_OUTPUT)).not.toContain("JSON")
   })
 
   test("returns undefined for unrelated failures", () => {
@@ -38,56 +39,34 @@ describe("unresolvedProfileBundle", () => {
 })
 
 describe("removeProfileBundle", () => {
-  test("drops the named bundle and reports the change", () => {
-    const written = new Map<string, string>()
-    const changed = removeProfileBundle({
-      profileDir: "/home/u/.pawwork/dsh/profiles/web",
-      bundle: "dsh-lark-bot",
-      read: () => manifest(["@deepseek-ai/dsh-base", "dsh-lark-bot", "dshmarket"]),
-      write: (path, contents) => void written.set(path, contents),
+  test("drops the named bundle and leaves the dependency entry alone", () => {
+    const profileDir = profileDirWith({
+      name: "dsh-profile-web",
+      dependencies: { dshmarket: "1.21.0" },
+      dsh: { profile: { bundles: ["@deepseek-ai/dsh-base", "dsh-lark-bot", "dshmarket"] } },
     })
 
-    expect(changed).toBe(true)
-    const contents = written.get(join("/home/u/.pawwork/dsh/profiles/web", "package.json"))
-    expect(contents).toBeDefined()
-    expect(JSON.parse(contents!).dsh.profile.bundles).toEqual(["@deepseek-ai/dsh-base", "dshmarket"])
+    expect(removeProfileBundle({ profileDir, bundle: "dsh-lark-bot" })).toBe(true)
+    expect(manifestOf(profileDir).dsh?.profile?.bundles).toEqual(["@deepseek-ai/dsh-base", "dshmarket"])
+    expect(manifestOf(profileDir).dependencies).toEqual({ dshmarket: "1.21.0" })
   })
 
-  test("leaves the dependency entry alone", () => {
-    let contents = ""
-    removeProfileBundle({
-      profileDir: "/profile",
-      bundle: "dsh-lark-bot",
-      read: () => manifest(["dsh-lark-bot"]),
-      write: (_path, value) => void (contents = value),
+  test("does not rewrite the manifest when the bundle is absent", () => {
+    const profileDir = profileDirWith({
+      name: "dsh-profile-web",
+      dsh: { profile: { bundles: ["@deepseek-ai/dsh-base"] } },
     })
+    const before = readFileSync(join(profileDir, "package.json"), "utf8")
 
-    expect(JSON.parse(contents).dependencies).toEqual({ dshmarket: "1.21.0" })
+    expect(removeProfileBundle({ profileDir, bundle: "dsh-lark-bot" })).toBe(false)
+    expect(readFileSync(join(profileDir, "package.json"), "utf8")).toBe(before)
   })
 
-  test("does not write when the bundle is absent", () => {
-    let wrote = false
-    const changed = removeProfileBundle({
-      profileDir: "/profile",
-      bundle: "dsh-lark-bot",
-      read: () => manifest(["@deepseek-ai/dsh-base"]),
-      write: () => void (wrote = true),
-    })
+  test("does not rewrite the manifest when it declares no bundles", () => {
+    const profileDir = profileDirWith({ name: "dsh-profile-web" })
+    const before = readFileSync(join(profileDir, "package.json"), "utf8")
 
-    expect(changed).toBe(false)
-    expect(wrote).toBe(false)
-  })
-
-  test("does not write when the manifest declares no bundles", () => {
-    let wrote = false
-    const changed = removeProfileBundle({
-      profileDir: "/profile",
-      bundle: "dsh-lark-bot",
-      read: () => JSON.stringify({ name: "dsh-profile-web" }),
-      write: () => void (wrote = true),
-    })
-
-    expect(changed).toBe(false)
-    expect(wrote).toBe(false)
+    expect(removeProfileBundle({ profileDir, bundle: "dsh-lark-bot" })).toBe(false)
+    expect(readFileSync(join(profileDir, "package.json"), "utf8")).toBe(before)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-profile-repair.ts
+++ b/packages/desktop-electron/src/main/dsh-profile-repair.ts
@@ -1,0 +1,49 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+// DSH refuses to boot when the profile declares a bundle it cannot resolve, and
+// it names the offender in the message it dies with. A failed market install is
+// the way users get here: the install rolls back the dependency but leaves the
+// bundle declaration behind, so every later start hits the same wall and the
+// only in-app action — retry — cannot change the outcome.
+const UNRESOLVED_BUNDLE = /cannot resolve profile bundle "([^"]+)"/
+
+/** The bundle DSH could not resolve, read from its own failure output. */
+export function unresolvedProfileBundle(output: string) {
+  return UNRESOLVED_BUNDLE.exec(output)?.[1]
+}
+
+type RemoveProfileBundleOptions = {
+  profileDir: string
+  bundle: string
+  read?: (path: string) => string
+  write?: (path: string, contents: string) => void
+}
+
+/**
+ * Drop one bundle from the profile manifest so DSH can boot again.
+ *
+ * Only `dsh.profile.bundles` is touched. A dependency entry, if one survived,
+ * is left alone: it is inert as far as booting goes, and removing packages is
+ * the market's job, not a recovery path's.
+ *
+ * @returns whether the manifest changed.
+ */
+export function removeProfileBundle(options: RemoveProfileBundleOptions) {
+  const read = options.read ?? ((path: string) => readFileSync(path, "utf8"))
+  const write = options.write ?? ((path: string, contents: string) => writeFileSync(path, contents, "utf8"))
+  const manifestPath = join(options.profileDir, "package.json")
+
+  const manifest = JSON.parse(read(manifestPath)) as {
+    dsh?: { profile?: { bundles?: unknown } }
+  }
+  const bundles = manifest.dsh?.profile?.bundles
+  if (!Array.isArray(bundles)) return false
+
+  const kept = bundles.filter((entry) => entry !== options.bundle)
+  if (kept.length === bundles.length) return false
+
+  manifest.dsh!.profile!.bundles = kept
+  write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  return true
+}

--- a/packages/desktop-electron/src/main/dsh-profile-repair.ts
+++ b/packages/desktop-electron/src/main/dsh-profile-repair.ts
@@ -16,8 +16,6 @@ export function unresolvedProfileBundle(output: string) {
 type RemoveProfileBundleOptions = {
   profileDir: string
   bundle: string
-  read?: (path: string) => string
-  write?: (path: string, contents: string) => void
 }
 
 /**
@@ -30,11 +28,9 @@ type RemoveProfileBundleOptions = {
  * @returns whether the manifest changed.
  */
 export function removeProfileBundle(options: RemoveProfileBundleOptions) {
-  const read = options.read ?? ((path: string) => readFileSync(path, "utf8"))
-  const write = options.write ?? ((path: string, contents: string) => writeFileSync(path, contents, "utf8"))
   const manifestPath = join(options.profileDir, "package.json")
 
-  const manifest = JSON.parse(read(manifestPath)) as {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
     dsh?: { profile?: { bundles?: unknown } }
   }
   const bundles = manifest.dsh?.profile?.bundles
@@ -44,6 +40,6 @@ export function removeProfileBundle(options: RemoveProfileBundleOptions) {
   if (kept.length === bundles.length) return false
 
   manifest.dsh!.profile!.bundles = kept
-  write(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8")
   return true
 }

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -100,7 +100,7 @@ let dshOutputTail = ""
 // Set by launchDsh: the recovery path needs the profile directory, and the home
 // is only settled once the migration inside launchDsh has run.
 let dshHome: string | undefined
-let startupColorScheme: StartupColorScheme | undefined = readStartupColorScheme({ path: STARTUP_THEME_FILE })
+let startupColorScheme: StartupColorScheme | undefined = readStartupColorScheme(STARTUP_THEME_FILE)
 let currentProgress: number | null = null
 const dshHostToken = randomUUID()
 
@@ -203,7 +203,7 @@ function setupApp() {
     if (colorScheme !== "dark" && colorScheme !== "light") return
     if (colorScheme === startupColorScheme) return
     startupColorScheme = colorScheme
-    writeStartupColorScheme({ path: STARTUP_THEME_FILE }, colorScheme)
+    writeStartupColorScheme(STARTUP_THEME_FILE, colorScheme)
   })
 
   app.on("second-instance", () => focusMainWindow(true))
@@ -366,7 +366,14 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
       type: "error" as const,
       title: copy.title,
       message: copy.message,
-      detail: [note, bundle === undefined ? error : copy.pluginCause(bundle), `${copy.log}: ${logPath}`]
+      // The runtime output only earns its space when nothing else explains the
+      // failure: once the bundle is named, the tail is the same stack the
+      // sentence already summarizes.
+      detail: [
+        note,
+        ...(bundle === undefined ? [error, dshOutputTail.trim()] : [copy.pluginCause(bundle)]),
+        `${copy.log}: ${logPath}`,
+      ]
         .filter(Boolean)
         .join("\n\n"),
       buttons,

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -32,15 +32,24 @@ import {
 } from "./dsh-product-home"
 import { launchDshSidecar } from "./dsh-sidecar"
 import { prepareDshToolsEnvironment } from "./dsh-tools"
+import { removeProfileBundle, unresolvedProfileBundle } from "./dsh-profile-repair"
 import { migrateDshHome, resolveDshHome } from "./pawwork-home"
 import { initLogging } from "./logging"
-import { detectSystemMenuLocale } from "./menu-labels"
+import { detectSystemMenuLocale, type MenuLocale } from "./menu-labels"
 import { createUpdateFeed, githubFeed, r2Feed, type FeedTarget } from "./update-feed"
 import { PAWWORK_GITHUB_ISSUE_URL } from "./support-links"
 import { createUpdaterController } from "./updater"
 import { pendingUpdateCacheDir } from "./updater-cache"
 import { updaterDialogLabels } from "./updater-dialog-labels"
-import { createMainWindow, navigateWindow, setDockIcon, setTitlebarColorScheme, STARTUP_URL } from "./windows"
+import { readStartupColorScheme, writeStartupColorScheme } from "./startup-theme"
+import {
+  createMainWindow,
+  navigateWindow,
+  setDockIcon,
+  setTitlebarColorScheme,
+  startupUrl,
+  type StartupColorScheme,
+} from "./windows"
 
 contextMenu({ showSaveImageAs: true, showLookUpSelection: false, showSearchWithGoogle: false })
 
@@ -65,9 +74,14 @@ app.setPath("userData", join(userDataRoot, appIdentity.id))
 if (CI_SMOKE_HOME) app.setPath("logs", join(app.getPath("userData"), "logs"))
 
 const CI_SMOKE_READY_FILE = join(app.getPath("userData"), "ci-smoke-ready.json")
+const STARTUP_THEME_FILE = join(app.getPath("userData"), "startup-theme.json")
 const { autoUpdater } = pkg
 const logger = initLogging()
-const menuLocale = detectSystemMenuLocale(app.getLocale())
+// Both the value and the reading of it have to wait for `ready`: before it,
+// getLocale() answers "" and getSystemLocale() throws. getLocale() is also the
+// wrong question — it reports the locale Electron's own UI was built for, which
+// is en-US on a zh-CN machine. Everything that reads this runs after ready.
+let menuLocale: MenuLocale = "en"
 
 // Pure path work over values that never change for the life of the process, so
 // there is nothing to sequence and nothing that can be read before it is set.
@@ -83,6 +97,10 @@ const productPreload = join(productResources.dsh, "product", "preload.cjs")
 // Keeping the tail costs a few kilobytes.
 const DSH_OUTPUT_TAIL_CHARS = 4_000
 let dshOutputTail = ""
+// Set by launchDsh: the recovery path needs the profile directory, and the home
+// is only settled once the migration inside launchDsh has run.
+let dshHome: string | undefined
+let startupColorScheme: StartupColorScheme | undefined = readStartupColorScheme({ path: STARTUP_THEME_FILE })
 let currentProgress: number | null = null
 const dshHostToken = randomUUID()
 
@@ -144,11 +162,24 @@ function setupApp() {
     dshUrl: communityMarketUrlFor(event),
     hostToken: dshHostToken,
   }))
-  ipcMain.handle("pawwork:dsh-community-market:enable", (event) => requestDshCommunityMarket({
-    action: "enable",
-    dshUrl: communityMarketUrlFor(event),
-    hostToken: dshHostToken,
-  }))
+  ipcMain.handle("pawwork:dsh-community-market:enable", async (event) => {
+    // Anything running in the product frame can reach this channel, plugins
+    // included, and the frame check cannot tell them apart from the settings
+    // page. The confirmation is native so the decision to hand third-party code
+    // PawWork's permissions is always the user's, made outside the page.
+    const dshUrl = communityMarketUrlFor(event)
+    if (!(await confirmCommunityMarket(event, "enable"))) {
+      return requestDshCommunityMarket({ action: "status", dshUrl, hostToken: dshHostToken })
+    }
+    return requestDshCommunityMarket({ action: "enable", dshUrl, hostToken: dshHostToken })
+  })
+  ipcMain.handle("pawwork:dsh-community-market:disable", async (event) => {
+    const dshUrl = communityMarketUrlFor(event)
+    if (!(await confirmCommunityMarket(event, "disable"))) {
+      return requestDshCommunityMarket({ action: "status", dshUrl, hostToken: dshHostToken })
+    }
+    return requestDshCommunityMarket({ action: "disable", dshUrl, hostToken: dshHostToken })
+  })
   ipcMain.on("pawwork:dsh-restart", (event) => {
     try {
       communityMarketUrlFor(event)
@@ -169,6 +200,10 @@ function setupApp() {
     if (event.senderFrame !== event.sender.mainFrame) return
     const owner = BrowserWindow.fromWebContents(event.sender)
     if (owner) setTitlebarColorScheme(owner, process.platform, colorScheme)
+    if (colorScheme !== "dark" && colorScheme !== "light") return
+    if (colorScheme === startupColorScheme) return
+    startupColorScheme = colorScheme
+    writeStartupColorScheme({ path: STARTUP_THEME_FILE }, colorScheme)
   })
 
   app.on("second-instance", () => focusMainWindow(true))
@@ -194,6 +229,7 @@ function setupApp() {
   void app
     .whenReady()
     .then(() => {
+      menuLocale = detectSystemMenuLocale(app.getSystemLocale())
       app.setAsDefaultProtocolClient("pawwork")
       setDockIcon()
       setupAutoUpdater()
@@ -211,6 +247,50 @@ function setupApp() {
       logger.error("app initialization failed", error)
       app.exit(1)
     })
+}
+
+async function confirmCommunityMarket(event: Electron.IpcMainInvokeEvent, action: "disable" | "enable") {
+  const copy = menuLocale === "zh"
+    ? {
+        enable: {
+          message: "启用 DSH 社区插件市场？",
+          detail: "市场及其中的插件由第三方维护，安装后会以爪印的权限运行。你可以随时在设置里停用市场。",
+          confirm: "启用",
+        },
+        disable: {
+          message: "停用 DSH 社区插件市场？",
+          detail: "市场会从爪印的 DSH 环境中移除，已安装的社区插件将不再加载。设置里可以重新启用。",
+          confirm: "停用",
+        },
+        cancel: "取消",
+      }
+    : {
+        enable: {
+          message: "Enable the DSH community plugin market?",
+          detail: "The market and its plugins are maintained by third parties and run with PawWork's permissions."
+            + " You can turn the market off again from Settings at any time.",
+          confirm: "Enable",
+        },
+        disable: {
+          message: "Disable the DSH community plugin market?",
+          detail: "The market is removed from PawWork's DSH environment and installed community plugins stop loading."
+            + " You can enable it again from Settings.",
+          confirm: "Disable",
+        },
+        cancel: "Cancel",
+      }
+  const prompt = copy[action]
+  const owner = BrowserWindow.fromWebContents(event.sender)
+  const options = {
+    type: "question" as const,
+    message: prompt.message,
+    detail: prompt.detail,
+    buttons: [prompt.confirm, copy.cancel],
+    defaultId: 0,
+    cancelId: 1,
+  }
+  const result = owner ? await dialog.showMessageBox(owner, options) : await dialog.showMessageBox(options)
+  return result.response === 0
 }
 
 function communityMarketUrlFor(event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent) {
@@ -234,7 +314,7 @@ function dshUrl() {
 }
 
 function showStartupPage() {
-  for (const win of liveWindows()) navigateWindow(win, STARTUP_URL)
+  for (const win of liveWindows()) navigateWindow(win, startupUrl(startupColorScheme))
 }
 
 async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed" }>) {
@@ -242,41 +322,84 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
     ? {
         title: state.reason === "startup" ? "爪印无法启动" : "爪印已停止",
         message: state.reason === "startup" ? "智能体运行时未能启动。" : "智能体运行时意外退出。",
-        buttons: ["重试", "显示日志", "反馈问题", "退出"],
+        pluginCause: (bundle: string) =>
+          `插件「${bundle}」没有安装完整，运行时因此起不来。移除它就能重新打开爪印，之后可以在设置里重新安装。`,
+        removePlugin: "移除该插件并重试",
+        removeFailed: (bundle: string) => `没能移除插件「${bundle}」，请查看日志。`,
+        retry: "重试",
+        showLog: "显示日志",
+        report: "反馈问题",
+        quit: "退出",
         log: "完整日志",
       }
     : {
         title: state.reason === "startup" ? "PawWork Could Not Start" : "PawWork Stopped",
         message: state.reason === "startup" ? "The agent runtime did not start." : "The agent runtime stopped unexpectedly.",
-        buttons: ["Try Again", "Show Log", "Report a Problem", "Quit"],
+        pluginCause: (bundle: string) =>
+          `The plugin "${bundle}" is not fully installed, which stops the runtime from starting.`
+          + " Removing it lets PawWork open again; you can reinstall it from Settings afterwards.",
+        removePlugin: "Remove Plugin and Retry",
+        removeFailed: (bundle: string) => `Could not remove the plugin "${bundle}". See the log for details.`,
+        retry: "Try Again",
+        showLog: "Show Log",
+        report: "Report a Problem",
+        quit: "Quit",
         log: "Full log",
       }
   const logPath = logger.transports.file.getFile().path
   const error = state.error instanceof Error ? state.error.message : String(state.error ?? "")
-  const detail = [error, dshOutputTail.trim(), `${copy.log}: ${logPath}`].filter(Boolean).join("\n\n")
+  // The runtime's own stderr is a Node stack over DSH's internals; it belongs in
+  // the log, not in front of someone who just wants their app back. Only the one
+  // fact they can act on is lifted out of it.
+  const bundle = dshHome === undefined ? undefined : unresolvedProfileBundle(`${error}\n${dshOutputTail}`)
+  let note = ""
 
   for (;;) {
+    const buttons = [
+      ...(bundle === undefined ? [] : [copy.removePlugin]),
+      copy.retry,
+      copy.showLog,
+      copy.report,
+      copy.quit,
+    ]
     const options = {
       type: "error" as const,
       title: copy.title,
       message: copy.message,
-      detail,
-      buttons: copy.buttons,
+      detail: [note, bundle === undefined ? error : copy.pluginCause(bundle), `${copy.log}: ${logPath}`]
+        .filter(Boolean)
+        .join("\n\n"),
+      buttons,
       defaultId: 0,
-      cancelId: 3,
+      cancelId: buttons.length - 1,
     }
     const owner = BrowserWindow.getFocusedWindow() ?? liveWindows()[0]
     const result = owner ? await dialog.showMessageBox(owner, options) : await dialog.showMessageBox(options)
-    if (result.response === 0) {
+    const chosen = buttons[result.response]
+
+    if (chosen === copy.removePlugin && bundle !== undefined && dshHome !== undefined) {
+      try {
+        removeProfileBundle({ profileDir: join(dshHome, "profiles", "web"), bundle })
+      } catch (failure) {
+        logger.error("failed to remove unresolved profile bundle", failure)
+        note = copy.removeFailed(bundle)
+        continue
+      }
+      logger.log("removed unresolved profile bundle", { bundle })
       focusMainWindow(true)
       lifecycle.start()
       return
     }
-    if (result.response === 1) {
+    if (chosen === copy.retry) {
+      focusMainWindow(true)
+      lifecycle.start()
+      return
+    }
+    if (chosen === copy.showLog) {
       shell.showItemInFolder(logPath)
       continue
     }
-    if (result.response === 2) {
+    if (chosen === copy.report) {
       await shell.openExternal(PAWWORK_GITHUB_ISSUE_URL).catch((failure) => logger.error("failed to open issue form", failure))
       continue
     }
@@ -328,6 +451,7 @@ function launchDsh() {
     }),
     resources: productResources.dsh,
   })
+  dshHome = product.home
   const require = createRequire(import.meta.url)
   const dshPackage = resolveDshPackagePath({
     isPackaged: app.isPackaged,
@@ -372,6 +496,7 @@ function openMainWindow() {
   const win = createMainWindow({
     preload: productPreload,
     dshUrl,
+    startupColorScheme,
   })
   if (currentProgress !== null) win.setProgressBar(currentProgress)
   return win

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -378,10 +378,19 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
     const chosen = buttons[result.response]
 
     if (chosen === copy.removePlugin && bundle !== undefined && dshHome !== undefined) {
+      let removed: boolean
       try {
-        removeProfileBundle({ profileDir: join(dshHome, "profiles", "web"), bundle })
+        removed = removeProfileBundle({ profileDir: join(dshHome, "profiles", "web"), bundle })
       } catch (failure) {
         logger.error("failed to remove unresolved profile bundle", failure)
+        note = copy.removeFailed(bundle)
+        continue
+      }
+      // Nothing removed means the row was never in this manifest — the bundle
+      // comes from somewhere we do not own, so restarting would hit the same
+      // failure. Say so rather than reporting a repair that did not happen.
+      if (!removed) {
+        logger.error("unresolved profile bundle was not declared in the profile", { bundle })
         note = copy.removeFailed(bundle)
         continue
       }

--- a/packages/desktop-electron/src/main/startup-theme.ts
+++ b/packages/desktop-electron/src/main/startup-theme.ts
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import type { StartupColorScheme } from "./windows"
+
+// The appearance the product last published, kept across runs so the startup
+// page can match the app someone is about to see rather than their OS. It is a
+// cache, not settings: DSH owns the real preference, and a missing or damaged
+// file only costs one launch of the system default.
+type StartupThemeIo = {
+  path: string
+  read?: (path: string) => string
+  write?: (path: string, contents: string) => void
+}
+
+export function readStartupColorScheme(io: StartupThemeIo): StartupColorScheme | undefined {
+  const read = io.read ?? ((path: string) => readFileSync(path, "utf8"))
+  try {
+    const scheme = (JSON.parse(read(io.path)) as { colorScheme?: unknown }).colorScheme
+    return scheme === "dark" || scheme === "light" ? scheme : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function writeStartupColorScheme(io: StartupThemeIo, scheme: StartupColorScheme) {
+  const write = io.write ?? ((path: string, contents: string) => writeFileSync(path, contents, "utf8"))
+  try {
+    write(io.path, `${JSON.stringify({ colorScheme: scheme })}\n`)
+  } catch {
+    // A cache that cannot be written is still a cache; the next launch just
+    // falls back to the system appearance.
+  }
+}

--- a/packages/desktop-electron/src/main/startup-theme.ts
+++ b/packages/desktop-electron/src/main/startup-theme.ts
@@ -5,26 +5,18 @@ import type { StartupColorScheme } from "./windows"
 // page can match the app someone is about to see rather than their OS. It is a
 // cache, not settings: DSH owns the real preference, and a missing or damaged
 // file only costs one launch of the system default.
-type StartupThemeIo = {
-  path: string
-  read?: (path: string) => string
-  write?: (path: string, contents: string) => void
-}
-
-export function readStartupColorScheme(io: StartupThemeIo): StartupColorScheme | undefined {
-  const read = io.read ?? ((path: string) => readFileSync(path, "utf8"))
+export function readStartupColorScheme(path: string): StartupColorScheme | undefined {
   try {
-    const scheme = (JSON.parse(read(io.path)) as { colorScheme?: unknown }).colorScheme
+    const scheme = (JSON.parse(readFileSync(path, "utf8")) as { colorScheme?: unknown }).colorScheme
     return scheme === "dark" || scheme === "light" ? scheme : undefined
   } catch {
     return undefined
   }
 }
 
-export function writeStartupColorScheme(io: StartupThemeIo, scheme: StartupColorScheme) {
-  const write = io.write ?? ((path: string, contents: string) => writeFileSync(path, contents, "utf8"))
+export function writeStartupColorScheme(path: string, scheme: StartupColorScheme) {
   try {
-    write(io.path, `${JSON.stringify({ colorScheme: scheme })}\n`)
+    writeFileSync(path, `${JSON.stringify({ colorScheme: scheme })}\n`, "utf8")
   } catch {
     // A cache that cannot be written is still a cache; the next launch just
     // falls back to the system appearance.

--- a/packages/desktop-electron/src/main/windows.test.ts
+++ b/packages/desktop-electron/src/main/windows.test.ts
@@ -83,12 +83,12 @@ vi.mock("electron-window-state", () => ({
   default: () => ({ x: 0, y: 0, width: 1280, height: 800, manage: () => {} }),
 }))
 
-const { createMainWindow, setTitlebarColorScheme, STARTUP_URL } = await import("./windows")
+const { createMainWindow, setTitlebarColorScheme, startupUrl } = await import("./windows")
 
 const DSH = "http://127.0.0.1:4321/"
 
 function openWindow(dshUrl?: string) {
-  webContents.url = dshUrl ?? STARTUP_URL
+  webContents.url = dshUrl ?? startupUrl()
   return createMainWindow({
     preload: "/preload.cjs",
     dshUrl: () => dshUrl,
@@ -160,7 +160,7 @@ describe("main window wiring", () => {
   // the meantime; loading nothing is what the 30-second blank start used to be.
   test("opens on the local startup page until DSH has a URL", () => {
     openWindow()
-    expect(win.loaded).toEqual([STARTUP_URL])
+    expect(win.loaded).toEqual([startupUrl()])
 
     win.loaded.length = 0
     openWindow(DSH)
@@ -171,7 +171,7 @@ describe("main window wiring", () => {
   // was showing a moment before it died.
   test("denies every DSH-origin navigation once the runtime is gone", () => {
     openWindow()
-    webContents.url = STARTUP_URL
+    webContents.url = startupUrl()
 
     expect(navigate("http://127.0.0.1:4321/settings", true).preventDefault).toHaveBeenCalled()
     expect(navigate("http://127.0.0.1:4321/settings", false).preventDefault).toHaveBeenCalled()

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -8,8 +8,15 @@ import { decideDshNavigation, guardDshNavigation, handleDshWindowOpen } from "./
 import { dshTitleBarOptions, dshWebPreferences, titleBarOverlayStyle } from "./window-options"
 
 const root = dirname(fileURLToPath(import.meta.url))
-const STARTUP_HTML = `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
-:root{--bg:#fff;--line:#e3e3e7;--accent:#fc5c14}@media(prefers-color-scheme:dark){:root{--bg:#191919;--line:#2d2d31}}
+// The startup page is shown before DSH can say which appearance the user chose,
+// so a system-only default flashes the wrong one at anybody whose app setting
+// disagrees with their OS. `scheme` is the last appearance the product
+// published; the media query stays as the answer for the very first launch,
+// when there is nothing remembered yet.
+const startupHtml = (scheme?: StartupColorScheme) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
+:root{--bg:#fff;--line:#e3e3e7;--accent:#fc5c14}${scheme === undefined
+  ? "@media(prefers-color-scheme:dark){:root{--bg:#191919;--line:#2d2d31}}"
+  : scheme === "dark" ? ":root{--bg:#191919;--line:#2d2d31}" : ""}
 html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);display:flex;justify-content:center}
 .titlebar{-webkit-app-region:drag;height:var(--pawwork-titlebar-host-height,env(titlebar-area-height,0px));left:0;position:fixed;right:0;top:0}
 .spinner{animation:spin .8s linear infinite;border:2px solid var(--line);border-radius:50%;box-sizing:border-box;height:20px;position:relative;width:20px}
@@ -17,7 +24,11 @@ html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);disp
 @keyframes spin{to{transform:rotate(360deg)}}@media(prefers-reduced-motion:reduce){.spinner{animation:none}}
 </style></head><body><div class="titlebar"></div><div aria-label="PawWork is starting" class="spinner" role="progressbar"></div></body></html>`
 
-export const STARTUP_URL = `data:text/html;charset=utf-8,${encodeURIComponent(STARTUP_HTML)}`
+export type StartupColorScheme = "dark" | "light"
+
+export function startupUrl(scheme?: StartupColorScheme) {
+  return `data:text/html;charset=utf-8,${encodeURIComponent(startupHtml(scheme))}`
+}
 
 function iconsDir() {
   return app.isPackaged ? join(process.resourcesPath, "icons") : join(root, "../../resources/icons")
@@ -36,6 +47,7 @@ export function setDockIcon() {
 
 type MainWindowOptions = {
   preload: string
+  startupColorScheme?: StartupColorScheme
   // Read on every navigation rather than captured: the window is created before
   // DSH has an origin, and outlives the one it eventually gets.
   dshUrl: () => string | undefined
@@ -118,7 +130,7 @@ export function createMainWindow(options: MainWindowOptions) {
     event.preventDefault()
     win.setTitle(pawworkWindowTitle(title))
   })
-  navigateWindow(win, options.dshUrl() ?? STARTUP_URL)
+  navigateWindow(win, options.dshUrl() ?? startupUrl(options.startupColorScheme))
   win.once("ready-to-show", () => win.show())
 
   return win


### PR DESCRIPTION
## Why

Driving the v2 app end to end turned up one blocking failure and a set of smaller defects around it.

**The blocker.** A community market install that fails after pnpm has written the profile manifest leaves the bundle declared in `dsh.profile.bundles` with nothing installed under `dependencies`. DSH's `resolveBundleDir` throws on every boot from then on, so the app never starts. The failure dialog does appear, but it dumps a raw Node stack and its only actionable button — Try Again — re-runs the same deterministic failure. The only real fix was hand-editing JSON in `~/.pawwork`.

The rollback gap is upstream's: dsh-market#202 is the same root cause, closed without a fix, and the harness repo has issues disabled. So PawWork has to be able to recover on its own.

## What

- **Recovery button.** When the DSH output names a bundle it cannot resolve, the failure dialog offers to remove just that row from the profile manifest and start again. `dependencies` is untouched, other bundles are untouched, and the raw stack is replaced by a sentence naming the plugin at fault. If the repair itself fails, the dialog says so and stays open.
- **Disabling the market clears its bundle row**, so the bricking state can no longer be created from inside the product.
- **Both market toggles confirm first.** Enabling installs third-party code that runs with PawWork's permissions; disabling unloads plugins someone may still be using. Declining is a no-op — manifest and `node_modules` are left exactly as they were.
- **Menu locale.** Read `getSystemLocale()` after `ready` instead of `getLocale()` at module load. `getLocale()` reports the locale Electron's own UI was built for — en-US on a zh-CN machine — and before `ready` it is the empty string, so the shipped release always showed an English menu bar. Now zh-CN gets 文件/编辑/视图/窗口/帮助.
- **Startup appearance.** Cache the appearance the product last published so the startup page opens in it instead of flashing the system appearance. It is a cache, not settings: a missing or damaged file costs one launch of the system default.
- **Copy and layout.** "重新启动 DSH" → "重新启动后台服务" (DSH is not a name the product exposes), and the two market buttons are grouped so the growing status sentence stops wrapping their labels.

## Verification

Real Electron app, dev build, macOS:

- Injected an unresolvable bundle → dialog named the plugin → recovery button → `removed unresolved profile bundle { bundle: 'dsh-lark-bot' }` → DSH up, other bundles intact.
- Enable-cancel and disable-cancel: `dependencies`, `bundles`, and `node_modules/dshmarket` all unchanged.
- Enable-confirm → "已安装，重启后可用" with both buttons on one row; disable-confirm → all three removed, profile back to the two builtin bundles.
- Menu bar reads 文件 编辑 视图 窗口 帮助 on this zh-CN machine.

`pnpm run typecheck`, `pnpm test` (392 vitest + 121 node), `pnpm -w run lint` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to disable the community market from the desktop app.
  - Added confirmation prompts before enabling or disabling the community market.
  - Added automatic recovery when a failed plugin installation prevents startup, including removing the problematic plugin and retrying.

- **Improvements**
  - Community market actions now provide clearer progress, success, and error feedback.
  - Startup screens preserve the previously selected light or dark theme.
  - Updated messaging to consistently reference the background service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->