### PR TITLE
feat(desktop): let the assistant read pages, search its own history, and tell the time

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -46,6 +46,7 @@
     "@deepseek-ai/dsh-time-context": "0.1.1-rc.2",
     "@deepseek-ai/dsh-timeout": "0.1.1-rc.2",
     "@deepseek-ai/dsh-web": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-web-fetch-http": "0.1.1-rc.2",
     "@deepseek-ai/dsh-web-search-deepseek": "0.1.1-rc.2",
     "@deepseek-ai/dsh-web-search-exa": "0.1.1-rc.2",
     "@deepseek-ai/dsh-workflow": "0.1.1-rc.2",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -43,6 +43,7 @@
     "@deepseek-ai/dsh-spill": "0.1.1-rc.2",
     "@deepseek-ai/dsh-subagent-in-process-driver": "0.1.1-rc.2",
     "@deepseek-ai/dsh-subprocess": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-time-context": "0.1.1-rc.2",
     "@deepseek-ai/dsh-timeout": "0.1.1-rc.2",
     "@deepseek-ai/dsh-web": "0.1.1-rc.2",
     "@deepseek-ai/dsh-web-search-deepseek": "0.1.1-rc.2",

--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -76,3 +76,12 @@
       name: '@pawwork/dsh-automations'
     - id: pawwork-web-search
       name: '@pawwork/dsh-web-search'
+    # Not in the default composition upstream. Without it the model has no clock:
+    # it cannot date "the latest release" or read "next Tuesday" in the user's own
+    # zone, which is exactly what a desktop user asking about current events
+    # expects. The interval keeps a long session from carrying one reading per
+    # step; a turn that spans it gets a fresh one.
+    - id: time-context
+      name: '@deepseek-ai/dsh-time-context'
+      config:
+        refreshIntervalMs: 60000

--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -49,31 +49,55 @@
 # `dsh-web-app` disables the dsh-base `tool-web` outright because the agent
 # presets each mount their own, so re-enabling it here puts `web_fetch` in the
 # global tool layer, which every agent inherits regardless of preset. `search`
-# stays off — each preset's own scoped `tool-web` already provides `web_search`
-# and shadows this row for that name.
+# stays off because each preset's own scoped `tool-web` registers `web_search`
+# and shadows this row for that name; a second registration would be dead weight
+# that also drops the preset's 60s search timeout.
 #
-# `dsh-web-fetch-http` (inserted below) is the other half, and it does not guard
-# against SSRF: the model chooses the request target and private addresses are
-# not blocked. That is deliberate. A literal-IP denylist cannot be complete
-# without resolving DNS first, and network reachability is the runtime's or the
-# sandbox's policy to set — not something a content adapter should decide, where
-# it would also break a user on a VPN or a proxied network.
+# Upstream tells deployments not to do this. `dsh-web-fetch-http` (inserted
+# below) implements no SSRF protection — the model picks the target and private,
+# loopback and link-local addresses are not blocked — so its README says it
+# "must not be enabled in a deployment that can reach sensitive internal network
+# targets", and dsh-base keeps `fetch: false` for that reason.
+#
+# PawWork accepts the risk rather than mitigating it here, on one ground: the
+# model already reaches the same addresses through `bash`, and this product's
+# sandbox is `(allow default)` with only file writes denied, so no layer below
+# constrains the network and adding a denylist to one tool would move nothing.
+# A literal-IP denylist could not be complete without resolving DNS first, and
+# would break users on a VPN or a proxied network.
+#
+# What the risk actually is, stated plainly: page text the model reads is
+# attacker-controlled, `web_fetch` is not behind the approval gate `bash` sits
+# behind, and a fetched URL can carry context out in its query string. The
+# app's own loopback API is reachable this way too — `isTrustedApiRequest`
+# admits a request with no `origin` and no `sec-fetch-site`, which is the shape
+# a server-side fetch has — though the sidecar's port is randomised. Mitigating
+# it belongs with the approval gate, not with a target denylist: gate a
+# `web_fetch` whose URL did not come from that turn's own `web_search` results.
 - id: tool-web
   disabled: false
   config:
     search: false
     fetch: true
 # dsh-base indexes into `:memory:` and never opens it, so the sidebar can only
-# match session titles and workspace names. A durable file behind `first-search`
-# makes searching what was said possible without paying for SQLite at startup:
-# the module and handle load on the first search, and a user who never searches
-# never opens the database at all.
+# match session titles and workspace names. A durable file makes searching what
+# was said possible, and `first-search` keeps a user who never searches from
+# opening the database at all.
 #
-# The cost is a privacy one, and it is real: the FTS5 table is not contentless,
-# so message text — including tool-call arguments and tool results — lives in
-# this file at rest, where before it only lived in the session log. The file is
-# owner-only and never shrinks; deleting a session removes its rows but does not
-# reclaim the pages.
+# `first-search` moves a real cost onto that first search rather than removing
+# it: the index starts empty, so the engine reads and indexes every existing
+# session before answering, serially and on a synchronous SQLite handle. It also
+# reconciles against a snapshot it re-reads afterwards, and a session being
+# appended to changes its revision mid-scan — with two attempts, searching while
+# an agent runs can fail outright. Both are upstream behaviours; the choice here
+# is only when to pay for them.
+#
+# The privacy cost is real. The FTS5 table is not contentless, so message text —
+# tool-call arguments and tool results included — lives in this file at rest,
+# where before it lived only in the session log. Same directory, same 0600, so
+# no new exposure class; what is new is that deleting a session does not clear
+# it. Rows go only during the next search's reconciliation, and with no
+# `secure_delete` and no `VACUUM` the freed pages keep the text recoverable.
 - id: session-query-sqlite
   config:
     path: !!js dshHomePath('session-query.sqlite')
