### PR TITLE
build(desktop): trim 26MB from the packaged app

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -5,7 +5,7 @@
 PawWork bundles `uv` by Astral to supply a Python runtime for Excel/Word/PowerPoint skills that generate or edit Office files via Python libraries.
 
 - Project: https://github.com/astral-sh/uv
-- Version: 0.11.28
+- Version: 0.12.5
 - License: MIT OR Apache-2.0 (dual-licensed; PawWork relies on the Apache-2.0 grant, whose text is included below)
 
 The Apache License 2.0 text for uv follows.

--- a/packages/desktop-electron/bundled-tools.json
+++ b/packages/desktop-electron/bundled-tools.json
@@ -1,19 +1,19 @@
 {
   "uv": {
-    "version": "0.11.28",
+    "version": "0.12.5",
     "repo": "astral-sh/uv",
     "assets": {
       "darwin-arm64": {
         "name": "uv-aarch64-apple-darwin.tar.gz",
-        "sha256": "33540eb7c883ab857eff79bd5ac2aa31fe27b595abecb4a9c003a2c998447232"
+        "sha256": "5bb0e5fe008a773c3dbcb97ff79cd89e1241464fe9d2f986d52ad8f1b037bd62"
       },
       "darwin-x64": {
         "name": "uv-x86_64-apple-darwin.tar.gz",
-        "sha256": "2ad79983127ffca7d77b77ce6a24278d7e4f7b817a1acf72fea5f8124b4aac5e"
+        "sha256": "b3b2137477cf96c9686ebfb71524614cec780c673fd73e59bce099aef02e70e8"
       },
       "win32-x64": {
         "name": "uv-x86_64-pc-windows-msvc.zip",
-        "sha256": "0a23463216d09c6a72ff80ef5dc5a795f07dc1575cb84d24596c2f124a441b7b"
+        "sha256": "4c4d49d8738847d9b71ba319e49a5688c93eac0fe6204b1df24e98528dddf39a"
       }
     }
   }

--- a/packages/desktop-electron/electron-builder-app-update.test.ts
+++ b/packages/desktop-electron/electron-builder-app-update.test.ts
@@ -52,7 +52,9 @@ describe("electron builder app-update config", () => {
       "!node_modules/**/*.d.ts",
       "!node_modules/**/*.d.mts",
       "!node_modules/**/*.d.cts",
-      "!node_modules/**/*.md",
+      "!node_modules/**/README*.md",
+      "!node_modules/**/CHANGELOG*.md",
+      "!node_modules/**/HISTORY*.md",
       "!node_modules/pnpm/artifacts/**/*",
     ])
     expect(dshResources).toMatchObject({ filter: ["**/*", "!**/*.test.cjs"] })

--- a/packages/desktop-electron/electron-builder-app-update.test.ts
+++ b/packages/desktop-electron/electron-builder-app-update.test.ts
@@ -52,9 +52,6 @@ describe("electron builder app-update config", () => {
       "!node_modules/**/*.d.ts",
       "!node_modules/**/*.d.mts",
       "!node_modules/**/*.d.cts",
-      "!node_modules/**/README*.md",
-      "!node_modules/**/CHANGELOG*.md",
-      "!node_modules/**/HISTORY*.md",
       "!node_modules/pnpm/artifacts/**/*",
     ])
     expect(dshResources).toMatchObject({ filter: ["**/*", "!**/*.test.cjs"] })

--- a/packages/desktop-electron/electron-builder-app-update.test.ts
+++ b/packages/desktop-electron/electron-builder-app-update.test.ts
@@ -53,6 +53,7 @@ describe("electron builder app-update config", () => {
       "!node_modules/**/*.d.mts",
       "!node_modules/**/*.d.cts",
       "!node_modules/**/*.md",
+      "!node_modules/pnpm/artifacts/**/*",
     ])
     expect(dshResources).toMatchObject({ filter: ["**/*", "!**/*.test.cjs"] })
     expect(config.extraResources).toEqual([

--- a/packages/desktop-electron/electron-builder-app-update.test.ts
+++ b/packages/desktop-electron/electron-builder-app-update.test.ts
@@ -46,7 +46,14 @@ describe("electron builder app-update config", () => {
     if (!Array.isArray(extraResources)) throw new Error("extraResources must be a list")
     const dshResources = extraResources.find((resource) => typeof resource === "object" && resource.to === "dsh/")
 
-    expect(config.files).toEqual(["out/main/**/*"])
+    expect(config.files).toEqual([
+      "out/main/**/*",
+      "!node_modules/**/*.map",
+      "!node_modules/**/*.d.ts",
+      "!node_modules/**/*.d.mts",
+      "!node_modules/**/*.d.cts",
+      "!node_modules/**/*.md",
+    ])
     expect(dshResources).toMatchObject({ filter: ["**/*", "!**/*.test.cjs"] })
     expect(config.extraResources).toEqual([
       expect.objectContaining({ to: "dsh/" }),
@@ -55,6 +62,17 @@ describe("electron builder app-update config", () => {
       expect.objectContaining({ to: "THIRD_PARTY_NOTICES.md" }),
       expect.objectContaining({ to: "tools/" }),
     ])
+  })
+
+  // electron-builder deletes every locale that does not match this list, and it
+  // matches against the file names Electron ships: en.lproj / zh_CN.lproj on
+  // macOS, en-US.pak / zh-CN.pak on Windows. Spelling both platforms the same
+  // way looks tidier and deletes Chinese from one of them.
+  test("bundled locales are spelled the way each platform names them", () => {
+    const config = createConfig("prod")
+    expect(config.mac?.electronLanguages).toEqual(["en", "zh_CN"])
+    expect(config.win?.electronLanguages).toEqual(["en-US", "zh-CN"])
+    expect(config.electronLanguages).toBeUndefined()
   })
 
   test("only the production build publishes to the PawWork repository", () => {

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -45,15 +45,22 @@ const getBase = (channel: PawWorkChannel): Configuration => ({
   // at runtime: declaration files, source maps (no source-map-support is
   // installed, so nothing reads them) and package docs. Dropping them cuts the
   // installed footprint and, more usefully, the file count that signing and
-  // notarization have to walk. LICENSE files are extensionless and stay.
+  // notarization have to walk.
+  //
+  // Markdown is named file by file rather than excluded wholesale: `**/*.md`
+  // also takes out every LICENSE.md in the closure, which we have to ship, and
+  // the SKILL.md files under dsh/config/agent-presets, which are agent presets
+  // DSH loads at runtime, not documentation.
   files: [
     "out/main/**/*",
     "!node_modules/**/*.map",
     "!node_modules/**/*.d.ts",
     "!node_modules/**/*.d.mts",
     "!node_modules/**/*.d.cts",
-    "!node_modules/**/*.md",
-    // pnpm ships its CLI twice: dist/ and a byte-identical copy under
+    "!node_modules/**/README*.md",
+    "!node_modules/**/CHANGELOG*.md",
+    "!node_modules/**/HISTORY*.md",
+    // pnpm ships its CLI twice: dist/ and a near-identical copy under
     // artifacts/exe/dist/ that only its own standalone-executable build reads.
     // We invoke bin/pnpm.mjs (see dsh-tools.ts), so the second copy is 14M of
     // nothing.

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -42,24 +42,22 @@ const getBase = (channel: PawWorkChannel): Configuration => ({
     buildResources: "resources",
   },
   // The DSH dependency closure ships ~20k files, a fifth of which nothing loads
-  // at runtime: declaration files, source maps (no source-map-support is
-  // installed, so nothing reads them) and package docs. Dropping them cuts the
-  // installed footprint and, more usefully, the file count that signing and
-  // notarization have to walk.
+  // at runtime: declaration files and source maps (no source-map-support is
+  // installed, so nothing reads them). Dropping them cuts the installed
+  // footprint and, more usefully, the file count that signing and notarization
+  // have to walk.
   //
-  // Markdown is named file by file rather than excluded wholesale: `**/*.md`
-  // also takes out every LICENSE.md in the closure, which we have to ship, and
-  // the SKILL.md files under dsh/config/agent-presets, which are agent presets
-  // DSH loads at runtime, not documentation.
+  // Documentation is deliberately NOT excluded. Markdown is only ~1.8M here,
+  // but the closure uses .md for real payload too — the SKILL.md agent presets
+  // under dsh/config/agent-presets and every LICENSE.md we are obliged to ship
+  // — so any doc rule has to be maintained against whatever the next DSH
+  // release adds. Not worth it for 0.4MB of DMG.
   files: [
     "out/main/**/*",
     "!node_modules/**/*.map",
     "!node_modules/**/*.d.ts",
     "!node_modules/**/*.d.mts",
     "!node_modules/**/*.d.cts",
-    "!node_modules/**/README*.md",
-    "!node_modules/**/CHANGELOG*.md",
-    "!node_modules/**/HISTORY*.md",
     // pnpm ships its CLI twice: dist/ and a near-identical copy under
     // artifacts/exe/dist/ that only its own standalone-executable build reads.
     // We invoke bin/pnpm.mjs (see dsh-tools.ts), so the second copy is 14M of

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -41,7 +41,19 @@ const getBase = (channel: PawWorkChannel): Configuration => ({
     output: "dist",
     buildResources: "resources",
   },
-  files: ["out/main/**/*"],
+  // The DSH dependency closure ships ~20k files, a fifth of which nothing loads
+  // at runtime: declaration files, source maps (no source-map-support is
+  // installed, so nothing reads them) and package docs. Dropping them cuts the
+  // installed footprint and, more usefully, the file count that signing and
+  // notarization have to walk. LICENSE files are extensionless and stay.
+  files: [
+    "out/main/**/*",
+    "!node_modules/**/*.map",
+    "!node_modules/**/*.d.ts",
+    "!node_modules/**/*.d.mts",
+    "!node_modules/**/*.d.cts",
+    "!node_modules/**/*.md",
+  ],
   // electron-builder reads .git/config for repository info, which fails on
   // CI runners with persist-credentials: false. Set explicitly via
   // extraMetadata to avoid "Cannot detect repository by .git/config".
@@ -82,6 +94,13 @@ const getBase = (channel: PawWorkChannel): Configuration => ({
     },
   ],
   mac: {
+    // Chromium's own native strings (context menus, file dialogs, media
+    // controls) — unrelated to anything DSH renders, and PawWork only ships
+    // English and Simplified Chinese. electron-builder matches these against
+    // the locale file names on disk, which differ per platform: macOS has
+    // en.lproj and zh_CN.lproj, Windows has en-US.pak and zh-CN.pak. Using the
+    // wrong spelling silently deletes the locale it was meant to keep.
+    electronLanguages: ["en", "zh_CN"],
     category: "public.app-category.developer-tools",
     icon: `resources/icons/icon.icns`,
     hardenedRuntime: true,
@@ -103,6 +122,7 @@ const getBase = (channel: PawWorkChannel): Configuration => ({
     schemes: ["pawwork"],
   },
   win: {
+    electronLanguages: ["en-US", "zh-CN"],
     icon: `resources/icons/icon.ico`,
     target: [{ target: "nsis", arch: ["x64"] }],
   },

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -53,6 +53,11 @@ const getBase = (channel: PawWorkChannel): Configuration => ({
     "!node_modules/**/*.d.mts",
     "!node_modules/**/*.d.cts",
     "!node_modules/**/*.md",
+    // pnpm ships its CLI twice: dist/ and a byte-identical copy under
+    // artifacts/exe/dist/ that only its own standalone-executable build reads.
+    // We invoke bin/pnpm.mjs (see dsh-tools.ts), so the second copy is 14M of
+    // nothing.
+    "!node_modules/pnpm/artifacts/**/*",
   ],
   // electron-builder reads .git/config for repository info, which fails on
   // CI runners with persist-credentials: false. Set explicitly via


### PR DESCRIPTION
## Why

`pawwork-mac-arm64-2026.8.7.dmg` is 175MB. Four megabyte piles are paid for nothing:

- **Electron locales.** All 220 `.lproj` bundles ship, 47M uncompressed, for Chromium's own native strings (context menus, file dialogs, media controls). PawWork ships English and Simplified Chinese.
- **Declaration files and source maps.** 20.8M across the DSH dependency closure. No `source-map-support` is installed, so nothing reads a `.map`, and Node never resolves a `.d.ts`.
- **pnpm's second copy of itself.** `pnpm/artifacts/exe/dist/` duplicates `pnpm/dist/`, 14M, and only pnpm's own standalone-executable build reads it. We invoke `bin/pnpm.mjs`.
- **A stale `uv` pin.** 0.11.28, ten minor releases behind, and 9.8MB larger than current.

## What

- `electronLanguages` per platform. The codes are spelled differently on purpose: electron-builder matches them against the file names Electron ships, which are `en.lproj` / `zh_CN.lproj` on macOS and `en-US.pak` / `zh-CN.pak` on Windows. A single shared list silently deletes Chinese from one of the two platforms — a test pins the difference so it does not get tidied up later.
- Negative globs in `files` for `*.map`, `*.d.ts` / `*.d.mts` / `*.d.cts`, and `pnpm/artifacts`.
- `bundled-tools.json` to uv 0.12.5, checksums verified against the pinned release assets, and the version in `THIRD_PARTY_NOTICES.md` brought along.

**Documentation is deliberately left in.** An earlier revision of this branch excluded `**/*.md` and that removed real payload: the `SKILL.md` agent presets DSH loads from `dsh/config/agent-presets/cordis/skills`, the `dsh-skill-badge` asset, and 13 `LICENSE.md` files we are obliged to ship. Narrowing to README/CHANGELOG/HISTORY fixed that instance, but the rule would still have to be re-checked against whatever `.md` the next DSH release ships as an asset — and the whole category is worth 0.8MB of DMG. The `.d.ts` and `.map` rules stay because their reasoning is settled rather than per-file.

`asarUnpack` is untouched: DSH still needs its dependency closure outside the asar for the profile symlinks to stay traversable.

## Result

Measured on a local mac-arm64 package:

| | before | after |
|---|---|---|
| DMG | 175MB (released, signed) | 149MB (local, unsigned) |
| Electron locales | 220 | 2 |
| dependency files | 19,671 | 12,423 |
| bundled pnpm | 27M | 14M |
| bundled uv | 52.0MB | 42.2MB |

Signing adds a few MB back, so the released artifact should land near 151–153MB.

The dropped file count also shortens signing and notarization, which walk every file in the bundle.

## Verification

- `typecheck`, full `test` (391 passing), `lint`
- `scripts/ci-smoke.ts packaged` against the real packaged app, exit 0, re-run after each packaging change
- The packaged pnpm still reports `11.23.0` when run from `bin/pnpm.cjs`
- Confirmed in the final package: 2 `SKILL.md` presets, 13 `LICENSE.md`, 276 `.md` in total
- Confirmed the `afterPack` localized display name survives locale cleanup: electron-builder's cleanup runs in `beforeCopyExtraFiles`, before `afterPack`, and `zh-Hans.lproj` / `zh_CN.lproj` are both present in the packaged bundle
- `uv --version` reports 0.12.5 from the prepared binary

## Not in scope

The remaining weight is Electron itself (~90MB compressed), uv (~15MB compressed, required by the code runtime), and the DSH dependency closure. Follow-ups worth their own change, largest first: uv on first use instead of bundled; the 11.4M of TypeScript `src/` directories that `@mistralai`, `zod`, `openai` and `@anthropic-ai/sdk` ship but never resolve to; `libvk_swiftshader` (16M, the software-Vulkan fallback); and `dmg.format: "ULFO"`. The LLM provider SDKs are all static top-level imports inside `pi-ai`, so converging those has to happen upstream in DSH.