### PR TITLE
fix: make upgrading from PawWork v1 visible instead of silent

### DIFF
--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1-automations.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1-automations.cjs
@@ -174,9 +174,10 @@ async function runV1AutomationImport({
   if (typeof importRun !== 'function') throw new Error('v1 importRun adapter is required');
   const { ledger, save } = openMigrationLedger(home);
   guardV1DatabaseIdentity(ledger, sourceDatabase);
+  let importedCount = 0;
   if (!sourceDatabase) {
     await save();
-    return;
+    return importedCount;
   }
 
   if (!snapshot) throw new Error('v1 automation import requires a database snapshot');
@@ -200,6 +201,7 @@ async function runV1AutomationImport({
       signal?.throwIfAborted();
       if (!['imported', 'skipped'].includes(outcome)) throw new Error(`invalid definition outcome: ${outcome}`);
       delete ledger.failures.automationDefinitions[definition.id];
+      if (outcome === 'imported') importedCount += 1;
     } catch (error) {
       signal?.throwIfAborted();
       const message = error instanceof Error ? error.message : String(error);
@@ -218,6 +220,7 @@ async function runV1AutomationImport({
       signal?.throwIfAborted();
       if (!['imported', 'skipped'].includes(outcome)) throw new Error(`invalid run outcome: ${outcome}`);
       delete ledger.failures.automationRuns[run.id];
+      if (outcome === 'imported') importedCount += 1;
     } catch (error) {
       signal?.throwIfAborted();
       const message = error instanceof Error ? error.message : String(error);
@@ -226,6 +229,7 @@ async function runV1AutomationImport({
     await save();
   }
   await save();
+  return importedCount;
 }
 
 module.exports = {

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1-settings.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1-settings.cjs
@@ -142,9 +142,10 @@ async function runV1SettingsImport({
     throw new Error(`v1 settings source changed from ${ledger.sourceAppData} to ${sourceAppData}`);
   }
   if (sourceAppData) ledger.sourceAppData = sourceAppData;
+  let importedCount = 0;
   if (!sourceAppData) {
     await save();
-    return;
+    return importedCount;
   }
 
   const preferences = readV1Preferences(sourceAppData);
@@ -167,6 +168,7 @@ async function runV1SettingsImport({
         ledger.failures.settings[setting.id] = { message: `v1 setting is unsupported: ${setting.id}` };
       } else {
         delete ledger.failures.settings[setting.id];
+        if (outcome === 'imported') importedCount += 1;
       }
     } catch (error) {
       signal?.throwIfAborted();
@@ -177,6 +179,7 @@ async function runV1SettingsImport({
   }
 
   await save();
+  return importedCount;
 }
 
 module.exports = {

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.cjs
@@ -331,9 +331,10 @@ async function runV1SessionImport({
   if (typeof importSession !== 'function') throw new Error('v1 importSession adapter is required');
   const { ledger, save } = openMigrationLedger(home);
   guardV1DatabaseIdentity(ledger, sourceDatabase);
+  let importedCount = 0;
   if (!sourceDatabase) {
     await save();
-    return;
+    return importedCount;
   }
 
   if (!snapshot) throw new Error('v1 session import requires a database snapshot');
@@ -350,8 +351,12 @@ async function runV1SessionImport({
       const workspaceOutcome = await importSession(imported);
       signal?.throwIfAborted();
       if (!['attached', 'unavailable'].includes(workspaceOutcome)) throw new Error(`invalid workspace outcome: ${workspaceOutcome}`);
-      if (workspaceOutcome === 'attached') delete ledger.failures.sessions[sourceSession.id];
-      else ledger.failures.sessions[sourceSession.id] = { message: `v1 workspace is unavailable: ${imported.meta.cwd}` };
+      if (workspaceOutcome === 'attached') {
+        delete ledger.failures.sessions[sourceSession.id];
+        importedCount += 1;
+      } else {
+        ledger.failures.sessions[sourceSession.id] = { message: `v1 workspace is unavailable: ${imported.meta.cwd}` };
+      }
     } catch (error) {
       signal?.throwIfAborted();
       const message = error instanceof Error ? error.message : String(error);
@@ -360,6 +365,7 @@ async function runV1SessionImport({
     await save();
   }
   await save();
+  return importedCount;
 }
 
 module.exports = {

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
@@ -1613,6 +1613,7 @@ test('reports a locked v1 database as blocked and completes once it is released'
     locked = false;
     const done = await waitForPhase(plugin.status, 'done');
     assert.equal(done.phase, 'done');
+    assert.equal(done.notice.imported, 1);
     await stopPlugin();
     stopPlugin = undefined;
   } finally {
@@ -1699,7 +1700,15 @@ test('a snapshot failure that is not a lock is reported once and lets the other 
     const plugin = applyImportPlugin(apply, { logger: { warn: (message) => warnings.push(message) } });
     stopPlugin = plugin.stopPlugin;
 
-    await waitForPhase(plugin.status, 'done');
+    const done = await waitForPhase(plugin.status, 'done');
+    // Only the settings stage reads files rather than the database, so its one
+    // import plus the single snapshot failure is the whole result.
+    assert.deepEqual(done.notice, {
+      imported: 1,
+      failed: 1,
+      reasons: ['snapshot directory is read-only'],
+      ledgerPath: path.join(home, 'import-v1', 'ledger.json'),
+    });
     assert.deepEqual(warnings, ['v1 database snapshot failed: snapshot directory is read-only']);
     const ledger = JSON.parse(fs.readFileSync(path.join(home, 'import-v1', 'ledger.json'), 'utf8'));
     assert.deepEqual(ledger.failures.sessions.snapshot, { message: 'snapshot directory is read-only' });
@@ -1711,5 +1720,92 @@ test('a snapshot failure that is not a lock is reported once and lets the other 
     restoreStages();
     restoreEnvironment();
     if (stopPlugin) await stopPlugin().catch(() => {});
+  }
+});
+
+test('writes the run result to the ledger and reports it once', async () => {
+  const root = temporaryDirectory();
+  const source = path.join(root, 'pawwork.db');
+  const home = path.join(root, 'v2-home');
+  const ledgerFile = path.join(home, 'import-v1', 'ledger.json');
+  createV1Fixture(source);
+  fs.mkdirSync(path.dirname(ledgerFile), { recursive: true });
+  fs.writeFileSync(ledgerFile, JSON.stringify({
+    schema: 1,
+    failures: { sessions: { ses_broken: { message: 'invalid JSON in message m1' } } },
+  }));
+  const restoreEnvironment = withV1Environment(home, source);
+  const restoreStages = stubbedImportRun({ sessions: 2, settings: 1, automations: 0 });
+  let stopPlugin;
+
+  try {
+    const { apply } = await import(`${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?summary=${Date.now()}`);
+    const plugin = applyImportPlugin(apply);
+    stopPlugin = plugin.stopPlugin;
+
+    const done = await waitForPhase(plugin.status, 'done');
+    assert.deepEqual(done.notice, {
+      imported: 3,
+      failed: 1,
+      reasons: ['invalid JSON in message m1'],
+      ledgerPath: ledgerFile,
+    });
+    // The reply that carried the result is the only one that does: a poll still
+    // running must not put a dismissed strip back on screen.
+    assert.equal((await plugin.status('status', {})).value.notice, undefined);
+
+    assert.deepEqual(JSON.parse(fs.readFileSync(ledgerFile, 'utf8')).summary, {
+      imported: 3,
+      failed: 1,
+      reasons: ['invalid JSON in message m1'],
+    });
+
+    await stopPlugin();
+    stopPlugin = undefined;
+  } finally {
+    restoreStages();
+    restoreEnvironment();
+    if (stopPlugin) await stopPlugin().catch(() => {});
+  }
+});
+
+// A second launch re-reconciles what the first one imported: the stages that
+// recognise their own earlier result answer "skipped", so the run reports fewer
+// items than the one that did the work.
+test('a launch that only re-reconciles an earlier import says nothing again', async () => {
+  const root = temporaryDirectory();
+  const source = path.join(root, 'pawwork.db');
+  const home = path.join(root, 'v2-home');
+  const ledgerFile = path.join(home, 'import-v1', 'ledger.json');
+  createV1Fixture(source);
+  const restoreEnvironment = withV1Environment(home, source);
+
+  async function launch(stages) {
+    const restoreStages = stubbedImportRun(stages);
+    let stopPlugin;
+    try {
+      const { apply } = await import(`${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?relaunch=${Date.now()}${Math.random()}`);
+      const plugin = applyImportPlugin(apply);
+      stopPlugin = plugin.stopPlugin;
+      const done = await waitForPhase(plugin.status, 'done');
+      await stopPlugin();
+      stopPlugin = undefined;
+      return done.notice;
+    } finally {
+      restoreStages();
+      if (stopPlugin) await stopPlugin().catch(() => {});
+    }
+  }
+
+  try {
+    const first = await launch({ sessions: 151, settings: 1, automations: 0 });
+    assert.equal(first.imported, 152);
+
+    const second = await launch({ sessions: 151, settings: 0, automations: 0 });
+    assert.equal(second, undefined);
+    const ledger = JSON.parse(fs.readFileSync(ledgerFile, 'utf8'));
+    assert.deepEqual(ledger.summary, { imported: 152, failed: 0, reasons: [] });
+  } finally {
+    restoreEnvironment();
   }
 });

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
@@ -33,6 +33,29 @@ function temporaryDirectory() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'pawwork-import-v1-'));
 }
 
+// The plugin reads both homes from the environment, so a test that drives it
+// without a v1 fixture has to say there is none: left unset, the run finds
+// whatever v1 data the machine running the test happens to hold.
+function withoutV1Data() {
+  const original = {
+    HOME: process.env.HOME,
+    APPDATA: process.env.APPDATA,
+    DSH_HOME: process.env.DSH_HOME,
+    PAWWORK_V1_DATABASE: process.env.PAWWORK_V1_DATABASE,
+  };
+  const root = temporaryDirectory();
+  process.env.HOME = path.join(root, 'user');
+  process.env.APPDATA = path.join(root, 'roaming');
+  process.env.DSH_HOME = path.join(root, 'v2-home');
+  delete process.env.PAWWORK_V1_DATABASE;
+  return () => {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
 function fileDigest(file) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 }
@@ -96,6 +119,7 @@ test('retires each persisted v1 session through the paired live lifecycle', asyn
       backgroundFinished();
     }
   };
+  const restoreEnvironment = withoutV1Data();
   try {
     const pluginUrl = `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?status=${Date.now()}`;
     const { apply } = await import(pluginUrl);
@@ -162,6 +186,7 @@ test('retires each persisted v1 session through the paired live lifecycle', asyn
     settingsModule.createDshSettingImporter = originalCreateSettingImporter;
     settingsModule.runV1SettingsImport = originalSettingsRun;
     automationsModule.runV1AutomationImport = originalAutomationsRun;
+    restoreEnvironment();
   }
 });
 
@@ -389,6 +414,7 @@ test('saves a session\'s images once and leaves an already-imported one alone', 
   settingsModule.createDshSettingImporter = () => async () => 'skipped';
   settingsModule.runV1SettingsImport = async () => ({ status: 'complete' });
   automationsModule.runV1AutomationImport = async () => ({ status: 'complete' });
+  const restoreEnvironment = withoutV1Data();
 
   try {
     const pluginUrl = `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?images=${Date.now()}`;
@@ -432,6 +458,7 @@ test('saves a session\'s images once and leaves an already-imported one alone', 
     settingsModule.createDshSettingImporter = originals.settingImporter;
     settingsModule.runV1SettingsImport = originals.settingsRun;
     automationsModule.runV1AutomationImport = originals.automationsRun;
+    restoreEnvironment();
   }
 
   assert.equal(saved.length, 1);
@@ -617,6 +644,7 @@ test('plugin disposal aborts and awaits the background migration', async () => {
   };
   settingsModule.runV1SettingsImport = async () => { settingsCalls += 1; };
   automationsModule.runV1AutomationImport = async () => { automationCalls += 1; };
+  const restoreEnvironment = withoutV1Data();
   try {
     const pluginUrl = `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?dispose=${Date.now()}`;
     const { apply } = await import(pluginUrl);
@@ -640,6 +668,7 @@ test('plugin disposal aborts and awaits the background migration', async () => {
     importerModule.runV1SessionImport = originalRun;
     settingsModule.runV1SettingsImport = originalSettingsRun;
     automationsModule.runV1AutomationImport = originalAutomationsRun;
+    restoreEnvironment();
   }
 });
 
@@ -1480,4 +1509,207 @@ test('preserves source identity and failures written by another migration stage'
   assert.equal(ledger.sourceAppData, '/tmp/v1-app-data');
   assert.deepEqual(ledger.failures.settings, { theme: { message: 'settings store unavailable' } });
   assert.deepEqual(ledger.failures.sessions, {});
+});
+
+// --- upgrade feedback -------------------------------------------------------
+// v1 holds its database open while it runs, so the first launch after an
+// upgrade can find the source locked. These cover what the user is told about
+// it, which the stage tests above cannot see.
+
+function lockedV1DatabaseError() {
+  const error = new Error('v1 database is in use');
+  error.errcode = 5;
+  return error;
+}
+
+function applyImportPlugin(apply, overrides = {}) {
+  let status;
+  let stopPlugin;
+  apply({
+    connection: { rpc: { handle: (_channel, handler) => { status = handler; return async () => {}; } } },
+    effect: (setup) => { stopPlugin = setup(); },
+    llm: { listProviders: () => [], listModels: async () => [] },
+    logger: { warn: () => {} },
+    agentDefaultModel: { currentSelection: () => ({ provider: 'opencode', model: 'big-pickle' }) },
+    pawworkAutomations: { scheduler: { refresh: () => {} }, store: { activateImportedDefinitions: () => {} } },
+    sessionPersistence: { inspect: async (id) => { throw new Error(`session "${id}" not found`); } },
+    sessionTitle: { rename: () => {} },
+    sessions: { announce: () => {}, enter: () => () => {}, flush: async () => {}, prepare: () => ({}) },
+    attachments: { saveImage: async () => {} },
+    workspaceRegistry: {},
+    ...overrides,
+  });
+  return { status, stopPlugin };
+}
+
+async function waitForPhase(status, phase, deadlineMs = 15_000) {
+  const started = Date.now();
+  for (;;) {
+    const current = (await status('status', {})).value;
+    if (current.phase === phase) return current;
+    if (Date.now() - started > deadlineMs) {
+      throw new Error(`v1 import stayed in phase ${current.phase} instead of reaching ${phase}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+function stubbedImportRun({ sessions, settings, automations }) {
+  const importerModule = require('./import-v1.cjs');
+  const settingsModule = require('./import-v1-settings.cjs');
+  const automationsModule = require('./import-v1-automations.cjs');
+  const originals = {
+    run: importerModule.runV1SessionImport,
+    settingsRun: settingsModule.runV1SettingsImport,
+    createSettingImporter: settingsModule.createDshSettingImporter,
+    automationsRun: automationsModule.runV1AutomationImport,
+  };
+  importerModule.runV1SessionImport = async () => sessions;
+  settingsModule.createDshSettingImporter = () => async () => 'skipped';
+  settingsModule.runV1SettingsImport = async () => settings;
+  automationsModule.runV1AutomationImport = async () => automations;
+  return () => {
+    importerModule.runV1SessionImport = originals.run;
+    settingsModule.runV1SettingsImport = originals.settingsRun;
+    settingsModule.createDshSettingImporter = originals.createSettingImporter;
+    automationsModule.runV1AutomationImport = originals.automationsRun;
+  };
+}
+
+function withV1Environment(home, sourceDatabase) {
+  const original = { home: process.env.DSH_HOME, source: process.env.PAWWORK_V1_DATABASE };
+  process.env.DSH_HOME = home;
+  process.env.PAWWORK_V1_DATABASE = sourceDatabase;
+  return () => {
+    if (original.home === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = original.home;
+    if (original.source === undefined) delete process.env.PAWWORK_V1_DATABASE;
+    else process.env.PAWWORK_V1_DATABASE = original.source;
+  };
+}
+
+test('reports a locked v1 database as blocked and completes once it is released', { timeout: 20_000 }, async () => {
+  const migrationIoModule = require('./migration-io.cjs');
+  const originalOpen = migrationIoModule.openV1Snapshot;
+  const root = temporaryDirectory();
+  const source = path.join(root, 'pawwork.db');
+  const home = path.join(root, 'v2-home');
+  createV1Fixture(source);
+  const restoreEnvironment = withV1Environment(home, source);
+  const restoreStages = stubbedImportRun({ sessions: 1, settings: 0, automations: 0 });
+  let locked = true;
+  migrationIoModule.openV1Snapshot = async (options) => {
+    if (locked) throw lockedV1DatabaseError();
+    return originalOpen(options);
+  };
+  let stopPlugin;
+
+  try {
+    const { apply } = await import(`${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?blocked=${Date.now()}`);
+    const plugin = applyImportPlugin(apply);
+    stopPlugin = plugin.stopPlugin;
+
+    await waitForPhase(plugin.status, 'blocked');
+    locked = false;
+    const done = await waitForPhase(plugin.status, 'done');
+    assert.equal(done.phase, 'done');
+    await stopPlugin();
+    stopPlugin = undefined;
+  } finally {
+    migrationIoModule.openV1Snapshot = originalOpen;
+    restoreStages();
+    restoreEnvironment();
+    if (stopPlugin) await stopPlugin().catch(() => {});
+  }
+});
+
+test('a disposal during the locked-database wait stops the import at once', { timeout: 20_000 }, async () => {
+  const migrationIoModule = require('./migration-io.cjs');
+  const originalOpen = migrationIoModule.openV1Snapshot;
+  const root = temporaryDirectory();
+  const source = path.join(root, 'pawwork.db');
+  const home = path.join(root, 'v2-home');
+  createV1Fixture(source);
+  const restoreEnvironment = withV1Environment(home, source);
+  const restoreStages = stubbedImportRun({ sessions: 0, settings: 0, automations: 0 });
+  migrationIoModule.openV1Snapshot = async () => { throw lockedV1DatabaseError(); };
+
+  try {
+    const { apply } = await import(`${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?abort=${Date.now()}`);
+    const plugin = applyImportPlugin(apply);
+    await waitForPhase(plugin.status, 'blocked');
+
+    const started = Date.now();
+    await plugin.stopPlugin();
+    // The retry sleeps for a second before its next attempt; an abort that only
+    // took effect between attempts would hold shutdown for at least that long.
+    assert.ok(Date.now() - started < 500, `disposal waited ${Date.now() - started}ms for the retry`);
+    assert.equal(fs.existsSync(path.join(home, 'import-v1', 'ledger.json')), false);
+  } finally {
+    migrationIoModule.openV1Snapshot = originalOpen;
+    restoreStages();
+    restoreEnvironment();
+  }
+});
+
+test('waits only for a v1 database another process holds', async () => {
+  const { isLockedV1Database } = await import(
+    `${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?locked=${Date.now()}`);
+  const root = temporaryDirectory();
+  const source = path.join(root, 'pawwork.db');
+  createV1Fixture(source);
+  const holder = new DatabaseSync(source);
+  holder.exec('PRAGMA locking_mode=EXCLUSIVE');
+  holder.exec('BEGIN EXCLUSIVE');
+  holder.exec("INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)"
+    + " VALUES ('ses_open', 'project_1', 'open', '/Users/alice/work', 'Open', '1.2.3', 9000, 9000)");
+
+  try {
+    await assert.rejects(
+      () => createDatabaseSnapshot(source, path.join(root, 'snapshot.db')),
+      (error) => error.errcode === 5 && isLockedV1Database(error),
+    );
+  } finally {
+    holder.close();
+  }
+
+  // A source that is not there will never unlock, so CANTOPEN must not be waited
+  // out.
+  await assert.rejects(
+    () => createDatabaseSnapshot(path.join(root, 'absent.db'), path.join(root, 'snapshot.db')),
+    (error) => error.errcode === 14 && !isLockedV1Database(error),
+  );
+});
+
+test('a snapshot failure that is not a lock is reported once and lets the other stages finish', async () => {
+  const migrationIoModule = require('./migration-io.cjs');
+  const originalOpen = migrationIoModule.openV1Snapshot;
+  const root = temporaryDirectory();
+  const source = path.join(root, 'pawwork.db');
+  const home = path.join(root, 'v2-home');
+  createV1Fixture(source);
+  const restoreEnvironment = withV1Environment(home, source);
+  const restoreStages = stubbedImportRun({ sessions: 5, settings: 1, automations: 4 });
+  migrationIoModule.openV1Snapshot = async () => { throw new Error('snapshot directory is read-only'); };
+  const warnings = [];
+  let stopPlugin;
+
+  try {
+    const { apply } = await import(`${pathToFileURL(path.join(__dirname, 'index.mjs')).href}?cantopen=${Date.now()}`);
+    const plugin = applyImportPlugin(apply, { logger: { warn: (message) => warnings.push(message) } });
+    stopPlugin = plugin.stopPlugin;
+
+    await waitForPhase(plugin.status, 'done');
+    assert.deepEqual(warnings, ['v1 database snapshot failed: snapshot directory is read-only']);
+    const ledger = JSON.parse(fs.readFileSync(path.join(home, 'import-v1', 'ledger.json'), 'utf8'));
+    assert.deepEqual(ledger.failures.sessions.snapshot, { message: 'snapshot directory is read-only' });
+
+    await stopPlugin();
+    stopPlugin = undefined;
+  } finally {
+    migrationIoModule.openV1Snapshot = originalOpen;
+    restoreStages();
+    restoreEnvironment();
+    if (stopPlugin) await stopPlugin().catch(() => {});
+  }
 });

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/import-v1.test.cjs
@@ -190,14 +190,15 @@ test('retires each persisted v1 session through the paired live lifecycle', asyn
   }
 });
 
-// The sidebar is the only status consumer, so its barrier belongs to the
-// session stage: once the cold sessions are flushed, later settings and
-// Automation work must not delay the authoritative list refresh.
-test('reports the session import settled while later migration stages continue', async () => {
+// "done" is the one reply the client acts on and then stops polling, so it may
+// not appear before the result it has to carry: every stage, the summary
+// included, is behind that barrier.
+test('reports done only once every stage has run and the result is recorded', async () => {
   const importerModule = require('./import-v1.cjs');
   const settingsModule = require('./import-v1-settings.cjs');
   const automationsModule = require('./import-v1-automations.cjs');
   const originalRun = importerModule.runV1SessionImport;
+  const originalAttach = importerModule.attachDshWorkspace;
   const originalSettingsRun = settingsModule.runV1SettingsImport;
   const originalCreateSettingImporter = settingsModule.createDshSettingImporter;
   const originalAutomationsRun = automationsModule.runV1AutomationImport;
@@ -222,6 +223,7 @@ test('reports the session import settled while later migration stages continue',
   let releaseAutomations;
   const automationsGate = new Promise((resolve) => { releaseAutomations = resolve; });
   let sessionFlushed = false;
+  importerModule.attachDshWorkspace = async () => 'attached';
   importerModule.runV1SessionImport = async ({ importSession }) => {
     await sessionsGate;
     await importSession({
@@ -231,18 +233,18 @@ test('reports the session import settled while later migration stages continue',
       seed: [{ type: 'pawwork-v1/session', data: { sourceSessionId: 'session' } }],
       title: 'Imported session',
     });
-    return { status: 'complete' };
+    return 1;
   };
   settingsModule.createDshSettingImporter = () => async () => 'skipped';
   settingsModule.runV1SettingsImport = async () => {
     settingsStarted();
     await settingsGate;
-    return { status: 'complete' };
+    return 1;
   };
   automationsModule.runV1AutomationImport = async () => {
     automationsStarted();
     await automationsGate;
-    return { status: 'complete' };
+    return 0;
   };
   let registration;
   let status;
@@ -289,22 +291,32 @@ test('reports the session import settled while later migration stages continue',
     assert.equal(sessionFlushed, true);
     assert.deepEqual(await status('status', {}), {
       ok: true,
-      value: { phase: 'done', sessionId: 'pawwork-v1-session' },
+      value: { phase: 'running', sessionId: 'pawwork-v1-session' },
     });
 
     releaseSettings();
     await automationsStage;
     assert.deepEqual(await status('status', {}), {
       ok: true,
-      value: { phase: 'done', sessionId: 'pawwork-v1-session' },
+      value: { phase: 'running', sessionId: 'pawwork-v1-session' },
     });
+
     releaseAutomations();
+    const done = await waitForPhase(status, 'done');
+    assert.equal(done.sessionId, 'pawwork-v1-session');
+    assert.deepEqual(done.notice, {
+      imported: 2,
+      failed: 0,
+      reasons: [],
+      ledgerPath: path.join(home, 'import-v1', 'ledger.json'),
+    });
     await stopPlugin();
   } finally {
     releaseSessions?.();
     releaseSettings?.();
     releaseAutomations?.();
     importerModule.runV1SessionImport = originalRun;
+    importerModule.attachDshWorkspace = originalAttach;
     settingsModule.createDshSettingImporter = originalCreateSettingImporter;
     settingsModule.runV1SettingsImport = originalSettingsRun;
     automationsModule.runV1AutomationImport = originalAutomationsRun;
@@ -347,8 +359,7 @@ test('settles the session status when source discovery fails before import', asy
       workspaceRegistry: {},
     });
 
-    await new Promise((resolve) => setImmediate(resolve));
-    assert.deepEqual(await status('status', {}), { ok: true, value: { phase: 'done' } });
+    assert.deepEqual(await waitForPhase(status, 'done'), { phase: 'done' });
     await stopPlugin();
   } finally {
     migrationIoModule.discoverV1Database = originalDiscover;

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
@@ -110,6 +110,75 @@ export function createDshSessionImporter(ctx, onPersisted = () => {}) {
   };
 }
 
+// `new DatabaseSync` already waits out a five-second busy timeout of its own, so
+// a fixed pause on top of that is about six seconds between attempts.
+const SNAPSHOT_RETRY_MS = 1_000;
+
+function delay(ms, signal) {
+  return new Promise((resolve, reject) => {
+    signal.throwIfAborted();
+    const abort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', abort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', abort, { once: true });
+  });
+}
+
+// A running v1 holds its database open. SQLite reports that contention as one
+// of two result codes carrying different words, and both mean the same thing
+// here: the user still has v1 open, so wait. Extended result codes carry the
+// primary code in their low byte. Every other code, CANTOPEN included, names
+// something no amount of waiting will change, such as a snapshot directory this
+// machine cannot write.
+const SQLITE_BUSY = 5;
+const SQLITE_LOCKED = 6;
+
+export function isLockedV1Database(error) {
+  const primary = typeof error?.errcode === 'number' ? error.errcode & 0xff : undefined;
+  return primary === SQLITE_BUSY || primary === SQLITE_LOCKED;
+}
+
+// v1 keeps its database open for as long as it runs, and this import is the
+// first thing the upgraded app does. Failing here would silently drop every
+// session the user has; waiting costs nothing and finishes on its own once they
+// quit v1. The wait is only worth taking while the source is still there: a
+// source that disappeared will never unlock.
+export async function openSnapshotWhenAvailable({ sourceDatabase, signal, onBlocked, onResumed }) {
+  for (;;) {
+    signal.throwIfAborted();
+    try {
+      const snapshot = await migrationIo.openV1Snapshot({ home: process.env.DSH_HOME, sourceDatabase });
+      onResumed();
+      return snapshot;
+    } catch (error) {
+      if (!isLockedV1Database(error)) throw error;
+      if (migrationIo.discoverV1Database() !== sourceDatabase) throw error;
+      onBlocked();
+      await delay(SNAPSHOT_RETRY_MS, signal);
+    }
+  }
+}
+
+// A snapshot that cannot be taken belongs to no single v1 session, so it takes
+// a reserved key in the same category and is cleared the moment one opens.
+const SNAPSHOT_FAILURE_ID = 'snapshot';
+
+async function recordSnapshotFailure(message) {
+  const { ledger, save } = migrationIo.openMigrationLedger(process.env.DSH_HOME);
+  if (message === undefined) {
+    if (ledger.failures.sessions[SNAPSHOT_FAILURE_ID] === undefined) return;
+    delete ledger.failures.sessions[SNAPSHOT_FAILURE_ID];
+  } else {
+    ledger.failures.sessions[SNAPSHOT_FAILURE_ID] = { message };
+  }
+  await save();
+}
+
 export function apply(ctx) {
   const controller = new AbortController();
   let lastPersistedSessionId;
@@ -125,21 +194,36 @@ export function apply(ctx) {
         sourceDatabase = migrationIo.discoverV1Database();
         if (sourceDatabase) {
           try {
-            snapshot = await migrationIo.openV1Snapshot({ home: process.env.DSH_HOME, sourceDatabase });
+            snapshot = await openSnapshotWhenAvailable({
+              sourceDatabase,
+              signal: controller.signal,
+              onBlocked: () => { sessionPhase = 'blocked'; },
+              onResumed: () => { sessionPhase = 'running'; },
+            });
+            await recordSnapshotFailure(undefined);
           } catch (error) {
-            ctx.logger.warn(`v1 database snapshot failed: ${error instanceof Error ? error.message : String(error)}`);
+            sessionPhase = 'running';
+            if (controller.signal.aborted) throw error;
+            const message = error instanceof Error ? error.message : String(error);
+            // Both database-backed stages read this one snapshot, so a snapshot
+            // this machine cannot take is a single failure the user is told
+            // about once. The stages that read files instead still run.
+            ctx.logger.warn(`v1 database snapshot failed: ${message}`);
+            await recordSnapshotFailure(message);
           }
         }
-        const importSession = createDshSessionImporter(ctx, (id) => { lastPersistedSessionId = id; });
-        controller.signal.throwIfAborted();
-        await importer.runV1SessionImport({
-          home: process.env.DSH_HOME,
-          sourceDatabase,
-          snapshot: snapshot?.path,
-          importSession,
-          signal: controller.signal,
-        });
-        controller.signal.throwIfAborted();
+        if (!sourceDatabase || snapshot) {
+          const importSession = createDshSessionImporter(ctx, (id) => { lastPersistedSessionId = id; });
+          controller.signal.throwIfAborted();
+          await importer.runV1SessionImport({
+            home: process.env.DSH_HOME,
+            sourceDatabase,
+            snapshot: snapshot?.path,
+            importSession,
+            signal: controller.signal,
+          });
+          controller.signal.throwIfAborted();
+        }
       } catch (error) {
         if (controller.signal.aborted) return;
         ctx.logger.warn(`v1 session import failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -163,29 +247,31 @@ export function apply(ctx) {
         ctx.logger.warn(`v1 settings import failed: ${error instanceof Error ? error.message : String(error)}`);
       }
 
-      try {
-        controller.signal.throwIfAborted();
-        await automationImporter.runV1AutomationImport({
-          home: process.env.DSH_HOME,
-          sourceDatabase,
-          snapshot: snapshot?.path,
-          resolveModel: createAutomationModelResolver(ctx),
-          importDefinition: async (definition) => {
-            if (definition.context === 'continue'
-              && !await hasPersistedV1Session(ctx.sessionPersistence, definition.sourceSessionId)) {
-              throw new Error(`v1 automation source session is unavailable: ${definition.sourceSessionId}`);
-            }
-            return ctx.pawworkAutomations.store.importDefinition(definition);
-          },
-          importRun: async (run) => ctx.pawworkAutomations.store.importRun(run),
-          signal: controller.signal,
-        });
-        controller.signal.throwIfAborted();
-        ctx.pawworkAutomations.store.activateImportedDefinitions();
-        ctx.pawworkAutomations.scheduler.refresh();
-      } catch (error) {
-        if (controller.signal.aborted) return;
-        ctx.logger.warn(`v1 automation import failed: ${error instanceof Error ? error.message : String(error)}`);
+      if (!sourceDatabase || snapshot) {
+        try {
+          controller.signal.throwIfAborted();
+          await automationImporter.runV1AutomationImport({
+            home: process.env.DSH_HOME,
+            sourceDatabase,
+            snapshot: snapshot?.path,
+            resolveModel: createAutomationModelResolver(ctx),
+            importDefinition: async (definition) => {
+              if (definition.context === 'continue'
+                && !await hasPersistedV1Session(ctx.sessionPersistence, definition.sourceSessionId)) {
+                throw new Error(`v1 automation source session is unavailable: ${definition.sourceSessionId}`);
+              }
+              return ctx.pawworkAutomations.store.importDefinition(definition);
+            },
+            importRun: async (run) => ctx.pawworkAutomations.store.importRun(run),
+            signal: controller.signal,
+          });
+          controller.signal.throwIfAborted();
+          ctx.pawworkAutomations.store.activateImportedDefinitions();
+          ctx.pawworkAutomations.scheduler.refresh();
+        } catch (error) {
+          if (controller.signal.aborted) return;
+          ctx.logger.warn(`v1 automation import failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
       }
     } finally {
       // Everything else in this task is caught per stage, so this is the one

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
@@ -113,6 +113,7 @@ export function createDshSessionImporter(ctx, onPersisted = () => {}) {
 // `new DatabaseSync` already waits out a five-second busy timeout of its own, so
 // a fixed pause on top of that is about six seconds between attempts.
 const SNAPSHOT_RETRY_MS = 1_000;
+const NOTICE_REASON_LIMIT = 3;
 
 function delay(ms, signal) {
   return new Promise((resolve, reject) => {
@@ -179,10 +180,46 @@ async function recordSnapshotFailure(message) {
   await save();
 }
 
+function ledgerReasons(ledger) {
+  const messages = Object.values(ledger.failures)
+    .flatMap((records) => Object.values(records).map((record) => record.message));
+  return [...new Set(messages)].slice(0, NOTICE_REASON_LIMIT);
+}
+
 export function apply(ctx) {
   const controller = new AbortController();
   let lastPersistedSessionId;
   let sessionPhase = 'running';
+  let notice;
+  let importedTotal = 0;
+  const count = (imported) => { importedTotal += imported || 0; };
+
+  // The result is worth one sentence to the user, once. The counts of the last
+  // run that carried something live in the ledger, because that is the only
+  // thing that survives the window and the next launch has to recognise its own
+  // earlier work.
+  function recordImportSummary() {
+    const { file, ledger, save } = migrationIo.openMigrationLedger(process.env.DSH_HOME);
+    // Every stage records each failure under its own key in the ledger, so what
+    // did not make it is read back from there rather than tallied a second time.
+    const failed = Object.values(ledger.failures).reduce((sum, records) => sum + Object.keys(records).length, 0);
+    // A later launch reconciles the same data again and reports less than the
+    // run that did the work: a stage that recognises its own earlier result
+    // answers "skipped", and no total counts a skip. So the question is not
+    // whether the summary changed but whether this run carried more than the
+    // recorded one; anything else is the same result reached again and must not
+    // greet the user a second time.
+    const advanced = (importedTotal > 0 || failed > 0) && (
+      ledger.summary === undefined
+      || importedTotal > ledger.summary.imported
+      || failed > ledger.summary.failed
+    );
+    if (!advanced) return;
+    ledger.summary = { imported: importedTotal, failed, reasons: ledgerReasons(ledger) };
+    notice = { ...ledger.summary, ledgerPath: file };
+    return save();
+  }
+
   const importTask = (async () => {
     let sourceDatabase;
     let snapshot;
@@ -215,13 +252,13 @@ export function apply(ctx) {
         if (!sourceDatabase || snapshot) {
           const importSession = createDshSessionImporter(ctx, (id) => { lastPersistedSessionId = id; });
           controller.signal.throwIfAborted();
-          await importer.runV1SessionImport({
+          count(await importer.runV1SessionImport({
             home: process.env.DSH_HOME,
             sourceDatabase,
             snapshot: snapshot?.path,
             importSession,
             signal: controller.signal,
-          });
+          }));
           controller.signal.throwIfAborted();
         }
       } catch (error) {
@@ -236,11 +273,11 @@ export function apply(ctx) {
       try {
         controller.signal.throwIfAborted();
         const importSetting = settingsImporter.createDshSettingImporter(ctx);
-        await settingsImporter.runV1SettingsImport({
+        count(await settingsImporter.runV1SettingsImport({
           home: process.env.DSH_HOME,
           importSetting,
           signal: controller.signal,
-        });
+        }));
         controller.signal.throwIfAborted();
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -250,7 +287,7 @@ export function apply(ctx) {
       if (!sourceDatabase || snapshot) {
         try {
           controller.signal.throwIfAborted();
-          await automationImporter.runV1AutomationImport({
+          count(await automationImporter.runV1AutomationImport({
             home: process.env.DSH_HOME,
             sourceDatabase,
             snapshot: snapshot?.path,
@@ -264,7 +301,7 @@ export function apply(ctx) {
             },
             importRun: async (run) => ctx.pawworkAutomations.store.importRun(run),
             signal: controller.signal,
-          });
+          }));
           controller.signal.throwIfAborted();
           ctx.pawworkAutomations.store.activateImportedDefinitions();
           ctx.pawworkAutomations.scheduler.refresh();
@@ -272,6 +309,14 @@ export function apply(ctx) {
           if (controller.signal.aborted) return;
           ctx.logger.warn(`v1 automation import failed: ${error instanceof Error ? error.message : String(error)}`);
         }
+      }
+
+      try {
+        controller.signal.throwIfAborted();
+        await recordImportSummary();
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        ctx.logger.warn(`v1 import summary failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     } finally {
       // Everything else in this task is caught per stage, so this is the one
@@ -289,13 +334,21 @@ export function apply(ctx) {
   ctx.effect(() => {
     const stopStatusRpc = ctx.connection.rpc.handle(
       '/pawwork-import-v1',
-      async () => ({
-        ok: true,
-        value: {
-          phase: sessionPhase,
-          ...(lastPersistedSessionId === undefined ? {} : { sessionId: lastPersistedSessionId }),
-        },
-      }),
+      async () => {
+        // The result goes out with the first reply that carries it and is gone
+        // from this task afterwards, so a poll that keeps running cannot put a
+        // dismissed strip back on screen.
+        const carried = notice;
+        notice = undefined;
+        return {
+          ok: true,
+          value: {
+            phase: sessionPhase,
+            ...(lastPersistedSessionId === undefined ? {} : { sessionId: lastPersistedSessionId }),
+            ...(carried === undefined ? {} : { notice: carried }),
+          },
+        };
+      },
       { authority: 'loopback' },
     );
     return async () => {

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/index.mjs
@@ -264,11 +264,6 @@ export function apply(ctx) {
       } catch (error) {
         if (controller.signal.aborted) return;
         ctx.logger.warn(`v1 session import failed: ${error instanceof Error ? error.message : String(error)}`);
-      } finally {
-        // The sidebar consumes only session persistence. Settings and
-        // Automation continue independently after this barrier and must not
-        // delay the client's cold-session list refresh.
-        sessionPhase = 'done';
       }
       try {
         controller.signal.throwIfAborted();
@@ -319,6 +314,10 @@ export function apply(ctx) {
         ctx.logger.warn(`v1 import summary failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     } finally {
+      // "done" means the summary has been recorded, so a reply that carries
+      // this phase also carries the notice when there is one. Every path out
+      // of the task, abort included, passes through here.
+      sessionPhase = 'done';
       // Everything else in this task is caught per stage, so this is the one
       // statement that can reject it — and nothing awaits importTask until the
       // plugin is disposed, so a rejection here reaches DSH's fail-loud handler

--- a/packages/desktop-electron/resources/dsh/home/plugins/import-v1/migration-io.cjs
+++ b/packages/desktop-electron/resources/dsh/home/plugins/import-v1/migration-io.cjs
@@ -119,7 +119,7 @@ function openMigrationLedger(home) {
   for (const category of ['sessions', 'settings', 'automationDefinitions', 'automationRuns']) {
     ledger.failures[category] ||= {};
   }
-  return { ledger, save: () => writeJsonAtomically(file, ledger) };
+  return { file, ledger, save: () => writeJsonAtomically(file, ledger) };
 }
 
 // The session and automation stages read one database and record one identity,

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -197,6 +197,8 @@ html body :is(button, [role="button"], [role="treeitem"], [role="tab"], [role="m
   display: flex; flex-direction: column; gap: 6px; padding: 10px 12px; pointer-events: auto;
 }
 .pawwork-import-feedback p { font-size: 12px; line-height: 19px; margin: 0; }
+.pawwork-import-detail { color: var(--dsw-alias-label-tertiary); overflow-wrap: anywhere; }
+.pawwork-import-dismiss { align-self: flex-end; }
 /* The rc.8 locale registry throws on a duplicate namespace and offers no override point, so DSH's
    own headline and preview badge are replaced visually, anchored on data-slot rather than on class
    names that carry a per-version hash. Zeroing font-size alone leaves a 32px line box that lifts
@@ -404,14 +406,14 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
     const IMPORT_POLL_MAX_RETRY_MS = 30_000
     const IMPORT_PHASES = ["running", "blocked", "done"]
 
-    // What the import has to say out loud, starting with the fact that it is
-    // waiting on the old app. The watcher below already owns the poll, so it
-    // publishes here and the overlay only renders.
+    // Two things the import has to say out loud: that it is waiting on the old
+    // app, and what it ended up doing. The watcher below already owns the poll,
+    // so it publishes here and the overlay only renders.
     function createImportFeedback() {
-      let state = { blocked: false }
+      let state = { blocked: false, notice: null }
       const listeners = new Set()
       const publish = (next) => {
-        if (next.blocked === state.blocked) return
+        if (next.blocked === state.blocked && next.notice === state.notice) return
         state = next
         for (const listener of listeners) listener(state)
       }
@@ -422,16 +424,36 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
           return () => { listeners.delete(listener) }
         },
         setBlocked: (blocked) => publish({ ...state, blocked }),
+        setNotice: (notice) => publish({ ...state, notice }),
+        dismiss: () => publish({ ...state, notice: null }),
       }
     }
 
     function V1ImportNotice({ feedback }) {
       const [state, setState] = useState(feedback.get())
       useEffect(() => feedback.subscribe(setState), [feedback])
-      if (!state.blocked) return null
+      const notice = state.notice
+      if (!state.blocked && !notice) return null
       return h("div", { className: "pawwork-import-feedback" },
-        h("div", { role: "status" }, h("p", null,
-          text("请先退出旧版爪印，导入会自动继续。", "Quit the older PawWork; the import continues on its own."))))
+        state.blocked
+          ? h("div", { role: "status" }, h("p", null,
+            text("请先退出旧版爪印，导入会自动继续。", "Quit the older PawWork; the import continues on its own.")))
+          : null,
+        notice
+          ? h("div", { role: notice.failed > 0 ? "alert" : "status" },
+            h("p", null, notice.failed > 0
+              ? text(`已从旧版爪印导入 ${notice.imported} 项，${notice.failed} 项没能导入。`,
+                `Imported ${notice.imported} items from the older PawWork. ${notice.failed} could not be imported.`)
+              : text(`已从旧版爪印导入 ${notice.imported} 项。`,
+                `Imported ${notice.imported} items from the older PawWork.`)),
+            notice.reasons?.length
+              ? h("p", { className: "pawwork-import-detail" }, notice.reasons.join(" / "))
+              : null,
+            h("p", { className: "pawwork-import-detail" },
+              text(`详细记录：${notice.ledgerPath}`, `Full record: ${notice.ledgerPath}`)),
+            h(Button, { className: "pawwork-import-dismiss", onClick: () => feedback.dismiss(), size: "sm" },
+              text("知道了", "Got it")))
+          : null)
     }
 
     function watchV1Import({ connection, sessions }, feedback) {
@@ -474,6 +496,7 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
           schedule(IMPORT_POLL_INTERVAL_MS)
           return
         }
+        if (value.notice) feedback.setNotice(value.notice)
         // refreshList reuses a still in-flight fetch, which at this point may be one that started
         // before the import finished, so the first read only settles it and the second is the one
         // guaranteed to begin after the completion barrier.

--- a/packages/desktop-electron/resources/dsh/product/lib/client.js
+++ b/packages/desktop-electron/resources/dsh/product/lib/client.js
@@ -182,6 +182,21 @@ html body :is(button, [role="button"], [role="treeitem"], [role="tab"], [role="m
 .pawwork-market-actions { display: flex; flex-shrink: 0; gap: 8px; white-space: nowrap; }
 .pawwork-market-action { align-self: flex-start; }
 .pawwork-market-error { color: var(--dsw-alias-state-error-primary); font-size: 12px; line-height: 19px; }
+/* The v1 import runs before the user has done anything, so what it has to say
+   sits over the shell rather than inside a view they may never open. Only the
+   strip itself takes pointer events; the rest of the overlay row stays
+   transparent. */
+.pawwork-import-feedback {
+  bottom: 16px; display: flex; flex-direction: column; gap: 8px; left: 50%;
+  max-width: min(560px, calc(100vw - 32px)); pointer-events: none; position: fixed;
+  transform: translateX(-50%); z-index: 20;
+}
+.pawwork-import-feedback > * {
+  background: var(--dsw-alias-bg-module-platform); border: 1px solid var(--dsw-alias-border-l1);
+  border-radius: 8px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12); color: var(--dsw-alias-label-primary);
+  display: flex; flex-direction: column; gap: 6px; padding: 10px 12px; pointer-events: auto;
+}
+.pawwork-import-feedback p { font-size: 12px; line-height: 19px; margin: 0; }
 /* The rc.8 locale registry throws on a duplicate namespace and offers no override point, so DSH's
    own headline and preview badge are replaced visually, anchored on data-slot rather than on class
    names that carry a per-version hash. Zeroing font-size alone leaves a 32px line box that lifts
@@ -387,8 +402,39 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
     // public snapshot.
     const IMPORT_POLL_INTERVAL_MS = 1_000
     const IMPORT_POLL_MAX_RETRY_MS = 30_000
+    const IMPORT_PHASES = ["running", "blocked", "done"]
 
-    function watchV1Import({ connection, sessions }) {
+    // What the import has to say out loud, starting with the fact that it is
+    // waiting on the old app. The watcher below already owns the poll, so it
+    // publishes here and the overlay only renders.
+    function createImportFeedback() {
+      let state = { blocked: false }
+      const listeners = new Set()
+      const publish = (next) => {
+        if (next.blocked === state.blocked) return
+        state = next
+        for (const listener of listeners) listener(state)
+      }
+      return {
+        get: () => state,
+        subscribe(listener) {
+          listeners.add(listener)
+          return () => { listeners.delete(listener) }
+        },
+        setBlocked: (blocked) => publish({ ...state, blocked }),
+      }
+    }
+
+    function V1ImportNotice({ feedback }) {
+      const [state, setState] = useState(feedback.get())
+      useEffect(() => feedback.subscribe(setState), [feedback])
+      if (!state.blocked) return null
+      return h("div", { className: "pawwork-import-feedback" },
+        h("div", { role: "status" }, h("p", null,
+          text("请先退出旧版爪印，导入会自动继续。", "Quit the older PawWork; the import continues on its own."))))
+    }
+
+    function watchV1Import({ connection, sessions }, feedback) {
       let retryDelay = IMPORT_POLL_INTERVAL_MS
       let timer = null
       let stopped = false
@@ -417,12 +463,13 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
         if (stopped) return
         const value = result?.ok === true ? result.value : undefined
         if (value === null || typeof value !== "object"
-          || (value.phase !== "running" && value.phase !== "done")
+          || !IMPORT_PHASES.includes(value.phase)
           || (value.sessionId !== undefined && typeof value.sessionId !== "string")) {
           retry()
           return
         }
-        if (value.phase === "running") {
+        feedback.setBlocked(value.phase === "blocked")
+        if (value.phase !== "done") {
           retryDelay = IMPORT_POLL_INTERVAL_MS
           schedule(IMPORT_POLL_INTERVAL_MS)
           return
@@ -445,8 +492,11 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
     }
 
     function apply(ctx) {
+      const feedback = createImportFeedback()
       ctx.slots.inject("shell.overlay", () => ctx.slots.register({ name: "shell.overlay", id: "pawwork-window-chrome", order: -100 },
         () => WindowChrome({ toggleSidebar: () => ctx.layout.toggleSidebar() })))
+      ctx.slots.inject("shell.overlay", () => ctx.slots.register({ name: "shell.overlay", id: "pawwork-v1-import", order: -90 },
+        () => V1ImportNotice({ feedback })))
       ctx.slots.inject("sidebar.brand.mark", () => ctx.slots.register({ name: "sidebar.brand.mark", priority: -100 }, PawReadyMark))
       ctx.slots.inject("sidebar.brand.name", () => ctx.slots.register({ name: "sidebar.brand.name", priority: -100 }, BrandName))
       ctx.slots.inject("conversation.hero.brand.mark", () => ctx.slots.register({ name: "conversation.hero.brand.mark", priority: -100 }, PawGloveMark))
@@ -456,7 +506,7 @@ span:has(> [data-slot="conversation.hero.brand.mark"]) + span + span { display: 
         label: () => text("社区市场", "Community market"),
       }, CommunityMarketTab))
       ctx.slots.inject("conversation.input.left", () => ctx.slots.register({ name: "conversation.input.left", id: "pawwork-files", order: -100 }, FileAction))
-      ctx.effect(() => watchV1Import(ctx))
+      ctx.effect(() => watchV1Import(ctx, feedback))
     }
 
     return { inject, apply }

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -330,9 +330,9 @@ describe("PawWork DSH client product layer", () => {
 
     expect(plugin.inject).toEqual(["slots", "connection", "sessions", "layout"])
     const overlay = registrations.filter((entry) => entry.options.name === "shell.overlay")
-    expect(overlay).toHaveLength(1)
-    expect(overlay[0].options.id).toBe("pawwork-window-chrome")
-    const tree = overlay[0].component(overlay[0].options.inject?.()) as {
+    expect(overlay.map((entry) => entry.options.id)).toEqual(["pawwork-window-chrome", "pawwork-v1-import"])
+    const chrome = overlay[0]
+    const tree = chrome.component(chrome.options.inject?.()) as {
       props: { children: Array<{ type: unknown; props: Record<string, unknown> }> }
     }
     const button = tree.props.children[1]
@@ -611,6 +611,68 @@ describe("PawWork DSH client product layer", () => {
     await new Promise((resolve) => setImmediate(resolve))
     expect(refresh).toHaveBeenCalledTimes(2)
     expect(timers).toHaveLength(0)
+  })
+
+  // The import overlay is the only thing that tells an upgrading user why their
+  // sessions are not there yet, so it is rendered through the real store the
+  // watcher publishes into rather than against a hand-made state.
+  async function renderImportOverlay(value: unknown) {
+    const timers: Array<() => void> = []
+    const definition = loadDshClientModule(resolve(productRoot, "lib/client.js"), {
+      document: {
+        title: "DeepSeek Harness",
+        documentElement: { lang: "zh-CN" },
+        querySelector: () => null,
+        createElement: () => ({ dataset: {}, textContent: "" }),
+        head: { appendChild: () => {} },
+      },
+      setTimeout: (callback: () => void) => timers.push(callback),
+      clearTimeout: () => {},
+    })
+    const createElement = (type: unknown, props: Record<string, unknown> | null, ...children: unknown[]): unknown => {
+      const nextProps = { ...props, children }
+      return typeof type === "function" ? type(nextProps) : { type, props: nextProps }
+    }
+    const plugin = definition.factory((name) => {
+      if (name === "react") {
+        return {
+          createElement,
+          useEffect: (effect: () => void) => { effect() },
+          useRef: <T>(initial: T) => ({ current: initial }),
+          useState: (initial: unknown) => [initial, vi.fn()],
+        }
+      }
+      if (name === "@deepseek-ai/dsh-client-ui-primitives") {
+        return { Button: (props: Record<string, unknown>) => ({ type: "button", props }), IconPanelLeftOutline16: () => null }
+      }
+      throw new Error(`unexpected product client dependency: ${name}`)
+    })
+    const call = vi.fn(async () => ({ ok: true, value }))
+    let overlay: (() => unknown) | undefined
+    plugin.apply({
+      connection: { rpc: { call } },
+      effect: (fn: () => unknown) => fn(),
+      layout: { toggleSidebar: vi.fn() },
+      sessions: { list: { getSnapshot: () => ({ ids: [] }) }, refresh: vi.fn(async () => {}) },
+      slots: {
+        inject: (_name: string, register: () => void) => register(),
+        register: (options: { id?: string; inject?: () => unknown }, component: (props: unknown) => unknown) => {
+          if (options.id === "pawwork-v1-import") overlay = () => component(options.inject?.())
+        },
+      },
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+    return { call, tree: overlay!(), timers }
+  }
+
+  test("keeps a standing strip up while the old PawWork still holds the v1 database", async () => {
+    const { tree, timers } = await renderImportOverlay({ phase: "blocked" })
+
+    expect(textOf(tree)).toContain("请先退出旧版爪印，导入会自动继续。")
+    expect(visit(tree).some((element) => element.props.role === "status")).toBe(true)
+    // Blocked is not an error state: the watcher keeps its steady cadence so the
+    // strip disappears on its own once the user quits v1.
+    expect(timers).toHaveLength(1)
   })
 
   test("stops polling when the client plugin is disposed", async () => {

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -675,6 +675,19 @@ describe("PawWork DSH client product layer", () => {
     expect(timers).toHaveLength(1)
   })
 
+  test("reports the import result the host handed it", async () => {
+    const { tree } = await renderImportOverlay({
+      phase: "done",
+      notice: { imported: 3, failed: 1, reasons: ["invalid JSON in message m1"], ledgerPath: "/home/import-v1/ledger.json" },
+    })
+
+    const texts = textOf(tree)
+    expect(texts).toContain("已从旧版爪印导入 3 项，1 项没能导入。")
+    expect(texts).toContain("invalid JSON in message m1")
+    expect(texts).toContain("详细记录：/home/import-v1/ledger.json")
+    expect(visit(tree).some((element) => element.props.role === "alert")).toBe(true)
+  })
+
   test("stops polling when the client plugin is disposed", async () => {
     const timers: Array<() => void> = []
     const plugin = loadPlugin(timers)

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -76,6 +76,20 @@ const MARKET_UPGRADE_NOTICE: Record<MenuLocale, string> = {
   en: "Updating the community plugin market…",
   zh: "正在更新社区插件市场…",
 }
+// Shown when a second launch finds the data already in use. Without it the Dock
+// icon bounces once and the launch disappears with nothing said.
+const SECOND_INSTANCE_NOTICE: Record<MenuLocale, { message: string; detail: string; button: string }> = {
+  en: {
+    message: "PawWork is already running",
+    detail: "Another PawWork window is using the same data. If you just upgraded, quit the older PawWork first, then open it again.",
+    button: "OK",
+  },
+  zh: {
+    message: "爪印已经在运行",
+    detail: "另一个爪印窗口正在使用同一份数据。如果你刚从旧版本升级，请先退出旧版爪印，再重新打开。",
+    button: "好",
+  },
+}
 
 const userDataRoot = CI_SMOKE_HOME ?? app.getPath("appData")
 const appChannel = app.isPackaged ? CHANNEL : "dev"
@@ -197,11 +211,6 @@ function setupApp() {
   app.commandLine.appendSwitch("proxy-bypass-list", "<-loopback>")
   for (const [name, value] of ciSmokeCdpSwitches(process.env)) app.commandLine.appendSwitch(name, value)
 
-  if (!CI_SMOKE_ENABLED && !app.requestSingleInstanceLock()) {
-    app.quit()
-    return
-  }
-
   ipcMain.handle("pawwork:pick-conversation-files", (event) => {
     const state = lifecycle.state
     if (state.phase !== "ready") throw new Error("Cannot pick files before DSH is ready")
@@ -308,6 +317,25 @@ function setupApp() {
     .whenReady()
     .then(async () => {
       menuLocale = detectSystemMenuLocale(app.getSystemLocale())
+
+      // The lock is claimed after ready and before anything with an effect: a
+      // process that requests it before ready and loses never becomes ready, so
+      // it could only ever exit in silence.
+      if (!CI_SMOKE_ENABLED && !app.requestSingleInstanceLock()) {
+        const copy = SECOND_INSTANCE_NOTICE[menuLocale]
+        logger.info("second instance: PawWork is already running, notice shown")
+        dialog.showMessageBoxSync({
+          type: "info",
+          message: copy.message,
+          detail: copy.detail,
+          buttons: [copy.button],
+          defaultId: 0,
+          cancelId: 0,
+        })
+        app.exit(0)
+        return
+      }
+
       app.setAsDefaultProtocolClient("pawwork")
       setDockIcon()
       setupAutoUpdater()
@@ -631,6 +659,7 @@ function openMainWindow() {
 function focusMainWindow(openIfMissing = false) {
   const [existing] = liveWindows()
   const win = existing ?? (openIfMissing ? openMainWindow() : undefined)
+  if (win?.isMinimized()) win.restore()
   win?.show()
   win?.focus()
 }


### PR DESCRIPTION
## Why

Upgrading from PawWork v1 to v2 was meant to be invisible, and in three places it was invisible in the wrong way: the launch vanished, the import stalled with nothing on screen, and the import finished without a word.

## What the user sees now

1. **Opening v2 while v1 is still running shows a notice instead of nothing.** v1 and v2 share one appId, so the second launch loses the single-instance lock. Before, that launch quit with no window and no message. Now it shows a native "PawWork is already running" dialog (zh/en) that tells the user to quit the older PawWork first, and exits once dismissed. The lock is claimed after `ready`: a process that requests it before `ready` and loses never becomes ready, so it could only ever exit in silence.
2. **An import blocked by v1's open database is visible and resumes on its own.** A running v1 holds its SQLite database, which the import reported as a failure and dropped every session. Now SQLITE_BUSY / SQLITE_LOCKED put the import into a `blocked` phase that retries every second (on top of SQLite's own 5s busy timeout) while the shell shows a standing strip: "Quit the older PawWork; the import continues on its own." Any other SQLite error, CANTOPEN included, is still a plain failure recorded once in the ledger.
3. **The finished import reports its result once.** The shell shows "Imported N items from the older PawWork" (plus the failed count, up to three distinct reasons, and the ledger path) with a Got it button. The counts of the last run that carried something are written to the ledger as `summary`; a later launch re-reconciles the same data and reports it again only when it carried more than the recorded run, so the same result never greets the user twice.

## Trade-offs

- The second-instance dialog is synchronous and the process exits only when it is dismissed. There is no auto-dismiss timeout: on macOS a parentless alert runs a modal loop in which `app.exit`, `app.quit` and `process.exit` all have no effect, so a timer could not end the launch anyway.
- The wait for v1 has no overall limit. The strip stays up for as long as v1 holds the database, which is the true state; the import finishes as soon as v1 quits.
- A window closed before the result strip renders does not get the result again on the next launch. The data and the ledger are intact either way; only one sentence is lost.
- On Windows a v1 holding the database may surface as SQLITE_CANTOPEN rather than BUSY/LOCKED. That is treated as a plain failure and retried on the next launch. Not reproducible on macOS.

## Left as is (P3)

- `focusMainWindow` does not use `app.focus({ steal: true })` when the running instance is handed a second launch.
- The feedback strip is centered on the viewport rather than the content area.
- `ledgerReasons` takes the first three distinct messages across all failure categories rather than per category.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm --filter @pawwork/desktop test` (vitest 509, node 156) green.
- Real Electron driven over CDP against the dev build, each on a fresh HOME with the CI smoke v1 fixture:
  - first launch shows the result strip once (152 items), Got it dismisses it, the imported session is in the sidebar;
  - relaunch on the same HOME shows nothing;
  - with the fixture held open by another process (`BEGIN EXCLUSIVE`), the blocked strip is up until the holder exits, then the result strip appears;
  - a fixture with one session whose workspace no longer exists reports "1 could not be imported" once and stays quiet on relaunch;
  - a second launch without the CI smoke bypass reaches `ready`, logs the notice, and calls `showMessageBoxSync` with the localized copy (captured through `--inspect-brk` by stubbing the dialog); it exits with status 0 once the dialog returns.
- Each design element here was ablated one at a time against those scenarios; the ones kept are the ones whose removal made a scenario fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a migration progress overlay for legacy imports, including blocked, running, and completed states.
  - Completed imports now show imported and failed item counts, failure details, and the migration record location.
  - Added localized messaging when a second app instance is opened.

- **Bug Fixes**
  - Legacy imports now wait and resume when the source database is temporarily locked.
  - Improved handling and reporting of unavailable source data.
  - Import completion is reported only after all migration stages finish.
  - Restored minimized windows when bringing an existing app instance to the foreground.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->