### PR TITLE
fix(desktop): serve every free OpenCode model on a protocol it answers

### DIFF
--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -4,20 +4,34 @@
   config:
     provider: opencode
     model: big-pickle
+# The zen gateway serves one wire protocol per model, and a pi-ai route carries
+# one protocol for every model on it, so OpenCode Free arrives as two routes.
+# Both name their protocol and endpoint here rather than deferring to the
+# bundled catalog: the catalog does not describe every free id (it has no
+# `ling-3.0-flash-fin-free`, and only the paid `muse-spark-1.2`), so a route
+# without them cannot serve those models before the first refresh lands.
+# resources/dsh/product/lib/opencode-free.cjs keeps both lists current.
 - id: llm-pi-ai
   config:
     providers:
       opencode:
         apiKeyEnv: OPENCODE_API_KEY
         displayName: OpenCode Free
+        api: openai-completions
+        baseURL: https://opencode.ai/zen/v1
         models:
           - id: big-pickle
-          - id: hy3-free
           - id: ling-3.0-flash-fin-free
           - id: mimo-v2.5-free
-          - id: muse-spark-1.2-contributor-free
           - id: nemotron-3-ultra-free
           - id: nemotron-3.5-lightning-free
+      opencode-responses:
+        apiKeyEnv: OPENCODE_API_KEY
+        displayName: OpenCode Free (Responses)
+        api: openai-responses
+        baseURL: https://opencode.ai/zen/v1
+        models:
+          - id: muse-spark-1.2-contributor-free
 - id: llm-deepseek
   disabled: true
 # Silences the `dsh web:` URL line; `pawwork-web-ready` below reports the same

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -13,10 +13,23 @@ const { isDeepStrictEqual } = require('node:util');
 const OPENCODE_MODELS_URL = 'https://models.dev/api.json';
 /** The settings namespace the pi-ai adapter owns. */
 const LLM_PI_AI_NAMESPACE = 'llm-pi-ai';
-/** Path of the opencode model list inside that namespace. */
-const MODELS_PATH = ['providers', 'opencode', 'models'];
-const OPENCODE_ROUTE_API = 'openai-completions';
 const OPENCODE_ROUTE_BASE_URL = 'https://opencode.ai/zen/v1';
+/**
+ * The zen gateway serves one wire protocol per model, not one per gateway: a
+ * model reached on the wrong endpoint answers 500 on every attempt. A pi-ai
+ * route carries a single protocol (`PiAiModelProfile` has no per-model `api`),
+ * so the free set is split across one route per protocol PawWork serves.
+ *
+ * `catalogProvider` is the models.dev `provider.npm` marker, which is what the
+ * gateway's own endpoint table is keyed by: absent means `/chat/completions`
+ * and `@ai-sdk/openai` means `/responses`. A free model marked for a protocol
+ * no route claims (`@ai-sdk/anthropic`, `@ai-sdk/google`) is left out rather
+ * than routed somewhere it cannot answer.
+ */
+const OPENCODE_ROUTES = [
+	{ route: 'opencode', api: 'openai-completions', catalogProvider: undefined },
+	{ route: 'opencode-responses', api: 'openai-responses', catalogProvider: '@ai-sdk/openai' },
+];
 /** Capabilities the current pi-ai adapter can express. */
 const SUPPORTED_INPUT_MODALITIES = new Set(['text', 'image']);
 const SUPPORTED_REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
