### PR TITLE
chore(release): prepare 2026.8.8

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.8.7",
+  "version": "2026.8.8",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
## Summary

- bump the desktop release version from `2026.8.7` to `2026.8.8`

## Why

- prepare the next desktop release after the package trimming, unpinned Community Market, Automations editor, keyless web search, session search/time context, and Windows directory-picker fixes landed

## How To Verify

- typecheck, lint, Vitest (452), DSH Node tests (125), label policy (10)
- built unsigned production-channel macOS arm64 DMG/ZIP as `2026.8.8`
- raw and packaged production CDP smoke, including V1 migration, Automations, layout, persistence, and restart
- packaged real-agent smoke for keyless `web_search`, `web_fetch`, current-time context, and `session.search`
- clean-profile Community Market install, restart activation, and Settings UI verification
- exact-head GitHub CI: macOS arm64/x64, Windows x64, and packaged desktop smoke

## Risk

- low: the code change only updates desktop package metadata; release behavior was verified from the built `2026.8.8` production package