### PR TITLE
fix(desktop): stop killing a slow DSH start

### DIFF
--- a/.github/workflows/repro-1614.yml
+++ b/.github/workflows/repro-1614.yml
@@ -1,0 +1,213 @@
+# Reproduction harness for #1614: PawWork v2 never finishes starting on Windows
+# after an update from v1, with the DSH sidecar producing no output at all
+# before the 30s readiness timeout.
+#
+# ci.yml already installs and smokes a freshly packaged v2 on windows-latest and
+# passes, so a clean install is not the trigger. The only thing the reporter's
+# log has that CI does not is pre-existing v1 state under
+# %APPDATA%\ai.pawwork.desktop, which v2 renames into ~\.pawwork\dsh on first
+# run. This workflow runs both halves of that comparison so the difference is
+# attributable rather than assumed.
+#
+# PAWWORK_CI_SMOKE=true is set for the launch (but NOT PAWWORK_CI_SMOKE_HOME, so
+# every path stays the real user-profile path a shipped install would use). It
+# only changes two things that matter here: the startup failure exits the
+# process instead of opening a modal dialog that would hang the runner, and a
+# successful start writes ci-smoke-ready.json we can poll for.
+#
+# Neither leg fails the job on a reproduction - both always upload their logs,
+# and the verdict goes to the run summary.
+name: repro-1614
+
+on:
+  workflow_dispatch:
+    inputs:
+      baseline_version:
+        description: v1 version installed first (upgrade leg only)
+        default: "2026.8.5"
+      target_version:
+        description: v2 version under test
+        default: "2026.8.8"
+  push:
+    branches: [debug/1614-windows-upgrade-repro]
+
+permissions:
+  contents: read
+
+jobs:
+  repro:
+    name: ${{ matrix.scenario }}
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [clean, upgrade]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      GH_TOKEN: ${{ github.token }}
+      SCENARIO: ${{ matrix.scenario }}
+      BASELINE_VERSION: ${{ inputs.baseline_version || '2026.8.5' }}
+      TARGET_VERSION: ${{ inputs.target_version || '2026.8.8' }}
+      # app-identity.ts pins userData to <appData>\<appId> regardless of
+      # productName, which is why the reporter's log shows ai.pawwork.desktop.
+      APP_ID: ai.pawwork.desktop
+    steps:
+      - name: Resolve paths
+        run: |
+          $evidence = "$env:RUNNER_TEMP\evidence"
+          New-Item -ItemType Directory -Force -Path $evidence, "$env:RUNNER_TEMP\installers" | Out-Null
+          $userData = "$env:APPDATA\$env:APP_ID"
+          @(
+            "EVIDENCE_DIR=$evidence",
+            "USER_DATA=$userData",
+            "MAIN_LOG=$userData\logs\main.log",
+            "DSH_HOME=$env:USERPROFILE\.pawwork"
+          ) | Add-Content $env:GITHUB_ENV
+
+      - name: Download installers
+        run: |
+          $dir = "$env:RUNNER_TEMP\installers"
+          gh release download "v$env:TARGET_VERSION" -R Astro-Han/pawwork -D $dir `
+            -p "pawwork-win-x64-$env:TARGET_VERSION.exe"
+          if ($env:SCENARIO -eq 'upgrade') {
+            gh release download "v$env:BASELINE_VERSION" -R Astro-Han/pawwork -D $dir `
+              -p "pawwork-win-x64-$env:BASELINE_VERSION.exe"
+          }
+          Get-ChildItem $dir | Format-Table Name, Length
+
+      # /allusers matches the reporter, whose app.asar resolved under
+      # C:\Program Files\PawWork. The default silent install is per-user, so
+      # leaving it off would test a different install root than the report.
+      - name: Install v1 baseline
+        if: matrix.scenario == 'upgrade'
+        run: |
+          $installer = "$env:RUNNER_TEMP\installers\pawwork-win-x64-$env:BASELINE_VERSION.exe"
+          Start-Process -FilePath $installer -ArgumentList '/S','/allusers' -Wait
+          Get-ChildItem 'C:\Program Files' -Filter '*PawWork*' | Format-Table FullName
+
+      # v1 has to actually run once: the whole question is what state it leaves
+      # behind for v2 to migrate. An install alone writes no user data.
+      - name: Run v1 once to lay down real state
+        if: matrix.scenario == 'upgrade'
+        run: |
+          $exe = Get-ChildItem 'C:\Program Files' -Recurse -Depth 2 -Filter '*.exe' -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match 'PawWork' -and $_.Name -notmatch 'Uninstall' } |
+            Select-Object -First 1
+          if (-not $exe) { throw "v1 executable not found after install" }
+          "v1 executable: $($exe.FullName)"
+          $proc = Start-Process -FilePath $exe.FullName -PassThru
+          Start-Sleep -Seconds 90
+          Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+          Start-Sleep -Seconds 5
+          Get-Process -Name 'PawWork*' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+      # Recorded before v2 touches anything: this is what tells us whether v1
+      # even creates the <userData>\dsh directory the reporter's migration
+      # renamed, or whether that legacy home came from somewhere else.
+      - name: Snapshot pre-upgrade state
+        if: matrix.scenario == 'upgrade'
+        run: |
+          $out = "$env:EVIDENCE_DIR\pre-upgrade-state.txt"
+          "== $env:USER_DATA ==" | Set-Content $out
+          Get-ChildItem $env:USER_DATA -Recurse -Depth 3 -ErrorAction SilentlyContinue |
+            Select-Object FullName, Length | Out-String | Add-Content $out
+          "== $env:DSH_HOME ==" | Add-Content $out
+          Get-ChildItem $env:DSH_HOME -Recurse -Depth 3 -ErrorAction SilentlyContinue |
+            Select-Object FullName, Length | Out-String | Add-Content $out
+          Copy-Item $env:MAIN_LOG "$env:EVIDENCE_DIR\v1-main.log" -ErrorAction SilentlyContinue
+          Get-Content $out | Select-Object -First 60
+
+      - name: Install v2 under test
+        run: |
+          $installer = "$env:RUNNER_TEMP\installers\pawwork-win-x64-$env:TARGET_VERSION.exe"
+          Start-Process -FilePath $installer -ArgumentList '/S','/allusers' -Wait
+          $exe = Get-ChildItem 'C:\Program Files' -Recurse -Depth 2 -Filter '*.exe' -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match 'PawWork' -and $_.Name -notmatch 'Uninstall' } |
+            Select-Object -First 1
+          if (-not $exe) { throw "v2 executable not found after install" }
+          "V2_EXE=$($exe.FullName)" | Add-Content $env:GITHUB_ENV
+
+      # The reporter's log cannot distinguish "sidecar never spawned" from
+      # "sidecar spawned and hung", because index.ts forwards both stdout and
+      # stderr to the logger and neither produced a line. Sampling the process
+      # table during the wait answers that directly.
+      - name: Launch v2 and watch for the sidecar
+        run: |
+          $procLog = "$env:EVIDENCE_DIR\process-samples.txt"
+          $readyFile = "$env:USER_DATA\ci-smoke-ready.json"
+          Remove-Item $readyFile -ErrorAction SilentlyContinue
+          Remove-Item $env:MAIN_LOG -ErrorAction SilentlyContinue
+
+          $sampler = Start-Job -ArgumentList $procLog -ScriptBlock {
+            param($out)
+            1..90 | ForEach-Object {
+              $stamp = (Get-Date).ToString('HH:mm:ss.fff')
+              $rows = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -match 'PawWork|node' -or $_.CommandLine -match 'dsh' } |
+                ForEach-Object { "$stamp pid=$($_.ProcessId) ppid=$($_.ParentProcessId) $($_.Name) :: $($_.CommandLine)" }
+              if ($rows) { $rows | Add-Content $out }
+              Start-Sleep -Seconds 2
+            }
+          }
+
+          $env:PAWWORK_CI_SMOKE = 'true'
+          $proc = Start-Process -FilePath $env:V2_EXE -PassThru
+          $deadline = (Get-Date).AddSeconds(180)
+          $verdict = 'timeout-waiting-for-app'
+          while ((Get-Date) -lt $deadline) {
+            if (Test-Path $readyFile) { $verdict = 'ready'; break }
+            if ($proc.HasExited) { $verdict = "exited-code-$($proc.ExitCode)"; break }
+            Start-Sleep -Seconds 2
+          }
+          Stop-Job $sampler -ErrorAction SilentlyContinue
+          Receive-Job $sampler -ErrorAction SilentlyContinue | Out-Null
+          Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+          Get-Process -Name 'PawWork*' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+          "LAUNCH_VERDICT=$verdict" | Add-Content $env:GITHUB_ENV
+
+      - name: Collect evidence
+        if: always()
+        run: |
+          Copy-Item $env:MAIN_LOG "$env:EVIDENCE_DIR\v2-main.log" -ErrorAction SilentlyContinue
+          $out = "$env:EVIDENCE_DIR\post-upgrade-state.txt"
+          "== $env:USER_DATA ==" | Set-Content $out
+          Get-ChildItem $env:USER_DATA -Recurse -Depth 3 -ErrorAction SilentlyContinue |
+            Select-Object FullName, Length | Out-String | Add-Content $out
+          "== $env:DSH_HOME ==" | Add-Content $out
+          Get-ChildItem $env:DSH_HOME -Recurse -Depth 3 -ErrorAction SilentlyContinue |
+            Select-Object FullName, Length | Out-String | Add-Content $out
+
+      - name: Report verdict
+        if: always()
+        run: |
+          $log = "$env:EVIDENCE_DIR\v2-main.log"
+          $text = if (Test-Path $log) { Get-Content $log -Raw } else { '' }
+          $stalled = $text -match 'did not announce readiness'
+          $migrated = [regex]::Match($text, 'DSH home migrated[^\}]*\}').Value
+          $sidecarOutput = ($text -split "`n" | Where-Object { $_ -match 'DSH std(out|err)' }).Count
+
+          $lines = @(
+            "## $env:SCENARIO",
+            '',
+            "- launch verdict: ``$env:LAUNCH_VERDICT``",
+            "- readiness timeout hit: **$stalled**",
+            "- DSH stdout/stderr lines before the verdict: **$sidecarOutput**",
+            "- migration: ``$(if ($migrated) { $migrated } else { 'none logged' })``"
+          )
+          if ($stalled) {
+            $lines += '', '**#1614 reproduced.** See process-samples.txt in the artifact for whether the sidecar process ever existed.'
+          }
+          $lines | Add-Content $env:GITHUB_STEP_SUMMARY
+          $lines | Write-Host
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: repro-1614-${{ matrix.scenario }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: warn
+          retention-days: 7

--- a/packages/desktop-electron/src/main/dsh-lifecycle.test.ts
+++ b/packages/desktop-electron/src/main/dsh-lifecycle.test.ts
@@ -102,27 +102,34 @@ describe("DshLifecycle", () => {
     expect(states.map((state) => state.phase)).toEqual(["starting", "loading", "ready"])
   })
 
-  test("fails when the product tree never becomes ready", async () => {
+  // A product tree that is slow to commit is still loading, not broken: the
+  // window is already showing it, and giving up would close a session that was
+  // about to open. Report it and keep waiting (#1614).
+  test("keeps loading when the product tree is slow to become ready", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] })
     const spawned = run()
+    let slowCalls = 0
     const lifecycle = new DshLifecycle({
       launch: () => spawned.sidecar,
       onChange: () => {},
+      onSlowProduct: () => {
+        slowCalls += 1
+      },
     })
 
     lifecycle.start()
     spawned.ready.resolve("http://127.0.0.1:43123")
     await vi.advanceTimersByTimeAsync(30_000)
 
-    expect(spawned.stop).toHaveBeenCalledTimes(1)
-    expect(lifecycle.state).toMatchObject({
-      phase: "failed",
-      reason: "startup",
-      error: new Error("DSH product did not become ready within 30000ms"),
-    })
+    expect(slowCalls).toBe(1)
+    expect(spawned.stop).not.toHaveBeenCalled()
+    expect(lifecycle.state.phase).toBe("loading")
+
+    lifecycle.productReady("http://127.0.0.1:43123/session/new")
+    expect(lifecycle.state.phase).toBe("ready")
   })
 
