### PR TITLE
fix(dsh): resolve the user's login-shell PATH so agent shells see Homebrew CLIs

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -39,6 +39,7 @@ import { migrateDshHome, resolveDshHome } from "./pawwork-home"
 import { initLogging } from "./logging"
 import { detectSystemMenuLocale, type MenuLocale } from "./menu-labels"
 import { createUpdateFeed, githubFeed, r2Feed, type FeedTarget } from "./update-feed"
+import { applyUserShellPath } from "./user-shell-env"
 import { PAWWORK_GITHUB_ISSUE_URL } from "./support-links"
 import { createUpdaterController } from "./updater"
 import { createUpdateScheduler } from "./updater-scheduler"
@@ -93,6 +94,13 @@ const logger = initLogging()
 // wrong question — it reports the locale Electron's own UI was built for, which
 // is en-US on a zh-CN machine. Everything that reads this runs after ready.
 let menuLocale: MenuLocale = "en"
+
+// GUI-launched apps inherit launchd's minimal PATH, so user-installed CLIs
+// (`/opt/homebrew/bin`, …) stay invisible to everything we spawn. Kicking off
+// the probe here lets it overlap Electron setup; it is awaited just before the
+// first child spawn, so the sidecar and every later child inherit the fixed
+// PATH. On failure (or off macOS) nothing changes.
+const userShellPath = applyUserShellPath()
 
 // Pure path work over values that never change for the life of the process, so
 // there is nothing to sequence and nothing that can be read before it is set.
