### PR TITLE
fix(desktop): retry OpenCode catalog refresh after startup failures

### DIFF
--- a/packages/desktop-electron/resources/dsh/product/lib/index.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/index.js
@@ -16,6 +16,7 @@ export const inject = ['settings', 'timer', 'agentDefaultModel', 'subprocess', '
 // without a PawWork release; the cadence balances freshness against the one
 // cheap GET per sweep and the (no-op when unchanged) settings write.
 const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+const STARTUP_RETRY_DELAYS_MS = [60 * 1000, 5 * 60 * 1000];
 
 function runRefresh(ctx, controller) {
 	return refreshOpenCodeFreeModels({
@@ -30,6 +31,17 @@ function runRefresh(ctx, controller) {
 			`OpenCode Free catalog refresh failed: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	});
+}
+
+async function runStartupRefresh(ctx, controller, retryIndex = 0) {
+	const refreshed = await runRefresh(ctx, controller);
+	if (refreshed !== undefined || controller.signal.aborted) return;
+	const delay = STARTUP_RETRY_DELAYS_MS[retryIndex];
+	if (delay === undefined) return;
+	ctx.setTimeout(
+		() => void runStartupRefresh(ctx, controller, retryIndex + 1),
+		delay,
+	);
 }
 
 export function apply(ctx) {
@@ -60,8 +72,9 @@ export function apply(ctx) {
 
 	const controller = new AbortController();
 	// Immediate refresh so a fresh launch picks up the current catalog right
-	// away, then periodic sweeps to follow upstream as it changes.
-	void runRefresh(ctx, controller);
+	// away. Retry transient startup failures twice before falling back to the
+	// normal periodic sweep.
+	void runStartupRefresh(ctx, controller);
 	ctx.interval(() => runRefresh(ctx, controller), REFRESH_INTERVAL_MS);
 	ctx.effect(() => () => controller.abort(new Error('PawWork product stopped')));
 }

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -311,12 +311,81 @@ test('product lifecycle immediately refreshes the runtime catalog through settin
 				assert.equal(typeof callback, 'function');
 				assert.equal(milliseconds, 60 * 60 * 1000);
 			},
+			setTimeout() { assert.fail('a successful startup refresh must not schedule a retry'); },
 			effect(register) { dispose = register(); },
 		});
 		await wrote;
 		assert.equal(writes.length, 1);
 		assert.equal(writes[0].revision, 0);
 		assert.deepEqual(writtenModels(writes[0]), [{ id: 'live-free', contextWindow: 190000, maxTokens: 64000 }]);
+	} finally {
+		dispose?.();
+		globalThis.fetch = originalFetch;
+		for (const [name, value] of Object.entries(previousEnvironment)) {
+			if (value === undefined) delete process.env[name];
+			else process.env[name] = value;
+		}
+	}
+});
+
+test('product lifecycle retries a failed startup refresh after one and five minutes', { timeout: 2000 }, async (t) => {
+	const originalFetch = globalThis.fetch;
+	const home = fs.mkdtempSync(path.join(os.tmpdir(), 'pawwork-product-retry-'));
+	const profileDir = path.join(home, 'profiles', 'web');
+	fs.mkdirSync(profileDir, { recursive: true });
+	t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+	fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
+		dependencies: {},
+		dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } },
+	}));
+	const hostEnvironment = {
+		PAWWORK_DSH_BIN: '/app/dsh/bin.js',
+		DSH_HOME: home,
+		PAWWORK_NODE_EXECUTABLE: '/app/PawWork',
+		PAWWORK_HOST_TOKEN: 'test-host-token',
+	};
+	const previousEnvironment = Object.fromEntries(
+		Object.keys(hostEnvironment).map((name) => [name, process.env[name]]),
+	);
+	Object.assign(process.env, hostEnvironment);
+	let attempts = 0;
+	let dispose;
+	const scheduled = [];
+	globalThis.fetch = async () => {
+		attempts += 1;
+		throw new Error('network down');
+	};
+	try {
+		const { apply } = await import('./index.js');
+		const value = { providers: { opencode: { models: [{ id: 'packaged-free' }] } } };
+		apply({
+			settings: {
+				get: (ns) => ns === 'llm-pi-ai' ? value : undefined,
+				describe: () => [{ ns: 'llm-pi-ai', value, revision: 0 }],
+				async mutate() { throw new Error('unexpected settings write'); },
+			},
+			agentDefaultModel: { currentSelection: () => ({ provider: 'opencode', model: 'live-free' }) },
+			provide() {},
+			subprocess: { spawn() { throw new Error('unexpected plugin operation'); } },
+			webServer: { register() { return () => {}; } },
+			logger: { info() {}, warn() {} },
+			interval() {},
+			setTimeout(callback, milliseconds) { scheduled.push({ callback, milliseconds }); },
+			effect(register) { dispose = register(); },
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(attempts, 1);
+		assert.equal(scheduled[0]?.milliseconds, 60 * 1000);
+
+		scheduled[0].callback();
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(attempts, 2);
+		assert.equal(scheduled[1]?.milliseconds, 5 * 60 * 1000);
+
+		scheduled[1].callback();
+		await new Promise((resolve) => setImmediate(resolve));
+		assert.equal(attempts, 3);
+		assert.equal(scheduled.length, 2);
 	} finally {
 		dispose?.();
 		globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary

- retry a failed OpenCode Free catalog refresh after 1 minute and again after 5 minutes
- stop startup retries as soon as a refresh succeeds
- preserve the existing hourly refresh and packaged offline fallback

## Testing

- `pnpm --filter @pawwork/desktop test`
- `pnpm --filter @pawwork/desktop typecheck`
- `pnpm exec eslint packages/desktop-electron/resources/dsh/product/lib/index.js packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup data refresh reliability by automatically retrying transient failures.
  * Retries occur after one minute and five minutes before returning to the regular refresh schedule.
  * Successful startup refreshes no longer trigger unnecessary retry scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->