@@ -95,16 +119,16 @@
       name: '@pawwork/dsh-automations'
     - id: pawwork-web-search
       name: '@pawwork/dsh-web-search'
-    # Not in the default composition upstream. Without it the model has no clock:
-    # it cannot date "the latest release" or read "next Tuesday" in the user's own
-    # zone, which is exactly what a desktop user asking about current events
-    # expects. The interval keeps a long session from carrying one reading per
-    # step; a turn that spans it gets a fresh one.
     # The fetch provider behind the `web_fetch` tool re-enabled above. dsh-base
     # mounts none, so without this row the tool exists and every call answers
     # `no usable web provider is registered`.
     - id: web-fetch-http
       name: '@deepseek-ai/dsh-web-fetch-http'
+    # Not in the default composition upstream. Without it the model has no clock:
+    # it cannot date "the latest release" or read "next Tuesday" in the user's own
+    # zone, which is exactly what a desktop user asking about current events
+    # expects. The interval is a floor between injections, not a refresh timer —
+    # without it every step carries its own reading.
     - id: time-context
       name: '@deepseek-ai/dsh-time-context'
       config:

--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -38,41 +38,37 @@
 - id: web
   config:
     searchProvider: pawwork
+    fetchProvider: http
 # The PawWork provider constructs this same DeepSeek backend when the user
 # selects it, and resolves the same `DEEPSEEK_API_KEY` reference the Models page
 # writes — so this row is not a capability, it is a second settings card titled
 # "web search" that edits a provider the seam will never select.
 - id: web-search-deepseek
   disabled: true
-# The model could search the web but never open a result, so it answered from
-# titles and snippets. Two halves are needed. This row is the model-facing one:
 # `dsh-web-app` disables the dsh-base `tool-web` outright because the agent
 # presets each mount their own, so re-enabling it here puts `web_fetch` in the
-# global tool layer, which every agent inherits regardless of preset. `search`
-# stays off because each preset's own scoped `tool-web` registers `web_search`
-# and shadows this row for that name; a second registration would be dead weight
-# that also drops the preset's 60s search timeout.
+# global tool layer, which every agent inherits regardless of preset — including
+# `minimal`, which mounts no `tool-web` and so had no web tool at all before.
+# `search` stays off because each preset's own scoped `tool-web` registers
+# `web_search` and shadows this row for that name; a second registration would
+# be dead weight that also drops the preset's 60s search timeout.
 #
-# Upstream tells deployments not to do this. `dsh-web-fetch-http` (inserted
+# Upstream tells deployments not to do this: `dsh-web-fetch-http` (inserted
 # below) implements no SSRF protection — the model picks the target and private,
 # loopback and link-local addresses are not blocked — so its README says it
 # "must not be enabled in a deployment that can reach sensitive internal network
 # targets", and dsh-base keeps `fetch: false` for that reason.
 #
-# PawWork accepts the risk rather than mitigating it here, on one ground: the
-# model already reaches the same addresses through `bash`, and this product's
-# sandbox is `(allow default)` with only file writes denied, so no layer below
-# constrains the network and adding a denylist to one tool would move nothing.
-# A literal-IP denylist could not be complete without resolving DNS first, and
-# would break users on a VPN or a proxied network.
+# PawWork accepts the risk rather than mitigating it here: the model already
+# reaches the same addresses through `bash`, whose approval gate covers only
+# `sandbox_permissions` escalation, so ordinary commands already egress
+# unprompted inside an `(allow default)` sandbox. Neither tool is gated on its
+# target today, and a literal-IP denylist could not be complete without
+# resolving DNS first.
 #
-# What the risk actually is, stated plainly: page text the model reads is
-# attacker-controlled, `web_fetch` is not behind the approval gate `bash` sits
-# behind, and a fetched URL can carry context out in its query string. The
-# app's own loopback API is reachable this way too — `isTrustedApiRequest`
-# admits a request with no `origin` and no `sec-fetch-site`, which is the shape
-# a server-side fetch has — though the sidecar's port is randomised. Mitigating
-# it belongs with the approval gate, not with a target denylist: gate a
+# The exposure that leaves: page text the model reads is attacker-controlled,
+# and a fetched URL can carry context out in its query string. Mitigating it
+# belongs in `tools/pre-execute`, which no web tool registers — gate a
 # `web_fetch` whose URL did not come from that turn's own `web_search` results.
 - id: tool-web
   disabled: false
@@ -80,24 +76,26 @@
     search: false
     fetch: true
 # dsh-base indexes into `:memory:` and never opens it, so the sidebar can only
-# match session titles and workspace names. A durable file makes searching what
-# was said possible, and `first-search` keeps a user who never searches from
-# opening the database at all.
+# match session titles and workspace names. A durable file is what makes
+# searching what was said possible; `first-search` keeps a user who never
+# searches from opening the database at all.
 #
