### PR TITLE
fix(desktop): upgrade an outdated community market before DSH loads it

### DIFF
--- a/packages/desktop-electron/resources/dsh/product/lib/desktop-host.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/desktop-host.cjs
@@ -3,11 +3,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const MARKET_NAME = 'dshmarket';
-// The floor is a compatibility contract, not a pin: it is the first market
-// release that works with the Desktop services we inject in place of its own
-// profile and package runtime. Installing targets the latest release, per the
-// market's own install instructions, and the market updates itself from there.
-const MARKET_MINIMUM_VERSION = '1.21.0';
 const MARKET_OPERATION_TIMEOUT_MS = 15 * 60 * 1000;
 
 function readProfile(profileDir) {
@@ -27,31 +22,13 @@ function installedMarketVersion(profileDir) {
   }
 }
 
-function versionAtLeast(version, minimum) {
-  const parse = (value) => {
-    const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(value);
-    return match === null
-      ? undefined
-      : { numbers: match.slice(1, 4).map(Number), prerelease: match[4] };
-  };
-  const candidate = parse(version);
-  const floor = parse(minimum);
-  if (candidate === undefined || floor === undefined) return false;
-  for (let index = 0; index < 3; index += 1) {
-    if (candidate.numbers[index] !== floor.numbers[index]) {
-      return candidate.numbers[index] > floor.numbers[index];
-    }
-  }
-  return floor.prerelease !== undefined || candidate.prerelease === undefined;
-}
-
 function marketStatus(profileDir) {
   const manifest = readProfile(profileDir);
   const declared = typeof manifest.dependencies?.[MARKET_NAME] === 'string';
   const version = installedMarketVersion(profileDir);
   const active = (manifest.dsh?.profile?.bundles ?? []).includes(MARKET_NAME);
   return {
-    enabled: declared && active && version !== null && versionAtLeast(version, MARKET_MINIMUM_VERSION),
+    enabled: declared && active && version !== null,
     version,
   };
 }