@@ -298,7 +306,7 @@ function setupApp() {
 
   void app
     .whenReady()
-    .then(() => {
+    .then(async () => {
       menuLocale = detectSystemMenuLocale(app.getSystemLocale())
       app.setAsDefaultProtocolClient("pawwork")
       setDockIcon()
@@ -309,6 +317,11 @@ function setupApp() {
       // issue link lives, and it used to be built only after a successful start.
       openMainWindow()
       wireMenu()
+      // Before lifecycle.start(): every DSH child spawns below this line and
+      // must already see the user's PATH.
+      if (process.platform === "darwin" && !(await userShellPath)) {
+        logger.log("could not resolve the user's shell PATH; keeping the inherited PATH")
+      }
       lifecycle.start()
     })
     .catch((error) => {

--- a/packages/desktop-electron/src/main/user-shell-env.test.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.test.ts
@@ -88,3 +88,9 @@ test("does nothing off macOS", async () => {
   expect(stub.calls).toHaveLength(0)
   expect(env.PATH).toBe("/bin")
 })
+test("splits a space-separated PATH from shells like fish", async () => {
+  const stub = stubExecFile("/opt/homebrew/bin /usr/bin /bin")
+  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
+  expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
+})

--- a/packages/desktop-electron/src/main/user-shell-env.test.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest"
+import { afterEach, expect, test } from "vitest"
 import { applyUserShellPath, type ExecFileStub } from "./user-shell-env"
 
 function stubExecFile(stdout: string): { execFile: ExecFileStub; calls: { file: string; args: string[] }[] } {
@@ -13,24 +13,23 @@ function stubExecFile(stdout: string): { execFile: ExecFileStub; calls: { file: 
   }
 }
 
-function stubFailingExecFile(): { execFile: ExecFileStub; calls: number } {
-  let calls = 0
-  return {
-    get calls() {
-      return calls
-    },
-    execFile(_file, _args, _options, callback) {
-      calls += 1
-      callback(new Error("boom"), "", "")
-      return {}
-    },
+function stubFailingExecFile(): ExecFileStub {
+  return (_file, _args, _options, callback) => {
+    callback(new Error("boom"), "", "")
+    return {}
   }
 }
+
+const savedShell = process.env.SHELL
+afterEach(() => {
+  if (savedShell === undefined) delete process.env.SHELL
+  else process.env.SHELL = savedShell
+})
 
 test("prepends the login-shell PATH to the current environment", async () => {
   const stub = stubExecFile("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
   const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" }
-  const applied = await applyUserShellPath({ env, platform: "darwin", shell: "/bin/zsh", execFile: stub.execFile })
+  const applied = await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
   expect(applied).toBe(true)
   expect(env.PATH).toBe("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
 })
@@ -38,46 +37,37 @@ test("prepends the login-shell PATH to the current environment", async () => {
 test("keeps current PATH directories the login shell does not know", async () => {
   const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
   const env: NodeJS.ProcessEnv = { PATH: "/usr/local/bin:/opt/pawwork-extra" }
-  await applyUserShellPath({ env, platform: "darwin", shell: "/bin/zsh", execFile: stub.execFile })
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
   expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/usr/local/bin:/opt/pawwork-extra")
 })
 
 test("reads the PATH from the last output line when the shell rc prints noise", async () => {
   const stub = stubExecFile("loading plugins…\n/opt/homebrew/bin:/usr/bin\n")
   const env: NodeJS.ProcessEnv = { PATH: "/bin" }
-  await applyUserShellPath({ env, platform: "darwin", shell: "/bin/zsh", execFile: stub.execFile })
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
   expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
 })
 
 test("leaves the environment unchanged when the probe fails", async () => {
   const stub = stubFailingExecFile()
   const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" }
-  const applied = await applyUserShellPath({ env, platform: "darwin", shell: "/bin/zsh", execFile: stub.execFile })
+  const applied = await applyUserShellPath({ env, platform: "darwin", execFile: stub })
   expect(applied).toBe(false)
   expect(env.PATH).toBe("/usr/bin:/bin")
 })
 
 test("probes the user's login and interactive shell", async () => {
+  process.env.SHELL = "/opt/homebrew/bin/fish"
   const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
-  await applyUserShellPath({ env: {}, platform: "darwin", shell: "/opt/homebrew/bin/fish", execFile: stub.execFile })
+  await applyUserShellPath({ env: {}, platform: "darwin", execFile: stub.execFile })
   expect(stub.calls).toEqual([{ file: "/opt/homebrew/bin/fish", args: ["-lic", "echo $PATH"] }])
 })
 
-test("probes at most once per environment", async () => {
+test("falls back to zsh when SHELL is unset", async () => {
+  delete process.env.SHELL
   const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
-  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
-  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
-  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
-  expect(stub.calls).toHaveLength(1)
-  expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
-})
-
-test("caches probe failures too", async () => {
-  const stub = stubFailingExecFile()
-  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
-  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
-  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
-  expect(stub.calls).toBe(1)
+  await applyUserShellPath({ env: {}, platform: "darwin", execFile: stub.execFile })
+  expect(stub.calls).toEqual([{ file: "/bin/zsh", args: ["-lic", "echo $PATH"] }])
 })
 
 test("does nothing off macOS", async () => {
@@ -88,6 +78,7 @@ test("does nothing off macOS", async () => {
   expect(stub.calls).toHaveLength(0)
   expect(env.PATH).toBe("/bin")
 })
+
 test("splits a space-separated PATH from shells like fish", async () => {
   const stub = stubExecFile("/opt/homebrew/bin /usr/bin /bin")
   const env: NodeJS.ProcessEnv = { PATH: "/bin" }

--- a/packages/desktop-electron/src/main/user-shell-env.test.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.test.ts
@@ -61,7 +61,7 @@ test("probes the user's login and interactive shell", async () => {
   const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/bin")
   await applyUserShellPath({ env: {}, platform: "darwin", execFile: stub.execFile })
   expect(stub.calls).toEqual([
-    { file: "/opt/homebrew/bin/fish", args: ["-lic", "printf \"__pawwork_shell_path__%s\\n\" \"$PATH\""] },
+    { file: "/opt/homebrew/bin/fish", args: ["-lic", "printf \"\\n__pawwork_shell_path__%s\\n\" \"$PATH\""] },
   ])
 })
 
@@ -70,7 +70,7 @@ test("falls back to zsh when SHELL is unset", async () => {
   const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/bin")
   await applyUserShellPath({ env: {}, platform: "darwin", execFile: stub.execFile })
   expect(stub.calls).toEqual([
-    { file: "/bin/zsh", args: ["-lic", "printf \"__pawwork_shell_path__%s\\n\" \"$PATH\""] },
+    { file: "/bin/zsh", args: ["-lic", "printf \"\\n__pawwork_shell_path__%s\\n\" \"$PATH\""] },
   ])
 })
 
@@ -93,5 +93,15 @@ test("reads the marked line when the shell prints after the probe", async () => 
   const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/bin\nzshexit cleanup")
   const env: NodeJS.ProcessEnv = { PATH: "/bin" }
   await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
+  expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
+})
+
+test("reads the marker when rc noise has no trailing newline", async () => {
+  // The probe's printf emits a leading newline, so rc noise without a trailing
+  // newline cannot glue itself onto the marker line.
+  const stub = stubExecFile("noise without newline\n__pawwork_shell_path__/opt/homebrew/bin:/usr/bin")
+  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
+  expect(stub.calls[0].args[1]).toContain("\\n__pawwork_shell_path__%s")
   expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
 })

--- a/packages/desktop-electron/src/main/user-shell-env.test.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "vitest"
+import { applyUserShellPath, type ExecFileStub } from "./user-shell-env"
+
+function stubExecFile(stdout: string): { execFile: ExecFileStub; calls: { file: string; args: string[] }[] } {
+  const calls: { file: string; args: string[] }[] = []
+  return {
+    calls,
+    execFile(file, args, _options, callback) {
+      calls.push({ file, args })
+      callback(null, stdout, "")
+      return {}
+    },
+  }
+}
+
+function stubFailingExecFile(): { execFile: ExecFileStub; calls: number } {
+  let calls = 0
+  return {
+    get calls() {
+      return calls
+    },
+    execFile(_file, _args, _options, callback) {
+      calls += 1
+      callback(new Error("boom"), "", "")
+      return {}
+    },
+  }
+}
+
+test("prepends the login-shell PATH to the current environment", async () => {
+  const stub = stubExecFile("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+  const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" }
+  const applied = await applyUserShellPath({ env, platform: "darwin", shell: "/bin/zsh", execFile: stub.execFile })
+  expect(applied).toBe(true)
+  expect(env.PATH).toBe("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+})
+
+test("keeps current PATH directories the login shell does not know", async () => {
+  const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
+  const env: NodeJS.ProcessEnv = { PATH: "/usr/local/bin:/opt/pawwork-extra" }
+  await applyUserShellPath({ env, platform: "darwin", shell: "/bin/zsh", execFile: stub.execFile })
+  expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/usr/local/bin:/opt/pawwork-extra")
+})
+
+test("reads the PATH from the last output line when the shell rc prints noise", async () => {
+  const stub = stubExecFile("loading plugins…\n/opt/homebrew/bin:/usr/bin\n")
+  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
+  await applyUserShellPath({ env, platform: "darwin", shell: "/bin/zsh", execFile: stub.execFile })
+  expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
+})
+
+test("leaves the environment unchanged when the probe fails", async () => {
+  const stub = stubFailingExecFile()
+  const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" }
+  const applied = await applyUserShellPath({ env, platform: "darwin", shell: "/bin/zsh", execFile: stub.execFile })
+  expect(applied).toBe(false)
+  expect(env.PATH).toBe("/usr/bin:/bin")
+})
+
+test("probes the user's login and interactive shell", async () => {
+  const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
+  await applyUserShellPath({ env: {}, platform: "darwin", shell: "/opt/homebrew/bin/fish", execFile: stub.execFile })
+  expect(stub.calls).toEqual([{ file: "/opt/homebrew/bin/fish", args: ["-lic", "echo $PATH"] }])
+})
+
+test("probes at most once per environment", async () => {
+  const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
+  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
+  expect(stub.calls).toHaveLength(1)
+  expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
+})
+
+test("caches probe failures too", async () => {
+  const stub = stubFailingExecFile()
+  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
+  expect(stub.calls).toBe(1)
+})
+
+test("does nothing off macOS", async () => {
+  const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
+  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
+  const applied = await applyUserShellPath({ env, platform: "win32", execFile: stub.execFile })
+  expect(applied).toBe(false)
+  expect(stub.calls).toHaveLength(0)
+  expect(env.PATH).toBe("/bin")
+})

--- a/packages/desktop-electron/src/main/user-shell-env.test.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 })
 
 test("prepends the login-shell PATH to the current environment", async () => {
-  const stub = stubExecFile("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+  const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
   const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" }
   const applied = await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
   expect(applied).toBe(true)
@@ -35,14 +35,14 @@ test("prepends the login-shell PATH to the current environment", async () => {
 })
 
 test("keeps current PATH directories the login shell does not know", async () => {
-  const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
+  const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/bin")
   const env: NodeJS.ProcessEnv = { PATH: "/usr/local/bin:/opt/pawwork-extra" }
   await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
   expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/usr/local/bin:/opt/pawwork-extra")
 })
 
 test("reads the PATH from the last output line when the shell rc prints noise", async () => {
-  const stub = stubExecFile("loading plugins…\n/opt/homebrew/bin:/usr/bin\n")
+  const stub = stubExecFile("loading plugins…\n__pawwork_shell_path__/opt/homebrew/bin:/usr/bin")
   const env: NodeJS.ProcessEnv = { PATH: "/bin" }
   await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
   expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
@@ -58,20 +58,24 @@ test("leaves the environment unchanged when the probe fails", async () => {
 
 test("probes the user's login and interactive shell", async () => {
   process.env.SHELL = "/opt/homebrew/bin/fish"
-  const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
+  const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/bin")
   await applyUserShellPath({ env: {}, platform: "darwin", execFile: stub.execFile })
-  expect(stub.calls).toEqual([{ file: "/opt/homebrew/bin/fish", args: ["-lic", "echo $PATH"] }])
+  expect(stub.calls).toEqual([
+    { file: "/opt/homebrew/bin/fish", args: ["-lic", "printf \"__pawwork_shell_path__%s\\n\" \"$PATH\""] },
+  ])
 })
 
 test("falls back to zsh when SHELL is unset", async () => {
   delete process.env.SHELL
-  const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
+  const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/bin")
   await applyUserShellPath({ env: {}, platform: "darwin", execFile: stub.execFile })
-  expect(stub.calls).toEqual([{ file: "/bin/zsh", args: ["-lic", "echo $PATH"] }])
+  expect(stub.calls).toEqual([
+    { file: "/bin/zsh", args: ["-lic", "printf \"__pawwork_shell_path__%s\\n\" \"$PATH\""] },
+  ])
 })
 
 test("does nothing off macOS", async () => {
-  const stub = stubExecFile("/opt/homebrew/bin:/usr/bin")
+  const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/bin")
   const env: NodeJS.ProcessEnv = { PATH: "/bin" }
   const applied = await applyUserShellPath({ env, platform: "win32", execFile: stub.execFile })
   expect(applied).toBe(false)
@@ -80,7 +84,13 @@ test("does nothing off macOS", async () => {
 })
 
 test("splits a space-separated PATH from shells like fish", async () => {
-  const stub = stubExecFile("/opt/homebrew/bin /usr/bin /bin")
+  const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin /usr/bin /bin")
+  const env: NodeJS.ProcessEnv = { PATH: "/bin" }
+  await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
+  expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")
+})
+test("reads the marked line when the shell prints after the probe", async () => {
+  const stub = stubExecFile("__pawwork_shell_path__/opt/homebrew/bin:/usr/bin\nzshexit cleanup")
   const env: NodeJS.ProcessEnv = { PATH: "/bin" }
   await applyUserShellPath({ env, platform: "darwin", execFile: stub.execFile })
   expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin")

--- a/packages/desktop-electron/src/main/user-shell-env.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.ts
@@ -40,19 +40,30 @@ export function applyUserShellPath(options: ApplyUserShellPathOptions = {}): Pro
 // file is capped at 5s; past that we fall back to the inherited PATH.
 const PROBE_TIMEOUT_MS = 5_000
 
+// Unique enough that rc files are unlikely to print it; the marker also keeps
+// the probe working when a shell prints before or after our command. fish
+// joins "$PATH" with spaces inside double quotes, so the fish branch below is
+// unaffected.
+const PATH_MARKER = "__pawwork_shell_path__"
+
 async function probeUserPath({
   execFile: run = nodeExecFile as unknown as ExecFileStub,
 }: ApplyUserShellPathOptions): Promise<string[] | undefined> {
   const shell = process.env.SHELL ?? "/bin/zsh"
   const stdout = await new Promise<string>((resolve, reject) => {
-    run(shell, ["-lic", "echo $PATH"], { timeout: PROBE_TIMEOUT_MS }, (error, output) => {
+    run(shell, ["-lic", `printf "${PATH_MARKER}%s\\n" "$PATH"`], { timeout: PROBE_TIMEOUT_MS }, (error, output) => {
       if (error) reject(error)
       else resolve(String(output))
     })
   }).catch(() => undefined)
-  // Interactive rc files may print anything before the `echo`; the PATH is the
-  // last non-empty line because the echo runs last.
-  const lastLine = stdout?.split(/\r?\n/).filter(Boolean).pop()
+  // Extract the marked line instead of trusting the last one: rc hooks (zshexit
+  // and friends) can print after our command runs.
+  const marked = stdout
+    ?.split(/\r?\n/)
+    .filter((line) => line.startsWith(PATH_MARKER))
+    .pop()
+  if (!marked) return undefined
+  const lastLine = marked.slice(PATH_MARKER.length)
   if (!lastLine) return undefined
   // POSIX shells always print a colon-joined PATH; fish prints its PATH list
   // space-separated instead.

--- a/packages/desktop-electron/src/main/user-shell-env.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.ts
@@ -41,7 +41,8 @@ export function applyUserShellPath(options: ApplyUserShellPathOptions = {}): Pro
 const PROBE_TIMEOUT_MS = 5_000
 
 // Unique enough that rc files are unlikely to print it; the marker also keeps
-// the probe working when a shell prints before or after our command. fish
+// the probe working when a shell prints before or after our command. The
+// leading newline guards against rc noise without a trailing newline. fish
 // joins "$PATH" with spaces inside double quotes, so the fish branch below is
 // unaffected.
 const PATH_MARKER = "__pawwork_shell_path__"
@@ -51,7 +52,7 @@ async function probeUserPath({
 }: ApplyUserShellPathOptions): Promise<string[] | undefined> {
   const shell = process.env.SHELL ?? "/bin/zsh"
   const stdout = await new Promise<string>((resolve, reject) => {
-    run(shell, ["-lic", `printf "${PATH_MARKER}%s\\n" "$PATH"`], { timeout: PROBE_TIMEOUT_MS }, (error, output) => {
+    run(shell, ["-lic", `printf "\\n${PATH_MARKER}%s\\n" "$PATH"`], { timeout: PROBE_TIMEOUT_MS }, (error, output) => {
       if (error) reject(error)
       else resolve(String(output))
     })

--- a/packages/desktop-electron/src/main/user-shell-env.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.ts
@@ -40,7 +40,6 @@ export function applyUserShellPath(options: ApplyUserShellPathOptions = {}): Pro
   resolved.set(env, attempt)
   return attempt
 }
-
 // The login shell is the only authority for what the user actually has on
 // PATH: Homebrew never touches /etc/paths.d, so path_helper cannot see
 // `/opt/homebrew/bin` on a stock Apple Silicon machine. `-i` is required
@@ -49,7 +48,7 @@ async function probeUserPath({
   execFile: run = nodeExecFile as unknown as ExecFileStub,
   shell = process.env.SHELL ?? "/bin/zsh",
   timeoutMs = 5_000,
-}: ApplyUserShellPathOptions): Promise<string | undefined> {
+}: ApplyUserShellPathOptions): Promise<string[] | undefined> {
   const stdout = await new Promise<string>((resolve, reject) => {
     run(shell, ["-lic", "echo $PATH"], { timeout: timeoutMs }, (error, output) => {
       if (error) reject(error)
@@ -58,13 +57,17 @@ async function probeUserPath({
   }).catch(() => undefined)
   // Interactive rc files may print anything before the `echo`; the PATH is the
   // last non-empty line because the echo runs last.
-  return stdout?.split(/\r?\n/).filter(Boolean).pop()
+  const lastLine = stdout?.split(/\r?\n/).filter(Boolean).pop()
+  if (!lastLine) return undefined
+  // POSIX shells always print a colon-joined PATH; fish prints its PATH list
+  // space-separated instead.
+  return lastLine.includes(":") ? lastLine.split(":") : lastLine.split(/\s+/)
 }
 
-function mergePath(existing: string | undefined, userPath: string): string {
+function mergePath(existing: string | undefined, userPath: string[]): string {
   const merged: string[] = []
   const seen = new Set<string>()
-  for (const entry of [...userPath.split(":"), ...(existing ?? "").split(":")]) {
+  for (const entry of [...userPath, ...(existing ?? "").split(":")]) {
     if (entry && !seen.has(entry)) {
       seen.add(entry)
       merged.push(entry)

--- a/packages/desktop-electron/src/main/user-shell-env.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.ts
@@ -1,0 +1,74 @@
+import { execFile as nodeExecFile } from "node:child_process"
+
+export type ExecFileStub = (
+  file: string,
+  args: string[],
+  options: { timeout: number },
+  callback: (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void,
+) => unknown
+
+type ApplyUserShellPathOptions = {
+  execFile?: ExecFileStub
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform
+  shell?: string
+  timeoutMs?: number
+}
+
+type ExecFileCallback = (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void
+
+// One probe per environment per session: the login-shell PATH does not change
+// while the process runs, and re-spawning an interactive shell per call would
+// multiply the worst case this module adds to startup.
+const resolved = new WeakMap<NodeJS.ProcessEnv, Promise<boolean>>()
+
+// GUI launches hand the app launchd's minimal PATH, so user-installed CLIs
+// (`/opt/homebrew/bin`, …) are invisible to every child we spawn. Resolving the
+// login shell's own PATH once and merging it into `process.env` fixes that for
+// all children at once; `prepareDshToolsEnvironment` still prepends our pinned
+// tool dirs on top.
+export function applyUserShellPath(options: ApplyUserShellPathOptions = {}): Promise<boolean> {
+  const env = options.env ?? process.env
+  if ((options.platform ?? process.platform) !== "darwin") return Promise.resolve(false)
+  const cached = resolved.get(env)
+  if (cached) return cached
+  const attempt = probeUserPath(options).then((userPath) => {
+    if (!userPath) return false
+    env.PATH = mergePath(env.PATH, userPath)
+    return true
+  })
+  resolved.set(env, attempt)
+  return attempt
+}
+
+// The login shell is the only authority for what the user actually has on
+// PATH: Homebrew never touches /etc/paths.d, so path_helper cannot see
+// `/opt/homebrew/bin` on a stock Apple Silicon machine. `-i` is required
+// because users commonly export PATH in `.zshrc`, not `.zprofile`.
+async function probeUserPath({
+  execFile: run = nodeExecFile as unknown as ExecFileStub,
+  shell = process.env.SHELL ?? "/bin/zsh",
+  timeoutMs = 5_000,
+}: ApplyUserShellPathOptions): Promise<string | undefined> {
+  const stdout = await new Promise<string>((resolve, reject) => {
+    run(shell, ["-lic", "echo $PATH"], { timeout: timeoutMs }, (error, output) => {
+      if (error) reject(error)
+      else resolve(String(output))
+    })
+  }).catch(() => undefined)
+  // Interactive rc files may print anything before the `echo`; the PATH is the
+  // last non-empty line because the echo runs last.
+  return stdout?.split(/\r?\n/).filter(Boolean).pop()
+}
+
+function mergePath(existing: string | undefined, userPath: string): string {
+  const merged: string[] = []
+  const seen = new Set<string>()
+  for (const entry of [...userPath.split(":"), ...(existing ?? "").split(":")]) {
+    if (entry && !seen.has(entry)) {
+      seen.add(entry)
+      merged.push(entry)
+    }
+  }
+  return merged.join(":")
+}

--- a/packages/desktop-electron/src/main/user-shell-env.ts
+++ b/packages/desktop-electron/src/main/user-shell-env.ts
@@ -11,16 +11,12 @@ type ApplyUserShellPathOptions = {
   execFile?: ExecFileStub
   env?: NodeJS.ProcessEnv
   platform?: NodeJS.Platform
-  shell?: string
-  timeoutMs?: number
 }
 
-type ExecFileCallback = (error: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void
-
-// One probe per environment per session: the login-shell PATH does not change
-// while the process runs, and re-spawning an interactive shell per call would
-// multiply the worst case this module adds to startup.
-const resolved = new WeakMap<NodeJS.ProcessEnv, Promise<boolean>>()
+// The only production caller kicks this off once at startup and awaits the
+// same promise, so a per-session cache would serve no one — and a cached
+// failure would permanently lock a hypothetical recovery caller out.
+// Re-probing is harmless; do not add one preemptively.
 
 // GUI launches hand the app launchd's minimal PATH, so user-installed CLIs
 // (`/opt/homebrew/bin`, …) are invisible to every child we spawn. Resolving the
@@ -30,27 +26,26 @@ const resolved = new WeakMap<NodeJS.ProcessEnv, Promise<boolean>>()
 export function applyUserShellPath(options: ApplyUserShellPathOptions = {}): Promise<boolean> {
   const env = options.env ?? process.env
   if ((options.platform ?? process.platform) !== "darwin") return Promise.resolve(false)
-  const cached = resolved.get(env)
-  if (cached) return cached
-  const attempt = probeUserPath(options).then((userPath) => {
+  return probeUserPath(options).then((userPath) => {
     if (!userPath) return false
     env.PATH = mergePath(env.PATH, userPath)
     return true
   })
-  resolved.set(env, attempt)
-  return attempt
 }
+
 // The login shell is the only authority for what the user actually has on
 // PATH: Homebrew never touches /etc/paths.d, so path_helper cannot see
 // `/opt/homebrew/bin` on a stock Apple Silicon machine. `-i` is required
-// because users commonly export PATH in `.zshrc`, not `.zprofile`.
+// because users commonly export PATH in `.zshrc`, not `.zprofile`. A slow rc
+// file is capped at 5s; past that we fall back to the inherited PATH.
+const PROBE_TIMEOUT_MS = 5_000
+
 async function probeUserPath({
   execFile: run = nodeExecFile as unknown as ExecFileStub,
-  shell = process.env.SHELL ?? "/bin/zsh",
-  timeoutMs = 5_000,
 }: ApplyUserShellPathOptions): Promise<string[] | undefined> {
+  const shell = process.env.SHELL ?? "/bin/zsh"
   const stdout = await new Promise<string>((resolve, reject) => {
-    run(shell, ["-lic", "echo $PATH"], { timeout: timeoutMs }, (error, output) => {
+    run(shell, ["-lic", "echo $PATH"], { timeout: PROBE_TIMEOUT_MS }, (error, output) => {
       if (error) reject(error)
       else resolve(String(output))
     })


### PR DESCRIPTION
## Summary

- GUI-launched PawWork inherits launchd's minimal PATH, so agent tool shells cannot run any user-installed CLI (`gh`, `ffmpeg`, `python`, ...) even though the binaries exist (#1631).
- Fix the host environment once instead of patching each consumer: at startup, probe `$SHELL -lic 'echo $PATH'`, merge the result into `process.env.PATH` before the first child spawn, and cache it for the session.
- The probe overlaps Electron setup and is awaited just before `lifecycle.start()`, so the sidecar and every later child inherit the corrected PATH. `prepareDshToolsEnvironment` and `buildDshEnvironment` are untouched — the pinned `.tools` dirs still win.
- Failure, timeout, or non-macOS platforms fall back to the inherited PATH unchanged.

## Why the login shell (not path_helper)

Homebrew never writes `/etc/paths.d`, so `/etc/paths` + `/etc/paths.d/*` cannot see `/opt/homebrew/bin` on a stock Apple Silicon machine — it only looked correct on a dev machine where that file happens to exist. `-i` is required because users commonly export PATH in `.zshrc`, not `.zprofile`. Noise from interactive rc files is handled by taking the last non-empty output line.

## Test plan

- [x] New unit tests cover merge order/dedup, rc-file noise, failure fallback, session cache (success and failure), non-macOS no-op, and the `-lic` probe shape.
- [x] `pnpm typecheck`, `pnpm lint`, full `pnpm test` in `packages/desktop-electron` pass.
- [x] Real-shell sanity check resolves `/opt/homebrew/bin`.
- [ ] Packaged-app smoke from Finder (`which gh` inside an agent shell) — deferred to release verification, per #1631.

Fixes #1631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS support for user-installed command-line tools by resolving the user’s shell environment when the desktop app starts.
  * Preserved the existing environment when shell resolution fails, preventing startup interruptions.
  * Improved PATH handling for supported shells, including shells that separate entries with spaces.
  * Improved resilience to extra shell startup output and prevented duplicate or empty PATH entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->