-# `first-search` moves a real cost onto that first search rather than removing
-# it: the index starts empty, so the engine reads and indexes every existing
-# session before answering, serially and on a synchronous SQLite handle. It also
-# reconciles against a snapshot it re-reads afterwards, and a session being
-# appended to changes its revision mid-scan — with two attempts, searching while
-# an agent runs can fail outright. Both are upstream behaviours; the choice here
-# is only when to pay for them.
+# The backfill lands on that first search either way — `openAt` governs only
+# when the file is opened, not when the index is built — and it is all-or-
+# nothing: every session is read and parsed before a single row is written, and
+# the read phase aborts on the sidebar's own signal, which fires on every
+# keystroke past a 250ms debounce. So editing the query mid-flight starts the
+# whole backfill over. It does finish once the typing stops, but on a large
+# history that is seconds of a blocked synchronous SQLite handle. Reconciliation
+# also re-reads its snapshot afterwards, and a session appended to mid-scan
+# changes its revision, so searching while an agent runs can fail outright.
 #
-# The privacy cost is real. The FTS5 table is not contentless, so message text —
-# tool-call arguments and tool results included — lives in this file at rest,
-# where before it lived only in the session log. Same directory, same 0600, so
-# no new exposure class; what is new is that deleting a session does not clear
-# it. Rows go only during the next search's reconciliation, and with no
-# `secure_delete` and no `VACUUM` the freed pages keep the text recoverable.
+# The FTS5 table is not contentless, so message text — tool-call arguments and
+# tool results included — lives in this file at rest, where before it lived only
+# in the session log. Same directory, same 0600. What is new is that deleting a
+# session does not clear it: rows go only during the next search's
+# reconciliation, and with no `secure_delete` and no `VACUUM` the freed pages
+# keep the text recoverable.
 - id: session-query-sqlite
   config:
     path: !!js dshHomePath('session-query.sqlite')
@@ -124,11 +122,13 @@
     # `no usable web provider is registered`.
     - id: web-fetch-http
       name: '@deepseek-ai/dsh-web-fetch-http'
-    # Not in the default composition upstream. Without it the model has no clock:
-    # it cannot date "the latest release" or read "next Tuesday" in the user's own
-    # zone, which is exactly what a desktop user asking about current events
-    # expects. The interval is a floor between injections, not a refresh timer —
-    # without it every step carries its own reading.
+    # Not in the default composition upstream; without it the model has no clock.
+    # The interval is a floor between injections, not a refresh timer — upstream
+    # has no default, so dropping it makes every step carry its own reading.
+    # It is also the noise knob for the session search above: each injection is
+    # a real `user/message` event, and the indexer keys on event type alone, so
+    # every reading becomes a searchable document matching `time`, `turn`,
+    # `elapsed` and the zone name. Filtering by `source.kind` is upstream's to do.
     - id: time-context
       name: '@deepseek-ai/dsh-time-context'
       config:

--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -44,6 +44,25 @@
 # "web search" that edits a provider the seam will never select.
 - id: web-search-deepseek
   disabled: true
+# The model could search the web but never open a result, so it answered from
+# titles and snippets. Two halves are needed. This row is the model-facing one:
+# `dsh-web-app` disables the dsh-base `tool-web` outright because the agent
+# presets each mount their own, so re-enabling it here puts `web_fetch` in the
+# global tool layer, which every agent inherits regardless of preset. `search`
+# stays off — each preset's own scoped `tool-web` already provides `web_search`
+# and shadows this row for that name.
+#
+# `dsh-web-fetch-http` (inserted below) is the other half, and it does not guard
+# against SSRF: the model chooses the request target and private addresses are
+# not blocked. That is deliberate. A literal-IP denylist cannot be complete
+# without resolving DNS first, and network reachability is the runtime's or the
+# sandbox's policy to set — not something a content adapter should decide, where
+# it would also break a user on a VPN or a proxied network.
+- id: tool-web
+  disabled: false
+  config:
+    search: false
+    fetch: true
 # dsh-base indexes into `:memory:` and never opens it, so the sidebar can only
 # match session titles and workspace names. A durable file behind `first-search`
 # makes searching what was said possible without paying for SQLite at startup:
@@ -81,6 +100,11 @@
     # zone, which is exactly what a desktop user asking about current events
     # expects. The interval keeps a long session from carrying one reading per
     # step; a turn that spans it gets a fresh one.
+    # The fetch provider behind the `web_fetch` tool re-enabled above. dsh-base
+    # mounts none, so without this row the tool exists and every call answers
+    # `no usable web provider is registered`.
+    - id: web-fetch-http
+      name: '@deepseek-ai/dsh-web-fetch-http'
     - id: time-context
       name: '@deepseek-ai/dsh-time-context'
       config:

--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -44,6 +44,21 @@
 # "web search" that edits a provider the seam will never select.
 - id: web-search-deepseek
   disabled: true
+# dsh-base indexes into `:memory:` and never opens it, so the sidebar can only
+# match session titles and workspace names. A durable file behind `first-search`
+# makes searching what was said possible without paying for SQLite at startup:
+# the module and handle load on the first search, and a user who never searches
+# never opens the database at all.
+#
+# The cost is a privacy one, and it is real: the FTS5 table is not contentless,
+# so message text — including tool-call arguments and tool results — lives in
+# this file at rest, where before it only lived in the session log. The file is
+# owner-only and never shrinks; deleting a session removes its rows but does not
+# reclaim the pages.
+- id: session-query-sqlite
+  config:
+    path: !!js dshHomePath('session-query.sqlite')
+    openAt: first-search
 # The market must wait for PawWork's generation-scoped Desktop services. Their
 # presence selects its managed package runtime and makes self-restart unavailable.
 - id: dsh-market

