### PR TITLE
fix(desktop): stop pinning the community market to its compatibility floor

### DIFF
--- a/packages/desktop-electron/resources/dsh/product/lib/desktop-host.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/desktop-host.cjs
@@ -3,8 +3,11 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const MARKET_NAME = 'dshmarket';
+// The floor is a compatibility contract, not a pin: it is the first market
+// release that works with the Desktop services we inject in place of its own
+// profile and package runtime. Installing targets the latest release, per the
+// market's own install instructions, and the market updates itself from there.
 const MARKET_MINIMUM_VERSION = '1.21.0';
-const MARKET_TARGET = `${MARKET_NAME}@${MARKET_MINIMUM_VERSION}`;
 const MARKET_OPERATION_TIMEOUT_MS = 15 * 60 * 1000;
 
 function readProfile(profileDir) {
@@ -51,6 +54,26 @@ function marketStatus(profileDir) {
     enabled: declared && active && version !== null && versionAtLeast(version, MARKET_MINIMUM_VERSION),
     version,
   };
+}
+
+function dropMarketBundle(profileDir) {
+  const manifest = readProfile(profileDir);
+  const bundles = manifest.dsh?.profile?.bundles;
+  if (!Array.isArray(bundles) || !bundles.includes(MARKET_NAME)) return;
+  manifest.dsh.profile.bundles = bundles.filter((bundle) => bundle !== MARKET_NAME);
+  fs.writeFileSync(path.join(profileDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+// A bundle row left declared but not installable is what stops DSH from booting
+// at all, and neither `dsh plugin add` nor the market rolls it back on failure
+// (dsh-market/dsh-market#339, still open against 1.29.2). A failed install drops
+// only such a row: one that resolves is the user's to keep, even when it is too
+// old for us to drive.
+function pruneUnresolvableMarketBundle(profileDir) {
+  const manifest = readProfile(profileDir);
+  const declared = typeof manifest.dependencies?.[MARKET_NAME] === 'string';
+  if (declared && installedMarketVersion(profileDir) !== null) return;
+  dropMarketBundle(profileDir);
 }
 
 function createDesktopProfiles(profileDir) {
@@ -165,24 +188,28 @@ function createDesktopHost(options) {
       async enable() {
         const current = await status();
         if (current.enabled) return current;
-        await runMarketPlugin(['add', MARKET_TARGET, '--save-exact'], 'DSH plugin install');
-        const installed = await status();
-        if (!installed.enabled) throw new Error('DSH did not activate a compatible community market');
-        return installed;
+        try {
+          await runMarketPlugin(['add', MARKET_NAME], 'DSH plugin install');
+          const installed = await status();
+          if (!installed.enabled) {
+            throw new Error(installed.version === null
+              ? 'DSH did not activate a compatible community market'
+              : `The community market requires ${MARKET_MINIMUM_VERSION} or newer, but ${installed.version} was installed`);
+          }
+          return installed;
+        } catch (error) {
+          pruneUnresolvableMarketBundle(profileDir);
+          throw error;
+        }
       },
       async disable() {
         const current = await status();
         if (!current.enabled && !readProfile(profileDir).dsh?.profile?.bundles?.includes(MARKET_NAME)) return current;
         await runMarketPlugin(['remove', MARKET_NAME], 'DSH plugin removal');
-        // A bundle left declared but not installed is what stops DSH from
-        // booting at all, so turning the market off must not be able to leave
-        // one behind — the removal is only complete once the row is gone too.
-        const manifest = readProfile(profileDir);
-        const bundles = manifest.dsh?.profile?.bundles;
-        if (Array.isArray(bundles) && bundles.includes(MARKET_NAME)) {
-          manifest.dsh.profile.bundles = bundles.filter((bundle) => bundle !== MARKET_NAME);
-          fs.writeFileSync(path.join(profileDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
-        }
+        // Turning the market off must not be able to leave a row behind: the
+        // removal is only complete once the bundle row is gone too, whatever
+        // state DSH left the rest of the manifest in.
+        dropMarketBundle(profileDir);
         return status();
       },
     },
@@ -229,7 +256,6 @@ function registerCommunityMarketRoutes(webServer, market, hostToken) {
 module.exports = {
   MARKET_MINIMUM_VERSION,
   MARKET_NAME,
-  MARKET_TARGET,
   createDesktopHost,
   registerCommunityMarketRoutes,
 };

--- a/packages/desktop-electron/resources/dsh/product/lib/desktop-host.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/desktop-host.test.cjs
@@ -182,7 +182,7 @@ test('requires restart when the running market is removed from the profile', asy
   });
 })
 
-test('installs only the pinned compatible market through the managed service', async () => {
+test('installs the latest market through the managed service', async () => {
   const { home, profileDir } = profileHome();
   const managed = managedSubprocess();
   const host = createDesktopHost({
@@ -201,22 +201,74 @@ test('installs only the pinned compatible market through the managed service', a
     '--profile',
     'web',
     'add',
-    'dshmarket@1.21.0',
-    '--save-exact',
+    'dshmarket',
   ]);
   assert.equal(managed.spawns[0].signal instanceof AbortSignal, true);
   fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
-    dependencies: { dshmarket: '1.21.0' },
+    dependencies: { dshmarket: '^1.29.2' },
     dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket'] } },
   }));
-  writeInstalledMarket(profileDir, '1.21.0');
+  writeInstalledMarket(profileDir, '1.29.2');
   managed.settle({ exitCode: 0, signal: null });
 
   assert.deepEqual(await enabling, {
     enabled: true,
     restartRequired: true,
-    version: '1.21.0',
+    version: '1.29.2',
   });
+})
+
+test('reports the installed version when it is below the compatibility floor', async () => {
+  const { home, profileDir } = profileHome();
+  const managed = managedSubprocess();
+  const host = createDesktopHost({
+    dshBin: '/app/dsh/bin.js',
+    home,
+    nodeExecutable: '/app/PawWork',
+    subprocess: managed.subprocess,
+  });
+
+  const enabling = host.communityMarket.enable();
+  await Promise.resolve();
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    dependencies: { dshmarket: '1.20.4' },
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket'] } },
+  }));
+  writeInstalledMarket(profileDir, '1.20.4');
+  managed.settle({ exitCode: 0, signal: null });
+
+  await assert.rejects(enabling, /requires 1\.21\.0 or newer, but 1\.20\.4 was installed/);
+  // The row resolves, so it is the user's to keep — pruning it would break a
+  // profile that still boots fine.
+  const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+  assert.deepEqual(manifest.dsh.profile.bundles, ['@deepseek-ai/dsh-base', 'dshmarket']);
+})
+
+test('prunes the orphan bundle row when the install fails', async () => {
+  const { home, profileDir } = profileHome();
+  const managed = managedSubprocess();
+  const host = createDesktopHost({
+    dshBin: '/app/dsh/bin.js',
+    home,
+    nodeExecutable: '/app/PawWork',
+    subprocess: managed.subprocess,
+  });
+
+  const enabling = host.communityMarket.enable();
+  await Promise.resolve();
+  // `dsh plugin add` writes the bundle row before the install can fail, and
+  // neither it nor the market rolls it back (dsh-market/dsh-market#339). Left
+  // behind, it makes the next DSH boot fail to resolve the bundle.
+  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+    dependencies: {},
+    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket'] } },
+  }));
+  managed.child.stderr.write('build scripts are blocked by pnpm by default');
+  managed.settle({ exitCode: 1, signal: null });
+
+  await assert.rejects(enabling, /build scripts are blocked/);
+  const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
+  assert.deepEqual(manifest.dsh.profile.bundles, ['@deepseek-ai/dsh-base']);
 })
 
 test('keeps a newer compatible market without spawning a downgrade', async () => {


### PR DESCRIPTION
## Problem

The community market version lived in a single constant that served two jobs at once:

```js
const MARKET_MINIMUM_VERSION = '1.21.0';
const MARKET_TARGET = `${MARKET_NAME}@${MARKET_MINIMUM_VERSION}`;
```

It was both the floor `marketStatus()` validates against and the target `enable()` installs — with `--save-exact`. So every user who turned the market on got exactly 1.21.0, while upstream had shipped through 1.29.2, and the only way off it was a PawWork release. Because the market is installed into the user's DSH profile at runtime rather than declared in `package.json`, no dependency-update tooling could see it either.

## What changed

**Install the latest release.** `enable()` now runs `dsh plugin --profile web add dshmarket`, matching the market's own documented install command, and `1.21.0` stays purely as the compatibility contract it actually describes: the first release that works with the Desktop services (`desktopProfiles`, `desktopPnpm`) we inject in place of the market's own profile and package runtime. From there the market updates itself through its plugin settings card, which it supports on dsh `0.1.0-rc.7`+ — its `peerDependencies` (`@deepseek-ai/dsh-settings: ^0.1.0-rc.7 || ^0.1.1-rc.2`) cover the `0.1.1-rc.2` we ship. Existing users stuck on 1.21.0 can move without waiting for us.

**Roll back the orphan bundle row on a failed install.** `dsh plugin add` writes the `dsh.profile.bundles` row before the install can fail, and neither dsh nor the market reverts it — the next DSH boot then dies in `resolveBundleDir` with `cannot resolve profile bundle "dshmarket"`. dsh-market/dsh-market#339 is still open and the gap is present in the 1.29.2 sources, with an independent reproduction on plain `dsh web` on macOS, so this is not something to wait on. Installing the latest release means meeting failed installs (blocked build scripts, network) more often, so `enable()` now drops that row when the install fails.

It drops it **only when it no longer resolves**: a row backed by a package on disk is the user's to keep, even when that package is too old for us to drive. That case now reports the version it actually found instead of a generic failure.

`disable()`'s existing half-done-removal cleanup is factored into a shared `dropMarketBundle()` and keeps its unconditional semantics — turning the market off should clear the row whatever state DSH left the rest of the manifest in.

## Note on #1601

This does **not** let us retire the boot-failure recovery from #1601. That backstop is still the only thing standing between a user and a hand-edited JSON file, and it stays.

## Verification

- `pnpm run typecheck` — clean
- `pnpm run test` (vitest + `node --test`) — 125 passing

New coverage: install targets the bare package name; a below-floor install reports the found version and leaves the resolvable row alone; a failed install prunes the orphan row.

No user-visible layout change — the settings tab's copy and controls are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Community Market installations now retrieve the latest compatible release automatically.
  * Installations verify the active Market version before completing.

* **Bug Fixes**
  * Failed installations clean up unresolved Market entries without removing valid bundles.
  * Disabling the Community Market now reliably removes its bundle entry.
  * Improved handling of versions below the minimum compatibility requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->