-  test("stopping product loading cancels its deadline", async () => {
+  test("stopping product loading cancels its slow report", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] })
     const spawned = run()
     const lifecycle = new DshLifecycle({

--- a/packages/desktop-electron/src/main/dsh-lifecycle.ts
+++ b/packages/desktop-electron/src/main/dsh-lifecycle.ts
@@ -15,15 +15,20 @@ type DshTerminalState = Extract<DshLifecycleState, { phase: "stopped" | "failed"
 type DshLifecycleOptions = {
   launch(): DshRun
   onChange(state: DshLifecycleState): void
+  // Fired once per start when the runtime is up but the product UI has not
+  // reported in yet. Informational, like the sidecar's own slow signal: a
+  // window that has to load the whole product plus its plugins can outlast any
+  // deadline worth guessing, and the guess is not worth an unusable app.
+  onSlowProduct?(): void
 }
 
-const PRODUCT_TIMEOUT_MS = 30_000
+const PRODUCT_SLOW_AFTER_MS = 30_000
 
 export class DshLifecycle {
   #state: DshLifecycleState = { phase: "stopped" }
   #run: DshRun | undefined
   #stopping: { promise: Promise<void>; terminal: DshTerminalState } | undefined
-  #productTimeout: ReturnType<typeof setTimeout> | undefined
+  #productSlowTimer: ReturnType<typeof setTimeout> | undefined
 
   constructor(private readonly options: DshLifecycleOptions) {}
 
@@ -53,9 +58,10 @@ export class DshLifecycle {
       (url) => {
         if (this.#run !== run) return
         this.#publish({ phase: "loading", url })
-        this.#productTimeout = setTimeout(() => {
-          void this.#fail(run, "startup", new Error(`DSH product did not become ready within ${PRODUCT_TIMEOUT_MS}ms`))
-        }, PRODUCT_TIMEOUT_MS)
+        this.#productSlowTimer = setTimeout(() => {
+          if (this.#run !== run) return
+          this.options.onSlowProduct?.()
+        }, PRODUCT_SLOW_AFTER_MS)
       },
       (error) => void this.#fail(run, "startup", error),
     )
@@ -72,7 +78,7 @@ export class DshLifecycle {
     } catch {
       return
     }
-    this.#clearProductTimeout()
+    this.#clearProductSlowTimer()
     this.#publish({ phase: "ready", url: this.#state.url })
   }
 
@@ -91,7 +97,7 @@ export class DshLifecycle {
 
   #finish(run: DshRun | undefined, terminal: DshTerminalState) {
     this.#run = undefined
-    this.#clearProductTimeout()
+    this.#clearProductSlowTimer()
     const stopping = { promise: Promise.resolve(), terminal }
     stopping.promise = Promise.resolve()
       .then(() => run?.stop())
@@ -104,10 +110,10 @@ export class DshLifecycle {
     return stopping.promise
   }
 
-  #clearProductTimeout() {
-    if (this.#productTimeout === undefined) return
-    clearTimeout(this.#productTimeout)
-    this.#productTimeout = undefined
+  #clearProductSlowTimer() {
+    if (this.#productSlowTimer === undefined) return
+    clearTimeout(this.#productSlowTimer)
+    this.#productSlowTimer = undefined
   }
 
   #publish(state: DshLifecycleState) {

--- a/packages/desktop-electron/src/main/dsh-sidecar.test.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.test.ts
@@ -58,7 +58,7 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: { PATH: "/app/tools:/usr/bin", DSH_HOME: "/data/dsh", ELECTRON_RUN_AS_NODE: "1" },
-      timeoutMs: 100,
+      slowAfterMs: 100,
       spawn: (executable, args, options) => {
         invocation = { executable, args, options }
         return child
@@ -103,7 +103,7 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
+      slowAfterMs: 100,
       spawn: () => child,
     })
 
@@ -126,7 +126,7 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: { PATH: "/usr/bin" },
-      timeoutMs: 500,
+      slowAfterMs: 500,
       spawn: () => child,
     })
 
@@ -149,7 +149,7 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
+      slowAfterMs: 100,
       spawn: () => child,
     })
 