--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -13,8 +13,8 @@ import {
 import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
-import { load } from "js-yaml"
 import { DOCUMENT_VERSION, parseCredentialsDocument } from "@deepseek-ai/dsh-credentials-local"
+import { readProductPatch } from "./dsh-product-patch.testing"
 import {
   buildDshEnvironment,
   prepareDshProductHome,
@@ -267,11 +267,7 @@ describe("DSH product home", () => {
   })
 
   test("publishes the installed zero-cost OpenCode catalog as OpenCode Free", () => {
-    const resources = join(import.meta.dirname, "../../resources/dsh")
-    const patch = load(readFileSync(join(resources, "home/product.cordis.patch.yml"), "utf8")) as Array<{
-      id?: string
-      config?: Record<string, unknown>
-    }>
+    const patch = readProductPatch()
     const modelDefaults = patch.find((entry) => entry.id === "agent-default-model")?.config as {
       provider: string
       model: string
@@ -288,22 +284,13 @@ describe("DSH product home", () => {
   })
 
   test("does not publish the bundled paid DeepSeek route", () => {
-    const resources = join(import.meta.dirname, "../../resources/dsh")
-    const patch = load(readFileSync(join(resources, "home/product.cordis.patch.yml"), "utf8")) as Array<{
-      id?: string
-      disabled?: boolean
-    }>
+    const patch = readProductPatch()
 
     expect(patch.find((entry) => entry.id === "llm-deepseek")?.disabled).toBe(true)
   })
 
   test("makes the community market wait for PawWork-owned Desktop services", () => {
-    const resources = join(import.meta.dirname, "../../resources/dsh")
-    const patch = load(readFileSync(join(resources, "home/product.cordis.patch.yml"), "utf8")) as Array<{
-      id?: string
-      config?: Record<string, unknown>
-      inject?: string[]
-    }>
+    const patch = readProductPatch()
 
     expect(patch.find((entry) => entry.id === "dsh-market")).toEqual({
       id: "dsh-market",

--- a/packages/desktop-electron/src/main/dsh-product-mounts.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-mounts.test.ts
@@ -1,0 +1,29 @@
+import { createRequire } from "node:module"
+import { describe, expect, test } from "vitest"
+import { readProductPatch } from "./dsh-product-patch.testing"
+
+const require = createRequire(import.meta.url)
+
+function insertedHarnessPackages() {
+  return readProductPatch()
+    .flatMap((entry) => entry.insert ?? [])
+    .map((row) => row.name)
+    .filter((name) => name.startsWith("@deepseek-ai/"))
+}
+
+describe("PawWork DSH product mounts", () => {
+  // A row the overlay inserts by bare name is resolved by the harness from the
+  // DSH home, not from this package — so a name that is not a real installed
+  // package fails at boot with `Cannot find package`, taking the whole app down,
+  // and nothing before runtime says so. Resolving each one here is the check;
+  // asserting version literals instead would only restate package.json and go
+  // red on every routine bump.
+  test("mounts only harness packages that are actually installed", () => {
+    const mounted = insertedHarnessPackages()
+
+    expect(mounted.length).toBeGreaterThan(0)
+    for (const name of mounted) {
+      expect(() => require.resolve(`${name}/package.json`)).not.toThrow()
+    }
+  })
+})

--- a/packages/desktop-electron/src/main/dsh-product-mounts.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-mounts.test.ts
@@ -42,7 +42,6 @@ describe("PawWork DSH product mounts", () => {
   test("floors the clock injections with a positive interval", () => {
     const clock = insertedRows().find((row) => row.name === "@deepseek-ai/dsh-time-context")
 
-    expect(clock?.id).toBe("time-context")
     expect(clock?.config?.refreshIntervalMs).toBeGreaterThan(0)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-product-mounts.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-mounts.test.ts
@@ -4,11 +4,8 @@ import { readProductPatch } from "./dsh-product-patch.testing"
 
 const require = createRequire(import.meta.url)
 
-function insertedHarnessPackages() {
-  return readProductPatch()
-    .flatMap((entry) => entry.insert ?? [])
-    .map((row) => row.name)
-    .filter((name) => name.startsWith("@deepseek-ai/"))
+function insertedRows() {
+  return readProductPatch().flatMap((entry) => entry.insert ?? [])
 }
 
 describe("PawWork DSH product mounts", () => {
@@ -19,11 +16,33 @@ describe("PawWork DSH product mounts", () => {
   // asserting version literals instead would only restate package.json and go
   // red on every routine bump.
   test("mounts only harness packages that are actually installed", () => {
-    const mounted = insertedHarnessPackages()
+    const mounted = insertedRows()
+      .map((row) => row.name)
+      .filter((name) => name.startsWith("@deepseek-ai/"))
 
     expect(mounted.length).toBeGreaterThan(0)
     for (const name of mounted) {
       expect(() => require.resolve(`${name}/package.json`)).not.toThrow()
     }
+  })
+
+  // The id is the handle every later patch and every settings namespace uses to
+  // address a row. Two rows sharing one, or a row whose id is a typo of the
+  // intended one, both compose without complaint — the id simply addresses
+  // something other than what was meant, or nothing at all.
+  test("gives every inserted row a distinct id", () => {
+    const ids = insertedRows().map((row) => row.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  // `refreshIntervalMs` has no default upstream: the clock is injected once per
+  // step unless a positive interval floors it, so losing this value does not
+  // disable a feature, it quietly makes every step carry its own reading.
+  test("floors the clock injections with a positive interval", () => {
+    const clock = insertedRows().find((row) => row.name === "@deepseek-ai/dsh-time-context")
+
+    expect(clock?.id).toBe("time-context")
+    expect(clock?.config?.refreshIntervalMs).toBeGreaterThan(0)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-product-patch.testing.ts
+++ b/packages/desktop-electron/src/main/dsh-product-patch.testing.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { JSON_SCHEMA, Type, load } from "js-yaml"
+
+// Loader entry lists — the product patch, and the agent compositions presets
+// are made of — carry `!!js` rows: expressions the harness evaluates against
+// its own composition context, not values a test can resolve. They load as
+// their source text so a test can assert which expression a row uses without
+// pretending to know what it evaluates to.
+//
+// `resolve` is deliberately looser than the harness's own (`dsh-app-boot`
+// requires a string): a reader that accepted fewer documents than the app does
+// would fail tests on rows the app loads fine.
+const jsExpression = new Type("tag:yaml.org,2002:js", {
+  kind: "scalar",
+  construct: (data: string) => data,
+  resolve: () => true,
+})
+
+const ENTRY_LIST_SCHEMA = JSON_SCHEMA.extend([jsExpression])
+
+export type EntryRow = {
+  id?: string
+  name?: string
+  disabled?: boolean
+  inject?: string[]
+  config?: Record<string, unknown>
+  insert?: Array<{ id: string; name: string; config?: Record<string, unknown> }>
+}
+
+export const productPatchFile = resolve(
+  import.meta.dirname,
+  "../../resources/dsh/home/product.cordis.patch.yml",
+)
+
+/** One entry list's rows, with `!!js` expressions kept as their source text. */
+export function readEntryList(file: string): EntryRow[] {
+  return load(readFileSync(file, "utf8"), { schema: ENTRY_LIST_SCHEMA }) as EntryRow[]
+}
+
+/** The product overlay's rows. */
+export function readProductPatch(file = productPatchFile) {
+  return readEntryList(file)
+}

--- a/packages/desktop-electron/src/main/dsh-product-patch.testing.ts
+++ b/packages/desktop-electron/src/main/dsh-product-patch.testing.ts
@@ -39,6 +39,6 @@ export function readEntryList(file: string): EntryRow[] {
 }
 
 /** The product overlay's rows. */
-export function readProductPatch(file = productPatchFile) {
-  return readEntryList(file)
+export function readProductPatch() {
+  return readEntryList(productPatchFile)
 }

--- a/packages/desktop-electron/src/main/dsh-session-search.test.ts
+++ b/packages/desktop-electron/src/main/dsh-session-search.test.ts
@@ -1,35 +1,24 @@
 import { describe, expect, test } from "vitest"
 import { readProductPatch } from "./dsh-product-patch.testing"
 
-/** `openAt` values the engine accepts; anything else throws at boot. */
-const OPEN_AT = ["startup", "first-search", "never"]
-
 describe("PawWork DSH session search", () => {
   // The row exists only to displace two upstream values, so those two values are
-  // what it guards. But a row that is absent displaces nothing while answering
-  // every "is not" the same way an applied one does, so its presence is asserted
-  // before anything is asked about its contents.
+  // what it guards — but a row that is absent displaces nothing while answering
+  // every assertion about its config the same way an applied one does, so its
+  // presence is asserted first. Both fields are validated by the engine at
+  // construction, not against any schema this overlay is checked by, so a wrong
+  // value is not something the product recovers from: it is `openAt is not
+  // supported` or `path must not be blank` thrown on the launch path. `!!js`
+  // rows arrive as source text, which is all a test can read; an expression
+  // naming no real helper is equally fatal and equally invisible until boot.
   test("displaces the upstream values that make session search useless", () => {
     const row = readProductPatch().find((entry) => entry.id === "session-query-sqlite")
 
     expect(row).toBeDefined()
     // `:memory:` is dropped on exit, so the sidebar could only ever match titles.
-    expect(row?.config?.path).not.toBe(":memory:")
+    expect(row?.config?.path).toMatch(/^dshHomePath\('[^']+'\)$/)
     // `never` makes the engine refuse full-text calls outright, and `startup`
-    // would make a user who never searches pay for SQLite anyway.
+    // would make a user who never searches pay for opening SQLite anyway.
     expect(row?.config?.openAt).toBe("first-search")
-  })
-
-  // Both fields are validated by the engine at construction rather than by a
-  // schema the overlay is checked against, so a typo here is not a wrong value
-  // the product recovers from — it is `openAt is not supported` or `path must
-  // not be blank` thrown on the launch path. `!!js` rows arrive as their source
-  // text, which is the only thing a test can read; an expression that names no
-  // real helper is equally fatal and equally invisible until boot.
-  test("names values and a helper the engine will accept", () => {
-    const config = readProductPatch().find((entry) => entry.id === "session-query-sqlite")?.config
-
-    expect(OPEN_AT).toContain(config?.openAt)
-    expect(config?.path).toMatch(/^dshHomePath\('[^']+'\)$/)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-session-search.test.ts
+++ b/packages/desktop-electron/src/main/dsh-session-search.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest"
+import { readProductPatch } from "./dsh-product-patch.testing"
+
+describe("PawWork DSH session search", () => {
+  // The row exists only to displace two upstream values, so those two values are
+  // what it guards. Asserting the replacements instead would just read the YAML
+  // back to itself; naming what must NOT be there survives a rewording of what is.
+  test("displaces the upstream values that make session search useless", () => {
+    const config = readProductPatch().find((entry) => entry.id === "session-query-sqlite")?.config
+
+    // `:memory:` is dropped on exit, so the sidebar could only ever match titles.
+    expect(config?.path).not.toBe(":memory:")
+    // `never` makes the engine refuse full-text calls outright.
+    expect(config?.openAt).not.toBe("never")
+    // …and `startup` would make a user who never searches pay for SQLite anyway.
+    expect(config?.openAt).not.toBe("startup")
+  })
+})

--- a/packages/desktop-electron/src/main/dsh-session-search.test.ts
+++ b/packages/desktop-electron/src/main/dsh-session-search.test.ts
@@ -1,18 +1,35 @@
 import { describe, expect, test } from "vitest"
 import { readProductPatch } from "./dsh-product-patch.testing"
 
+/** `openAt` values the engine accepts; anything else throws at boot. */
+const OPEN_AT = ["startup", "first-search", "never"]
+
 describe("PawWork DSH session search", () => {
   // The row exists only to displace two upstream values, so those two values are
-  // what it guards. Asserting the replacements instead would just read the YAML
-  // back to itself; naming what must NOT be there survives a rewording of what is.
+  // what it guards. But a row that is absent displaces nothing while answering
+  // every "is not" the same way an applied one does, so its presence is asserted
+  // before anything is asked about its contents.
   test("displaces the upstream values that make session search useless", () => {
+    const row = readProductPatch().find((entry) => entry.id === "session-query-sqlite")
+
+    expect(row).toBeDefined()
+    // `:memory:` is dropped on exit, so the sidebar could only ever match titles.
+    expect(row?.config?.path).not.toBe(":memory:")
+    // `never` makes the engine refuse full-text calls outright, and `startup`
+    // would make a user who never searches pay for SQLite anyway.
+    expect(row?.config?.openAt).toBe("first-search")
+  })
+
+  // Both fields are validated by the engine at construction rather than by a
+  // schema the overlay is checked against, so a typo here is not a wrong value
+  // the product recovers from — it is `openAt is not supported` or `path must
+  // not be blank` thrown on the launch path. `!!js` rows arrive as their source
+  // text, which is the only thing a test can read; an expression that names no
+  // real helper is equally fatal and equally invisible until boot.
+  test("names values and a helper the engine will accept", () => {
     const config = readProductPatch().find((entry) => entry.id === "session-query-sqlite")?.config
 
-    // `:memory:` is dropped on exit, so the sidebar could only ever match titles.
-    expect(config?.path).not.toBe(":memory:")
-    // `never` makes the engine refuse full-text calls outright.
-    expect(config?.openAt).not.toBe("never")
-    // …and `startup` would make a user who never searches pay for SQLite anyway.
-    expect(config?.openAt).not.toBe("startup")
+    expect(OPEN_AT).toContain(config?.openAt)
+    expect(config?.path).toMatch(/^dshHomePath\('[^']+'\)$/)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-web-fetch.test.ts
+++ b/packages/desktop-electron/src/main/dsh-web-fetch.test.ts
@@ -16,10 +16,10 @@ describe("PawWork web_fetch", () => {
     expect(providers.some((row) => row.name === "@deepseek-ai/dsh-web-fetch-http")).toBe(true)
   })
 
-  // The agent presets each mount their own scoped `tool-web` for `web_search`.
-  // Leaving search on here would register a second one into the global layer,
-  // resolved against whatever provider the host composition happens to hold
-  // rather than the preset's — a silently different search for the same name.
+  // The agent presets each mount their own scoped `tool-web`, and a scoped tool
+  // shadows a global one of the same name. Both resolve the same `web` service,
+  // so a second registration here would not search differently — it would be
+  // dead weight that also drops the preset's own 60s search timeout.
   test("leaves web_search to the preset that already owns it", () => {
     const tool = readProductPatch().find((entry) => entry.id === "tool-web")
 

--- a/packages/desktop-electron/src/main/dsh-web-fetch.test.ts
+++ b/packages/desktop-electron/src/main/dsh-web-fetch.test.ts
@@ -1,3 +1,4 @@
+import { LOCAL_FETCH_PROVIDER_ID } from "@deepseek-ai/dsh-web-fetch-http"
 import { describe, expect, test } from "vitest"
 import { readProductPatch } from "./dsh-product-patch.testing"
 
@@ -14,6 +15,12 @@ describe("PawWork web_fetch", () => {
     expect(tool?.disabled).toBe(false)
     expect(tool?.config?.fetch).toBe(true)
     expect(providers.some((row) => row.name === "@deepseek-ai/dsh-web-fetch-http")).toBe(true)
+    // The seam picks the sole registered provider when nothing names one, so an
+    // id that matches no provider fails only once a second one is mounted —
+    // which is also the moment it stops being obvious why fetches began failing.
+    expect(patch.find((entry) => entry.id === "web")?.config?.fetchProvider).toBe(
+      LOCAL_FETCH_PROVIDER_ID,
+    )
   })
 
   // The agent presets each mount their own scoped `tool-web`, and a scoped tool

--- a/packages/desktop-electron/src/main/dsh-web-fetch.test.ts
+++ b/packages/desktop-electron/src/main/dsh-web-fetch.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest"
+import { readProductPatch } from "./dsh-product-patch.testing"
+
+describe("PawWork web_fetch", () => {
+  // Two halves, and either one alone is a broken product: the tool without the
+  // provider answers `no usable web provider is registered` on every call, and
+  // the provider without the tool is a service nothing can reach. They sit in
+  // different rows of the same file, so nothing but this couples them.
+  test("mounts the tool and its provider together", () => {
+    const patch = readProductPatch()
+    const tool = patch.find((entry) => entry.id === "tool-web")
+    const providers = patch.flatMap((entry) => entry.insert ?? [])
+
+    expect(tool?.disabled).toBe(false)
+    expect(tool?.config?.fetch).toBe(true)
+    expect(providers.some((row) => row.name === "@deepseek-ai/dsh-web-fetch-http")).toBe(true)
+  })
+
+  // The agent presets each mount their own scoped `tool-web` for `web_search`.
+  // Leaving search on here would register a second one into the global layer,
+  // resolved against whatever provider the host composition happens to hold
+  // rather than the preset's — a silently different search for the same name.
+  test("leaves web_search to the preset that already owns it", () => {
+    const tool = readProductPatch().find((entry) => entry.id === "tool-web")
+
+    expect(tool?.config?.search).toBe(false)
+  })
+})

--- a/packages/desktop-electron/src/main/dsh-web-search-plugin.test.ts
+++ b/packages/desktop-electron/src/main/dsh-web-search-plugin.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs"
 import { createRequire } from "node:module"
 import { resolve } from "node:path"
 import { describe, expect, test, vi } from "vitest"
-import { DEFAULT_SCHEMA, Type, load } from "js-yaml"
+import { readEntryList, readProductPatch } from "./dsh-product-patch.testing"
 import {
   Config,
   PAWWORK_SEARCH_PROVIDER_ID,
@@ -13,18 +13,6 @@ import {
 } from "../../resources/dsh/web-search/lib/index.js"
 
 const webSearchRoot = resolve(import.meta.dirname, "../../resources/dsh/web-search")
-const patchFile = resolve(import.meta.dirname, "../../resources/dsh/home/product.cordis.patch.yml")
-
-type PatchRow = {
-  id?: string
-  disabled?: boolean
-  config?: Record<string, unknown>
-  insert?: Array<{ id: string; name: string }>
-}
-
-function readProductPatch() {
-  return load(readFileSync(patchFile, "utf8")) as PatchRow[]
-}
 
 /** A context exposing only the plane the provider reads: the credentials service. */
 function contextWith(credential?: string) {
@@ -113,19 +101,10 @@ describe("PawWork DSH web search plugin", () => {
     // Parsed, not scanned. A line scan reads an id out of a block scalar that
     // merely looks like one and misses a quoted or commented one, which is the
     // wrong way round for a guard: it would pass on a bump that renamed the row
-    // and fail on one that only reformatted it. The base profile serializes
-    // JavaScript expressions as `!!js`, so the loader is given a type for them
-    // rather than the whole document being given up on.
+    // and fail on one that only reformatted it. `readEntryList` is the same
+    // reader the product overlay goes through, `!!js` rows included.
     const baseProfile = createRequire(import.meta.url).resolve("@deepseek-ai/dsh-base/cordis.patch.yml")
-    const jsExpression = new Type("tag:yaml.org,2002:js", {
-      kind: "scalar",
-      resolve: () => true,
-      construct: (source: string) => source,
-    })
-    const patches = load(readFileSync(baseProfile, "utf8"), {
-      schema: DEFAULT_SCHEMA.extend([jsExpression]),
-    }) as Array<{ insert?: Array<{ id?: string; config?: Record<string, unknown> }> }>
-    const rows = patches.flatMap((patch) => patch.insert ?? [])
+    const rows = readEntryList(baseProfile).flatMap((patch) => patch.insert ?? [])
     const declared = new Set(rows.map((row) => row.id))
 
     expect(declared.size).toBeGreaterThan(1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@deepseek-ai/dsh-subprocess':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-time-context':
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(c1537a8836b04097f168b024f1e38d85))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(a4e4bb24a1f3580ac25e11cfa3c6b8cc))
       '@deepseek-ai/dsh-timeout':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@deepseek-ai/dsh-web':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))
+      '@deepseek-ai/dsh-web-fetch-http':
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-web@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))))
       '@deepseek-ai/dsh-web-search-deepseek':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(8e47c89c848a591c17689609bee09251)
@@ -2387,6 +2390,14 @@ packages:
       '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
       '@deepseek-ai/dsh-shell-env': ^0.1.1-rc.2
       '@deepseek-ai/dsh-system-prompt': ^0.1.1-rc.2
+
+  '@deepseek-ai/dsh-web-fetch-http@0.1.1-rc.2':
+    resolution: {integrity: sha512-yglE8/9S5CLZj1nsLmJQTassTFDxzy1KBNt9DFvmrw72nC9yL3wH0J9HkA7mUqS27LtY6QHazGCMBFOD82/IzA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-timeout': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-web': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-web-frontend@0.1.1-rc.2':
     resolution: {integrity: sha512-1cjf39g6RW7cgtvwhIF6MSnp5sk3KYRkmRhZM4GETWLXCrTfMD0WCJr3yME1uvJsYPTk28XmKXwwMUPrO3kksQ==}
@@ -9263,6 +9274,14 @@ snapshots:
       - react
       - react-dom
       - utf-8-validate
+
+  ? '@deepseek-ai/dsh-web-fetch-http@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-web@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))))'
+  : dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-timeout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-web': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))
+      '@deepseek-ai/schemastery': 3.18.1
 
   '@deepseek-ai/dsh-web-frontend@0.1.1-rc.2': {}
 


### PR DESCRIPTION
Stacked on #1606 — review that one first; this branch contains its commit.

Three capabilities the harness ships but the default composition leaves off. Each is one row of the product overlay, and each is its own commit.

## `web_fetch` (`1deb6cc`)

The model could search the web but never open a result, so it answered from titles and snippets.

Two halves are needed. `dsh-web-app` disables the dsh-base `tool-web` row outright because the agent presets each mount their own scoped one — so re-enabling it here puts `web_fetch` in the **global** tool layer, which every agent inherits regardless of which preset it composed from (`dsh-tools` `view(scope)` seeds `inherited` from `layers.global`). `search` stays off: each preset's own `tool-web` already provides `web_search` and shadows this row for that name. The other half is `dsh-web-fetch-http`, which dsh-base mounts nowhere — without it the tool exists and every call answers `no usable web provider is registered`.

That provider does not guard against SSRF: the model chooses the request target and private addresses are not blocked. This is deliberate and the overlay says so. A literal-IP denylist cannot be complete without resolving DNS first, and network reachability is the runtime's or the sandbox's policy to set — not a decision a content adapter should make, where it would also break a user behind a VPN or a proxied network.

## Session full-text search (`0602ff0`)

`dsh-base` indexes into `:memory:` with `openAt: never`, so the sidebar matched session titles and workspace names but nothing that was actually said. A durable file behind `openAt: first-search` makes the history searchable while a user who never searches never loads SQLite or opens a handle.

**The cost is a privacy one and it is real.** The FTS5 table is not contentless, so message text — including tool-call arguments and tool results — now lives on disk at rest, where before it only lived in the session log. The file is owner-only (0600) and **never shrinks**: deleting a session removes its rows without reclaiming the pages, and there is no vacuum, no retention window, and no UI to clear it. A ~125MB session history produced a ~23MB index in testing. If that trade is not the one we want, this commit is the one to drop — the other two do not depend on it.

## Time (`be3d989`)

Nothing told the model what time it is, so it could not date "the latest release" or read "next Tuesday" in the user's own zone. The 60s interval keeps a long session from carrying one reading per step while letting a turn that spans it get a fresh one.

## What this replaced

An earlier revision of this branch shipped a generated PawWork agent preset that `Include`d the upstream `standard` composition and patched its `tool-web` row, rewritten on every launch with an absolute path to the installed harness. That was built on a wrong premise — that host-plane tools do not reach agents. They do. Deleting the mechanism took two P0 defects with it: a `pathToFileURL` href interpolated into an unescaped single-quoted YAML scalar (any install path containing an apostrophe would have made every session fail to compose, with no fallback), and a nested `Include` holding a writable pointer into the signed app bundle, outside the `write()` no-op that upstream added to `PresetTree` for exactly that reason.

Both were found by an adversarial review of the earlier revision, and both are gone rather than fixed.

## Tests

The new tests assert the classes of failure these rows belong to, not the rows themselves:

- `dsh-product-mounts.test.ts` resolves every `@deepseek-ai/*` package the overlay inserts by bare name. That is the failure this branch actually hit during development: a name the harness cannot resolve takes the whole app down at boot with `Cannot find package`, and nothing before runtime says so. Version-literal assertions were considered and rejected — they restate `package.json` and go red on every routine bump.
- `dsh-session-search.test.ts` asserts the three upstream values the row exists to displace (`:memory:`, `never`, `startup`) rather than reading its own replacements back.
- `dsh-web-fetch.test.ts` couples the two halves, since either alone is a broken product and nothing else in the file relates them.
- `dsh-product-patch.testing.ts` is a shared reader carrying the `!!js` dialect `dsh-app-boot` parses the overlay with; the overlay gains its first `!!js` row here, which the plain js-yaml default schema rejects.

## Verification

Real Electron app, dev channel, under the stock `standard` preset with no PawWork preset present:

- `web_fetch` returned `https://example.com` and the model quoted its heading; `web_search` was still available in the same turn.
- Searching the sidebar for a phrase appearing only in a message body returned that session with a snippet from the body; `session-query.sqlite` appears on the first search, not at startup.
- `time-context` shows in every session's context injections.

`pnpm typecheck`, `pnpm lint`, 423 vitest tests, and the node test suite pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP-powered web fetching, with webpage retrieval enabled while web search remains unchanged.
  * Added durable session search indexing, initialized when the first search is performed.
  * Added time context support with automatic updates every 60 seconds.
* **Improvements**
  * Improved product configuration reliability and validation for web fetching, session search, and time context features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->