### PR TITLE
fix(desktop): stop giving up on a slow DSH start

### DIFF
--- a/packages/desktop-electron/src/main/dsh-sidecar.test.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.test.ts
@@ -58,7 +58,6 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: { PATH: "/app/tools:/usr/bin", DSH_HOME: "/data/dsh", ELECTRON_RUN_AS_NODE: "1" },
-      timeoutMs: 100,
       spawn: (executable, args, options) => {
         invocation = { executable, args, options }
         return child
@@ -103,7 +102,6 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
       spawn: () => child,
     })
 
@@ -126,7 +124,6 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: { PATH: "/usr/bin" },
-      timeoutMs: 500,
       spawn: () => child,
     })
 
@@ -149,7 +146,6 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
       spawn: () => child,
     })
 
@@ -166,7 +162,6 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
       spawn: () => child,
     })
 
@@ -187,7 +182,6 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
       spawn: () => child,
       onError: (error) => errors.push(error),
     })
@@ -202,27 +196,9 @@ describe("DSH sidecar lifecycle", () => {
     expect([child.messages, child.killSignals]).toEqual([[], []])
   })
 
-  test("force-terminates the owned child process when readiness times out", async () => {
-    const child = new FakeChildProcess()
-    child.gracefulExit = false
-    const launched = launchDshSidecar({
-      executable: "/app/PawWork",
-      dshBin: "/app/dsh.js",
-      sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
-      productPatch: "/data/dsh/product.cordis.patch.yml",
-      env: {},
-      timeoutMs: 1,
-      stopTimeoutMs: 1,
-      spawn: () => child,
-    })
-
-    await expect(launched.ready).rejects.toThrow("DSH did not announce readiness within 1ms")
-    await launched.exited
-    expect(child.messages).toEqual(["SIGTERM"])
-    expect(child.killSignals).toEqual(["SIGKILL"])
-  })
-
-  test("reports a readiness timeout before the resulting process exit", async () => {
+  // #1614: DSH is silent until its ready line, so a slow start looks exactly
+  // like a wedged one. Nothing may terminate the child on elapsed time alone.
+  test("leaves a silent child running instead of giving up on it", async () => {
     const child = new FakeChildProcess()
     const launched = launchDshSidecar({
       executable: "/app/PawWork",
@@ -230,17 +206,20 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 1,
       spawn: () => child,
     })
-    const outcomes: string[] = []
+    let settled = false
+    void launched.ready.finally(() => {
+      settled = true
+    })
 
-    await Promise.all([
-      launched.ready.catch((error: Error) => outcomes.push(error.message)),
-      launched.exited.then(() => outcomes.push("exited")),
-    ])
+    await new Promise((resolve) => setTimeout(resolve, 50))
 
-    expect(outcomes).toEqual(["DSH did not announce readiness within 1ms", "exited"])
+    expect(settled).toBe(false)
+    expect([child.messages, child.killSignals]).toEqual([[], []])
+
+    child.stdout.write("dsh web: http://127.0.0.1:4321\n")
+    await expect(launched.ready).resolves.toBe("http://127.0.0.1:4321")
   })
 
   test("stops the owned child process once across concurrent and repeated calls", async () => {
@@ -251,7 +230,6 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
       spawn: () => child,
     })
     child.stdout.write("dsh web: http://127.0.0.1:43123\n")
@@ -277,7 +255,6 @@ describe("DSH sidecar lifecycle", () => {
       sidecarPreload: "file:///app/dsh/sidecar-preload.mjs",
       productPatch: "/data/dsh/product.cordis.patch.yml",
       env: {},
-      timeoutMs: 100,
       stopTimeoutMs: 1,
       spawn: () => child,
     })

--- a/packages/desktop-electron/src/main/dsh-sidecar.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.ts
@@ -31,7 +31,6 @@ type LaunchDshSidecarOptions = {
   sidecarPreload: string
   productPatch: string
   env: NodeJS.ProcessEnv
-  timeoutMs: number
   stopTimeoutMs?: number
   spawn: SpawnDshProcess
   onStdout?: (chunk: string) => void
@@ -88,7 +87,6 @@ export function launchDshSidecar(options: LaunchDshSidecarOptions): DshRun {
   let stdoutBuffer = ""
   let settled = false
   let stopping: Promise<void> | undefined
-  let timeout: ReturnType<typeof setTimeout> | undefined
   let rejectReady!: (error: Error) => void
   const stopTimeoutMs = options.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS
 
@@ -104,7 +102,6 @@ export function launchDshSidecar(options: LaunchDshSidecarOptions): DshRun {
   }
 
   const cleanupReadiness = () => {
-    if (timeout !== undefined) clearTimeout(timeout)
     child.stdout?.off("data", onStdout)
     child.off("exit", onEarlyExit)
   }
@@ -180,9 +177,11 @@ export function launchDshSidecar(options: LaunchDshSidecarOptions): DshRun {
   child.once("exit", onEarlyExit)
   child.on("error", onSpawnError)
 
-  timeout = setTimeout(() => {
-    void fail(new Error(`DSH did not announce readiness within ${options.timeoutMs}ms`), true)
-  }, options.timeoutMs)
-
+  // There is deliberately no readiness deadline. DSH prints nothing at all
+  // until its ready line, so elapsed silence cannot tell a wedged runtime from
+  // a slow one — a first launch behind an antivirus scan of the freshly
+  // unpacked runtime looks exactly like a hang. A deadline here only ever
+  // killed starts that were about to succeed (#1614). The failures that are
+  // real announce themselves above: the process exits, or the spawn errors.
   return { ready, exited, stop: stopProcess }
 }

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -557,7 +557,6 @@ function launchDsh() {
     sidecarPreload: pathToFileURL(product.sidecarPreload).href,
     productPatch: product.patch,
     env: environment,
-    timeoutMs: 30_000,
     spawn: (executable, args, options) => spawn(executable, args, options),
     onStdout: (chunk) => logger.log("DSH stdout", { chunk: chunk.trimEnd() }),
     onStderr: (chunk) => {


### PR DESCRIPTION
Closes #1614. Replaces #1617.

## What was wrong

DSH prints nothing at all until its ready line, so elapsed silence carries no information about whether the runtime is wedged or merely slow. The sidecar's readiness deadline read that silence as failure and force-terminated the runtime 30s after spawn. On a first launch that is still unpacking behind an antivirus scan, that converts a start which was about to succeed into an app that can never open. The reporter's log is the whole story — 31 seconds, zero output, then killed:

```
[00:05:18] spawning DSH sidecar
[00:05:49] DSH lifecycle failed: DSH did not announce readiness within 30000ms
```

Their Try Again hit the same 30s wall every time.

## Why removed rather than lengthened

A Windows reproduction job recorded the real startup timeline on `windows-latest`. A healthy start emits exactly one stdout line — the ready line — about 2.5s after spawn, with nothing before it:

```
06:19:43.248  spawning DSH sidecar
06:19:45.741  DSH stdout { chunk: 'dsh web: http://127.0.0.1:59843' }
```

Silence is what a healthy start looks like right up until the moment it is ready, so no threshold can separate slow from stuck. Any replacement number would be the same guess with a longer fuse. The same job also ruled out pre-existing v1 state as the trigger: v1 leaves no `<userData>\dsh` behind, and the v1→v2 upgrade leg starts in 2s.

The failures that are real announce themselves and are untouched — the process exits, or the spawn errors — and both still reach the existing failure dialog with its retry, log, report and plugin-repair actions. What is removed is only the path that fired on a guess.

## Scope

Deletion only, and only the deadline #1614 actually names: no new option, callback, state, or UI. Net −25 lines across 3 files.

Two earlier drafts were cut back. One added a "still starting" page behind a 30s threshold — dropped, because it reintroduced the same arbitrary number to say what a spinner already says, about a cause it cannot verify. The other also deleted the lifecycle's product-readiness deadline — reverted, because that argument does not transfer: the sidecar is mute by design, but a renderer that fails to load emits explicit events, and removing the phase's only terminal state left a crashed or failed product load hanging in `loading` forever with no reachable restart. The product deadline is unsound for its own reasons, but it has never been reported to fire and curing it is not this change.

## Verification

- `pnpm run typecheck`, `pnpm run lint`, `pnpm run test` (468 vitest + 138 + 10 node) all pass
- One test added pinning the new contract: a silent child is neither signalled nor killed, and still resolves when it finally announces readiness. It fails against `main`.
- Started a real Electron app on macOS and reached the product UI

## Known gap

A genuinely wedged runtime — hung before printing anything, never exiting — now has no terminal state: the window spins until the user quits and relaunches. That case has never been reported, the OS-level quit and the existing Restart menu item both still work, and every mechanism that would detect it is another guess. Left alone deliberately.