@@ -166,7 +166,7 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
+      slowAfterMs: 100,
       spawn: () => child,
     })
 
@@ -187,7 +187,7 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
+      slowAfterMs: 100,
       spawn: () => child,
       onError: (error) => errors.push(error),
     })
@@ -202,45 +202,53 @@ describe("DSH sidecar lifecycle", () => {
     expect([child.messages, child.killSignals]).toEqual([[], []])
   })
 
-  test("force-terminates the owned child process when readiness times out", async () => {
+  // #1614: DSH is silent until its ready line, so a slow start is
+  // indistinguishable from a wedged one from the outside. Killing on a deadline
+  // turned installs that were merely slow into an app that could never open.
+  test("keeps waiting on a silent child instead of killing it, and says it is slow", async () => {
     const child = new FakeChildProcess()
-    child.gracefulExit = false
+    let slowCalls = 0
     const launched = launchDshSidecar({
       executable: "/app/PawWork",
       dshBin: "/app/dsh.js",
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 1,
-      stopTimeoutMs: 1,
+      slowAfterMs: 1,
       spawn: () => child,
+      onSlow: () => {
+        slowCalls += 1
+      },
     })
 
-    await expect(launched.ready).rejects.toThrow("DSH did not announce readiness within 1ms")
-    await launched.exited
-    expect(child.messages).toEqual(["SIGTERM"])
-    expect(child.killSignals).toEqual(["SIGKILL"])
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(slowCalls).toBe(1)
+    expect([child.messages, child.killSignals]).toEqual([[], []])
+
+    child.stdout.write("dsh web: http://127.0.0.1:4321\n")
+    await expect(launched.ready).resolves.toBe("http://127.0.0.1:4321")
   })
 
-  test("reports a readiness timeout before the resulting process exit", async () => {
+  test("does not report slowness once the child is already ready", async () => {
     const child = new FakeChildProcess()
+    let slowCalls = 0
     const launched = launchDshSidecar({
       executable: "/app/PawWork",
       dshBin: "/app/dsh.js",
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 1,
+      slowAfterMs: 10,
       spawn: () => child,
+      onSlow: () => {
+        slowCalls += 1
+      },
     })
-    const outcomes: string[] = []
 
-    await Promise.all([
-      launched.ready.catch((error: Error) => outcomes.push(error.message)),
-      launched.exited.then(() => outcomes.push("exited")),
-    ])
-
-    expect(outcomes).toEqual(["DSH did not announce readiness within 1ms", "exited"])
+    child.stdout.write("dsh web: http://127.0.0.1:4321\n")
+    await launched.ready
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(slowCalls).toBe(0)
   })
 
   test("stops the owned child process once across concurrent and repeated calls", async () => {
@@ -251,7 +259,7 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
+      slowAfterMs: 100,
       spawn: () => child,
     })
     child.stdout.write("dsh web: http://127.0.0.1:43123\n")
@@ -277,7 +285,7 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
+      slowAfterMs: 100,
       stopTimeoutMs: 1,
       spawn: () => child,
     })

--- a/packages/desktop-electron/src/main/dsh-sidecar.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.ts
@@ -31,12 +31,13 @@ type LaunchDshSidecarOptions = {
   sidecarPreload: string
   productPatch: string
   env: NodeJS.ProcessEnv
-  timeoutMs: number
+  slowAfterMs: number
   stopTimeoutMs?: number
   spawn: SpawnDshProcess
   onStdout?: (chunk: string) => void
   onStderr?: (chunk: string) => void
   onError?: (error: Error) => void
+  onSlow?: () => void
 }
 
 export type DshRun = {
@@ -88,7 +89,7 @@ export function launchDshSidecar(options: LaunchDshSidecarOptions): DshRun {
   let stdoutBuffer = ""
   let settled = false
   let stopping: Promise<void> | undefined
-  let timeout: ReturnType<typeof setTimeout> | undefined
+  let slowTimer: ReturnType<typeof setTimeout> | undefined
   let rejectReady!: (error: Error) => void
   const stopTimeoutMs = options.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS
 
@@ -104,7 +105,7 @@ export function launchDshSidecar(options: LaunchDshSidecarOptions): DshRun {
   }
 
   const cleanupReadiness = () => {
-    if (timeout !== undefined) clearTimeout(timeout)
+    if (slowTimer !== undefined) clearTimeout(slowTimer)
     child.stdout?.off("data", onStdout)
     child.off("exit", onEarlyExit)
   }
@@ -180,9 +181,14 @@ export function launchDshSidecar(options: LaunchDshSidecarOptions): DshRun {
   child.once("exit", onEarlyExit)
   child.on("error", onSpawnError)
 
-  timeout = setTimeout(() => {
-    void fail(new Error(`DSH did not announce readiness within ${options.timeoutMs}ms`), true)
-  }, options.timeoutMs)
+  // DSH prints nothing at all until the ready line, so elapsed silence carries
+  // no information about whether it is wedged or merely slow — a first launch
+  // behind an antivirus scan of the freshly unpacked runtime looks exactly like
+  // a hang. Treating a deadline as failure here only ever killed installs that
+  // were about to succeed (#1614). The failures that are real announce
+  // themselves: the process exits, or the spawn errors. This timer just says
+  // "still going" so the window can stop pretending nothing is happening.
+  slowTimer = setTimeout(() => options.onSlow?.(), options.slowAfterMs)
 
   return { ready, exited, stop: stopProcess }
 }

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -63,6 +63,10 @@ if (process.platform === "darwin") {
 const CI_SMOKE_HOME = process.env.PAWWORK_CI_SMOKE_HOME
 const CI_SMOKE_ENABLED = process.env.PAWWORK_CI_SMOKE === "true"
 const UPDATE_FEED_TIMEOUT_MS = 10_000
+// How long a start may run before the window stops looking like a plain
+// spinner and says it is still working. Not a deadline: nothing is cancelled
+// when it passes.
+const DSH_SLOW_AFTER_MS = 30_000
 // Silent re-check cadence while the app runs: frequent enough that users who
 // never quit pick up a release the same day, sparse enough to stay noise-free.
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
@@ -109,7 +113,14 @@ let startupColorScheme: StartupColorScheme | undefined = readStartupColorScheme(
 let currentProgress: number | null = null
 const dshHostToken = randomUUID()
 
-const lifecycle = new DshLifecycle({ launch: launchDsh, onChange: handleLifecycleChange })
+const lifecycle = new DshLifecycle({
+  launch: launchDsh,
+  onChange: handleLifecycleChange,
+  // Log only. By this point the window is already loading the product page, and
+  // navigating it back to the startup page to show a note would abort the very
+  // load being waited on.
+  onSlowProduct: () => logger.warn("DSH product still loading"),
+})
 
 function buildUpdateFeeds(): FeedTarget[] {
   return [
@@ -372,8 +383,9 @@ function dshUrl() {
   return lifecycle.url
 }
 
-function showStartupPage() {
-  for (const win of liveWindows()) navigateWindow(win, startupUrl(startupColorScheme))
+function showStartupPage(slow = false) {
+  const locale = slow ? menuLocale : undefined
+  for (const win of liveWindows()) navigateWindow(win, startupUrl(startupColorScheme, locale))
 }
 
 async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed" }>) {
@@ -557,7 +569,11 @@ function launchDsh() {
     sidecarPreload: pathToFileURL(product.sidecarPreload).href,
     productPatch: product.patch,
     env: environment,
-    timeoutMs: 30_000,
+    slowAfterMs: DSH_SLOW_AFTER_MS,
+    onSlow: () => {
+      logger.warn("DSH runtime still starting", { afterMs: DSH_SLOW_AFTER_MS })
+      showStartupPage(true)
+    },
     spawn: (executable, args, options) => spawn(executable, args, options),
     onStdout: (chunk) => logger.log("DSH stdout", { chunk: chunk.trimEnd() }),
     onStderr: (chunk) => {

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -13,21 +13,36 @@ const root = dirname(fileURLToPath(import.meta.url))
 // disagrees with their OS. `scheme` is the last appearance the product
 // published; the media query stays as the answer for the very first launch,
 // when there is nothing remembered yet.
-const startupHtml = (scheme?: StartupColorScheme) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
-:root{--bg:#fff;--line:#e3e3e7;--accent:#fc5c14}${scheme === undefined
-  ? "@media(prefers-color-scheme:dark){:root{--bg:#191919;--line:#2d2d31}}"
-  : scheme === "dark" ? ":root{--bg:#191919;--line:#2d2d31}" : ""}
-html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);display:flex;justify-content:center}
+// Shown once a start has already run long enough to look stuck. It is not an
+// error: a first launch after an update can spend minutes unpacking and being
+// scanned before the runtime says anything at all, and the app used to give up
+// on those installs (#1614). Saying so beats a spinner that reads as a hang.
+const SLOW_NOTE = {
+  en: "Still starting. The first launch after an update can take a few minutes.",
+  zh: "仍在启动。更新后的首次启动可能需要几分钟。",
+} as const
+
+export type StartupLocale = keyof typeof SLOW_NOTE
+
+const startupHtml = (scheme?: StartupColorScheme, slowNote?: string) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
+:root{--bg:#fff;--line:#e3e3e7;--accent:#fc5c14;--note:#6b6b70}${scheme === undefined
+  ? "@media(prefers-color-scheme:dark){:root{--bg:#191919;--line:#2d2d31;--note:#9a9aa0}}"
+  : scheme === "dark" ? ":root{--bg:#191919;--line:#2d2d31;--note:#9a9aa0}" : ""}
+html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);display:flex;flex-direction:column;gap:16px;justify-content:center}
 .titlebar{-webkit-app-region:drag;height:var(--pawwork-titlebar-host-height,env(titlebar-area-height,0px));left:0;position:fixed;right:0;top:0}
 .spinner{animation:spin .8s linear infinite;border:2px solid var(--line);border-radius:50%;box-sizing:border-box;height:20px;position:relative;width:20px}
 .spinner:after{background:conic-gradient(var(--accent) 72deg,transparent 0);border-radius:inherit;content:"";inset:-2px;mask:radial-gradient(farthest-side,transparent calc(100% - 2px),#000 0);position:absolute;-webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 2px),#000 0)}
+.note{color:var(--note);font:13px/1.5 system-ui,-apple-system,"Segoe UI",sans-serif;margin:0;max-width:28em;padding:0 24px;text-align:center}
 @keyframes spin{to{transform:rotate(360deg)}}@media(prefers-reduced-motion:reduce){.spinner{animation:none}}
-</style></head><body><div class="titlebar"></div><div aria-label="PawWork is starting" class="spinner" role="progressbar"></div></body></html>`
+</style></head><body><div class="titlebar"></div><div aria-label="PawWork is starting" class="spinner" role="progressbar"></div>${
+  slowNote === undefined ? "" : `<p class="note">${slowNote}</p>`
+}</body></html>`
 
 export type StartupColorScheme = "dark" | "light"
 
-export function startupUrl(scheme?: StartupColorScheme) {
-  return `data:text/html;charset=utf-8,${encodeURIComponent(startupHtml(scheme))}`
+export function startupUrl(scheme?: StartupColorScheme, slowLocale?: StartupLocale) {
+  const html = startupHtml(scheme, slowLocale === undefined ? undefined : SLOW_NOTE[slowLocale])
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
 }
 
 function iconsDir() {


### PR DESCRIPTION
Closes #1614.

## What was wrong

DSH prints nothing at all until its ready line, so elapsed silence carries no information about whether the runtime is wedged or merely slow. Both startup deadlines read that silence as failure:

- `dsh-sidecar.ts` force-terminated the runtime 30s after spawn
- `dsh-lifecycle.ts` failed the start 30s after the product page began loading

On a first launch that is still unpacking behind an antivirus scan, that converts a start which was about to succeed into an app that can never open. The reporter's log is the whole story:

```
[00:05:18] spawning DSH sidecar
[00:05:49] DSH lifecycle failed: DSH did not announce readiness within 30000ms
```

Thirty seconds, zero output — which looks like a dead sidecar but is what a healthy one looks like too, right up until the moment it is ready.

## Evidence

A Windows reproduction job (`repro-1614.yml`, second commit) installs each release on `windows-latest` and records the real startup timeline. A healthy start emits exactly one stdout line, the ready line, ~2.5s after spawn:

```
06:19:43.248  spawning DSH sidecar
06:19:45.741  DSH stdout { chunk: 'dsh web: http://127.0.0.1:59843' }
```

There is no progress output to distinguish slow from stuck, and process sampling confirms the sidecar is a normal child of the main process throughout. The same job also rules out pre-existing v1 state as the trigger: v1 leaves no `<userData>\dsh` behind, and the v1→v2 upgrade leg starts in 2s.

## What changed

The failures that are real already announce themselves — the process exits, or the spawn errors — and both paths are untouched. The deadlines now only report:

- the sidecar's threshold swaps the startup page for one that says a first launch after an update can take a few minutes
- the product threshold logs, and does not navigate: the window is already loading the product page, and navigating away would abort the very load being waited on

Nothing is cancelled when either passes. A start that needs four minutes now takes four minutes instead of failing at thirty seconds.

## Verification

- `pnpm run typecheck`, `pnpm run lint`, `pnpm run test` (469 vitest + 138 + 10 node) all pass
- Verified in a real Electron app on macOS with the sidecar held silent: the slow page renders in the system locale and the app stays alive well past the old 30s deadline instead of showing the startup-failure dialog

## Not covered here

This does not explain why the reporter's machine was slow, and deliberately so — the fix does not need to know. If it turns out to be something we can address at the source, that is a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added slow-start detection for the desktop runtime and product interface.
  * Displays a localized notice when startup takes longer than expected while continuing initialization.
  * Preserves the loading state until the product is ready.

* **Bug Fixes**
  * Prevents slow startup from being incorrectly treated as a failure or terminating the runtime.

* **Tests**
  * Added coverage for slow, non-failing startup behavior and readiness transitions.

* **Chores**
  * Added a Windows workflow for reproducing and collecting evidence for startup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->