### PR TITLE
chore(release): prepare 2026.9.1

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.8.8",
+  "version": "2026.9.1",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
Bumps the desktop version to 2026.9.1 so the release tag has a version to build.

## What ships in 2026.9.1

- **App updates move into the in-app UI** (#1613) — update state renders in Settings on both platforms, a silent check runs once the app is ready and every four hours after, and a declined install no longer discards the downloaded update. Windows gains an entry it never had.
- **A slow DSH start is no longer given up on** (#1619) — the fixed readiness timeout could not tell a hung start from a slow one, so a slow machine saw a failure dialog for a start that would have succeeded.
- **Every free OpenCode model answers** (#1621) — the zen gateway pins a wire protocol per model, and pinning the whole route to `openai-completions` sent Muse Spark 1.2 Free to an endpoint that always answered 500. The free set is now split across one route per protocol.
- **The free model list recovers from a bad first network** (#1612) — a failed startup refresh retries after one and five minutes instead of waiting a full hour.
- **DSH upgraded to 0.1.2-alpha.3** (#1618, #1620).

## Verification

Beyond CI, on this branch's content in the real Electron app over CDP, on a fresh home:

- All six models opencode publishes as free answer a prompt, Muse Spark included.
- The Software Update panel renders and reports its status.
- The full `smoke:ci` CDP run passes, along with `pnpm test` (473), `pnpm lint`, and `pnpm typecheck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application to version 2026.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->