@@ -168,7 +145,7 @@ function createDesktopHost(options) {
     const operation = pnpm.service.runPlugin(
       args,
       profileDir,
-      AbortSignal.timeout(options.operationTimeoutMs ?? MARKET_OPERATION_TIMEOUT_MS),
+      AbortSignal.timeout(MARKET_OPERATION_TIMEOUT_MS),
     );
     let stderr = '';
     operation.stdout.on('data', () => {});
@@ -191,11 +168,7 @@ function createDesktopHost(options) {
         try {
           await runMarketPlugin(['add', MARKET_NAME], 'DSH plugin install');
           const installed = await status();
-          if (!installed.enabled) {
-            throw new Error(installed.version === null
-              ? 'DSH did not activate a compatible community market'
-              : `The community market requires ${MARKET_MINIMUM_VERSION} or newer, but ${installed.version} was installed`);
-          }
+          if (!installed.enabled) throw new Error('DSH did not activate the community market');
           return installed;
         } catch (error) {
           pruneUnresolvableMarketBundle(profileDir);
@@ -254,7 +227,6 @@ function registerCommunityMarketRoutes(webServer, market, hostToken) {
 }
 
 module.exports = {
-  MARKET_MINIMUM_VERSION,
   MARKET_NAME,
   createDesktopHost,
   registerCommunityMarketRoutes,

--- a/packages/desktop-electron/resources/dsh/product/lib/desktop-host.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/desktop-host.test.cjs
@@ -134,8 +134,8 @@ test('cancels and awaits the active package tree before the host disposes', asyn
   assert.equal(disposed, true);
 })
 
-test('requires the minimum market version and derives restart from the boot generation', async () => {
-  const { home, profileDir } = profileHome('1.20.0');
+test('derives restart from the boot generation', async () => {
+  const { home, profileDir } = profileHome();
   const host = createDesktopHost({
     dshBin: '/app/dsh/bin.js',
     home,
@@ -146,23 +146,23 @@ test('requires the minimum market version and derives restart from the boot gene
   assert.deepEqual(await host.communityMarket.status(), {
     enabled: false,
     restartRequired: false,
-    version: '1.20.0',
+    version: null,
   });
 
   fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
-    dependencies: { dshmarket: '1.21.0' },
+    dependencies: { dshmarket: '1.39.0' },
     dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket'] } },
   }));
-  writeInstalledMarket(profileDir, '1.21.0');
+  writeInstalledMarket(profileDir, '1.39.0');
   assert.deepEqual(await host.communityMarket.status(), {
     enabled: true,
     restartRequired: true,
-    version: '1.21.0',
+    version: '1.39.0',
   });
 })
 
 test('requires restart when the running market is removed from the profile', async () => {
-  const { home, profileDir } = profileHome('1.21.0');
+  const { home, profileDir } = profileHome('1.39.0');
   const host = createDesktopHost({
     dshBin: '/app/dsh/bin.js',
     home,
@@ -178,7 +178,7 @@ test('requires restart when the running market is removed from the profile', asy
   assert.deepEqual(await host.communityMarket.status(), {
     enabled: false,
     restartRequired: true,
-    version: '1.21.0',
+    version: '1.39.0',
   });
 })
 
@@ -218,32 +218,6 @@ test('installs the latest market through the managed service', async () => {
   });
 })
 
-test('reports the installed version when it is below the compatibility floor', async () => {
-  const { home, profileDir } = profileHome();
-  const managed = managedSubprocess();
-  const host = createDesktopHost({
-    dshBin: '/app/dsh/bin.js',
-    home,
-    nodeExecutable: '/app/PawWork',
-    subprocess: managed.subprocess,
-  });
-
-  const enabling = host.communityMarket.enable();
-  await Promise.resolve();
-  fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
-    dependencies: { dshmarket: '1.20.4' },
-    dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket'] } },
-  }));
-  writeInstalledMarket(profileDir, '1.20.4');
-  managed.settle({ exitCode: 0, signal: null });
-
-  await assert.rejects(enabling, /requires 1\.21\.0 or newer, but 1\.20\.4 was installed/);
-  // The row resolves, so it is the user's to keep — pruning it would break a
-  // profile that still boots fine.
-  const manifest = JSON.parse(fs.readFileSync(path.join(profileDir, 'package.json'), 'utf8'));
-  assert.deepEqual(manifest.dsh.profile.bundles, ['@deepseek-ai/dsh-base', 'dshmarket']);
-})
-
 test('prunes the orphan bundle row when the install fails', async () => {
   const { home, profileDir } = profileHome();
   const managed = managedSubprocess();
@@ -271,8 +245,8 @@ test('prunes the orphan bundle row when the install fails', async () => {
   assert.deepEqual(manifest.dsh.profile.bundles, ['@deepseek-ai/dsh-base']);
 })
 
-test('keeps a newer compatible market without spawning a downgrade', async () => {
-  const { home } = profileHome('1.24.0');
+test('keeps an installed market without spawning a redundant install', async () => {
+  const { home } = profileHome('1.39.0');
   const host = createDesktopHost({
     dshBin: '/app/dsh/bin.js',
     home,
@@ -283,12 +257,12 @@ test('keeps a newer compatible market without spawning a downgrade', async () =>
   assert.deepEqual(await host.communityMarket.enable(), {
     enabled: true,
     restartRequired: false,
-    version: '1.24.0',
+    version: '1.39.0',
   });
 })
 
 test('uses the installed package version instead of downgrading a newer dependency range', async () => {
-  const { home } = profileHome('^1.24.0', '1.24.3');
+  const { home } = profileHome('^1.39.0', '1.39.3');
   const host = createDesktopHost({
     dshBin: '/app/dsh/bin.js',
     home,
@@ -299,12 +273,12 @@ test('uses the installed package version instead of downgrading a newer dependen
   assert.deepEqual(await host.communityMarket.enable(), {
     enabled: true,
     restartRequired: false,
-    version: '1.24.3',
+    version: '1.39.3',
   });
 })
 
 test('does not report a manifest-only market as installed', async () => {
-  const { home } = profileHome('^1.24.0', null);
+  const { home } = profileHome('^1.39.0', null);
   const host = createDesktopHost({
     dshBin: '/app/dsh/bin.js',
     home,
@@ -333,7 +307,7 @@ test('rejects a successful command that did not activate the market', async () =
   await Promise.resolve();
   managed.settle({ exitCode: 0, signal: null });
 
-  await assert.rejects(enabling, /did not activate a compatible community market/);
+  await assert.rejects(enabling, /did not activate the community market/);
 })
 
 test('rejects market mutations that do not carry the per-launch host token', async () => {
@@ -356,9 +330,9 @@ test('rejects market mutations that do not carry the per-launch host token', asy
 })
 
 test('finishes a removal DSH left half-done, without touching the rest of the profile', async () => {
-  const { home, profileDir } = profileHome('1.21.0');
+  const { home, profileDir } = profileHome('1.39.0');
   fs.writeFileSync(path.join(profileDir, 'package.json'), JSON.stringify({
-    dependencies: { dshmarket: '1.21.0', 'dsh-notifier': '^2.0.0' },
+    dependencies: { dshmarket: '1.39.0', 'dsh-notifier': '^2.0.0' },
     dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'dshmarket', 'dsh-notifier'] } },
   }));
   const managed = managedSubprocess();

--- a/packages/desktop-electron/src/main/dsh-market-guard.test.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.test.ts
@@ -37,39 +37,52 @@ function profileWith(options: { declared?: string; installed?: string; bundled?:
 class FakeChild extends EventEmitter {
   readonly stdout = new EventEmitter()
   readonly stderr = new EventEmitter()
-  signals: Array<NodeJS.Signals | undefined> = []
-
-  kill(signal?: NodeJS.Signals) {
-    this.signals.push(signal)
-    queueMicrotask(() => this.emit("exit", null))
-    return true
-  }
+  readonly pid = 4321
 }
 
-function guard(profileDir: string, behaviour: (child: FakeChild) => void = (child) => child.emit("exit", 0)) {
+type GuardOptions = {
+  /** Whether a terminated process group actually dies. */
+  diesOnSignal?: boolean
+  killGraceMs?: number
+  signal?: AbortSignal
+  timeoutMs?: number
+}
+
+function guard(
+  profileDir: string,
+  behaviour: (child: FakeChild) => void = (child) => child.emit("exit", 0),
+  options: GuardOptions = {},
+) {
   const spawns: Array<{ executable: string; args: string[]; options: unknown }> = []
   const messages: Array<{ message: string; detail?: Record<string, unknown> }> = []
+  const kills: Array<{ pid: number; signal: NodeJS.Signals }> = []
   const children: FakeChild[] = []
   let notices = 0
   return {
     spawns,
     messages,
-    children,
+    kills,
     notices: () => notices,
-    run: (verifiedVersion = "1.39.0", timeoutMs?: number) => ensureVerifiedCommunityMarket({
+    run: (verifiedVersion = "1.39.0") => ensureVerifiedCommunityMarket({
       dshBin: "/app/dsh/bin.js",
       env: { DSH_HOME: "/home/u/.pawwork/dsh" },
       executable: "/app/PawWork",
       profileDir,
-      spawn: (executable, args, options) => {
+      spawn: (executable, args, spawnOptions) => {
         const child = new FakeChild()
         children.push(child)
-        spawns.push({ executable, args, options })
+        spawns.push({ executable, args, options: spawnOptions })
         queueMicrotask(() => behaviour(child))
         return child
       },
+      signal: options.signal ?? new AbortController().signal,
       verifiedVersion,
-      timeoutMs,
+      timeoutMs: options.timeoutMs,
+      killGraceMs: options.killGraceMs,
+      killTree: (pid, signal) => {
+        kills.push({ pid, signal })
+        if (options.diesOnSignal ?? true) queueMicrotask(() => children[0]?.emit("exit", null))
+      },
       onUpgradeStart: () => { notices += 1 },
       log: (message, detail) => messages.push({ message, detail }),
     }),
@@ -124,17 +137,10 @@ describe("ensureVerifiedCommunityMarket", () => {
 
     expect(harness.spawns).toEqual([{
       executable: "/app/PawWork",
-      args: [
-        "/app/dsh/bin.js",
-        "plugin",
-        "--profile",
-        "web",
-        "add",
-        "--config.minimumReleaseAge=0",
-        "dshmarket@1.39.0",
-      ],
+      args: ["/app/dsh/bin.js", "plugin", "--profile", "web", "add", "dshmarket@1.39.0"],
       options: {
         cwd: expect.stringContaining("pawwork-market-guard-") as unknown,
+        detached: true,
         env: { DSH_HOME: "/home/u/.pawwork/dsh" },
         stdio: ["ignore", "pipe", "pipe"],
       },
@@ -183,15 +189,47 @@ describe("ensureVerifiedCommunityMarket", () => {
     expect(harness.messages.at(-1)?.detail?.error).toBe("EACCES")
   })
 
-  test("terminates an install that outruns the deadline, and still starts", async () => {
-    // A wedged install: it exits on the signal and never on its own. Aborting
-    // the deadline does not terminate the child by itself, so without the kill
-    // this launch would wait forever.
-    const harness = guard(profileWith({ declared: "1.34.0", installed: "1.34.0" }), () => {})
+  // pnpm runs as a grandchild of the process spawned here, so the whole group
+  // has to go: anything still writing the profile when DSH starts is the crash
+  // this guard exists to prevent.
+  test("terminates the install group when the deadline runs out, and still starts", async () => {
+    const wedged = () => {}
+    const harness = guard(profileWith({ declared: "1.34.0", installed: "1.34.0" }), wedged, { timeoutMs: 1 })
 
-    await expect(harness.run("1.39.0", 1)).resolves.toBeUndefined()
+    await expect(harness.run()).resolves.toBeUndefined()
 
-    expect(harness.children[0]?.signals).toEqual(["SIGTERM"])
-    expect(harness.messages.at(-1)?.detail?.error).toMatch(/timed out/)
+    expect(harness.kills).toEqual([{ pid: 4321, signal: "SIGTERM" }])
+    expect(harness.messages.at(-1)?.detail?.error).toMatch(/was terminated/)
+  })
+
+  test("kills a group that ignores the termination rather than holding the launch", async () => {
+    const harness = guard(profileWith({ declared: "1.34.0", installed: "1.34.0" }), () => {}, {
+      diesOnSignal: false,
+      killGraceMs: 1,
+      timeoutMs: 1,
+    })
+
+    await expect(harness.run()).resolves.toBeUndefined()
+
+    expect(harness.kills.map((kill) => kill.signal)).toEqual(["SIGTERM", "SIGKILL"])
+    expect(harness.messages.at(-1)?.detail?.error).toMatch(/could not be terminated/)
+  })
+
+  // Quitting mid-upgrade: the install is stopped, and nothing is reported
+  // because nothing is about to start.
+  test("stops the install when the app is stopping, and reports nothing", async () => {
+    const stopping = new AbortController()
+    const harness = guard(
+      profileWith({ declared: "1.34.0", installed: "1.34.0" }),
+      () => stopping.abort(),
+      { signal: stopping.signal },
+    )
+
+    await expect(harness.run()).resolves.toBeUndefined()
+
+    expect(harness.kills).toEqual([{ pid: 4321, signal: "SIGTERM" }])
+    expect(harness.messages.map((entry) => entry.message)).toEqual([
+      "upgrading the community market before DSH starts",
+    ])
   })
 })

--- a/packages/desktop-electron/src/main/dsh-market-guard.test.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.test.ts
@@ -1,0 +1,275 @@
+import { EventEmitter } from "node:events"
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { gte } from "semver"
+import { describe, expect, test } from "vitest"
+import {
+  MARKET_NAME,
+  VERIFIED_COMMUNITY_MARKET,
+  createMarketPluginRunner,
+  ensureVerifiedCommunityMarket,
+  installedMarketVersion,
+  outdatedMarketVersion,
+} from "./dsh-market-guard"
+
+const require = createRequire(import.meta.url)
+
+// The Desktop host's own view of the market, which ships as CommonJS into the
+// DSH home and is therefore required rather than imported.
+const { MARKET_MINIMUM_VERSION, MARKET_NAME: HOST_MARKET_NAME } = require(
+  "../../resources/dsh/product/lib/desktop-host.cjs",
+) as { MARKET_MINIMUM_VERSION: string; MARKET_NAME: string }
+
+function profileWith(options: { declared?: string; installed?: string; bundled?: boolean }) {
+  const profileDir = mkdtempSync(join(tmpdir(), "pawwork-market-guard-"))
+  const bundled = options.bundled ?? options.declared !== undefined
+  writeFileSync(join(profileDir, "package.json"), JSON.stringify({
+    name: "dsh-profile-web",
+    dependencies: options.declared === undefined ? {} : { [MARKET_NAME]: options.declared },
+    dsh: {
+      profile: {
+        bundles: bundled ? ["@deepseek-ai/dsh-base", MARKET_NAME] : ["@deepseek-ai/dsh-base"],
+      },
+    },
+  }), "utf8")
+  if (options.installed !== undefined) {
+    const packageDir = join(profileDir, "node_modules", MARKET_NAME)
+    mkdirSync(packageDir, { recursive: true })
+    writeFileSync(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: MARKET_NAME, version: options.installed }),
+      "utf8",
+    )
+  }
+  return profileDir
+}
+
+function recordingRunner(outcome: () => Promise<void> = () => Promise.resolve()) {
+  const calls: Array<{ args: string[]; signal: AbortSignal }> = []
+  return {
+    calls,
+    run: (args: string[], signal: AbortSignal) => {
+      calls.push({ args, signal })
+      return outcome()
+    },
+  }
+}
+
+function fakeSpawn(behaviour: (child: FakeChild) => void) {
+  const spawns: Array<{ executable: string; args: string[]; options: unknown }> = []
+  return {
+    spawns,
+    spawn: (executable: string, args: string[], options: unknown) => {
+      const child = new FakeChild()
+      spawns.push({ executable, args, options })
+      queueMicrotask(() => behaviour(child))
+      return child
+    },
+  }
+}
+
+class FakeChild extends EventEmitter {
+  readonly stdout = new EventEmitter()
+  readonly stderr = new EventEmitter()
+  signals: Array<NodeJS.Signals | undefined> = []
+
+  kill(signal?: NodeJS.Signals) {
+    this.signals.push(signal)
+    return true
+  }
+}
+
+describe("the verified market release", () => {
+  // The tripwire that would have caught 1.34.0: it is only correct to inherit
+  // this pin while the DSH under it has not moved. Upgrading DSH means naming
+  // the market release the upgrade was validated against.
+  test("names the DSH release it was validated against", () => {
+    const installed = JSON.parse(
+      readFileSync(require.resolve("@deepseek-ai/dsh/package.json"), "utf8"),
+    ) as { version: string }
+
+    expect(VERIFIED_COMMUNITY_MARKET.dsh).toBe(installed.version)
+  })
+
+  test("is at or above the host compatibility floor, which stays a separate contract", () => {
+    expect(MARKET_NAME).toBe(HOST_MARKET_NAME)
+    expect(gte(VERIFIED_COMMUNITY_MARKET.market, MARKET_MINIMUM_VERSION)).toBe(true)
+  })
+})
+
+describe("outdatedMarketVersion", () => {
+  test("names an active market below the verified release", () => {
+    const profileDir = profileWith({ declared: "1.34.0", installed: "1.34.0" })
+
+    expect(outdatedMarketVersion(profileDir, "1.39.0")).toBe("1.34.0")
+    expect(installedMarketVersion(profileDir)).toBe("1.34.0")
+  })
+
+  test("leaves a market at or above the verified release alone", () => {
+    expect(outdatedMarketVersion(profileWith({ declared: "1.39.0", installed: "1.39.0" }), "1.39.0")).toBeUndefined()
+    expect(outdatedMarketVersion(profileWith({ declared: "^1.39.0", installed: "1.40.2" }), "1.39.0")).toBeUndefined()
+  })
+
+  test("ignores a market the profile does not load at boot", () => {
+    const profileDir = profileWith({ declared: "1.34.0", installed: "1.34.0", bundled: false })
+
+    expect(outdatedMarketVersion(profileDir, "1.39.0")).toBeUndefined()
+  })
+
+  // The orphan row is pruneUnresolvableMarketBundle's and the startup-failure
+  // dialog's to repair; installing over it here would mask their work.
+  test("ignores a bundle row with no package behind it", () => {
+    const profileDir = profileWith({ declared: "1.34.0" })
+
+    expect(outdatedMarketVersion(profileDir, "1.39.0")).toBeUndefined()
+  })
+
+  test("ignores a profile with no market and an unreadable manifest", () => {
+    expect(outdatedMarketVersion(profileWith({}), "1.39.0")).toBeUndefined()
+    expect(outdatedMarketVersion(join(tmpdir(), "pawwork-market-guard-absent"), "1.39.0")).toBeUndefined()
+  })
+
+  test("ignores a version it cannot compare", () => {
+    const profileDir = profileWith({ declared: "workspace:*", installed: "next" })
+
+    expect(outdatedMarketVersion(profileDir, "1.39.0")).toBeUndefined()
+  })
+})
+
+describe("ensureVerifiedCommunityMarket", () => {
+  test("installs the verified release before DSH starts", async () => {
+    const profileDir = profileWith({ declared: "1.34.0", installed: "1.34.0" })
+    const runner = recordingRunner()
+    const messages: string[] = []
+    let notices = 0
+
+    await ensureVerifiedCommunityMarket({
+      profileDir,
+      runPlugin: runner.run,
+      verifiedVersion: "1.39.0",
+      onUpgradeStart: () => { notices += 1 },
+      log: (message) => messages.push(message),
+    })
+
+    expect(runner.calls.map((call) => call.args)).toEqual([
+      ["add", "--config.minimumReleaseAge=0", "dshmarket@1.39.0"],
+    ])
+    expect(runner.calls[0]?.signal).toBeInstanceOf(AbortSignal)
+    expect(notices).toBe(1)
+    expect(messages).toEqual([
+      "upgrading the community market before DSH starts",
+      "community market upgraded",
+    ])
+  })
+
+  test("does nothing, and says nothing, on a normal start", async () => {
+    const runner = recordingRunner()
+    const messages: string[] = []
+    let notices = 0
+
+    await ensureVerifiedCommunityMarket({
+      profileDir: profileWith({ declared: "1.39.0", installed: "1.39.0" }),
+      runPlugin: runner.run,
+      verifiedVersion: "1.39.0",
+      onUpgradeStart: () => { notices += 1 },
+      log: (message) => messages.push(message),
+    })
+
+    expect(runner.calls).toEqual([])
+    expect(notices).toBe(0)
+    expect(messages).toEqual([])
+  })
+
+  // Degrade, never block: an app that cannot reach npm still has to open.
+  test("continues the launch when the upgrade fails", async () => {
+    const runner = recordingRunner(() => Promise.reject(new Error("ENOTFOUND registry.npmjs.org")))
+    const logged: Array<Record<string, unknown> | undefined> = []
+
+    await expect(ensureVerifiedCommunityMarket({
+      profileDir: profileWith({ declared: "1.34.0", installed: "1.34.0" }),
+      runPlugin: runner.run,
+      verifiedVersion: "1.39.0",
+      log: (_message, detail) => logged.push(detail),
+    })).resolves.toBeUndefined()
+
+    expect(logged.at(-1)).toEqual({ from: "1.34.0", to: "1.39.0", error: "ENOTFOUND registry.npmjs.org" })
+  })
+})
+
+describe("createMarketPluginRunner", () => {
+  test("runs dsh plugin against the web profile in the sidecar environment", async () => {
+    const spawner = fakeSpawn((child) => child.emit("exit", 0))
+    const run = createMarketPluginRunner({
+      dshBin: "/app/dsh/bin.js",
+      env: { DSH_HOME: "/home/u/.pawwork/dsh" },
+      executable: "/app/PawWork",
+      profileDir: "/home/u/.pawwork/dsh/profiles/web",
+      spawn: spawner.spawn,
+    })
+
+    await expect(run(["add", "dshmarket@1.39.0"], AbortSignal.timeout(1_000))).resolves.toBeUndefined()
+    expect(spawner.spawns).toEqual([{
+      executable: "/app/PawWork",
+      args: ["/app/dsh/bin.js", "plugin", "--profile", "web", "add", "dshmarket@1.39.0"],
+      options: {
+        cwd: "/home/u/.pawwork/dsh/profiles/web",
+        env: { DSH_HOME: "/home/u/.pawwork/dsh" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    }])
+  })
+
+  // pnpm's reason lands on stdout and `dsh plugin`'s summary on stderr; a log
+  // carrying only the summary says nothing anyone can act on.
+  test("reports the failure output of a non-zero exit from both streams", async () => {
+    const spawner = fakeSpawn((child) => {
+      child.stdout.emit("data", " ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/dshmarket\n")
+      child.stderr.emit("data", "dsh: pnpm failed in profile directory /profile\n")
+      child.emit("exit", 1)
+    })
+    const run = createMarketPluginRunner({
+      dshBin: "/app/dsh/bin.js",
+      env: {},
+      executable: "/app/PawWork",
+      profileDir: "/profile",
+      spawn: spawner.spawn,
+    })
+
+    await expect(run(["add", "dshmarket@9.9.9"], AbortSignal.timeout(1_000)))
+      .rejects.toThrow(/exited with code 1: ERR_PNPM_FETCH_404[\s\S]*pnpm failed in profile directory/)
+  })
+
+  test("terminates the install when the deadline passes", async () => {
+    let killed: FakeChild | undefined
+    const spawner = fakeSpawn((child) => { killed = child })
+    const run = createMarketPluginRunner({
+      dshBin: "/app/dsh/bin.js",
+      env: {},
+      executable: "/app/PawWork",
+      profileDir: "/profile",
+      spawn: spawner.spawn,
+    })
+
+    const pending = run(["add", "dshmarket@1.39.0"], AbortSignal.timeout(1))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    killed?.emit("exit", null)
+
+    await expect(pending).rejects.toThrow(/timed out/)
+    expect(killed?.signals).toEqual(["SIGTERM"])
+  })
+
+  test("reports a spawn failure instead of crashing the main process", async () => {
+    const spawner = fakeSpawn((child) => child.emit("error", new Error("EACCES")))
+    const run = createMarketPluginRunner({
+      dshBin: "/app/dsh/bin.js",
+      env: {},
+      executable: "/app/PawWork",
+      profileDir: "/profile",
+      spawn: spawner.spawn,
+    })
+
+    await expect(run(["add", "dshmarket@1.39.0"], AbortSignal.timeout(1_000))).rejects.toThrow("EACCES")
+  })
+})

--- a/packages/desktop-electron/src/main/dsh-market-guard.test.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.test.ts
@@ -41,6 +41,7 @@ class FakeChild extends EventEmitter {
 
   kill(signal?: NodeJS.Signals) {
     this.signals.push(signal)
+    queueMicrotask(() => this.emit("exit", null))
     return true
   }
 }
@@ -183,13 +184,12 @@ describe("ensureVerifiedCommunityMarket", () => {
   })
 
   test("terminates an install that outruns the deadline, and still starts", async () => {
-    // A wedged install: it never exits on its own.
+    // A wedged install: it exits on the signal and never on its own. Aborting
+    // the deadline does not terminate the child by itself, so without the kill
+    // this launch would wait forever.
     const harness = guard(profileWith({ declared: "1.34.0", installed: "1.34.0" }), () => {})
-    const started = harness.run("1.39.0", 1)
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    for (const child of harness.children) child.emit("exit", null)
 
-    await expect(started).resolves.toBeUndefined()
+    await expect(harness.run("1.39.0", 1)).resolves.toBeUndefined()
 
     expect(harness.children[0]?.signals).toEqual(["SIGTERM"])
     expect(harness.messages.at(-1)?.detail?.error).toMatch(/timed out/)

--- a/packages/desktop-electron/src/main/dsh-market-guard.test.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.test.ts
@@ -3,71 +3,35 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { gte } from "semver"
 import { describe, expect, test } from "vitest"
 import {
-  MARKET_NAME,
   VERIFIED_COMMUNITY_MARKET,
-  createMarketPluginRunner,
   ensureVerifiedCommunityMarket,
-  installedMarketVersion,
   outdatedMarketVersion,
 } from "./dsh-market-guard"
 
 const require = createRequire(import.meta.url)
-
-// The Desktop host's own view of the market, which ships as CommonJS into the
-// DSH home and is therefore required rather than imported.
-const { MARKET_MINIMUM_VERSION, MARKET_NAME: HOST_MARKET_NAME } = require(
-  "../../resources/dsh/product/lib/desktop-host.cjs",
-) as { MARKET_MINIMUM_VERSION: string; MARKET_NAME: string }
 
 function profileWith(options: { declared?: string; installed?: string; bundled?: boolean }) {
   const profileDir = mkdtempSync(join(tmpdir(), "pawwork-market-guard-"))
   const bundled = options.bundled ?? options.declared !== undefined
   writeFileSync(join(profileDir, "package.json"), JSON.stringify({
     name: "dsh-profile-web",
-    dependencies: options.declared === undefined ? {} : { [MARKET_NAME]: options.declared },
+    dependencies: options.declared === undefined ? {} : { dshmarket: options.declared },
     dsh: {
-      profile: {
-        bundles: bundled ? ["@deepseek-ai/dsh-base", MARKET_NAME] : ["@deepseek-ai/dsh-base"],
-      },
+      profile: { bundles: bundled ? ["@deepseek-ai/dsh-base", "dshmarket"] : ["@deepseek-ai/dsh-base"] },
     },
   }), "utf8")
   if (options.installed !== undefined) {
-    const packageDir = join(profileDir, "node_modules", MARKET_NAME)
+    const packageDir = join(profileDir, "node_modules", "dshmarket")
     mkdirSync(packageDir, { recursive: true })
     writeFileSync(
       join(packageDir, "package.json"),
-      JSON.stringify({ name: MARKET_NAME, version: options.installed }),
+      JSON.stringify({ name: "dshmarket", version: options.installed }),
       "utf8",
     )
   }
   return profileDir
-}
-
-function recordingRunner(outcome: () => Promise<void> = () => Promise.resolve()) {
-  const calls: Array<{ args: string[]; signal: AbortSignal }> = []
-  return {
-    calls,
-    run: (args: string[], signal: AbortSignal) => {
-      calls.push({ args, signal })
-      return outcome()
-    },
-  }
-}
-
-function fakeSpawn(behaviour: (child: FakeChild) => void) {
-  const spawns: Array<{ executable: string; args: string[]; options: unknown }> = []
-  return {
-    spawns,
-    spawn: (executable: string, args: string[], options: unknown) => {
-      const child = new FakeChild()
-      spawns.push({ executable, args, options })
-      queueMicrotask(() => behaviour(child))
-      return child
-    },
-  }
 }
 
 class FakeChild extends EventEmitter {
@@ -81,30 +45,49 @@ class FakeChild extends EventEmitter {
   }
 }
 
-describe("the verified market release", () => {
-  // The tripwire that would have caught 1.34.0: it is only correct to inherit
-  // this pin while the DSH under it has not moved. Upgrading DSH means naming
-  // the market release the upgrade was validated against.
-  test("names the DSH release it was validated against", () => {
-    const installed = JSON.parse(
-      readFileSync(require.resolve("@deepseek-ai/dsh/package.json"), "utf8"),
-    ) as { version: string }
+function guard(profileDir: string, behaviour: (child: FakeChild) => void = (child) => child.emit("exit", 0)) {
+  const spawns: Array<{ executable: string; args: string[]; options: unknown }> = []
+  const messages: Array<{ message: string; detail?: Record<string, unknown> }> = []
+  const children: FakeChild[] = []
+  let notices = 0
+  return {
+    spawns,
+    messages,
+    children,
+    notices: () => notices,
+    run: (verifiedVersion = "1.39.0", timeoutMs?: number) => ensureVerifiedCommunityMarket({
+      dshBin: "/app/dsh/bin.js",
+      env: { DSH_HOME: "/home/u/.pawwork/dsh" },
+      executable: "/app/PawWork",
+      profileDir,
+      spawn: (executable, args, options) => {
+        const child = new FakeChild()
+        children.push(child)
+        spawns.push({ executable, args, options })
+        queueMicrotask(() => behaviour(child))
+        return child
+      },
+      verifiedVersion,
+      timeoutMs,
+      onUpgradeStart: () => { notices += 1 },
+      log: (message, detail) => messages.push({ message, detail }),
+    }),
+  }
+}
 
-    expect(VERIFIED_COMMUNITY_MARKET.dsh).toBe(installed.version)
-  })
+// The tripwire for a forgotten pin: inheriting this market release is only
+// correct while the DSH under it has not moved.
+test("the verified market release names the DSH release it was validated against", () => {
+  const installed = JSON.parse(
+    readFileSync(require.resolve("@deepseek-ai/dsh/package.json"), "utf8"),
+  ) as { version: string }
 
-  test("is at or above the host compatibility floor, which stays a separate contract", () => {
-    expect(MARKET_NAME).toBe(HOST_MARKET_NAME)
-    expect(gte(VERIFIED_COMMUNITY_MARKET.market, MARKET_MINIMUM_VERSION)).toBe(true)
-  })
+  expect(VERIFIED_COMMUNITY_MARKET.dsh).toBe(installed.version)
 })
 
 describe("outdatedMarketVersion", () => {
   test("names an active market below the verified release", () => {
-    const profileDir = profileWith({ declared: "1.34.0", installed: "1.34.0" })
-
-    expect(outdatedMarketVersion(profileDir, "1.39.0")).toBe("1.34.0")
-    expect(installedMarketVersion(profileDir)).toBe("1.34.0")
+    expect(outdatedMarketVersion(profileWith({ declared: "1.34.0", installed: "1.34.0" }), "1.39.0")).toBe("1.34.0")
   })
 
   test("leaves a market at or above the verified release alone", () => {
@@ -118,12 +101,8 @@ describe("outdatedMarketVersion", () => {
     expect(outdatedMarketVersion(profileDir, "1.39.0")).toBeUndefined()
   })
 
-  // The orphan row is pruneUnresolvableMarketBundle's and the startup-failure
-  // dialog's to repair; installing over it here would mask their work.
   test("ignores a bundle row with no package behind it", () => {
-    const profileDir = profileWith({ declared: "1.34.0" })
-
-    expect(outdatedMarketVersion(profileDir, "1.39.0")).toBeUndefined()
+    expect(outdatedMarketVersion(profileWith({ declared: "1.34.0" }), "1.39.0")).toBeUndefined()
   })
 
   test("ignores a profile with no market and an unreadable manifest", () => {
@@ -132,144 +111,87 @@ describe("outdatedMarketVersion", () => {
   })
 
   test("ignores a version it cannot compare", () => {
-    const profileDir = profileWith({ declared: "workspace:*", installed: "next" })
-
-    expect(outdatedMarketVersion(profileDir, "1.39.0")).toBeUndefined()
+    expect(outdatedMarketVersion(profileWith({ declared: "workspace:*", installed: "next" }), "1.39.0")).toBeUndefined()
   })
 })
 
 describe("ensureVerifiedCommunityMarket", () => {
-  test("installs the verified release before DSH starts", async () => {
-    const profileDir = profileWith({ declared: "1.34.0", installed: "1.34.0" })
-    const runner = recordingRunner()
-    const messages: string[] = []
-    let notices = 0
+  test("installs the verified release through dsh plugin before DSH starts", async () => {
+    const harness = guard(profileWith({ declared: "1.34.0", installed: "1.34.0" }))
 
-    await ensureVerifiedCommunityMarket({
-      profileDir,
-      runPlugin: runner.run,
-      verifiedVersion: "1.39.0",
-      onUpgradeStart: () => { notices += 1 },
-      log: (message) => messages.push(message),
-    })
+    await harness.run()
 
-    expect(runner.calls.map((call) => call.args)).toEqual([
-      ["add", "--config.minimumReleaseAge=0", "dshmarket@1.39.0"],
-    ])
-    expect(runner.calls[0]?.signal).toBeInstanceOf(AbortSignal)
-    expect(notices).toBe(1)
-    expect(messages).toEqual([
+    expect(harness.spawns).toEqual([{
+      executable: "/app/PawWork",
+      args: [
+        "/app/dsh/bin.js",
+        "plugin",
+        "--profile",
+        "web",
+        "add",
+        "--config.minimumReleaseAge=0",
+        "dshmarket@1.39.0",
+      ],
+      options: {
+        cwd: expect.stringContaining("pawwork-market-guard-") as unknown,
+        env: { DSH_HOME: "/home/u/.pawwork/dsh" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    }])
+    expect(harness.notices()).toBe(1)
+    expect(harness.messages.map((entry) => entry.message)).toEqual([
       "upgrading the community market before DSH starts",
       "community market upgraded",
     ])
   })
 
   test("does nothing, and says nothing, on a normal start", async () => {
-    const runner = recordingRunner()
-    const messages: string[] = []
-    let notices = 0
+    const harness = guard(profileWith({ declared: "1.39.0", installed: "1.39.0" }))
 
-    await ensureVerifiedCommunityMarket({
-      profileDir: profileWith({ declared: "1.39.0", installed: "1.39.0" }),
-      runPlugin: runner.run,
-      verifiedVersion: "1.39.0",
-      onUpgradeStart: () => { notices += 1 },
-      log: (message) => messages.push(message),
-    })
+    await harness.run()
 
-    expect(runner.calls).toEqual([])
-    expect(notices).toBe(0)
-    expect(messages).toEqual([])
+    expect(harness.spawns).toEqual([])
+    expect(harness.notices()).toBe(0)
+    expect(harness.messages).toEqual([])
   })
 
   // Degrade, never block: an app that cannot reach npm still has to open.
-  test("continues the launch when the upgrade fails", async () => {
-    const runner = recordingRunner(() => Promise.reject(new Error("ENOTFOUND registry.npmjs.org")))
-    const logged: Array<Record<string, unknown> | undefined> = []
-
-    await expect(ensureVerifiedCommunityMarket({
-      profileDir: profileWith({ declared: "1.34.0", installed: "1.34.0" }),
-      runPlugin: runner.run,
-      verifiedVersion: "1.39.0",
-      log: (_message, detail) => logged.push(detail),
-    })).resolves.toBeUndefined()
-
-    expect(logged.at(-1)).toEqual({ from: "1.34.0", to: "1.39.0", error: "ENOTFOUND registry.npmjs.org" })
-  })
-})
-
-describe("createMarketPluginRunner", () => {
-  test("runs dsh plugin against the web profile in the sidecar environment", async () => {
-    const spawner = fakeSpawn((child) => child.emit("exit", 0))
-    const run = createMarketPluginRunner({
-      dshBin: "/app/dsh/bin.js",
-      env: { DSH_HOME: "/home/u/.pawwork/dsh" },
-      executable: "/app/PawWork",
-      profileDir: "/home/u/.pawwork/dsh/profiles/web",
-      spawn: spawner.spawn,
-    })
-
-    await expect(run(["add", "dshmarket@1.39.0"], AbortSignal.timeout(1_000))).resolves.toBeUndefined()
-    expect(spawner.spawns).toEqual([{
-      executable: "/app/PawWork",
-      args: ["/app/dsh/bin.js", "plugin", "--profile", "web", "add", "dshmarket@1.39.0"],
-      options: {
-        cwd: "/home/u/.pawwork/dsh/profiles/web",
-        env: { DSH_HOME: "/home/u/.pawwork/dsh" },
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    }])
-  })
-
-  // pnpm's reason lands on stdout and `dsh plugin`'s summary on stderr; a log
-  // carrying only the summary says nothing anyone can act on.
-  test("reports the failure output of a non-zero exit from both streams", async () => {
-    const spawner = fakeSpawn((child) => {
+  test("continues the launch when the install fails, reporting both output streams", async () => {
+    const harness = guard(profileWith({ declared: "1.34.0", installed: "1.34.0" }), (child) => {
       child.stdout.emit("data", " ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/dshmarket\n")
       child.stderr.emit("data", "dsh: pnpm failed in profile directory /profile\n")
       child.emit("exit", 1)
     })
-    const run = createMarketPluginRunner({
-      dshBin: "/app/dsh/bin.js",
-      env: {},
-      executable: "/app/PawWork",
-      profileDir: "/profile",
-      spawn: spawner.spawn,
-    })
 
-    await expect(run(["add", "dshmarket@9.9.9"], AbortSignal.timeout(1_000)))
-      .rejects.toThrow(/exited with code 1: ERR_PNPM_FETCH_404[\s\S]*pnpm failed in profile directory/)
+    await expect(harness.run()).resolves.toBeUndefined()
+
+    expect(harness.messages.at(-1)?.message).toBe("community market upgrade failed, starting with the installed market")
+    expect(harness.messages.at(-1)?.detail?.error).toMatch(
+      /exited with code 1: ERR_PNPM_FETCH_404[\s\S]*pnpm failed in profile directory/,
+    )
   })
 
-  test("terminates the install when the deadline passes", async () => {
-    let killed: FakeChild | undefined
-    const spawner = fakeSpawn((child) => { killed = child })
-    const run = createMarketPluginRunner({
-      dshBin: "/app/dsh/bin.js",
-      env: {},
-      executable: "/app/PawWork",
-      profileDir: "/profile",
-      spawn: spawner.spawn,
-    })
+  test("continues the launch when the install cannot be spawned", async () => {
+    const harness = guard(
+      profileWith({ declared: "1.34.0", installed: "1.34.0" }),
+      (child) => child.emit("error", new Error("EACCES")),
+    )
 
-    const pending = run(["add", "dshmarket@1.39.0"], AbortSignal.timeout(1))
+    await expect(harness.run()).resolves.toBeUndefined()
+
+    expect(harness.messages.at(-1)?.detail?.error).toBe("EACCES")
+  })
+
+  test("terminates an install that outruns the deadline, and still starts", async () => {
+    // A wedged install: it never exits on its own.
+    const harness = guard(profileWith({ declared: "1.34.0", installed: "1.34.0" }), () => {})
+    const started = harness.run("1.39.0", 1)
     await new Promise((resolve) => setTimeout(resolve, 20))
-    killed?.emit("exit", null)
+    for (const child of harness.children) child.emit("exit", null)
 
-    await expect(pending).rejects.toThrow(/timed out/)
-    expect(killed?.signals).toEqual(["SIGTERM"])
-  })
+    await expect(started).resolves.toBeUndefined()
 
-  test("reports a spawn failure instead of crashing the main process", async () => {
-    const spawner = fakeSpawn((child) => child.emit("error", new Error("EACCES")))
-    const run = createMarketPluginRunner({
-      dshBin: "/app/dsh/bin.js",
-      env: {},
-      executable: "/app/PawWork",
-      profileDir: "/profile",
-      spawn: spawner.spawn,
-    })
-
-    await expect(run(["add", "dshmarket@1.39.0"], AbortSignal.timeout(1_000))).rejects.toThrow("EACCES")
+    expect(harness.children[0]?.signals).toEqual(["SIGTERM"])
+    expect(harness.messages.at(-1)?.detail?.error).toMatch(/timed out/)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-market-guard.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.ts
@@ -3,37 +3,23 @@ import { join } from "node:path"
 import { gte, valid } from "semver"
 import { describeExit } from "./dsh-sidecar"
 
-/** The community market package, spelled the way `dsh plugin add` records it. */
-export const MARKET_NAME = "dshmarket"
+const MARKET_NAME = "dshmarket"
 
 /**
- * The community market release PawWork ships against, paired with the DSH it was
- * verified on.
+ * The community market release this build is verified against, and the DSH
+ * release that verification ran on.
  *
- * The market version is part of PawWork's release contract because nothing else
- * moves it: `dsh plugin add` writes an exact version into the profile, pnpm then
- * installs from the profile lockfile, and the market can only update itself once
- * it loads — which is precisely what a DSH upgrade it has not caught up with
- * takes away. The market sits in `dsh.profile.bundles`, so a market that throws
- * on load makes cordis roll back the whole config tree and DSH exit: users who
- * merely turned the market on once cannot open the app at all.
- *
- * `dsh` is what keeps this pair honest. The sentinel in dsh-market-guard.test.ts
- * fails as soon as the shipped DSH moves, so a DSH upgrade has to name the
- * market release it was validated against instead of silently inheriting this
- * one — which is how 1.34.0 was left behind across 0.1.2-alpha.3.
+ * The two move together: a DSH upgrade has to name the market release it was
+ * validated with, and dsh-market-guard.test.ts fails until it does.
  */
 export const VERIFIED_COMMUNITY_MARKET = {
   dsh: "0.1.2-alpha.3",
   market: "1.39.0",
 } as const
 
-// Long enough for a cold pnpm fetch of one package over a slow link, short
-// enough that an unreachable registry does not hold the window on the startup
-// page for minutes. Overrunning it is not fatal: the launch continues either way.
-const MARKET_UPGRADE_TIMEOUT_MS = 90_000
-
-const PLUGIN_OUTPUT_TAIL_CHARS = 4_000
+// Bounds the wait on the startup page. Overrunning it is not fatal.
+const UPGRADE_TIMEOUT_MS = 90_000
+const OUTPUT_TAIL_CHARS = 4_000
 
 function readJson(path: string): unknown {
   try {
@@ -43,8 +29,7 @@ function readJson(path: string): unknown {
   }
 }
 
-/** The market version materialized in the profile, or undefined when none is. */
-export function installedMarketVersion(profileDir: string) {
+function installedMarketVersion(profileDir: string) {
   const manifest = readJson(join(profileDir, "node_modules", MARKET_NAME, "package.json")) as
     | { version?: unknown }
     | undefined
@@ -63,12 +48,10 @@ function loadsMarketAtBoot(profileDir: string) {
  * The market version this launch has to replace, or undefined when there is
  * nothing to do.
  *
- * Deliberately narrow. Only a market DSH will actually load — declared in
- * `dsh.profile.bundles` *and* materialized in `node_modules` — can take the boot
- * down, and only one below the verified release is untested against the DSH this
- * build ships. A bundle row with no package behind it is a different failure
- * that `pruneUnresolvableMarketBundle` and the startup-failure dialog already
- * own; installing over it here would hide their repair rather than help it.
+ * Only a market that DSH will load counts: listed in `dsh.profile.bundles`,
+ * installed in `node_modules`, and below the verified release. A bundle row
+ * with no package behind it belongs to `pruneUnresolvableMarketBundle` and the
+ * startup-failure dialog instead.
  */
 export function outdatedMarketVersion(
   profileDir: string,
@@ -76,30 +59,25 @@ export function outdatedMarketVersion(
 ) {
   if (!loadsMarketAtBoot(profileDir)) return undefined
   const installed = installedMarketVersion(profileDir)
-  // An unparseable version is not something to reason about, let alone overwrite.
   if (installed === undefined || valid(installed) === null) return undefined
   return gte(installed, verified) ? undefined : installed
 }
 
-/** One `dsh plugin` invocation; rejects on anything but a clean exit. */
-export type MarketPluginRunner = (args: string[], signal: AbortSignal) => Promise<void>
-
 type MarketPluginStream = { on(event: "data", listener: (data: Buffer | string) => void): unknown } | null
 
 interface MarketPluginProcess {
-  // Both streams, because the diagnosis is split across them: `dsh plugin` says
-  // only that pnpm failed, on its stderr, while pnpm's own reason — a blocked
-  // build script, an unreachable registry — went to stdout before that.
+  // Both streams: `dsh plugin` reports only that pnpm failed, on stderr, while
+  // pnpm's own reason went to stdout ahead of it.
   readonly stdout: MarketPluginStream
   readonly stderr: MarketPluginStream
   kill(signal?: NodeJS.Signals): boolean
   on(event: "exit", listener: (code: number | null) => void): this
-  // Listened to because it must be: an EventEmitter with no "error" listener
-  // rethrows, and in the main process that is the app dying during startup.
+  // An EventEmitter with no "error" listener rethrows, which in the main
+  // process is the app dying during startup.
   on(event: "error", listener: (error: Error) => void): this
 }
 
-type CreateMarketPluginRunnerOptions = {
+type EnsureVerifiedCommunityMarketOptions = {
   dshBin: string
   /** The DSH sidecar environment: it carries DSH_HOME and the pnpm shim on PATH. */
   env: NodeJS.ProcessEnv
@@ -110,17 +88,18 @@ type CreateMarketPluginRunnerOptions = {
     args: string[],
     options: { cwd: string; env: NodeJS.ProcessEnv; stdio: ["ignore", "pipe", "pipe"] },
   ): MarketPluginProcess
+  verifiedVersion?: string
+  timeoutMs?: number
+  /** Called once, and only when an upgrade is about to run. */
+  onUpgradeStart?: () => void
+  log(message: string, detail?: Record<string, unknown>): void
 }
 
-/**
- * Runs profile plugin commands the way the Desktop host does, but from the main
- * process and before the sidecar exists. `dsh plugin` is a thin pnpm forwarder —
- * it initializes the profile if needed, runs pnpm in it, then reconciles
- * `dsh.profile.bundles` against what is installed — so it never loads a bundle
- * and cannot hit the failure this guard exists to prevent.
- */
-export function createMarketPluginRunner(options: CreateMarketPluginRunnerOptions): MarketPluginRunner {
-  return (args, signal) => new Promise<void>((resolve, reject) => {
+// `dsh plugin` initializes the profile if needed, forwards to pnpm, and
+// reconciles `dsh.profile.bundles` against what is installed. It never loads a
+// bundle, so it is safe to run before DSH boots.
+function runMarketPlugin(options: EnsureVerifiedCommunityMarketOptions, args: string[], signal: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
     const child = options.spawn(
       options.executable,
       [options.dshBin, "plugin", "--profile", "web", ...args],
@@ -128,7 +107,7 @@ export function createMarketPluginRunner(options: CreateMarketPluginRunnerOption
     )
     let output = ""
     const collect = (data: Buffer | string) => {
-      output = (output + data.toString()).slice(-PLUGIN_OUTPUT_TAIL_CHARS)
+      output = (output + data.toString()).slice(-OUTPUT_TAIL_CHARS)
     }
     child.stdout?.on("data", collect)
     child.stderr?.on("data", collect)
@@ -150,24 +129,14 @@ export function createMarketPluginRunner(options: CreateMarketPluginRunnerOption
   })
 }
 
-type EnsureVerifiedCommunityMarketOptions = {
-  profileDir: string
-  runPlugin: MarketPluginRunner
-  verifiedVersion?: string
-  timeoutMs?: number
-  /** Called once, and only when an upgrade is really about to run. */
-  onUpgradeStart?: () => void
-  log(message: string, detail?: Record<string, unknown>): void
-}
-
 /**
- * Bring the profile's community market up to the release this build was verified
- * against, before DSH is given the chance to load it.
+ * Bring the profile's community market up to the verified release before DSH is
+ * given the chance to load it.
  *
- * Never rejects and never blocks a launch it cannot repair: an unreachable
- * registry, a failed install or a timeout are logged and the start continues, so
- * the market can never be the reason the app does not open. A normal start pays
- * one `readFileSync` of the profile manifest and touches no network.
+ * A market listed in `dsh.profile.bundles` that throws on load aborts the whole
+ * DSH boot, so this has to finish first. It never rejects: an unreachable
+ * registry, a failed install or a timeout is logged and the launch continues.
+ * A start with nothing to do costs one manifest read and no network.
  */
 export async function ensureVerifiedCommunityMarket(options: EnsureVerifiedCommunityMarketOptions) {
   const verified = options.verifiedVersion ?? VERIFIED_COMMUNITY_MARKET.market
@@ -177,15 +146,14 @@ export async function ensureVerifiedCommunityMarket(options: EnsureVerifiedCommu
   options.log("upgrading the community market before DSH starts", { from: outdated, to: verified })
   options.onUpgradeStart?.()
   try {
-    await options.runPlugin(
-      // The release-age cooldown is pnpm's protection against *automatically*
-      // picking up a version nobody vetted. This version is the opposite: one
-      // release, named in this build, verified before shipping. Leaving the gate
-      // on would make a startup repair depend on how pnpm decides to handle a
-      // young version — silently rewriting the user's profile
-      // `pnpm-workspace.yaml` when it can prompt, failing when it cannot.
+    await runMarketPlugin(
+      options,
+      // The version is named in this build rather than resolved automatically,
+      // so pnpm's release-age cooldown does not apply. Left on, it either
+      // rewrites the profile's pnpm-workspace.yaml or fails outright, depending
+      // on whether pnpm believes it can prompt.
       ["add", "--config.minimumReleaseAge=0", `${MARKET_NAME}@${verified}`],
-      AbortSignal.timeout(options.timeoutMs ?? MARKET_UPGRADE_TIMEOUT_MS),
+      AbortSignal.timeout(options.timeoutMs ?? UPGRADE_TIMEOUT_MS),
     )
   } catch (error) {
     options.log("community market upgrade failed, starting with the installed market", {

--- a/packages/desktop-electron/src/main/dsh-market-guard.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { gte, valid } from "semver"
@@ -19,6 +20,8 @@ export const VERIFIED_COMMUNITY_MARKET = {
 
 // Bounds the wait on the startup page. Overrunning it is not fatal.
 const UPGRADE_TIMEOUT_MS = 90_000
+// How long a terminated install gets to unwind before it is killed outright.
+const KILL_GRACE_MS = 5_000
 const OUTPUT_TAIL_CHARS = 4_000
 
 function readJson(path: string): unknown {
@@ -53,14 +56,28 @@ function loadsMarketAtBoot(profileDir: string) {
  * with no package behind it belongs to `pruneUnresolvableMarketBundle` and the
  * startup-failure dialog instead.
  */
-export function outdatedMarketVersion(
-  profileDir: string,
-  verified: string = VERIFIED_COMMUNITY_MARKET.market,
-) {
+export function outdatedMarketVersion(profileDir: string, verified: string) {
   if (!loadsMarketAtBoot(profileDir)) return undefined
   const installed = installedMarketVersion(profileDir)
   if (installed === undefined || valid(installed) === null) return undefined
   return gte(installed, verified) ? undefined : installed
+}
+
+/**
+ * `dsh plugin` forwards to pnpm through a synchronous spawn, so the install is
+ * a grandchild: signalling the process we hold leaves pnpm running, and it goes
+ * on writing the profile that DSH is about to load. Terminate the group.
+ */
+function killProcessTree(pid: number, signal: NodeJS.Signals) {
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/pid", String(pid), "/t", "/f"])
+    return
+  }
+  try {
+    process.kill(-pid, signal)
+  } catch {
+    // Already gone.
+  }
 }
 
 type MarketPluginStream = { on(event: "data", listener: (data: Buffer | string) => void): unknown } | null
@@ -70,7 +87,7 @@ interface MarketPluginProcess {
   // pnpm's own reason went to stdout ahead of it.
   readonly stdout: MarketPluginStream
   readonly stderr: MarketPluginStream
-  kill(signal?: NodeJS.Signals): boolean
+  readonly pid?: number
   on(event: "exit", listener: (code: number | null) => void): this
   // An EventEmitter with no "error" listener rethrows, which in the main
   // process is the app dying during startup.
@@ -86,24 +103,40 @@ type EnsureVerifiedCommunityMarketOptions = {
   spawn(
     executable: string,
     args: string[],
-    options: { cwd: string; env: NodeJS.ProcessEnv; stdio: ["ignore", "pipe", "pipe"] },
+    options: {
+      cwd: string
+      // Group leader, so the whole install can be terminated at once.
+      detached: true
+      env: NodeJS.ProcessEnv
+      stdio: ["ignore", "pipe", "pipe"]
+    },
   ): MarketPluginProcess
+  /** Aborted when the app is stopping, so a quit is not held up by an install. */
+  signal: AbortSignal
   verifiedVersion?: string
   timeoutMs?: number
+  killGraceMs?: number
+  killTree?: (pid: number, signal: NodeJS.Signals) => void
   /** Called once, and only when an upgrade is about to run. */
   onUpgradeStart?: () => void
   log(message: string, detail?: Record<string, unknown>): void
 }
 
-// `dsh plugin` initializes the profile if needed, forwards to pnpm, and
-// reconciles `dsh.profile.bundles` against what is installed. It never loads a
-// bundle, so it is safe to run before DSH boots.
+/**
+ * `dsh plugin` initializes the profile if needed, forwards to pnpm, and
+ * reconciles `dsh.profile.bundles` against what is installed. It never loads a
+ * bundle, so it is safe to run before DSH boots.
+ *
+ * Settles only once the install is known to be over, terminated included:
+ * whatever comes next is entitled to a profile nothing is still writing.
+ */
 function runMarketPlugin(options: EnsureVerifiedCommunityMarketOptions, args: string[], signal: AbortSignal) {
+  const killTree = options.killTree ?? killProcessTree
   return new Promise<void>((resolve, reject) => {
     const child = options.spawn(
       options.executable,
       [options.dshBin, "plugin", "--profile", "web", ...args],
-      { cwd: options.profileDir, env: options.env, stdio: ["ignore", "pipe", "pipe"] },
+      { cwd: options.profileDir, detached: true, env: options.env, stdio: ["ignore", "pipe", "pipe"] },
     )
     let output = ""
     const collect = (data: Buffer | string) => {
@@ -111,20 +144,35 @@ function runMarketPlugin(options: EnsureVerifiedCommunityMarketOptions, args: st
     }
     child.stdout?.on("data", collect)
     child.stderr?.on("data", collect)
-    const abort = () => void child.kill("SIGTERM")
-    signal.addEventListener("abort", abort, { once: true })
+
+    let escalation: ReturnType<typeof setTimeout> | undefined
     const settle = (finish: () => void) => {
       signal.removeEventListener("abort", abort)
+      clearTimeout(escalation)
       finish()
     }
+    const failed = (cause: string) => {
+      const tail = output.trim()
+      return new Error(`dsh plugin ${cause}${tail === "" ? "" : `: ${tail}`}`)
+    }
+    function abort() {
+      const { pid } = child
+      if (pid === undefined) return
+      killTree(pid, "SIGTERM")
+      // A group that outlives SIGKILL is not going to report an exit either.
+      // Give up on it rather than hold the launch open indefinitely.
+      escalation = setTimeout(() => {
+        killTree(pid, "SIGKILL")
+        settle(() => reject(failed("could not be terminated")))
+      }, options.killGraceMs ?? KILL_GRACE_MS)
+    }
+    signal.addEventListener("abort", abort, { once: true })
+    if (signal.aborted) abort()
+
     child.on("error", (error) => settle(() => reject(error)))
     child.on("exit", (code) => settle(() => {
-      if (code === 0 && !signal.aborted) {
-        resolve()
-        return
-      }
-      const cause = signal.aborted ? "timed out" : `exited ${describeExit(code)}`
-      reject(new Error(`dsh plugin ${cause}${output.trim() === "" ? "" : `: ${output.trim()}`}`))
+      if (code === 0 && !signal.aborted) resolve()
+      else reject(failed(signal.aborted ? "was terminated" : `exited ${describeExit(code)}`))
     }))
   })
 }
@@ -135,27 +183,25 @@ function runMarketPlugin(options: EnsureVerifiedCommunityMarketOptions, args: st
  *
  * A market listed in `dsh.profile.bundles` that throws on load aborts the whole
  * DSH boot, so this has to finish first. It never rejects: an unreachable
- * registry, a failed install or a timeout is logged and the launch continues.
- * A start with nothing to do costs one manifest read and no network.
+ * registry, a failed install or a deadline overrun is logged and the launch
+ * continues. A start with nothing to do reads manifests and nothing else.
  */
 export async function ensureVerifiedCommunityMarket(options: EnsureVerifiedCommunityMarketOptions) {
   const verified = options.verifiedVersion ?? VERIFIED_COMMUNITY_MARKET.market
   const outdated = outdatedMarketVersion(options.profileDir, verified)
   if (outdated === undefined) return
 
-  options.log("upgrading the community market before DSH starts", { from: outdated, to: verified })
-  options.onUpgradeStart?.()
   try {
+    options.log("upgrading the community market before DSH starts", { from: outdated, to: verified })
+    options.onUpgradeStart?.()
     await runMarketPlugin(
       options,
-      // The version is named in this build rather than resolved automatically,
-      // so pnpm's release-age cooldown does not apply. Left on, it either
-      // rewrites the profile's pnpm-workspace.yaml or fails outright, depending
-      // on whether pnpm believes it can prompt.
-      ["add", "--config.minimumReleaseAge=0", `${MARKET_NAME}@${verified}`],
-      AbortSignal.timeout(options.timeoutMs ?? UPGRADE_TIMEOUT_MS),
+      ["add", `${MARKET_NAME}@${verified}`],
+      AbortSignal.any([options.signal, AbortSignal.timeout(options.timeoutMs ?? UPGRADE_TIMEOUT_MS)]),
     )
   } catch (error) {
+    // A quit is not a failure, and nothing is about to start.
+    if (options.signal.aborted) return
     options.log("community market upgrade failed, starting with the installed market", {
       from: outdated,
       to: verified,

--- a/packages/desktop-electron/src/main/dsh-market-guard.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.ts
@@ -1,0 +1,202 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { gte, valid } from "semver"
+import { describeExit } from "./dsh-sidecar"
+
+/** The community market package, spelled the way `dsh plugin add` records it. */
+export const MARKET_NAME = "dshmarket"
+
+/**
+ * The community market release PawWork ships against, paired with the DSH it was
+ * verified on.
+ *
+ * The market version is part of PawWork's release contract because nothing else
+ * moves it: `dsh plugin add` writes an exact version into the profile, pnpm then
+ * installs from the profile lockfile, and the market can only update itself once
+ * it loads — which is precisely what a DSH upgrade it has not caught up with
+ * takes away. The market sits in `dsh.profile.bundles`, so a market that throws
+ * on load makes cordis roll back the whole config tree and DSH exit: users who
+ * merely turned the market on once cannot open the app at all.
+ *
+ * `dsh` is what keeps this pair honest. The sentinel in dsh-market-guard.test.ts
+ * fails as soon as the shipped DSH moves, so a DSH upgrade has to name the
+ * market release it was validated against instead of silently inheriting this
+ * one — which is how 1.34.0 was left behind across 0.1.2-alpha.3.
+ */
+export const VERIFIED_COMMUNITY_MARKET = {
+  dsh: "0.1.2-alpha.3",
+  market: "1.39.0",
+} as const
+
+// Long enough for a cold pnpm fetch of one package over a slow link, short
+// enough that an unreachable registry does not hold the window on the startup
+// page for minutes. Overrunning it is not fatal: the launch continues either way.
+const MARKET_UPGRADE_TIMEOUT_MS = 90_000
+
+const PLUGIN_OUTPUT_TAIL_CHARS = 4_000
+
+function readJson(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"))
+  } catch {
+    return undefined
+  }
+}
+
+/** The market version materialized in the profile, or undefined when none is. */
+export function installedMarketVersion(profileDir: string) {
+  const manifest = readJson(join(profileDir, "node_modules", MARKET_NAME, "package.json")) as
+    | { version?: unknown }
+    | undefined
+  return typeof manifest?.version === "string" ? manifest.version : undefined
+}
+
+function loadsMarketAtBoot(profileDir: string) {
+  const manifest = readJson(join(profileDir, "package.json")) as
+    | { dsh?: { profile?: { bundles?: unknown } } }
+    | undefined
+  const bundles = manifest?.dsh?.profile?.bundles
+  return Array.isArray(bundles) && bundles.includes(MARKET_NAME)
+}
+
+/**
+ * The market version this launch has to replace, or undefined when there is
+ * nothing to do.
+ *
+ * Deliberately narrow. Only a market DSH will actually load — declared in
+ * `dsh.profile.bundles` *and* materialized in `node_modules` — can take the boot
+ * down, and only one below the verified release is untested against the DSH this
+ * build ships. A bundle row with no package behind it is a different failure
+ * that `pruneUnresolvableMarketBundle` and the startup-failure dialog already
+ * own; installing over it here would hide their repair rather than help it.
+ */
+export function outdatedMarketVersion(
+  profileDir: string,
+  verified: string = VERIFIED_COMMUNITY_MARKET.market,
+) {
+  if (!loadsMarketAtBoot(profileDir)) return undefined
+  const installed = installedMarketVersion(profileDir)
+  // An unparseable version is not something to reason about, let alone overwrite.
+  if (installed === undefined || valid(installed) === null) return undefined
+  return gte(installed, verified) ? undefined : installed
+}
+
+/** One `dsh plugin` invocation; rejects on anything but a clean exit. */
+export type MarketPluginRunner = (args: string[], signal: AbortSignal) => Promise<void>
+
+type MarketPluginStream = { on(event: "data", listener: (data: Buffer | string) => void): unknown } | null
+
+interface MarketPluginProcess {
+  // Both streams, because the diagnosis is split across them: `dsh plugin` says
+  // only that pnpm failed, on its stderr, while pnpm's own reason — a blocked
+  // build script, an unreachable registry — went to stdout before that.
+  readonly stdout: MarketPluginStream
+  readonly stderr: MarketPluginStream
+  kill(signal?: NodeJS.Signals): boolean
+  on(event: "exit", listener: (code: number | null) => void): this
+  // Listened to because it must be: an EventEmitter with no "error" listener
+  // rethrows, and in the main process that is the app dying during startup.
+  on(event: "error", listener: (error: Error) => void): this
+}
+
+type CreateMarketPluginRunnerOptions = {
+  dshBin: string
+  /** The DSH sidecar environment: it carries DSH_HOME and the pnpm shim on PATH. */
+  env: NodeJS.ProcessEnv
+  executable: string
+  profileDir: string
+  spawn(
+    executable: string,
+    args: string[],
+    options: { cwd: string; env: NodeJS.ProcessEnv; stdio: ["ignore", "pipe", "pipe"] },
+  ): MarketPluginProcess
+}
+
+/**
+ * Runs profile plugin commands the way the Desktop host does, but from the main
+ * process and before the sidecar exists. `dsh plugin` is a thin pnpm forwarder —
+ * it initializes the profile if needed, runs pnpm in it, then reconciles
+ * `dsh.profile.bundles` against what is installed — so it never loads a bundle
+ * and cannot hit the failure this guard exists to prevent.
+ */
+export function createMarketPluginRunner(options: CreateMarketPluginRunnerOptions): MarketPluginRunner {
+  return (args, signal) => new Promise<void>((resolve, reject) => {
+    const child = options.spawn(
+      options.executable,
+      [options.dshBin, "plugin", "--profile", "web", ...args],
+      { cwd: options.profileDir, env: options.env, stdio: ["ignore", "pipe", "pipe"] },
+    )
+    let output = ""
+    const collect = (data: Buffer | string) => {
+      output = (output + data.toString()).slice(-PLUGIN_OUTPUT_TAIL_CHARS)
+    }
+    child.stdout?.on("data", collect)
+    child.stderr?.on("data", collect)
+    const abort = () => void child.kill("SIGTERM")
+    signal.addEventListener("abort", abort, { once: true })
+    const settle = (finish: () => void) => {
+      signal.removeEventListener("abort", abort)
+      finish()
+    }
+    child.on("error", (error) => settle(() => reject(error)))
+    child.on("exit", (code) => settle(() => {
+      if (code === 0 && !signal.aborted) {
+        resolve()
+        return
+      }
+      const cause = signal.aborted ? "timed out" : `exited ${describeExit(code)}`
+      reject(new Error(`dsh plugin ${cause}${output.trim() === "" ? "" : `: ${output.trim()}`}`))
+    }))
+  })
+}
+
+type EnsureVerifiedCommunityMarketOptions = {
+  profileDir: string
+  runPlugin: MarketPluginRunner
+  verifiedVersion?: string
+  timeoutMs?: number
+  /** Called once, and only when an upgrade is really about to run. */
+  onUpgradeStart?: () => void
+  log(message: string, detail?: Record<string, unknown>): void
+}
+
+/**
+ * Bring the profile's community market up to the release this build was verified
+ * against, before DSH is given the chance to load it.
+ *
+ * Never rejects and never blocks a launch it cannot repair: an unreachable
+ * registry, a failed install or a timeout are logged and the start continues, so
+ * the market can never be the reason the app does not open. A normal start pays
+ * one `readFileSync` of the profile manifest and touches no network.
+ */
+export async function ensureVerifiedCommunityMarket(options: EnsureVerifiedCommunityMarketOptions) {
+  const verified = options.verifiedVersion ?? VERIFIED_COMMUNITY_MARKET.market
+  const outdated = outdatedMarketVersion(options.profileDir, verified)
+  if (outdated === undefined) return
+
+  options.log("upgrading the community market before DSH starts", { from: outdated, to: verified })
+  options.onUpgradeStart?.()
+  try {
+    await options.runPlugin(
+      // The release-age cooldown is pnpm's protection against *automatically*
+      // picking up a version nobody vetted. This version is the opposite: one
+      // release, named in this build, verified before shipping. Leaving the gate
+      // on would make a startup repair depend on how pnpm decides to handle a
+      // young version — silently rewriting the user's profile
+      // `pnpm-workspace.yaml` when it can prompt, failing when it cannot.
+      ["add", "--config.minimumReleaseAge=0", `${MARKET_NAME}@${verified}`],
+      AbortSignal.timeout(options.timeoutMs ?? MARKET_UPGRADE_TIMEOUT_MS),
+    )
+  } catch (error) {
+    options.log("community market upgrade failed, starting with the installed market", {
+      from: outdated,
+      to: verified,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return
+  }
+  options.log("community market upgraded", {
+    from: outdated,
+    to: installedMarketVersion(options.profileDir),
+  })
+}

--- a/packages/desktop-electron/src/main/dsh-sidecar.test.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest"
 import { EventEmitter } from "node:events"
 import { PassThrough } from "node:stream"
-import { launchDshSidecar, type DshChildProcess } from "./dsh-sidecar"
+import { deferDshRun, launchDshSidecar, type DshChildProcess } from "./dsh-sidecar"
 
 class FakeChildProcess extends EventEmitter implements DshChildProcess {
   readonly stdout = new PassThrough()
@@ -310,5 +310,77 @@ describe("DSH sidecar lifecycle", () => {
 
     expect(child.messages).toEqual(["SIGTERM"])
     expect(child.killSignals).toEqual(["SIGKILL"])
+  })
+})
+
+describe("deferDshRun", () => {
+  function fakeRun() {
+    let resolveReady!: (url: string) => void
+    const stopped = { count: 0 }
+    return {
+      stopped,
+      run: {
+        ready: new Promise<string>((resolve) => { resolveReady = resolve }),
+        exited: new Promise<number | null>(() => {}),
+        stop: () => {
+          stopped.count += 1
+          return Promise.resolve()
+        },
+      },
+      announceReady: (url: string) => resolveReady(url),
+    }
+  }
+
+  test("spawns only after the prelude settles, then reports the run it wrapped", async () => {
+    let release!: () => void
+    const prelude = new Promise<void>((resolve) => { release = resolve })
+    let launches = 0
+    const inner = fakeRun()
+
+    const deferred = deferDshRun(prelude, () => {
+      launches += 1
+      return inner.run
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(launches).toBe(0)
+
+    release()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(launches).toBe(1)
+    inner.announceReady("http://127.0.0.1:43123/?token=s3cr3t")
+    await expect(deferred.ready).resolves.toBe("http://127.0.0.1:43123/?token=s3cr3t")
+
+    await deferred.stop()
+    expect(inner.stopped.count).toBe(1)
+  })
+
+  test("does not spawn when the run is stopped while the prelude is still running", async () => {
+    let release!: () => void
+    const prelude = new Promise<void>((resolve) => { release = resolve })
+    let launches = 0
+
+    const deferred = deferDshRun(prelude, () => {
+      launches += 1
+      return fakeRun().run
+    })
+    const stopping = deferred.stop()
+    release()
+    await stopping
+
+    expect(launches).toBe(0)
+  })
+
+  // The lifecycle reports a launch that threw through `ready`; `exited` answering
+  // as well would race a second, wrongly worded failure into the same start.
+  test("reports a failed launch through readiness alone", async () => {
+    let exitedSettled = false
+    const deferred = deferDshRun(Promise.resolve(), () => {
+      throw new Error("DSH host module scope is missing")
+    })
+    void deferred.exited.then(() => { exitedSettled = true }, () => { exitedSettled = true })
+
+    await expect(deferred.ready).rejects.toThrow("DSH host module scope is missing")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(exitedSettled).toBe(false)
   })
 })

--- a/packages/desktop-electron/src/main/dsh-sidecar.test.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.test.ts
@@ -337,7 +337,7 @@ describe("deferDshRun", () => {
     let launches = 0
     const inner = fakeRun()
 
-    const deferred = deferDshRun(prelude, () => {
+    const deferred = deferDshRun(() => prelude, () => {
       launches += 1
       return inner.run
     })
@@ -354,19 +354,24 @@ describe("deferDshRun", () => {
     expect(inner.stopped.count).toBe(1)
   })
 
-  test("does not spawn when the run is stopped while the prelude is still running", async () => {
+  // Quitting during work that runs in front of DSH has to end that work, not
+  // wait it out: the prelude owns a process of its own, and its own deadline.
+  test("aborts the prelude when the run is stopped, and does not spawn", async () => {
+    let aborted: AbortSignal | undefined
     let release!: () => void
     const prelude = new Promise<void>((resolve) => { release = resolve })
     let launches = 0
 
-    const deferred = deferDshRun(prelude, () => {
+    const deferred = deferDshRun((signal) => {
+      signal.addEventListener("abort", () => { aborted = signal; release() })
+      return prelude
+    }, () => {
       launches += 1
       return fakeRun().run
     })
-    const stopping = deferred.stop()
-    release()
-    await stopping
+    await deferred.stop()
 
+    expect(aborted?.aborted).toBe(true)
     expect(launches).toBe(0)
   })
 
@@ -374,7 +379,7 @@ describe("deferDshRun", () => {
   // as well would race a second, wrongly worded failure into the same start.
   test("reports a failed launch through readiness alone", async () => {
     let exitedSettled = false
-    const deferred = deferDshRun(Promise.resolve(), () => {
+    const deferred = deferDshRun(() => Promise.resolve(), () => {
       throw new Error("DSH host module scope is missing")
     })
     void deferred.exited.then(() => { exitedSettled = true }, () => { exitedSettled = true })

--- a/packages/desktop-electron/src/main/dsh-sidecar.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.ts
@@ -76,19 +76,27 @@ function readyUrlOf(message: unknown) {
  * to finish before DSH loads the profile is still stoppable and still reports
  * failures through the startup path.
  *
- * With no child ever spawned, `exited` stays unsettled: it reports a process
- * that died, and `ready` already carries the failure.
+ * `stop()` aborts the signal the prelude was handed before awaiting it, so
+ * quitting during that work is bounded by the prelude's own teardown rather
+ * than by however long it had left to run.
+ *
+ * When no child is ever spawned, neither `ready` nor `exited` settles: a stop
+ * is not a failure to report, and a prelude that threw is reported by `ready`.
  */
-export function deferDshRun(prelude: Promise<unknown>, launch: () => DshRun): DshRun {
-  let stopped = false
+export function deferDshRun(
+  prelude: (signal: AbortSignal) => Promise<unknown>,
+  launch: () => DshRun,
+): DshRun {
+  const stopping = new AbortController()
   let started: DshRun | undefined
-  const child = prelude.then(() => (stopped ? undefined : (started = launch())))
   const pending = new Promise<never>(() => {})
+  const child = prelude(stopping.signal)
+    .then(() => (stopping.signal.aborted ? undefined : (started = launch())))
   return {
     ready: child.then((run) => run?.ready ?? pending),
     exited: child.then((run) => run?.exited ?? pending, () => pending),
     stop: async () => {
-      stopped = true
+      stopping.abort()
       await child.catch(() => undefined)
       await started?.stop()
     },

--- a/packages/desktop-electron/src/main/dsh-sidecar.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.ts
@@ -71,6 +71,33 @@ function readyUrlOf(message: unknown) {
   return url
 }
 
+/**
+ * A run whose process is only spawned once `prelude` settles, so preparation
+ * that has to finish *before* DSH loads the profile still looks like a run to
+ * the lifecycle — one that can be stopped, and whose failures are reported
+ * through the same startup path.
+ *
+ * `exited` is deliberately left unsettled when no child was ever spawned. It
+ * exists to report a process that died; a launch that never happened is already
+ * being reported through `ready`, and answering here as well would race a second
+ * failure into the lifecycle.
+ */
+export function deferDshRun(prelude: Promise<unknown>, launch: () => DshRun): DshRun {
+  let stopped = false
+  let started: DshRun | undefined
+  const child = prelude.then(() => (stopped ? undefined : (started = launch())))
+  const pending = new Promise<never>(() => {})
+  return {
+    ready: child.then((run) => run?.ready ?? pending),
+    exited: child.then((run) => run?.exited ?? pending, () => pending),
+    stop: async () => {
+      stopped = true
+      await child.catch(() => undefined)
+      await started?.stop()
+    },
+  }
+}
+
 export function launchDshSidecar(options: LaunchDshSidecarOptions): DshRun {
   const child = options.spawn(
     options.executable,

--- a/packages/desktop-electron/src/main/dsh-sidecar.ts
+++ b/packages/desktop-electron/src/main/dsh-sidecar.ts
@@ -72,15 +72,12 @@ function readyUrlOf(message: unknown) {
 }
 
 /**
- * A run whose process is only spawned once `prelude` settles, so preparation
- * that has to finish *before* DSH loads the profile still looks like a run to
- * the lifecycle — one that can be stopped, and whose failures are reported
- * through the same startup path.
+ * A run that spawns its process only once `prelude` settles, so work that has
+ * to finish before DSH loads the profile is still stoppable and still reports
+ * failures through the startup path.
  *
- * `exited` is deliberately left unsettled when no child was ever spawned. It
- * exists to report a process that died; a launch that never happened is already
- * being reported through `ready`, and answering here as well would race a second
- * failure into the lifecycle.
+ * With no child ever spawned, `exited` stays unsettled: it reports a process
+ * that died, and `ready` already carries the failure.
  */
 export function deferDshRun(prelude: Promise<unknown>, launch: () => DshRun): DshRun {
   let stopped = false

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -21,7 +21,7 @@ import {
 import { ciSmokeCdpSwitches } from "./ci-smoke-cdp"
 import { pickConversationFiles } from "./dsh-file-input"
 import { DshLifecycle, type DshLifecycleState } from "./dsh-lifecycle"
-import { createMarketPluginRunner, ensureVerifiedCommunityMarket } from "./dsh-market-guard"
+import { ensureVerifiedCommunityMarket } from "./dsh-market-guard"
 import { createDshMenu } from "./dsh-menu"
 import { assertDshPluginRequest, requestDshCommunityMarket } from "./dsh-plugins"
 import {
@@ -69,10 +69,8 @@ const UPDATE_FEED_TIMEOUT_MS = 10_000
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
 const UPDATE_CHANNEL_FILE = process.platform === "win32" ? `${UPDATE_CHANNEL}.yml` : `${UPDATE_CHANNEL}-mac.yml`
 const LATEST_RELEASE_URL = `https://github.com/${UPDATE_GITHUB_OWNER}/${UPDATE_GITHUB_REPO}/releases/latest`
-// Shown on the startup page for the one launch that has to install a newer
-// community market before DSH may load it. Naming the step is what separates it
-// from a hang: DSH prints nothing until it is ready, so an unexplained wait in
-// front of it reads as a frozen app.
+// Shown while the community market is upgraded ahead of DSH. DSH prints nothing
+// until it is ready, so an unnamed wait in front of it reads as a frozen app.
 const MARKET_UPGRADE_NOTICE: Record<MenuLocale, string> = {
   en: "Updating the community plugin market…",
   zh: "正在更新社区插件市场…",
@@ -559,21 +557,12 @@ function launchDsh() {
     productToolsDir: join(dirname(productResources.dsh), "tools"),
   })
 
-  // Ahead of the sidecar, not beside it: a market too old for the DSH this build
-  // ships throws while cordis is assembling the profile, and cordis answers by
-  // rolling the whole tree back, so DSH exits before anything can intervene. The
-  // guard is a no-op — one manifest read, no network — unless this profile is
-  // carrying such a market.
-  const profileDir = join(product.home, "profiles", "web")
   const marketGuard = ensureVerifiedCommunityMarket({
-    profileDir,
-    runPlugin: createMarketPluginRunner({
-      dshBin,
-      env: environment,
-      executable: process.execPath,
-      profileDir,
-      spawn: (executable, args, options) => spawn(executable, args, options),
-    }),
+    dshBin,
+    env: environment,
+    executable: process.execPath,
+    profileDir: join(product.home, "profiles", "web"),
+    spawn: (executable, args, options) => spawn(executable, args, options),
     onUpgradeStart: () => showStartupPage(MARKET_UPGRADE_NOTICE[menuLocale]),
     log: (message, detail) => logger.log(message, detail),
   })

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -557,17 +557,16 @@ function launchDsh() {
     productToolsDir: join(dirname(productResources.dsh), "tools"),
   })
 
-  const marketGuard = ensureVerifiedCommunityMarket({
+  return deferDshRun((signal) => ensureVerifiedCommunityMarket({
     dshBin,
     env: environment,
     executable: process.execPath,
     profileDir: join(product.home, "profiles", "web"),
     spawn: (executable, args, options) => spawn(executable, args, options),
+    signal,
     onUpgradeStart: () => showStartupPage(MARKET_UPGRADE_NOTICE[menuLocale]),
     log: (message, detail) => logger.log(message, detail),
-  })
-
-  return deferDshRun(marketGuard, () => {
+  }), () => {
     logger.log("spawning DSH sidecar")
     return launchDshSidecar({
       executable: process.execPath,

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -21,6 +21,7 @@ import {
 import { ciSmokeCdpSwitches } from "./ci-smoke-cdp"
 import { pickConversationFiles } from "./dsh-file-input"
 import { DshLifecycle, type DshLifecycleState } from "./dsh-lifecycle"
+import { createMarketPluginRunner, ensureVerifiedCommunityMarket } from "./dsh-market-guard"
 import { createDshMenu } from "./dsh-menu"
 import { assertDshPluginRequest, requestDshCommunityMarket } from "./dsh-plugins"
 import {
@@ -31,7 +32,7 @@ import {
   resolvePnpmPackagePath,
   resolveProductResources,
 } from "./dsh-product-home"
-import { launchDshSidecar } from "./dsh-sidecar"
+import { deferDshRun, launchDshSidecar } from "./dsh-sidecar"
 import { prepareDshToolsEnvironment } from "./dsh-tools"
 import { removeProfileBundle, unresolvedProfileBundle } from "./dsh-profile-repair"
 import { migrateDshHome, resolveDshHome } from "./pawwork-home"
@@ -68,6 +69,14 @@ const UPDATE_FEED_TIMEOUT_MS = 10_000
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
 const UPDATE_CHANNEL_FILE = process.platform === "win32" ? `${UPDATE_CHANNEL}.yml` : `${UPDATE_CHANNEL}-mac.yml`
 const LATEST_RELEASE_URL = `https://github.com/${UPDATE_GITHUB_OWNER}/${UPDATE_GITHUB_REPO}/releases/latest`
+// Shown on the startup page for the one launch that has to install a newer
+// community market before DSH may load it. Naming the step is what separates it
+// from a hang: DSH prints nothing until it is ready, so an unexplained wait in
+// front of it reads as a frozen app.
+const MARKET_UPGRADE_NOTICE: Record<MenuLocale, string> = {
+  en: "Updating the community plugin market…",
+  zh: "正在更新社区插件市场…",
+}
 
 const userDataRoot = CI_SMOKE_HOME ?? app.getPath("appData")
 const appChannel = app.isPackaged ? CHANNEL : "dev"
@@ -372,8 +381,8 @@ function dshUrl() {
   return lifecycle.url
 }
 
-function showStartupPage() {
-  for (const win of liveWindows()) navigateWindow(win, startupUrl(startupColorScheme))
+function showStartupPage(notice?: string) {
+  for (const win of liveWindows()) navigateWindow(win, startupUrl(startupColorScheme, notice))
 }
 
 async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed" }>) {
@@ -550,20 +559,41 @@ function launchDsh() {
     productToolsDir: join(dirname(productResources.dsh), "tools"),
   })
 
-  logger.log("spawning DSH sidecar")
-  return launchDshSidecar({
-    executable: process.execPath,
-    dshBin,
-    sidecarPreload: pathToFileURL(product.sidecarPreload).href,
-    productPatch: product.patch,
-    env: environment,
-    spawn: (executable, args, options) => spawn(executable, args, options),
-    onStdout: (chunk) => logger.log("DSH stdout", { chunk: chunk.trimEnd() }),
-    onStderr: (chunk) => {
-      dshOutputTail = (dshOutputTail + chunk).slice(-DSH_OUTPUT_TAIL_CHARS)
-      logger.error("DSH stderr", chunk.trimEnd())
-    },
-    onError: (error) => logger.error("DSH sidecar process error", error),
+  // Ahead of the sidecar, not beside it: a market too old for the DSH this build
+  // ships throws while cordis is assembling the profile, and cordis answers by
+  // rolling the whole tree back, so DSH exits before anything can intervene. The
+  // guard is a no-op — one manifest read, no network — unless this profile is
+  // carrying such a market.
+  const profileDir = join(product.home, "profiles", "web")
+  const marketGuard = ensureVerifiedCommunityMarket({
+    profileDir,
+    runPlugin: createMarketPluginRunner({
+      dshBin,
+      env: environment,
+      executable: process.execPath,
+      profileDir,
+      spawn: (executable, args, options) => spawn(executable, args, options),
+    }),
+    onUpgradeStart: () => showStartupPage(MARKET_UPGRADE_NOTICE[menuLocale]),
+    log: (message, detail) => logger.log(message, detail),
+  })
+
+  return deferDshRun(marketGuard, () => {
+    logger.log("spawning DSH sidecar")
+    return launchDshSidecar({
+      executable: process.execPath,
+      dshBin,
+      sidecarPreload: pathToFileURL(product.sidecarPreload).href,
+      productPatch: product.patch,
+      env: environment,
+      spawn: (executable, args, options) => spawn(executable, args, options),
+      onStdout: (chunk) => logger.log("DSH stdout", { chunk: chunk.trimEnd() }),
+      onStderr: (chunk) => {
+        dshOutputTail = (dshOutputTail + chunk).slice(-DSH_OUTPUT_TAIL_CHARS)
+        logger.error("DSH stderr", chunk.trimEnd())
+      },
+      onError: (error) => logger.error("DSH sidecar process error", error),
+    })
   })
 }
 

--- a/packages/desktop-electron/src/main/windows.test.ts
+++ b/packages/desktop-electron/src/main/windows.test.ts
@@ -177,6 +177,15 @@ describe("main window wiring", () => {
     expect(decodeURIComponent(startupUrl("dark"))).not.toContain("class=\"notice\"")
   })
 
+  // The notice lands in an attribute value as well as in text, so quotes have
+  // to be escaped or a notice could close the attribute and add its own.
+  test("escapes a notice into both the attribute and the text", () => {
+    const page = decodeURIComponent(startupUrl("dark", '"><img src=x onerror=alert(1)>'))
+
+    expect(page).toContain("aria-label=\"&quot;&gt;&lt;img src=x onerror=alert(1)&gt;\"")
+    expect(page).not.toContain("<img")
+  })
+
   // With no origin to belong to, nothing belongs to it — including the page DSH
   // was showing a moment before it died.
   test("denies every DSH-origin navigation once the runtime is gone", () => {

--- a/packages/desktop-electron/src/main/windows.test.ts
+++ b/packages/desktop-electron/src/main/windows.test.ts
@@ -167,6 +167,16 @@ describe("main window wiring", () => {
     expect(win.loaded).toEqual([DSH])
   })
 
+  // A wait in front of DSH is only distinguishable from a hang if the page names
+  // it: DSH itself prints nothing until it is ready.
+  test("names the step being waited on when the startup page is given a notice", () => {
+    const page = decodeURIComponent(startupUrl("dark", "Updating the community plugin market…"))
+
+    expect(page).toContain("<p class=\"notice\">Updating the community plugin market…</p>")
+    expect(page).toContain("aria-label=\"Updating the community plugin market…\"")
+    expect(decodeURIComponent(startupUrl("dark"))).not.toContain("class=\"notice\"")
+  })
+
   // With no origin to belong to, nothing belongs to it — including the page DSH
   // was showing a moment before it died.
   test("denies every DSH-origin navigation once the runtime is gone", () => {

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -35,11 +35,9 @@ html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);disp
 export type StartupColorScheme = "dark" | "light"
 
 /**
- * The page every window sits on while DSH is not serving one.
- *
- * `notice` names the step being waited on. DSH says nothing at all until it is
- * ready, so any wait added in front of it is indistinguishable from a hang
- * unless the page says what is happening (#1619).
+ * The page every window sits on while DSH is not serving one. `notice` names
+ * the step being waited on; without it a wait in front of DSH, which prints
+ * nothing until it is ready, is indistinguishable from a hang.
  */
 export function startupUrl(scheme?: StartupColorScheme, notice?: string) {
   return `data:text/html;charset=utf-8,${encodeURIComponent(startupHtml(scheme, notice))}`

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -13,21 +13,36 @@ const root = dirname(fileURLToPath(import.meta.url))
 // disagrees with their OS. `scheme` is the last appearance the product
 // published; the media query stays as the answer for the very first launch,
 // when there is nothing remembered yet.
-const startupHtml = (scheme?: StartupColorScheme) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
-:root{--bg:#fff;--line:#e3e3e7;--accent:#fc5c14}${scheme === undefined
-  ? "@media(prefers-color-scheme:dark){:root{--bg:#191919;--line:#2d2d31}}"
-  : scheme === "dark" ? ":root{--bg:#191919;--line:#2d2d31}" : ""}
-html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);display:flex;justify-content:center}
+const escapeHtml = (text: string) =>
+  text.replace(/[&<>]/g, (character) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[character] ?? character)
+
+const startupHtml = (scheme?: StartupColorScheme, notice?: string) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
+:root{--bg:#fff;--line:#e3e3e7;--accent:#fc5c14;--muted:#6b6b70}${scheme === undefined
+  ? "@media(prefers-color-scheme:dark){:root{--bg:#191919;--line:#2d2d31;--muted:#a1a1a6}}"
+  : scheme === "dark" ? ":root{--bg:#191919;--line:#2d2d31;--muted:#a1a1a6}" : ""}
+html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);display:flex;flex-direction:column;gap:16px;justify-content:center}
 .titlebar{-webkit-app-region:drag;height:var(--pawwork-titlebar-host-height,env(titlebar-area-height,0px));left:0;position:fixed;right:0;top:0}
 .spinner{animation:spin .8s linear infinite;border:2px solid var(--line);border-radius:50%;box-sizing:border-box;height:20px;position:relative;width:20px}
 .spinner:after{background:conic-gradient(var(--accent) 72deg,transparent 0);border-radius:inherit;content:"";inset:-2px;mask:radial-gradient(farthest-side,transparent calc(100% - 2px),#000 0);position:absolute;-webkit-mask:radial-gradient(farthest-side,transparent calc(100% - 2px),#000 0)}
+.notice{color:var(--muted);font:13px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;margin:0;max-width:32em;padding:0 24px;text-align:center}
 @keyframes spin{to{transform:rotate(360deg)}}@media(prefers-reduced-motion:reduce){.spinner{animation:none}}
-</style></head><body><div class="titlebar"></div><div aria-label="PawWork is starting" class="spinner" role="progressbar"></div></body></html>`
+</style></head><body><div class="titlebar"></div><div aria-label="${
+  escapeHtml(notice ?? "PawWork is starting")
+}" class="spinner" role="progressbar"></div>${
+  notice === undefined ? "" : `<p class="notice">${escapeHtml(notice)}</p>`
+}</body></html>`
 
 export type StartupColorScheme = "dark" | "light"
 
-export function startupUrl(scheme?: StartupColorScheme) {
-  return `data:text/html;charset=utf-8,${encodeURIComponent(startupHtml(scheme))}`
+/**
+ * The page every window sits on while DSH is not serving one.
+ *
+ * `notice` names the step being waited on. DSH says nothing at all until it is
+ * ready, so any wait added in front of it is indistinguishable from a hang
+ * unless the page says what is happening (#1619).
+ */
+export function startupUrl(scheme?: StartupColorScheme, notice?: string) {
+  return `data:text/html;charset=utf-8,${encodeURIComponent(startupHtml(scheme, notice))}`
 }
 
 function iconsDir() {

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -13,8 +13,17 @@ const root = dirname(fileURLToPath(import.meta.url))
 // disagrees with their OS. `scheme` is the last appearance the product
 // published; the media query stays as the answer for the very first launch,
 // when there is nothing remembered yet.
-const escapeHtml = (text: string) =>
-  text.replace(/[&<>]/g, (character) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[character] ?? character)
+// Covers the quote characters too: the result is interpolated into an attribute
+// value as well as into text.
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+}
+
+const escapeHtml = (text: string) => text.replace(/[&<>"']/g, (character) => HTML_ESCAPES[character] ?? character)
 
 const startupHtml = (scheme?: StartupColorScheme, notice?: string) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
 :root{--bg:#fff;--line:#e3e3e7;--accent:#fc5c14;--muted:#6b6b70}${scheme === undefined


### PR DESCRIPTION
## The failure

2026.9.1 shipped DSH `0.1.2-alpha.3`, which removed the `settingsNamespace` / `installSettingsSection` exports from `@deepseek-ai/dsh-settings`. The community market only adapted in `1.38.1` (2026-08-30).

`dsh plugin add dshmarket` writes an **exact** version into the profile (`"dshmarket": "1.34.0"` in practice), pnpm then installs from the profile lockfile, and the market can only update itself once it loads. So the pin never moves on its own, and a DSH upgrade the installed market has not caught up with removes the only mechanism that could move it.

The market sits in `dsh.profile.bundles`, so it throws while cordis assembles the profile, cordis rolls the whole tree back, and DSH exits 1:

```
Error: dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include):
failed to import loader entry dsh-market (dshmarket): The requested module
'@deepseek-ai/dsh-settings' does not provide an export named 'installSettingsSection'
```

Anyone who had ever turned the community market on before 2026-08-30 and had not manually updated it since could not open PawWork at all after upgrading — no third-party plugin needed. Verified boundary: `≤ 1.37.0` crashes, `≥ 1.38.1` boots.

## The fix

Make the market version part of PawWork's release contract. `VERIFIED_COMMUNITY_MARKET` records the market release this build was verified against, paired with the DSH it was verified on. Before the sidecar is spawned, a profile carrying an older market is brought up to that release, and only then is DSH allowed to load it.

- **Before DSH, in the launch path.** `deferDshRun` wraps the sidecar in a run that spawns only after the guard settles, so `launchDsh` keeps its contract with `DshLifecycle` — including `stop()` during the wait — and the retry path in the failure dialog re-runs the guard too.
- **Visible while it waits.** The startup page takes a notice ("Updating the community plugin market…" / "正在更新社区插件市场…") under the spinner. DSH prints nothing before its ready line, so an unexplained wait in front of it is indistinguishable from the frozen app #1619 already paid for once.
- **Zero cost otherwise.** The guard acts only on a market that is both declared in `dsh.profile.bundles` and materialized in `node_modules`, and below the verified release. A normal start reads those two manifests and touches no network.
- **Degrades, never blocks.** An unreachable registry, a failed install or a deadline overrun is logged with pnpm's own output and the launch proceeds; the market can never be the reason the app fails to open.
- **The install is owned, not just spawned.** `dsh plugin` forwards to pnpm through a synchronous spawn, so the install is a *grandchild*: signalling the process we hold would leave pnpm running and still writing the profile that DSH is about to load. It is spawned as a group leader, the group is terminated, SIGKILL follows if it does not go, and the guard settles only once the install is known to be over. `stop()` aborts the same path, so quitting or relaunching mid-upgrade ends the install instead of waiting out its deadline.
- **Stays out of the orphan-row path.** A bundle row with no package behind it is left to `pruneUnresolvableMarketBundle` and the startup-failure dialog — installing over it would mask their repair, and dsh-market/dsh-market#339 is still open.

## Keeping the pin from going stale

`1.34.0` was forgotten precisely because nothing tied it to a DSH bump. `VERIFIED_COMMUNITY_MARKET` therefore carries the DSH version it was validated on, and a test asserts that equals the `@deepseek-ai/dsh` the build actually installs. Any DSH upgrade now fails CI until someone edits the pin — the test forces the question, it cannot force the re-validation.

## What this deletes

A simplification audit over the market surfaces found two pieces of existing code the guard makes redundant, both removed in `102c33f`:

- **`MARKET_MINIMUM_VERSION` and `versionAtLeast`.** The floor (1.21.0) was a second version concept, checked only inside the running sidecar and never at startup. Now that every market DSH will load is floored at the verified release before boot, the floor was reachable only on a profile the guard had already failed to repair, where it did the same repair one process later and one click away. Gone, along with `marketStatus`'s floor term, `enable()`'s floor error branch, and 17 lines of hand-rolled semver that existed because `desktop-host.cjs` cannot resolve `semver` from the DSH home. `enabled` is now `declared && active && version !== null`, and `enable()`'s failure message no longer names a version. Capability given up: a pre-1.21.0 market that DSH nonetheless loads is reported as enabled instead of prompting for a reinstall.
- **`operationTimeoutMs`.** A `createDesktopHost` option with no producer anywhere — not index.js, not tests.

Comments across the touched files were also rewritten to state the rule a reader needs rather than how it was arrived at; the reasoning lives here and in the commit messages.

## Verification

Typecheck, lint, full suite (492 vitest + 150 node) and `smoke:ci` pass. End-to-end in a real Electron run against an isolated `DSH_HOME` whose profile was put in exactly the reported state (`"dshmarket": "1.34.0"` pinned, present in `dsh.profile.bundles`, package installed):

- Before: `DSH exited with code 1`, app never opens.
- After: startup page shows the notice, `upgrading the community market before DSH starts { from: '1.34.0', to: '1.39.0' }` → `community market upgraded` → `spawning DSH sidecar` → product ready.
- Next launch: no guard log lines at all, straight to `spawning DSH sidecar`.
- Deadline overrun, forced by building with a 400 ms budget: the group is terminated, `dsh plugin was terminated` is logged with pnpm's output, no pnpm process survives, the market is left intact at `1.34.0`, and DSH starts.
- Quitting mid-upgrade: the app exits in ~0.3 s rather than holding for the deadline.

Cross-platform packaging was not run locally, per AGENTS.md. The Windows branch of the group kill (`taskkill /t /f`) is unit-tested but not exercised on a Windows host.

## Release note

Bump `VERIFIED_COMMUNITY_MARKET` whenever DSH moves — the test will say so — and validate the pair before shipping. Prefer a market release that is not hours old: pnpm's release-age policy records its own exemption in the profile's `pnpm-workspace.yaml` for a version younger than the cooldown, so the guard is never the first thing to exercise a brand-new publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically verifies and updates the community plugin market before starting DSH when needed.
  * Displays a clear “Updating the community plugin market…” message during startup.
  * Safely handles market update failures, timeouts, cancellations, and interruptions while allowing startup to continue.
* **Bug Fixes**
  * Removed unnecessary market version restrictions from desktop market status and activation.
  * Improved startup coordination so DSH launches only after required preparation is complete.
* **Accessibility**
  * Startup notices now include accessible labels and safely handle special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->