@@ -68,31 +81,41 @@ function modelProfile(id, entry) {
 	return profile;
 }
 /**
- * Select the free, non-deprecated opencode models.
+ * Select the free, non-deprecated opencode models, split by the route that can
+ * actually serve each one.
  * @param catalog - the raw `models.dev/api.json` document.
- * @returns the selectable ids in sorted order, each shaped as a pi-ai model entry.
+ * @returns `routes`, each route's selectable ids in sorted order and shaped as
+ *   pi-ai model entries, plus `unroutable`, the free ids whose protocol no
+ *   route claims.
  */
 function selectFreeAndServed(catalog) {
-	const opencode = catalog?.opencode;
-	if (opencode === null || typeof opencode !== 'object') return [];
-	const models = opencode.models;
-	if (models === null || typeof models !== 'object') return [];
-	const out = [];
+	const routes = Object.fromEntries(OPENCODE_ROUTES.map(({ route }) => [route, []]));
+	const unroutable = [];
+	const models = catalog?.opencode?.models;
+	if (models === null || typeof models !== 'object' || models === undefined) return { routes, unroutable };
 	for (const [id, entry] of Object.entries(models)) {
 		if (entry === null || typeof entry !== 'object') continue;
 		if (entry.status === 'deprecated') continue;
 		if (!isZeroCost(entry.cost)) continue;
-		out.push(modelProfile(id, entry));
+		const target = OPENCODE_ROUTES.find(({ catalogProvider }) => catalogProvider === entry.provider?.npm);
+		if (target === undefined) {
+			unroutable.push(id);
+			continue;
+		}
+		routes[target.route].push(modelProfile(id, entry));
 	}
-	return out.sort((left, right) => left.id.localeCompare(right.id));
+	for (const list of Object.values(routes)) list.sort((left, right) => left.id.localeCompare(right.id));
+	return { routes, unroutable };
 }
 /**
  * Keep metadata models.dev cannot answer; its live catalog owns identity,
  * capacities, modalities, and selectable efforts for this product-managed
- * route. `compat` remains local because it describes this gateway's wire.
+ * route. `compat` remains local because it describes this gateway's wire —
+ * which is why it is only ever carried over within the same route: a switch
+ * one protocol declares is refused by another.
  */
