### PR TITLE
chore(release): prepare 2026.8.7

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.8.6",
+  "version": "2026.8.7",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## What

Bump `@pawwork/desktop` to `2026.8.7` for the next desktop release.

## Scope since 2026.8.6

- #1597 read global `AGENTS.md` via declarative `dshHome`
- #1598 align active session chrome across sidebar states
- #1599 integrate the DSH community market
- #1600 give Automations one page head
- #1601 recover from an unresolvable profile bundle

Version-only change; no product behavior is modified by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application package to version 2026.8.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->