### PR TITLE
chore(release): prepare 2026.9.2

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.9.1",
+  "version": "2026.9.2",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
Bumps the desktop version to 2026.9.2 so the release tag has a version to build.

## What ships in 2026.9.2

Both fixes address the same breakage from two sides: DSH 0.1.2-alpha dropped exports that installed community plugins still import, and upstream has not uniformly caught up.

- **A plugin that fails to load can now be removed** (#1625) — a plugin whose load throws left no removal control, so the only way out of a crash loop was editing the plugin directory by hand.
- **An outdated community market is upgraded before DSH loads it** (#1626) — stale market entries are refreshed ahead of load, so a plugin pinned to a version that no longer resolves against DSH does not take the app down with it.

The plugins that expose this in the wild: `dsh-better-sidebar` still references `settingsNamespace` as of 0.17.1 with no adapted release, and `dsh-plugin-subscriptions` only added a compat shim in 0.6.0 (0.5.3 still references `CallId`).

No code changes since 2026.9.1 beyond these two; #1627 was documentation and website copy only.

## Verification

CI on this branch, plus the pre-publish CDP pass over all six OpenCode Free models on the signed, notarized packaged build (not a dev build), per the release checklist. Results are reported on the release before it leaves draft.