-function mergeModelEntries(currentValue, selectable) {
-	const current = currentValue?.providers?.opencode?.models;
+function mergeModelEntries(currentValue, route, selectable) {
+	const current = currentValue?.providers?.[route]?.models;
 	if (!Array.isArray(current)) return selectable;
 	const existing = new Map(current.map((entry) => [entry?.id, entry]));
 	return selectable.map((entry) => {
@@ -109,10 +132,12 @@ function mergeModelEntries(currentValue, selectable) {
  *
  * The product ships `opencode/big-pickle` as the default; if the refresh stops
  * selecting it (upstream deprecation), new sessions would fail with an unknown
- * model. Move to the first surviving selectable model. Only touches an
- * `opencode` default; a user default on another provider is left alone.
+ * model. Move to the first surviving selectable model, preferring the route the
+ * retired default sat on so the replacement keeps its protocol. Only touches a
+ * default on a route this refresh owns; a user default on another provider is
+ * left alone.
  */
-async function ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selectable }) {
+async function ensureDefaultModelSurvives({ defaultModel, logger, routes }) {
 	if (defaultModel === undefined) return;
 	let current;
 	try {
@@ -120,19 +145,21 @@ async function ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selec
 	} catch {
 		return; // default-model service unavailable; leave selection untouched
 	}
-	if (current === undefined || current.provider !== 'opencode') return;
-	if (nextIds.includes(current.model)) return;
-	const fallback = selectable[0];
-	if (fallback === undefined) return;
+	if (current === undefined || routes[current.provider] === undefined) return;
+	if (routes[current.provider].some((entry) => entry.id === current.model)) return;
+	const candidate = [current.provider, ...OPENCODE_ROUTES.map(({ route }) => route)]
+		.map((route) => ({ route, entry: routes[route][0] }))
+		.find(({ entry }) => entry !== undefined);
+	if (candidate === undefined) return;
 	const next = {
-		provider: 'opencode',
-		model: fallback.id,
+		provider: candidate.route,
+		model: candidate.entry.id,
 	};
 	try {
 		await defaultModel.saveSelection(next);
-		logger?.info?.(`default opencode model ${current.model} retired; moved to ${fallback.id}`);
+		logger?.info?.(`default opencode model ${current.model} retired; moved to ${candidate.entry.id}`);
 	} catch (error) {
-		logger?.warn?.(`failed to move default opencode model from ${current.model} to ${fallback.id}: ${error instanceof Error ? error.message : String(error)}`);
+		logger?.warn?.(`failed to move default opencode model from ${current.model} to ${candidate.entry.id}: ${error instanceof Error ? error.message : String(error)}`);
 	}
 }
 /** Per-request bound so a hung gateway cannot leave a refresh pending forever. */
@@ -176,9 +203,11 @@ async function waitForNamespace(get, timeoutMs, signal) {
  * Refresh the OpenCode Free model list in the `llm-pi-ai` settings namespace.
  *
  * A fetch/parse failure or an empty usable set leaves the packaged list
- * untouched. A successful non-empty set replaces `providers.opencode.models`
- * and pins the gateway protocol and endpoint needed by IDs absent from the
- * bundled mixed-protocol catalog, which triggers the pi-ai adapter to rebuild.
+ * untouched. A successful non-empty set replaces each route's models and pins
+ * the gateway protocol and endpoint needed by IDs absent from the bundled
+ * mixed-protocol catalog, which triggers the pi-ai adapter to rebuild. A route
+ * the live catalog has nothing for keeps its packaged list rather than being
+ * emptied, because an empty list means "serve the whole bundled catalog".
  * Surviving models keep their configured metadata; when the opencode default
  * model is dropped, the default selection moves to a surviving model.
  * @param deps - settings service, optional default-model service, fetch impl, logger, abort signal.
@@ -197,42 +226,60 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 		logger?.warn?.(`OpenCode Free catalog refresh failed; leaving the packaged model list: ${error instanceof Error ? error.message : String(error)}`);
 		return undefined;
 	}
-	const selectable = selectFreeAndServed(catalog);
-	if (selectable.length === 0) {
+	const { routes, unroutable } = selectFreeAndServed(catalog);
+	const total = Object.values(routes).reduce((count, list) => count + list.length, 0);
+	if (total === 0) {
 		logger?.warn?.('OpenCode Free catalog refresh found no usable free models; leaving the packaged model list');
 		return undefined;
+	}
+	if (unroutable.length > 0) {
+		logger?.warn?.(`OpenCode Free catalog refresh left out ${unroutable.join(', ')}: no PawWork route serves their protocol`);
 	}
 	// The network request may outlive a settings edit. Re-read the authoritative
 	// descriptor immediately before deriving and committing the replacement,
 	// then let the settings revision reject any still-later concurrent change.
 	const descriptor = settings.describe?.().find((entry) => entry.ns === LLM_PI_AI_NAMESPACE);
 	const currentValue = descriptor?.value ?? value;
-	const nextIds = selectable.map((entry) => entry.id);
-	const merged = mergeModelEntries(currentValue, selectable);
-	const currentModels = currentValue?.providers?.opencode?.models;
-	const currentProvider = currentValue?.providers?.opencode;
-	// Skip the write when the live profiles and routing already match: a periodic
-	// refresh must not churn settings.yaml or rebuild the adapter every interval.
-	const unchanged = Array.isArray(currentModels)
-		&& currentProvider?.api === OPENCODE_ROUTE_API
-		&& currentProvider?.baseURL === OPENCODE_ROUTE_BASE_URL
-		&& isDeepStrictEqual(currentModels, merged);
-	if (!unchanged) {
-		await settings.mutate(LLM_PI_AI_NAMESPACE, [
-			{ op: 'set', path: ['providers', 'opencode', 'api'], value: OPENCODE_ROUTE_API },
-			{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: OPENCODE_ROUTE_BASE_URL },
-			{ op: 'set', path: MODELS_PATH, value: merged },
-		], descriptor?.revision);
-		logger?.info?.(`OpenCode Free catalog refreshed to ${selectable.length} models`);
+	const merged = {};
+	const ops = [];
+	for (const { route, api } of OPENCODE_ROUTES) {
+		const selectable = routes[route];
+		// A route the live catalog has nothing for keeps whatever it is configured
+		// with; writing `[]` would hand it the entire bundled catalog instead.
+		merged[route] = selectable.length === 0
+			? currentValue?.providers?.[route]?.models ?? []
+			: mergeModelEntries(currentValue, route, selectable);
+		if (selectable.length === 0) continue;
+		const currentProvider = currentValue?.providers?.[route];
+		// Skip the write when the live profiles and routing already match: a periodic
+		// refresh must not churn settings.yaml or rebuild the adapter every interval.
+		const unchanged = Array.isArray(currentProvider?.models)
+			&& currentProvider?.api === api
+			&& currentProvider?.baseURL === OPENCODE_ROUTE_BASE_URL
+			&& isDeepStrictEqual(currentProvider.models, merged[route]);
+		if (unchanged) continue;
+		ops.push(
+			{ op: 'set', path: ['providers', route, 'api'], value: api },
+			{ op: 'set', path: ['providers', route, 'baseURL'], value: OPENCODE_ROUTE_BASE_URL },
+			{ op: 'set', path: ['providers', route, 'models'], value: merged[route] },
+		);
+	}
+	if (ops.length > 0) {
+		await settings.mutate(LLM_PI_AI_NAMESPACE, ops, descriptor?.revision);
+		logger?.info?.(`OpenCode Free catalog refreshed to ${total} models`);
 	}
 	// Keep the opencode default usable when the refresh drops it from the set.
 	// Runs after (or without) a write, and also when the set is unchanged, so a
-	// default pointing outside the configured list is repaired either way.
-	await ensureDefaultModelSurvives({ defaultModel, logger, nextIds, selectable });
-	return selectable.length;
+	// default pointing outside the configured list is repaired either way. The
+	// merged lists are what the routes now serve, including a route this refresh
+	// left alone.
+	await ensureDefaultModelSurvives({ defaultModel, logger, routes: merged });
+	return total;
 }
 
 module.exports = {
+	OPENCODE_ROUTES,
+	OPENCODE_ROUTE_BASE_URL,
 	isZeroCost,
 	refreshOpenCodeFreeModels,
 	selectFreeAndServed,

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -31,8 +31,8 @@ function settingsHarness(value, descriptor) {
 	return { settings, writes };
 }
 
-function writtenModels(write) {
-	return write.ops.find((op) => op.path.at(-1) === 'models')?.value;
+function writtenModels(write, route = 'opencode') {
+	return write.ops.find((op) => op.path.at(-1) === 'models' && op.path.at(-2) === route)?.value;
 }
 
 test('isZeroCost accepts only fully zero-cost models', () => {
@@ -78,25 +78,51 @@ test('selectFreeAndServed returns only free AND non-deprecated models, sorted', 
 		'paid': { cost: { input: 2, output: 12 } },
 		'free-persisted': { cost: { input: 0, output: 0 }, reasoning: false },
 	});
-	assert.deepEqual(selectFreeAndServed(catalog), [
-		{ id: 'free-persisted', reasoningEfforts: false },
-		{
-			id: 'new-free',
-			name: 'New Free',
-			contextWindow: 190000,
-			maxTokens: 64000,
-			input: ['text', 'image'],
-			reasoningEfforts: { off: null, low: 'low', medium: 'medium', high: 'high' },
+	assert.deepEqual(selectFreeAndServed(catalog), {
+		routes: {
+			'opencode': [
+				{ id: 'free-persisted', reasoningEfforts: false },
+				{
+					id: 'new-free',
+					name: 'New Free',
+					contextWindow: 190000,
+					maxTokens: 64000,
+					input: ['text', 'image'],
+					reasoningEfforts: { off: null, low: 'low', medium: 'medium', high: 'high' },
+				},
+			],
+			'opencode-responses': [],
 		},
-	]);
+		unroutable: [],
+	});
+});
+
+// The gateway's endpoint per model is what `provider.npm` records: absent is
+// `/chat/completions`, `@ai-sdk/openai` is `/responses`, and the two vendor SDK
+// markers name endpoints no PawWork route speaks.
+test('selectFreeAndServed splits the free set by the protocol each model is served on', () => {
+	const catalog = catalogWith({
+		'plain-free': { cost: { input: 0, output: 0 } },
+		'responses-free': { cost: { input: 0, output: 0 }, provider: { npm: '@ai-sdk/openai' } },
+		'anthropic-free': { cost: { input: 0, output: 0 }, provider: { npm: '@ai-sdk/anthropic' } },
+		'google-free': { cost: { input: 0, output: 0 }, provider: { npm: '@ai-sdk/google' } },
+	});
+	assert.deepEqual(selectFreeAndServed(catalog), {
+		routes: {
+			'opencode': [{ id: 'plain-free' }],
+			'opencode-responses': [{ id: 'responses-free' }],
+		},
+		unroutable: ['anthropic-free', 'google-free'],
+	});
 });
 
 test('selectFreeAndServed tolerates missing opencode / models / malformed entries', () => {
-	assert.deepEqual(selectFreeAndServed({}), []);
-	assert.deepEqual(selectFreeAndServed({ opencode: {} }), []);
-	assert.deepEqual(selectFreeAndServed({ opencode: { models: { a: null } } }), []);
-	assert.deepEqual(selectFreeAndServed(null), []);
-	assert.deepEqual(selectFreeAndServed(catalogWith({ a: { cost: { input: 0 } } })), []);
+	const empty = { routes: { 'opencode': [], 'opencode-responses': [] }, unroutable: [] };
+	assert.deepEqual(selectFreeAndServed({}), empty);
+	assert.deepEqual(selectFreeAndServed({ opencode: {} }), empty);
+	assert.deepEqual(selectFreeAndServed({ opencode: { models: { a: null } } }), empty);
+	assert.deepEqual(selectFreeAndServed(null), empty);
+	assert.deepEqual(selectFreeAndServed(catalogWith({ a: { cost: { input: 0 } } })), empty);
 });
 
 test('waitForNamespace resolves with the registered value', async () => {
@@ -134,6 +160,117 @@ test('refresh writes free non-deprecated models with serviceable route wiring', 
 		{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: 'https://opencode.ai/zen/v1' },
 		{ op: 'set', path: ['providers', 'opencode', 'models'], value: [{ id: 'hy3-free' }] },
 	]);
+});
+
+test('refresh wires each protocol to its own route in one write', async () => {
+	const { settings, writes } = settingsHarness({
+		providers: { opencode: { models: [{ id: 'old' }] }, 'opencode-responses': { models: [{ id: 'old-resp' }] } },
+	});
+	const fetchImpl = fetchCatalog({
+		'plain-free': { cost: { input: 0, output: 0 } },
+		'responses-free': { cost: { input: 0, output: 0 }, provider: { npm: '@ai-sdk/openai' } },
+	});
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
+	assert.equal(count, 2);
+	assert.equal(writes.length, 1);
+	assert.deepEqual(writes[0].ops, [
+		{ op: 'set', path: ['providers', 'opencode', 'api'], value: 'openai-completions' },
+		{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: 'https://opencode.ai/zen/v1' },
+		{ op: 'set', path: ['providers', 'opencode', 'models'], value: [{ id: 'plain-free' }] },
+		{ op: 'set', path: ['providers', 'opencode-responses', 'api'], value: 'openai-responses' },
+		{ op: 'set', path: ['providers', 'opencode-responses', 'baseURL'], value: 'https://opencode.ai/zen/v1' },
+		{ op: 'set', path: ['providers', 'opencode-responses', 'models'], value: [{ id: 'responses-free' }] },
+	]);
+});
+
+// `compat` describes one protocol's wire, and a switch another protocol does not
+// declare is refused, so a model that moves between routes must not carry it.
+test('refresh keeps configured metadata within its own route', async () => {
+	const { settings, writes } = settingsHarness({
+		providers: {
+			opencode: { models: [{ id: 'moved', compat: { chatTemplateKwargs: {} } }] },
+			'opencode-responses': { models: [] },
+		},
+	});
+	const fetchImpl = fetchCatalog({
+		'moved': { cost: { input: 0, output: 0 }, provider: { npm: '@ai-sdk/openai' } },
+	});
+	await refreshOpenCodeFreeModels({ settings, fetchImpl });
+	assert.deepEqual(writtenModels(writes[0], 'opencode-responses'), [{ id: 'moved' }]);
+	// The route the model left keeps its packaged list rather than being emptied.
+	assert.equal(writtenModels(writes[0], 'opencode'), undefined);
+});
+
+test('refresh leaves a route the live catalog has nothing for untouched', async () => {
+	const { settings, writes } = settingsHarness({
+		providers: {
+			opencode: { api: 'openai-completions', baseURL: 'https://opencode.ai/zen/v1', models: [{ id: 'plain-free' }] },
+			'opencode-responses': { models: [{ id: 'packaged-resp' }] },
+		},
+	});
+	const fetchImpl = fetchCatalog({ 'plain-free': { cost: { input: 0, output: 0 } } });
+	const count = await refreshOpenCodeFreeModels({ settings, fetchImpl });
+	assert.equal(count, 1);
+	assert.equal(writes.length, 0);
+});
+
+test('refresh reports free models whose protocol no route serves', async () => {
+	const warnings = [];
+	const { settings } = settingsHarness({ providers: { opencode: { models: [] } } });
+	const fetchImpl = fetchCatalog({
+		'plain-free': { cost: { input: 0, output: 0 } },
+		'anthropic-free': { cost: { input: 0, output: 0 }, provider: { npm: '@ai-sdk/anthropic' } },
+	});
+	await refreshOpenCodeFreeModels({ settings, fetchImpl, logger: { info() {}, warn(message) { warnings.push(message); } } });
+	assert.equal(warnings.length, 1);
+	assert.match(warnings[0], /anthropic-free/);
+});
+
+test('refresh moves a dropped default to a model on its own route first', async () => {
+	const saves = [];
+	const { settings } = settingsHarness({
+		providers: { opencode: { models: [{ id: 'plain-free' }] }, 'opencode-responses': { models: [{ id: 'retired' }] } },
+	});
+	const defaultModel = {
+		currentSelection: () => ({ provider: 'opencode-responses', model: 'retired' }),
+		async saveSelection(next) { saves.push(next); },
+	};
+	const fetchImpl = fetchCatalog({
+		'plain-free': { cost: { input: 0, output: 0 } },
+		'responses-free': { cost: { input: 0, output: 0 }, provider: { npm: '@ai-sdk/openai' } },
+	});
+	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
+	assert.deepEqual(saves, [{ provider: 'opencode-responses', model: 'responses-free' }]);
+});
+
+test('refresh moves a dropped default across routes when its own route has nothing left', async () => {
+	const saves = [];
+	const { settings } = settingsHarness({
+		providers: { opencode: { models: [] }, 'opencode-responses': { models: [] } },
+	});
+	const defaultModel = {
+		currentSelection: () => ({ provider: 'opencode-responses', model: 'retired' }),
+		async saveSelection(next) { saves.push(next); },
+	};
+	const fetchImpl = fetchCatalog({ 'plain-free': { cost: { input: 0, output: 0 } } });
+	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
+	assert.deepEqual(saves, [{ provider: 'opencode', model: 'plain-free' }]);
+});
+
+// A route the refresh left alone still serves its packaged list, so a default
+// pointing into it is not "dropped" and must not be moved.
+test('refresh keeps a default served by a route the live catalog did not touch', async () => {
+	const saves = [];
+	const { settings } = settingsHarness({
+		providers: { opencode: { models: [] }, 'opencode-responses': { models: [{ id: 'packaged-resp' }] } },
+	});
+	const defaultModel = {
+		currentSelection: () => ({ provider: 'opencode-responses', model: 'packaged-resp' }),
+		async saveSelection(next) { saves.push(next); },
+	};
+	const fetchImpl = fetchCatalog({ 'plain-free': { cost: { input: 0, output: 0 } } });
+	await refreshOpenCodeFreeModels({ settings, defaultModel, fetchImpl });
+	assert.deepEqual(saves, []);
 });
 
 test('refresh does not write an empty list when nothing is usable', async () => {

--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -15,6 +15,10 @@ import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { DOCUMENT_VERSION, parseCredentialsDocument } from "@deepseek-ai/dsh-credentials-local"
 import { readProductPatch } from "./dsh-product-patch.testing"
+// The product plugin the packaged patch has to stay in step with.
+const { OPENCODE_ROUTES, OPENCODE_ROUTE_BASE_URL } = createRequire(import.meta.url)(
+  "../../resources/dsh/product/lib/opencode-free.cjs",
+) as { OPENCODE_ROUTES: Array<{ route: string; api: string }>; OPENCODE_ROUTE_BASE_URL: string }
 import {
   buildDshEnvironment,
   prepareDshProductHome,
@@ -39,19 +43,22 @@ function temporaryDirectory() {
   return directory
 }
 
-function installedOpenCodeFreeModels() {
+type InstalledOpenCodeModel = { id: string; cost?: { input?: number } }
+
+// The installed adapter's own opencode catalog, keyed by the wire protocol it
+// files each model under. This is the upgrade tripwire behind the route split:
+// PawWork names a protocol per route, so a pi-ai release that respells one, or
+// moves a model between them, has to fail here rather than at the gateway.
+function installedOpenCodeCatalog() {
   const require = createRequire(import.meta.url)
   const dshPackage = require.resolve("@deepseek-ai/dsh/package.json")
   const webAppPackage = createRequire(dshPackage).resolve("@deepseek-ai/dsh-web-app/package.json")
   const adapterPackage = createRequire(webAppPackage).resolve("@deepseek-ai/dsh-llm-pi-ai/package.json")
   const piAiRoot = join(dirname(adapterPackage), "..", "..", "@earendil-works", "pi-ai")
-  const catalog = JSON.parse(readFileSync(join(piAiRoot, "dist/providers/data/opencode.json"), "utf8"))
+  const catalog = JSON.parse(readFileSync(join(piAiRoot, "dist/providers/data/opencode.json"), "utf8")) as
+    Record<string, Record<string, InstalledOpenCodeModel>>
 
-  return Object.values(catalog)
-    .flatMap((models) => Object.values(models as Record<string, { id: string; cost?: { input?: number } }>))
-    .filter((model) => model.cost?.input === 0)
-    .map((model) => model.id)
-    .sort()
+  return new Map(Object.entries(catalog).map(([api, models]) => [api, new Map(Object.entries(models))]))
 }
 
 describe("DSH product home", () => {
@@ -269,21 +276,52 @@ describe("DSH product home", () => {
     expect([...parsed.refs]).toEqual([["OPENCODE_API_KEY", "public"]])
   })
 
-  test("publishes the installed zero-cost OpenCode catalog as OpenCode Free", () => {
+  test("publishes OpenCode Free on one route per protocol the gateway serves", () => {
     const patch = readProductPatch()
     const modelDefaults = patch.find((entry) => entry.id === "agent-default-model")?.config as {
       provider: string
       model: string
     }
     const providerConfig = patch.find((entry) => entry.id === "llm-pi-ai")?.config as {
-      providers: { opencode: { displayName?: string; models?: Array<{ id: string }> } }
+      providers: Record<string, {
+        apiKeyEnv?: string
+        displayName?: string
+        api?: string
+        baseURL?: string
+        models?: Array<{ id: string }>
+      }>
     }
-    const freeModels = installedOpenCodeFreeModels()
+    const catalog = installedOpenCodeCatalog()
 
-    expect(providerConfig.providers.opencode.displayName).toBe("OpenCode Free")
-    expect(providerConfig.providers.opencode.models?.map((model) => model.id).sort()).toEqual(freeModels)
+    // The patch and the refresh have to name the same routes: a route only one
+    // of them knows is either never refreshed or published as a third provider.
+    expect(Object.keys(providerConfig.providers).sort()).toEqual(
+      OPENCODE_ROUTES.map((entry) => entry.route).sort(),
+    )
+
+    for (const { route, api } of OPENCODE_ROUTES) {
+      const profile = providerConfig.providers[route]
+      expect(profile.apiKeyEnv).toBe("OPENCODE_API_KEY")
+      expect(profile.displayName).toMatch(/^OpenCode Free/)
+      expect(profile.baseURL).toBe(OPENCODE_ROUTE_BASE_URL)
+      // The protocol has to be one the installed adapter still spells this way.
+      expect([...catalog.keys()]).toContain(api)
+      expect(profile.api).toBe(api)
+      expect(profile.models?.length).toBeGreaterThan(0)
+
+      for (const { id } of profile.models ?? []) {
+        // A packaged id the catalog does not describe is exactly why each route
+        // names its own protocol; one it does describe must agree with it, and
+        // must still be free.
+        const served = [...catalog].find(([, models]) => models.has(id))
+        if (served === undefined) continue
+        expect(served[0]).toBe(api)
+        expect(served[1].get(id)?.cost?.input).toBe(0)
+      }
+    }
+
     expect(modelDefaults.provider).toBe("opencode")
-    expect(freeModels).toContain(modelDefaults.model)
+    expect(providerConfig.providers.opencode.models?.map((model) => model.id)).toContain(modelDefaults.model)
   })
 
   test("does not publish the bundled paid DeepSeek route", () => {

--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -15,10 +15,6 @@ import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { DOCUMENT_VERSION, parseCredentialsDocument } from "@deepseek-ai/dsh-credentials-local"
 import { readProductPatch } from "./dsh-product-patch.testing"
-// The product plugin the packaged patch has to stay in step with.
-const { OPENCODE_ROUTES, OPENCODE_ROUTE_BASE_URL } = createRequire(import.meta.url)(
-  "../../resources/dsh/product/lib/opencode-free.cjs",
-) as { OPENCODE_ROUTES: Array<{ route: string; api: string }>; OPENCODE_ROUTE_BASE_URL: string }
 import {
   buildDshEnvironment,
   prepareDshProductHome,
@@ -27,6 +23,12 @@ import {
   resolvePnpmPackagePath,
   resolveProductResources,
 } from "./dsh-product-home"
+
+// The product plugin the packaged patch has to stay in step with. It ships as
+// CommonJS into the DSH home, so it is required rather than imported.
+const { OPENCODE_ROUTES, OPENCODE_ROUTE_BASE_URL } = createRequire(import.meta.url)(
+  "../../resources/dsh/product/lib/opencode-free.cjs",
+) as { OPENCODE_ROUTES: Array<{ route: string; api: string }>; OPENCODE_ROUTE_BASE_URL: string }
 
 const appPath = join(import.meta.dirname, "../..")
 const hostModules = resolveHostModules({ appPath, isPackaged: false, resourcesPath: "/unused" })


### PR DESCRIPTION
## What was broken

Selecting **Muse Spark 1.2 Free** and sending anything failed on every attempt:

```
Retried model request (5/5) · 8s
This turn failed 500: {"type":"error","message":"Internal server error"}
```

Reproduced in the real app on a fresh home, and directly against the gateway — `/chat/completions` answers 500 for that model three times out of three, `/responses` answers 200.

## Why

The zen gateway pins a wire protocol **per model**, not per gateway. Its own endpoint table lists five free models at `/chat/completions` and `muse-spark-1.2-contributor-free` at `/responses`. The refresh pinned the entire `opencode` route to `openai-completions`, so that model was always sent to an endpoint that cannot serve it.

A pi-ai route carries one protocol for every model on it — `PiAiModelProfile` has no per-model `api` — so one route cannot cover both.

## The fix

The free set now arrives as **one route per protocol PawWork serves**, which is the shape pi-ai's `providers` dict already models — no new mechanism, no patched internals:

| route | protocol | free models today |
| --- | --- | --- |
| `opencode` | `openai-completions` | big-pickle, ling-3.0-flash-fin-free, mimo-v2.5-free, nemotron-3-ultra-free, nemotron-3.5-lightning-free |
| `opencode-responses` | `openai-responses` | muse-spark-1.2-contributor-free |

models.dev's `provider.npm` is the marker the gateway's endpoint table is keyed by: absent is `/chat/completions`, `@ai-sdk/openai` is `/responses`. A free model marked for a protocol no route claims (`@ai-sdk/anthropic`, `@ai-sdk/google` — none free today) is left out and named in a warning instead of being routed somewhere it cannot answer.

Also in scope, because they are the same intent:

- Both routes name their protocol and endpoint in the packaged patch. The bundled catalog does not describe every free id — it has no `ling-3.0-flash-fin-free` and only the paid `muse-spark-1.2` — so a route without them cannot serve those models before the first refresh lands.
- `hy3-free` leaves the packaged list; upstream deprecated it.
- A route the live catalog has nothing for keeps its packaged list rather than being emptied, since an empty list means "serve the whole bundled catalog".
- A dropped default moves to a survivor on its own route first, so the replacement keeps its protocol.
- `compat` is only carried over within a route — a switch one protocol declares is refused by another.

## Upgrade safety

The product-home contract test now reads the installed pi-ai catalog and fails if a DSH/pi-ai release respells a protocol, moves a packaged model between protocols, stops serving one for free, or if the patch and the refresh drift apart on which routes exist. That is the check this split needs to survive upgrades.

## Verification

Real Electron app, fresh home, driven over CDP:

- The startup refresh writes both routes with the right protocol and models.
- The model picker lists exactly the six models opencode publishes as free.
- **All six answer**, Muse Spark included:

| model | before | after |
| --- | --- | --- |
| Big Pickle | OK | OK |
| Ling 3.0 Flash Fin Free | OK | OK |
| MiMo V2.5 Free | OK | OK |
| Nemotron 3 Ultra Free | OK | OK |
| Nemotron 3.5 Lightning Free | OK | OK |
| Muse Spark 1.2 Free | 500 ×5 retries | OK, 2.3s |

`pnpm test` (473), `pnpm lint`, `pnpm typecheck` all pass, and the full `smoke:ci` CDP run passes.

## Known cosmetic note

Settings → Models now lists two entries, and pi-ai labels `opencode-responses` "Custom" because the bundled catalog does not describe that route. It is not deletable and behaves like the built-in one; nothing else changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated OpenCode Free model support with separate Completions and Responses API routes.
  * Added support for the `muse-spark-1.2-contributor-free` model through the Responses API.
  * Refreshed the available free model catalog and route-specific connection settings.

* **Bug Fixes**
  * Improved model selection recovery when models or routes change.
  * Prevented unsupported model protocols from being configured.
  * Preserved existing settings when a route has no refreshed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->