### PR TITLE
fix(desktop): offer the plugin removal button when a plugin fails to load

### DIFF
--- a/packages/desktop-electron/src/main/dsh-profile-repair.test.ts
+++ b/packages/desktop-electron/src/main/dsh-profile-repair.test.ts
@@ -2,16 +2,30 @@ import { describe, expect, test } from "vitest"
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { removeProfileBundle, unresolvedProfileBundle } from "./dsh-profile-repair"
+import { failingProfileBundle, removeProfileBundle } from "./dsh-profile-repair"
 
 // The exact shape DSH dies with when a market install left a bundle behind.
-const FAILURE_OUTPUT = [
+const MISSING_OUTPUT = [
   "file:///app/node_modules/@deepseek-ai/dsh-app-boot/lib/index.js:523",
   "\tthrow new Error(`${binName}: cannot resolve profile bundle ${JSON.stringify(packageName)} from the dsh installation`);",
   "",
   "Error: dsh: cannot resolve profile bundle \"dsh-lark-bot\" from the dsh installation or /home/u/.pawwork/dsh/profiles/web;"
     + " run 'dsh plugin --profile web install' if its dependency is not installed",
   "    at resolveBundleDir (file:///app/node_modules/@deepseek-ai/dsh-app-boot/lib/index.js:523:8)",
+].join("\n")
+
+// The shape a plugin built against a removed DSH export dies with: the package
+// is installed, the loader entry just cannot be imported. `better-sidebar` is
+// the entry id and `dsh-better-sidebar` the package, and only the package is
+// ever a bundle.
+const INCOMPATIBLE_OUTPUT = [
+  "Error: failed to import loader entry better-sidebar (dsh-better-sidebar):"
+    + " The requested module '@deepseek-ai/dsh-settings' does not provide an export named 'settingsNamespace'",
+  "    at updateError (file:///app/node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js:309:9)",
+  "  [cause]: file:///home/u/.pawwork/dsh/profiles/web/node_modules/dsh-better-sidebar/lib/index.js:11",
+  "  import { SettingsConflictError, settingsNamespace } from \"@deepseek-ai/dsh-settings\";",
+  "           ^^^^^^^^^^^^^^^^^^",
+  "  SyntaxError: The requested module '@deepseek-ai/dsh-settings' does not provide an export named 'settingsNamespace'",
 ].join("\n")
 
 function profileDirWith(manifest: unknown) {
@@ -27,14 +41,52 @@ function manifestOf(profileDir: string) {
   }
 }
 
-describe("unresolvedProfileBundle", () => {
+describe("failingProfileBundle", () => {
   test("names the bundle DSH could not resolve", () => {
-    expect(unresolvedProfileBundle(FAILURE_OUTPUT)).toBe("dsh-lark-bot")
+    expect(failingProfileBundle(MISSING_OUTPUT)).toEqual({ bundle: "dsh-lark-bot", cause: "missing" })
+  })
+
+  test("names the package behind a loader entry that would not import", () => {
+    expect(failingProfileBundle(INCOMPATIBLE_OUTPUT)).toEqual({ bundle: "dsh-better-sidebar", cause: "incompatible" })
+  })
+
+  test("takes the package in parentheses, not the entry id in front of it", () => {
+    const failure = failingProfileBundle("Error: failed to import loader entry better-sidebar (dsh-better-sidebar): boom")
+    expect(failure?.bundle).not.toBe("better-sidebar")
+    expect(failure?.bundle).toBe("dsh-better-sidebar")
+  })
+
+  test("reads a scoped package name", () => {
+    expect(failingProfileBundle("Error: failed to import loader entry modsearch (@liustack/modsearch): boom"))
+      .toEqual({ bundle: "@liustack/modsearch", cause: "incompatible" })
+  })
+
+  // A start can bring down several plugins at once, and the loader reports the
+  // group that held them before it reports either one. Naming the first real
+  // package is enough: removing it and restarting re-attributes to the next.
+  test("skips the loader's own wrapper entry and names the first failing package", () => {
+    const aggregate = [
+      "Error: failed to apply loader entry include (cordis:include): loader entries failed to apply",
+      "    at Include._apply (file:///app/node_modules/@deepseek-ai/dsh-app-boot/lib/index.js:240:3)",
+      "  [cause]: AggregateError: loader entries failed to apply",
+      "      [errors]: [",
+      "        Error: failed to import loader entry better-sidebar (dsh-better-sidebar): no export 'settingsNamespace',",
+      "        Error: failed to import loader entry llm-subscriptions (dsh-plugin-subscriptions): no export 'CallId'",
+      "      ]",
+    ].join("\n")
+
+    expect(failingProfileBundle(aggregate)).toEqual({ bundle: "dsh-better-sidebar", cause: "incompatible" })
+  })
+
+  // The wrapper alone names nothing that could be dropped from the manifest, so
+  // offering to remove it would be a button that cannot work.
+  test("ignores the wrapper entry when no package is named", () => {
+    expect(failingProfileBundle("Error: failed to apply loader entry include (cordis:include): boom")).toBeUndefined()
   })
 
   test("returns undefined for unrelated failures", () => {
-    expect(unresolvedProfileBundle("Error: listen EADDRINUSE: address already in use")).toBeUndefined()
-    expect(unresolvedProfileBundle("")).toBeUndefined()
+    expect(failingProfileBundle("Error: listen EADDRINUSE: address already in use")).toBeUndefined()
+    expect(failingProfileBundle("")).toBeUndefined()
   })
 })
 

--- a/packages/desktop-electron/src/main/dsh-profile-repair.ts
+++ b/packages/desktop-electron/src/main/dsh-profile-repair.ts
@@ -8,9 +8,41 @@ import { join } from "node:path"
 // only in-app action — retry — cannot change the outcome.
 const UNRESOLVED_BUNDLE = /cannot resolve profile bundle "([^"]+)"/
 
-/** The bundle DSH could not resolve, read from its own failure output. */
-export function unresolvedProfileBundle(output: string) {
-  return UNRESOLVED_BUNDLE.exec(output)?.[1]
+// The other way a single plugin takes the whole runtime down: the package is
+// installed, but it was built against an API this DSH no longer exports, so
+// importing it throws. cordis loads every entry with `Promise.allSettled` and
+// rethrows the failures, which rolls the whole configuration tree back — one
+// stale plugin is enough to leave the app unopenable. The loader names the
+// entry as `<id> (<name>)`; `name` is the package, and the package is what
+// `dsh.profile.bundles` holds, so the parenthesized half is the one to take.
+//
+// Only the `import` stage: the same failure surfaces again one level up as
+// `failed to apply loader entry include (cordis:include)`, and that wrapper is
+// the loader's own plumbing, not anything a profile could declare. The name
+// cannot hold a colon for the same reason — npm packages have none, and the
+// built-in plugins that do are never bundles.
+const FAILED_IMPORT_BUNDLE = /failed to import loader entry \S+ \(([^()\s:]+)\)/
+
+export type ProfileBundleFailure = {
+  bundle: string
+  /** `missing`: the package is not there. `incompatible`: it is, and it will not load. */
+  cause: "missing" | "incompatible"
+}
+
+/**
+ * The bundle that kept DSH from booting, read from its own failure output.
+ *
+ * An AggregateError lists every entry that failed; the first one is as good a
+ * place to start as any, and a restart re-attributes to whatever is left.
+ */
+export function failingProfileBundle(output: string): ProfileBundleFailure | undefined {
+  const missing = UNRESOLVED_BUNDLE.exec(output)?.[1]
+  if (missing !== undefined) return { bundle: missing, cause: "missing" }
+
+  const incompatible = FAILED_IMPORT_BUNDLE.exec(output)?.[1]
+  if (incompatible !== undefined) return { bundle: incompatible, cause: "incompatible" }
+
+  return undefined
 }
 
 type RemoveProfileBundleOptions = {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -33,7 +33,7 @@ import {
 } from "./dsh-product-home"
 import { launchDshSidecar } from "./dsh-sidecar"
 import { prepareDshToolsEnvironment } from "./dsh-tools"
-import { removeProfileBundle, unresolvedProfileBundle } from "./dsh-profile-repair"
+import { failingProfileBundle, removeProfileBundle } from "./dsh-profile-repair"
 import { migrateDshHome, resolveDshHome } from "./pawwork-home"
 import { initLogging } from "./logging"
 import { detectSystemMenuLocale, type MenuLocale } from "./menu-labels"
@@ -100,7 +100,15 @@ const productPreload = join(productResources.dsh, "product", "preload.cjs")
 // DSH states the cause and the fix on its own stderr before it exits, and the
 // window has no other copy of it: once DSH is gone, its stdio is gone with it.
 // Keeping the tail costs a few kilobytes.
-const DSH_OUTPUT_TAIL_CHARS = 4_000
+//
+// It has to be tens of kilobytes, not a few: Node prints a failed plugin import
+// as a chain of nested causes whose frames are all deep pnpm paths, so a single
+// one runs past 4 KB and several failing plugins push the sentence that names
+// them — the one fact the recovery path can act on — off the front of a short
+// tail. What the dialog shows is capped separately; nobody wants 40 KB of Node
+// stack in a message box.
+const DSH_OUTPUT_TAIL_CHARS = 40_000
+const DSH_OUTPUT_EXCERPT_CHARS = 4_000
 let dshOutputTail = ""
 // Set by launchDsh: the recovery path needs the profile directory, and the home
 // is only settled once the migration inside launchDsh has run.
@@ -381,8 +389,12 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
     ? {
         title: state.reason === "startup" ? "爪印无法启动" : "爪印已停止",
         message: state.reason === "startup" ? "智能体运行时未能启动。" : "智能体运行时意外退出。",
-        pluginCause: (bundle: string) =>
-          `插件「${bundle}」没有安装完整，运行时因此起不来。移除它就能重新打开爪印，之后可以在设置里重新安装。`,
+        pluginCause: {
+          missing: (bundle: string) =>
+            `插件「${bundle}」没有安装完整，运行时因此起不来。移除它就能重新打开爪印，之后可以在设置里重新安装。`,
+          incompatible: (bundle: string) =>
+            `插件「${bundle}」与当前版本的爪印不兼容，运行时因此起不来。移除它就能重新打开爪印；等插件发布适配新版本的更新后，再到设置里装回来。`,
+        },
         removePlugin: "移除该插件并重试",
         removeFailed: (bundle: string) => `没能移除插件「${bundle}」，请查看日志。`,
         retry: "重试",
@@ -394,9 +406,14 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
     : {
         title: state.reason === "startup" ? "PawWork Could Not Start" : "PawWork Stopped",
         message: state.reason === "startup" ? "The agent runtime did not start." : "The agent runtime stopped unexpectedly.",
-        pluginCause: (bundle: string) =>
-          `The plugin "${bundle}" is not fully installed, which stops the runtime from starting.`
-          + " Removing it lets PawWork open again; you can reinstall it from Settings afterwards.",
+        pluginCause: {
+          missing: (bundle: string) =>
+            `The plugin "${bundle}" is not fully installed, which stops the runtime from starting.`
+            + " Removing it lets PawWork open again; you can reinstall it from Settings afterwards.",
+          incompatible: (bundle: string) =>
+            `The plugin "${bundle}" is not compatible with this version of PawWork, which stops the runtime from starting.`
+            + " Removing it lets PawWork open again; you can install it again from Settings once the plugin ships an update.",
+        },
         removePlugin: "Remove Plugin and Retry",
         removeFailed: (bundle: string) => `Could not remove the plugin "${bundle}". See the log for details.`,
         retry: "Try Again",
@@ -410,12 +427,12 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
   // The runtime's own stderr is a Node stack over DSH's internals; it belongs in
   // the log, not in front of someone who just wants their app back. Only the one
   // fact they can act on is lifted out of it.
-  const bundle = dshHome === undefined ? undefined : unresolvedProfileBundle(`${error}\n${dshOutputTail}`)
+  const failure = dshHome === undefined ? undefined : failingProfileBundle(`${error}\n${dshOutputTail}`)
   let note = ""
 
   for (;;) {
     const buttons = [
-      ...(bundle === undefined ? [] : [copy.removePlugin]),
+      ...(failure === undefined ? [] : [copy.removePlugin]),
       copy.retry,
       copy.showLog,
       copy.report,
@@ -430,7 +447,9 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
       // sentence already summarizes.
       detail: [
         note,
-        ...(bundle === undefined ? [error, dshOutputTail.trim()] : [copy.pluginCause(bundle)]),
+        ...(failure === undefined
+          ? [error, dshOutputTail.slice(-DSH_OUTPUT_EXCERPT_CHARS).trim()]
+          : [copy.pluginCause[failure.cause](failure.bundle)]),
         `${copy.log}: ${logPath}`,
       ]
         .filter(Boolean)
@@ -443,12 +462,13 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
     const result = owner ? await dialog.showMessageBox(owner, options) : await dialog.showMessageBox(options)
     const chosen = buttons[result.response]
 
-    if (chosen === copy.removePlugin && bundle !== undefined && dshHome !== undefined) {
+    if (chosen === copy.removePlugin && failure !== undefined && dshHome !== undefined) {
+      const bundle = failure.bundle
       let removed: boolean
       try {
         removed = removeProfileBundle({ profileDir: join(dshHome, "profiles", "web"), bundle })
-      } catch (failure) {
-        logger.error("failed to remove unresolved profile bundle", failure)
+      } catch (removeFailure) {
+        logger.error("failed to remove failing profile bundle", removeFailure)
         note = copy.removeFailed(bundle)
         continue
       }
@@ -456,11 +476,11 @@ async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed
       // comes from somewhere we do not own, so restarting would hit the same
       // failure. Say so rather than reporting a repair that did not happen.
       if (!removed) {
-        logger.error("unresolved profile bundle was not declared in the profile", { bundle })
+        logger.error("failing profile bundle was not declared in the profile", { bundle, cause: failure.cause })
         note = copy.removeFailed(bundle)
         continue
       }
-      logger.log("removed unresolved profile bundle", { bundle })
+      logger.log("removed failing profile bundle", { bundle, cause: failure.cause })
       focusMainWindow(true)
       lifecycle.start()
       return


### PR DESCRIPTION
## Problem

A profile plugin compiled against an older DSH takes the whole app down. cordis imports every loader entry with `Promise.allSettled`, rethrows the failures and rolls the entire configuration tree back, so a single stale plugin ends the boot with `DSH exited with code 1` — no window, and nothing the user can do from inside the app.

2026.9.1 moved DSH from 0.1.1-rc.2 to 0.1.2-alpha.3 (#1618, #1620), and 0.1.2-alpha.1 dropped `settingsNamespace` / `deepEqualJson` / `installSettingsSection` from `@deepseek-ai/dsh-settings` and `CallId` from `@deepseek-ai/dsh-llm`. Plugins that were fine before now fail at their top-level named imports:

```
Error: failed to import loader entry better-sidebar (dsh-better-sidebar): The requested module
'@deepseek-ai/dsh-settings' does not provide an export named 'settingsNamespace'
```

`showDshFailure` already knows how to recover from this class of failure — it drops one row from `dsh.profile.bundles` and restarts — but attribution only matched `cannot resolve profile bundle "<name>"`, the shape a rolled-back market install leaves behind (#1601). A plugin that is installed and merely will not import matched nothing, so the dialog showed a Node stack and a Quit button.

## Change

- Attribute loader failures from `failed to import loader entry <id> (<name>)`. The parenthesized half is the package, and the package is what the manifest holds. Only the `import` stage counts: the same failure resurfaces one level up as `failed to apply loader entry include (cordis:include)`, and that wrapper names loader plumbing no profile can declare.
- `unresolvedProfileBundle` becomes `failingProfileBundle`, returning the bundle plus a `missing` / `incompatible` cause so the dialog can say which one it is. "Not fully installed" is wrong for a plugin that is installed and merely incompatible.
- Grow the retained DSH stderr from 4 KB to 40 KB. Node prints one failed import as a chain of nested causes over deep pnpm paths, well past 4 KB on its own, so with several failing plugins the sentence that names them fell off the front of the tail and nothing was attributed at all. What the dialog shows stays capped at 4 KB.

Out of scope, and deliberately not attempted: pre-flighting plugin API compatibility before boot. It needs a hand-written ESM/exports subpath resolver (`dsh-llm` alone has eight subpath entries), false positives would silently disable working plugins, and it still misses failures down the dependency chain.

## Verification

`pnpm --filter @pawwork/desktop test` (478), `pnpm typecheck`, `pnpm lint`.

Real app, driven over CDP against a scratch `DSH_HOME` whose `profiles/web` carries `dsh-better-sidebar@0.16.1` and `dsh-plugin-subscriptions@0.5.3` (both reference removed exports) with both declared in `dsh.profile.bundles`. Before the change the dialog offered only `["Try Again","Show Log","Report a Problem","Quit"]`. After:

```
The plugin "dsh-better-sidebar" is not compatible with this version of PawWork, which stops the
runtime from starting. Removing it lets PawWork open again; you can install it again from Settings
once the plugin ships an update.
buttons: ["Remove Plugin and Retry","Try Again","Show Log","Report a Problem","Quit"]
```

Clicking through removes one bundle per restart — `dsh-better-sidebar`, then `dsh-plugin-subscriptions` — and the third start reaches the product URL. `@deepseek-ai/dsh-base`, `@deepseek-ai/dsh-web-app` and the `dependencies` entries are untouched. Checked in both locales; the Chinese copy reads 「插件『X』与当前版本的爪印不兼容…」.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop plugin failure detection for missing or incompatible plugins.
  * Updated failure dialogs with cause-specific messaging and details, making troubleshooting clearer.
  * Improved handling of complex loader errors and filtered out unrelated failures from plugin repair prompts.
  * Increased captured error context while keeping displayed excerpts concise for readability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->