### PR TITLE
fix(ci): batch the v1 smoke fixture inserts into one transaction

### DIFF
--- a/packages/desktop-electron/scripts/ci-smoke-v1-fixture.ts
+++ b/packages/desktop-electron/scripts/ci-smoke-v1-fixture.ts
@@ -47,6 +47,11 @@ export function createCiSmokeV1Fixture(file: string, workspace: string) {
       );
     `)
 
+    // All inserts run in one transaction: outside one, node:sqlite creates and
+    // deletes a journal file per statement, which costs seconds of filesystem
+    // churn for the bulk rows on a contended filesystem.
+    database.exec("BEGIN")
+
     const insertSession = database.prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
     const insertMessage = database.prepare("INSERT INTO message VALUES (?, ?, ?, ?, ?)")
     const insertPart = database.prepare("INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)")
@@ -149,6 +154,8 @@ export function createCiSmokeV1Fixture(file: string, workspace: string) {
       2_000,
       JSON.stringify(automation),
     )
+
+    database.exec("COMMIT")
   } finally {
     database.close()
   }


### PR DESCRIPTION
Fixes #1628.

## Problem

`scripts/ci-smoke-v1-fixture.test.ts` timed out twice on `main` (`559c8f2b`, `266bdb4c`), both at the 5s `testTimeout` — 5,727 ms in one run and 32,353 ms in the next, on the same code that runs in ~130 ms locally.

The fixture is not slow, it is I/O-amplified: `createCiSmokeV1Fixture` inserts 150 rows into each of `session`, `message`, and `part` — 450 statements — with no surrounding transaction, and `node:sqlite` defaults to `journal_mode=delete`, so every statement was its own transaction that created and deleted a journal file. That per-statement journal lifecycle is unbounded filesystem churn on a contended CI runner. `synchronous=OFF` barely helps, which is how the cost was traced to the journal file lifecycle rather than fsync.

`CI_SMOKE_V1_BULK_SESSION_COUNT = 150` has been there since #1576 and has not changed; 2026-09-01 is simply when the runners were busy enough to cross 5s.

## Fix

Wrap all fixture inserts in one `BEGIN`/`COMMIT`. The fixture's contents and the test's assertions are unchanged, so the test stops depending on the runner's filesystem state.

- If an insert fails mid-transaction, the existing `database.close()` rolls the open transaction back (verified: zero rows survive), so no explicit rollback handling is added.
- Raising `testTimeout` was rejected — it moves the threshold and leaves the amplifier in place.

## Verification

- Focused test `scripts/ci-smoke-v1-fixture.test.ts`: 1 passed in 8 ms (was 5.7–32 s on contended CI runners).
- `pnpm --filter @pawwork/desktop typecheck`: clean.
- `eslint` on the changed file: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI smoke-test fixture setup by ensuring all database inserts complete together in a single transaction.
  * Prevented partially created fixtures when setup encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->