### PR TITLE
fix(ci): create one release draft before any asset upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -643,6 +643,22 @@ jobs:
         if: always() && runner.os == 'macOS' && (inputs.phase == 'finalize' || inputs.phase == 'full')
         run: rm -f "${{ runner.temp }}/apple-api-key.p8"
 
+      # electron-builder creates the release when the tag has none, and it
+      # uploads a target's assets concurrently, so the first phase to publish for
+      # a tag can produce two drafts and split its assets between them. Claim the
+      # single draft here, before any upload, and fail fast on a split.
+      - name: Ensure a single release draft
+        if: ${{ inputs.channel != 'dev' && ((runner.os == 'macOS' && (inputs.phase == 'finalize' || inputs.phase == 'full') && inputs.arch == matrix.arch_label) || (runner.os == 'Windows' && inputs.phase == 'full')) }}
+        run: pnpm exec tsx ./scripts/ensure-release-draft.ts
+        working-directory: packages/desktop-electron
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ env.PUBLISH_OWNER }}/${{ env.PUBLISH_REPO }}
+          RELEASE_TAG: v${{ steps.package_version.outputs.version }}
+          # Same phase-tied commit the publisher pins the tag to, so the draft
+          # starts out targeting the commit its assets are built from.
+          RELEASE_TARGET_SHA: ${{ inputs.phase == 'finalize' && inputs.source_sha || github.sha }}
+
       - name: Package notarized artifacts
         if: ${{ runner.os == 'macOS' && (inputs.phase == 'finalize' || inputs.phase == 'full') && inputs.arch == matrix.arch_label }}
         run: |

--- a/packages/desktop-electron/scripts/ensure-release-draft.test.ts
+++ b/packages/desktop-electron/scripts/ensure-release-draft.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs"
 import { join } from "node:path"
 
 import { decideDraftAction } from "./ensure-release-draft"
-import { type GithubRelease } from "./verify-release"
+import { fetchReleasesByTag, type GithubRelease } from "./verify-release"
 
 // Shaped like the /releases payload the guard filters by tag, trimmed to the
 // fields the decision reads.
@@ -14,6 +14,12 @@ const release = (id: number, tag: string, draft = true): GithubRelease & { id: n
   prerelease: false,
   assets: [],
 })
+
+// A full first page of unrelated releases, so the tag only appears on page two.
+const pagedReleases = (matchOnPage2: Array<GithubRelease & { id: number }>) => {
+  const first = Array.from({ length: 100 }, (_, index) => release(9000 + index, `v2025.1.${index + 1}`, false))
+  return async (url: string) => (new URL(url).searchParams.get("page") === "1" ? first : matchOnPage2)
+}
 
 describe("ensure-release-draft", () => {
   test("creates a draft when the tag has no release", () => {
@@ -50,6 +56,22 @@ describe("ensure-release-draft", () => {
     expect(decision.reason).toContain("380293071")
     expect(decision.reason).toContain("380293073")
     expect(decision.reason).toContain("keep the one holding the assets")
+  })
+
+  // A match missed because it sat past the first page reads as "no release for
+  // this tag", which is exactly the state that creates a duplicate.
+  test("reuses a release that only appears on a later page of the list", async () => {
+    const matches = await fetchReleasesByTag(
+      "Astro-Han/pawwork",
+      "v2026.6.1",
+      pagedReleases([release(7, "v2026.6.1")]),
+    )
+    expect(matches.map((match) => match.id)).toEqual([7])
+    expect(decideDraftAction("v2026.6.1", matches)).toEqual({
+      kind: "reuse",
+      published: false,
+      reason: expect.stringContaining("reusing draft 7"),
+    })
   })
 
   // The create is only half the guard: reading the list endpoint back too soon

--- a/packages/desktop-electron/scripts/ensure-release-draft.test.ts
+++ b/packages/desktop-electron/scripts/ensure-release-draft.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "vitest"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 
 import { decideDraftAction } from "./ensure-release-draft"
 import { type GithubRelease } from "./verify-release"
@@ -21,14 +23,21 @@ describe("ensure-release-draft", () => {
     })
   })
 
-  test("reuses the single existing release, draft or published", () => {
+  test("reuses the tag's only draft", () => {
     expect(decideDraftAction("v2026.6.1", [release(1, "v2026.6.1")])).toEqual({
       kind: "reuse",
-      reason: expect.stringContaining("draft"),
+      published: false,
+      reason: expect.stringContaining("reusing draft 1"),
     })
+  })
+
+  // Uploading into a release that is already live is legitimate on a re-run but
+  // is not what the caller assumes, so it is flagged rather than logged plain.
+  test("flags an already published release as a warning-worthy reuse", () => {
     expect(decideDraftAction("v2026.6.1", [release(1, "v2026.6.1", false)])).toEqual({
       kind: "reuse",
-      reason: expect.stringContaining("published"),
+      published: true,
+      reason: expect.stringContaining("already published"),
     })
   })
 
@@ -40,5 +49,17 @@ describe("ensure-release-draft", () => {
     expect(decision.reason).toContain("duplicate drafts for tag v2026.9.1")
     expect(decision.reason).toContain("380293071")
     expect(decision.reason).toContain("380293073")
+    expect(decision.reason).toContain("keep the one holding the assets")
+  })
+
+  // The create is only half the guard: reading the list endpoint back too soon
+  // can miss a concurrent job's release, and both would conclude they are alone.
+  test("jitters before creating and lets the list endpoint settle before judging", () => {
+    const source = readFileSync(join(import.meta.dirname, "ensure-release-draft.ts"), "utf8")
+    expect(source).toMatch(/await sleep\(Math\.random\(\) \* CREATE_JITTER_MS\)/)
+    expect(source).toMatch(/await sleep\(CREATE_SETTLE_MS\)\n\n\s*const settled =/)
+    // A missing token silently downgrades the list to anonymous, which cannot
+    // see drafts at all.
+    expect(source).toMatch(/requireEnv\("GH_TOKEN"\)/)
   })
 })

--- a/packages/desktop-electron/scripts/ensure-release-draft.test.ts
+++ b/packages/desktop-electron/scripts/ensure-release-draft.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest"
+
+import { decideDraftAction } from "./ensure-release-draft"
+import { type GithubRelease } from "./verify-release"
+
+// Shaped like the /releases payload the guard filters by tag, trimmed to the
+// fields the decision reads.
+const release = (id: number, tag: string, draft = true): GithubRelease & { id: number } => ({
+  id,
+  tag_name: tag,
+  draft,
+  prerelease: false,
+  assets: [],
+})
+
+describe("ensure-release-draft", () => {
+  test("creates a draft when the tag has no release", () => {
+    expect(decideDraftAction("v2026.6.1", [])).toEqual({
+      kind: "create",
+      reason: expect.stringContaining("no release for v2026.6.1"),
+    })
+  })
+
+  test("reuses the single existing release, draft or published", () => {
+    expect(decideDraftAction("v2026.6.1", [release(1, "v2026.6.1")])).toEqual({
+      kind: "reuse",
+      reason: expect.stringContaining("draft"),
+    })
+    expect(decideDraftAction("v2026.6.1", [release(1, "v2026.6.1", false)])).toEqual({
+      kind: "reuse",
+      reason: expect.stringContaining("published"),
+    })
+  })
+
+  // The observed failure mode: two drafts one second apart, assets split, and a
+  // checksum error that pointed nowhere near the cause.
+  test("fails on a split tag and names the duplicate drafts", () => {
+    const decision = decideDraftAction("v2026.9.1", [release(380293071, "v2026.9.1"), release(380293073, "v2026.9.1")])
+    expect(decision.kind).toBe("fail")
+    expect(decision.reason).toContain("duplicate drafts for tag v2026.9.1")
+    expect(decision.reason).toContain("380293071")
+    expect(decision.reason).toContain("380293073")
+  })
+})

--- a/packages/desktop-electron/scripts/ensure-release-draft.ts
+++ b/packages/desktop-electron/scripts/ensure-release-draft.ts
@@ -14,8 +14,18 @@ import { duplicateReleasesMessage, fetchReleasesByTag, normalizeTag, type Github
 
 type TaggedRelease = GithubRelease & { id: number }
 
+// Spread the creates of phases that start together, so the common case is one
+// job creating and the others simply seeing its release.
+const CREATE_JITTER_MS = 3_000
+// The list endpoint lags a create, so a second read taken immediately can miss
+// the other job's release and let both conclude they are alone. Same settle
+// window publish-when-complete uses before its final re-read.
+const CREATE_SETTLE_MS = 8_000
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
 export type DraftDecision =
-  | { kind: "reuse"; reason: string }
+  | { kind: "reuse"; reason: string; published: boolean }
   | { kind: "create"; reason: string }
   | { kind: "fail"; reason: string }
 
@@ -27,9 +37,12 @@ export function decideDraftAction(tag: string, releases: TaggedRelease[]): Draft
   const existing = releases[0]
   if (!existing) return { kind: "create", reason: `no release for ${tag}; creating an empty draft to upload into` }
 
+  if (existing.draft) return { kind: "reuse", reason: `reusing draft ${existing.id} for ${tag}`, published: false }
+
   return {
     kind: "reuse",
-    reason: `reusing release ${existing.id} for ${tag} (${existing.draft ? "draft" : "published"})`,
+    reason: `release ${existing.id} for ${tag} is already published; uploading into a live release, not a draft`,
+    published: true,
   }
 }
 
@@ -48,30 +61,45 @@ async function gh(args: string[]) {
   if (code !== 0) throw new Error(`gh ${args.join(" ")} exited ${code}`)
 }
 
+function report(decision: DraftDecision) {
+  // A published release means the assets are about to be uploaded to something
+  // that is already live, not to a draft this run controls. Legitimate on a
+  // re-run, worth saying out loud either way.
+  if (decision.kind === "reuse" && decision.published) console.warn(`ensure-release-draft: ${decision.reason}`)
+  else console.log(`ensure-release-draft: ${decision.reason}`)
+}
+
 async function main() {
   const repo = requireEnv("GH_REPO")
+  // Anonymous list requests cannot see drafts, so a missing token would make
+  // every run believe the tag has no release and create a second one.
+  requireEnv("GH_TOKEN")
   const tag = normalizeTag(requireEnv("RELEASE_TAG"))
   const targetSha = requireEnv("RELEASE_TARGET_SHA")
 
   const decision = decideDraftAction(tag, await fetchReleasesByTag<TaggedRelease>(repo, tag))
-  console.log(`ensure-release-draft: ${decision.reason}`)
+  report(decision)
   if (decision.kind === "fail") process.exit(1)
   if (decision.kind === "reuse") return
 
-  // Two phases can reach the create at the same time. Whether ours succeeds or
-  // loses to the other one, re-read and let the same policy judge the result:
-  // one release is fine no matter who made it, two is the split we exist to
-  // report. Notes stay empty — the release text is written into the draft by
-  // hand before it is published.
+  // Two phases can reach the create at the same time. Jitter first so they
+  // usually do not, then create, then let the list endpoint catch up before
+  // re-reading: reading it immediately can still show only our own release and
+  // leave both jobs believing they are the only one. Whether our create won or
+  // lost, the same policy judges the settled result — one release is fine no
+  // matter who made it, two is the split we exist to report. Notes stay empty;
+  // the release text is written into the draft by hand before it is published.
+  await sleep(Math.random() * CREATE_JITTER_MS)
   try {
     await gh(["release", "create", tag, "--repo", repo, "--draft", "--target", targetSha, "--notes", ""])
   } catch (error) {
     console.warn(`ensure-release-draft: create failed (${error instanceof Error ? error.message : String(error)})`)
   }
+  await sleep(CREATE_SETTLE_MS)
 
   const settled = decideDraftAction(tag, await fetchReleasesByTag<TaggedRelease>(repo, tag))
   if (settled.kind === "reuse") {
-    console.log(`ensure-release-draft: ${settled.reason}`)
+    report(settled)
     return
   }
   console.error(

--- a/packages/desktop-electron/scripts/ensure-release-draft.ts
+++ b/packages/desktop-electron/scripts/ensure-release-draft.ts
@@ -1,0 +1,88 @@
+// Guarantee exactly one release exists for the tag BEFORE electron-builder
+// starts uploading. electron-builder uploads a target's assets concurrently and
+// each upload creates the release when it is missing, so a first-to-publish
+// phase can end up with two drafts for one tag, assets split between them, and a
+// checksum failure much later that says nothing about the split.
+//
+// Idempotent and safe to run from every phase: one existing release is reused,
+// none is created. Two or more is a release-process error, not something to
+// choose between, so it fails fast and names the split.
+
+import { spawn } from "node:child_process"
+
+import { duplicateReleasesMessage, fetchReleasesByTag, normalizeTag, type GithubRelease } from "./verify-release"
+
+type TaggedRelease = GithubRelease & { id: number }
+
+export type DraftDecision =
+  | { kind: "reuse"; reason: string }
+  | { kind: "create"; reason: string }
+  | { kind: "fail"; reason: string }
+
+// Pure policy, so the split-tag guard is testable without GitHub. `releases` is
+// the releases the tag resolves to (the list endpoint filtered by tag_name).
+export function decideDraftAction(tag: string, releases: TaggedRelease[]): DraftDecision {
+  if (releases.length > 1) return { kind: "fail", reason: duplicateReleasesMessage(tag, releases) }
+
+  const existing = releases[0]
+  if (!existing) return { kind: "create", reason: `no release for ${tag}; creating an empty draft to upload into` }
+
+  return {
+    kind: "reuse",
+    reason: `reusing release ${existing.id} for ${tag} (${existing.draft ? "draft" : "published"})`,
+  }
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+async function gh(args: string[]) {
+  const code = await new Promise<number | null>((resolve, reject) => {
+    const child = spawn("gh", args, { stdio: "inherit" })
+    child.once("error", reject)
+    child.once("exit", resolve)
+  })
+  if (code !== 0) throw new Error(`gh ${args.join(" ")} exited ${code}`)
+}
+
+async function main() {
+  const repo = requireEnv("GH_REPO")
+  const tag = normalizeTag(requireEnv("RELEASE_TAG"))
+  const targetSha = requireEnv("RELEASE_TARGET_SHA")
+
+  const decision = decideDraftAction(tag, await fetchReleasesByTag<TaggedRelease>(repo, tag))
+  console.log(`ensure-release-draft: ${decision.reason}`)
+  if (decision.kind === "fail") process.exit(1)
+  if (decision.kind === "reuse") return
+
+  // Two phases can reach the create at the same time. Whether ours succeeds or
+  // loses to the other one, re-read and let the same policy judge the result:
+  // one release is fine no matter who made it, two is the split we exist to
+  // report. Notes stay empty — the release text is written into the draft by
+  // hand before it is published.
+  try {
+    await gh(["release", "create", tag, "--repo", repo, "--draft", "--target", targetSha, "--notes", ""])
+  } catch (error) {
+    console.warn(`ensure-release-draft: create failed (${error instanceof Error ? error.message : String(error)})`)
+  }
+
+  const settled = decideDraftAction(tag, await fetchReleasesByTag<TaggedRelease>(repo, tag))
+  if (settled.kind === "reuse") {
+    console.log(`ensure-release-draft: ${settled.reason}`)
+    return
+  }
+  console.error(
+    `ensure-release-draft: ${settled.kind === "fail" ? settled.reason : `still no release for ${tag} after creating one`}`,
+  )
+  process.exit(1)
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`ensure-release-draft failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  })
+}

--- a/packages/desktop-electron/scripts/publish-when-complete.test.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest"
 
-import { decidePublishAction, type ProvenanceMarker } from "./publish-when-complete"
+import { decidePublishAction, findRelease, type ProvenanceMarker } from "./publish-when-complete"
 import { releaseProvenanceAssetNames, type GithubRelease } from "./verify-release"
 
 const BUILD_SHA = "1111111111111111111111111111111111111111"
@@ -147,5 +147,33 @@ describe("decidePublishAction", () => {
     const decision = decide({ provenance: noHash })
     expect(decision.kind).toBe("fail")
     expect(decision.reason).toContain("no recorded hash")
+  })
+
+  describe("findRelease", () => {
+    // Same shape the list endpoint returns, with the id and upload_url the
+    // publisher needs; a full first page pushes the tag onto page two.
+    const apiRelease = (id: number, tag: string) => ({
+      id,
+      tag_name: tag,
+      draft: true,
+      prerelease: false,
+      assets: [],
+      upload_url: `https://uploads.example.com/releases/${id}/assets{?name,label}`,
+    })
+    const paged = (page2: ReturnType<typeof apiRelease>[]) => async (url: string) =>
+      new URL(url).searchParams.get("page") === "1"
+        ? Array.from({ length: 100 }, (_, index) => apiRelease(9000 + index, `v2025.1.${index + 1}`))
+        : page2
+
+    test("finds a release that only appears on a later page", async () => {
+      const release = await findRelease("Astro-Han/pawwork", "v2026.6.1", paged([apiRelease(7, "v2026.6.1")]))
+      expect(release.id).toBe(7)
+    })
+
+    test("refuses a tag split across duplicate releases", async () => {
+      await expect(
+        findRelease("Astro-Han/pawwork", "v2026.6.1", paged([apiRelease(7, "v2026.6.1"), apiRelease(8, "v2026.6.1")])),
+      ).rejects.toThrow(/duplicate drafts for tag v2026\.6\.1/)
+    })
   })
 })

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -198,8 +198,12 @@ async function ghFetch(url: string, init: RequestInit & { accept: string; conten
   }
 }
 
-async function findRelease(repo: string, tag: string): Promise<ApiRelease> {
-  const matches = await fetchReleasesByTag<ApiRelease>(repo, tag)
+export async function findRelease(
+  repo: string,
+  tag: string,
+  fetchPage?: (url: string) => Promise<ApiRelease[]>,
+): Promise<ApiRelease> {
+  const matches = await fetchReleasesByTag<ApiRelease>(repo, tag, fetchPage)
   // Picking one half of a split tag would surface much later as a missing
   // checksum, so name the split here instead.
   if (matches.length > 1) throw new Error(duplicateReleasesMessage(tag, matches))

--- a/packages/desktop-electron/scripts/publish-when-complete.ts
+++ b/packages/desktop-electron/scripts/publish-when-complete.ts
@@ -51,6 +51,8 @@
 // single orchestrated workflow.
 
 import {
+  duplicateReleasesMessage,
+  fetchReleasesByTag,
   normalizeTag,
   parseUpdaterShaByUrl,
   releaseAssetNames,
@@ -196,16 +198,13 @@ async function ghFetch(url: string, init: RequestInit & { accept: string; conten
   }
 }
 
-async function fetchReleases(repo: string): Promise<ApiRelease[]> {
-  const res = await ghFetch(`${GITHUB_API}/repos/${repo}/releases?per_page=100`, { accept: "application/vnd.github+json" })
-  if (!res.ok) throw new Error(`failed to list releases: ${res.status} ${res.statusText}`)
-  return (await res.json()) as ApiRelease[]
-}
-
 async function findRelease(repo: string, tag: string): Promise<ApiRelease> {
-  const releases = await fetchReleases(repo)
-  const release = releases.find((entry) => entry.tag_name === tag)
-  if (!release) throw new Error(`no release found for ${tag} among ${releases.length} releases`)
+  const matches = await fetchReleasesByTag<ApiRelease>(repo, tag)
+  // Picking one half of a split tag would surface much later as a missing
+  // checksum, so name the split here instead.
+  if (matches.length > 1) throw new Error(duplicateReleasesMessage(tag, matches))
+  const release = matches[0]
+  if (!release) throw new Error(`no release found for ${tag}`)
   return release
 }
 

--- a/packages/desktop-electron/scripts/release-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-workflow-contract.test.ts
@@ -57,6 +57,26 @@ describe("release workflow", () => {
     expect(publisher).not.toMatch(/MIRROR_REF.*\?\?/)
   })
 
+  // electron-builder creates the release when the tag has none and uploads a
+  // target's assets concurrently, so without a claimed draft the first phase to
+  // publish for a tag can split its assets across two of them.
+  test("claims one release draft before any step uploads assets", () => {
+    const ensure = indexOfStep("Ensure a single release draft")
+    expect(ensure).toBeGreaterThanOrEqual(0)
+    expect(steps[ensure].body).toMatch(/ensure-release-draft\.ts/)
+    expect(steps[ensure].body).toMatch(/inputs\.channel != 'dev'/)
+
+    const publishing = stepsRunning(/electron-builder .*--publish always/)
+    expect(publishing.map((step) => step.name)).toEqual(["Package notarized artifacts"])
+    for (const step of publishing) expect(steps.indexOf(step)).toBeGreaterThan(ensure)
+    // Windows resolves --publish through a variable, so it is ordered by name.
+    expect(indexOfStep("Package app")).toBeGreaterThan(ensure)
+  })
+
+  test("release lookup refuses a split tag instead of reading half of one", () => {
+    expect(publisher).toContain("duplicateReleasesMessage(tag, matches)")
+  })
+
   test("bundles uv before anything packages the app", () => {
     const packaging = stepsRunning(/electron-builder .*(--mac|\$\{\{ matrix\.platform_flag \}\})/)
     // submit packs the signed directory, finalize repacks it into dmg/zip, and

--- a/packages/desktop-electron/scripts/release-workflow-contract.test.ts
+++ b/packages/desktop-electron/scripts/release-workflow-contract.test.ts
@@ -23,6 +23,12 @@ function indexOfStep(name: string) {
   return steps.findIndex((step) => step.name === name)
 }
 
+function conditionOfStep(name: string) {
+  const condition = steps[indexOfStep(name)]?.body.match(/\n {8}if: (?<condition>.+)/)?.groups?.condition
+  if (!condition) throw new Error(`step "${name}" has no if: condition`)
+  return condition
+}
+
 function runSourceValidation(phase: string, githubRef: string, sourceRef = "") {
   const match = workflow.match(
     /- name: Validate release source branch\n\s+run: \|\n(?<script>(?: {10}.*\n|\n)+?)\s+env:/,
@@ -64,7 +70,9 @@ describe("release workflow", () => {
     const ensure = indexOfStep("Ensure a single release draft")
     expect(ensure).toBeGreaterThanOrEqual(0)
     expect(steps[ensure].body).toMatch(/ensure-release-draft\.ts/)
-    expect(steps[ensure].body).toMatch(/inputs\.channel != 'dev'/)
+    // Every target that uploads to the release has to claim the draft, and only
+    // those: the same gate the metadata finalizer runs under, word for word.
+    expect(conditionOfStep("Ensure a single release draft")).toBe(conditionOfStep("Finalize updater metadata"))
 
     const publishing = stepsRunning(/electron-builder .*--publish always/)
     expect(publishing.map((step) => step.name)).toEqual(["Package notarized artifacts"])

--- a/packages/desktop-electron/scripts/verify-release.test.ts
+++ b/packages/desktop-electron/scripts/verify-release.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "vitest"
 
 import {
   fetchJson,
+  fetchReleasesByTag,
   fetchText,
   normalizeTag,
   parseUpdaterFileUrls,
@@ -367,5 +368,43 @@ describe("parseUpdaterShaByUrl", () => {
     // The top-level `sha512:` after `path:` has no preceding `- url:` entry, so it
     // is not emitted as a phantom hash.
     expect(parseUpdaterShaByUrl(yml)).toEqual([{ name: "pawwork-win-x64-2026.6.1.exe", sha512: "HASH_WIN" }])
+  })
+})
+
+describe("fetchReleasesByTag", () => {
+  const release = (id: number, tag: string) => ({ id, tag_name: tag, draft: true, prerelease: false, assets: [] })
+  const fullPage = (offset: number) =>
+    Array.from({ length: 100 }, (_, index) => release(offset + index, `v2025.1.${offset + index}`))
+
+  test("walks every page and collects matches past the first one", async () => {
+    const requested: string[] = []
+    const pages = [fullPage(1), [...fullPage(200), release(7, "v2026.6.1")], [release(8, "v2026.6.1")]]
+    const matches = await fetchReleasesByTag("Astro-Han/pawwork", "v2026.6.1", async (url) => {
+      requested.push(url)
+      return pages[Number(new URL(url).searchParams.get("page")) - 1] ?? []
+    })
+
+    expect(matches.map((match) => match.id)).toEqual([7, 8])
+    // Page 3 is short, so the walk stops there rather than asking for a fourth.
+    expect(requested).toHaveLength(3)
+    expect(requested[0]).toContain("per_page=100&page=1")
+  })
+
+  test("stops at the first short page", async () => {
+    const requested: string[] = []
+    const matches = await fetchReleasesByTag("Astro-Han/pawwork", "v2026.6.1", async (url) => {
+      requested.push(url)
+      return [release(7, "v2026.6.1")]
+    })
+
+    expect(matches.map((match) => match.id)).toEqual([7])
+    expect(requested).toHaveLength(1)
+  })
+
+  // Silently truncating the walk is the failure it exists to prevent.
+  test("refuses to walk past the page cap instead of truncating", async () => {
+    await expect(fetchReleasesByTag("Astro-Han/pawwork", "v2026.6.1", async () => fullPage(1))).rejects.toThrow(
+      /Refusing to look v2026\.6\.1 up past \d+ pages/,
+    )
   })
 })

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -25,6 +25,10 @@ type VerificationInput = {
 const DEFAULT_REPO = `${PAWWORK_RELEASE_OWNER}/${PAWWORK_APP.prod.releaseRepo}`
 const FETCH_TIMEOUT_MS = 15_000
 const GITHUB_API = "https://api.github.com"
+const RELEASE_PAGE_SIZE = 100
+// 10k releases is far past anything this repo will hold; the cap only keeps a
+// misbehaving endpoint from looping forever.
+const RELEASE_PAGE_LIMIT = 100
 
 export function releaseAssetNames(version: string) {
   return [
@@ -160,9 +164,27 @@ export function normalizeTag(raw: string) {
 // A draft is NOT reachable via GET /releases/tags/{tag} (it 404s), so every
 // release lookup in the pipeline goes through the list endpoint and filters by
 // tag. More than one match means the tag was split across duplicate releases.
-export async function fetchReleasesByTag<T extends GithubRelease>(repo: string, tag: string): Promise<T[]> {
-  const releases = await fetchJson<T[]>(`${GITHUB_API}/repos/${repo}/releases?per_page=100`)
-  return releases.filter((release) => release.tag_name === tag)
+//
+// Every page is walked, not just the first: a match missed because it sat past
+// the page boundary reads as "this tag has no release", which is exactly the
+// state that creates a duplicate. `fetchPage` is injectable so the walk is
+// testable without GitHub.
+export async function fetchReleasesByTag<T extends GithubRelease>(
+  repo: string,
+  tag: string,
+  fetchPage: (url: string) => Promise<T[]> = (url) => fetchJson<T[]>(url),
+): Promise<T[]> {
+  const matches: T[] = []
+  for (let page = 1; page <= RELEASE_PAGE_LIMIT; page += 1) {
+    const releases = await fetchPage(`${GITHUB_API}/repos/${repo}/releases?per_page=${RELEASE_PAGE_SIZE}&page=${page}`)
+    matches.push(...releases.filter((release) => release.tag_name === tag))
+    // A short page is the last one. GitHub also serves a Link header, but
+    // fetchJson does not expose response headers and page walking needs no
+    // extra plumbing to stay injectable.
+    if (releases.length < RELEASE_PAGE_SIZE) return matches
+  }
+  // Truncating silently is the failure this walk exists to prevent, so refuse.
+  throw new Error(`Refusing to look ${tag} up past ${RELEASE_PAGE_LIMIT} pages of releases in ${repo}`)
 }
 
 // One wording for the split-tag failure, shared by everything that looks a

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -24,6 +24,7 @@ type VerificationInput = {
 
 const DEFAULT_REPO = `${PAWWORK_RELEASE_OWNER}/${PAWWORK_APP.prod.releaseRepo}`
 const FETCH_TIMEOUT_MS = 15_000
+const GITHUB_API = "https://api.github.com"
 
 export function releaseAssetNames(version: string) {
   return [
@@ -154,6 +155,22 @@ export function normalizeTag(raw: string) {
     throw new Error(`Invalid release tag: ${raw}. Expected vYYYY.M.D or YYYY.M.D.`)
   }
   return normalized
+}
+
+// A draft is NOT reachable via GET /releases/tags/{tag} (it 404s), so every
+// release lookup in the pipeline goes through the list endpoint and filters by
+// tag. More than one match means the tag was split across duplicate releases.
+export async function fetchReleasesByTag<T extends GithubRelease>(repo: string, tag: string): Promise<T[]> {
+  const releases = await fetchJson<T[]>(`${GITHUB_API}/repos/${repo}/releases?per_page=100`)
+  return releases.filter((release) => release.tag_name === tag)
+}
+
+// One wording for the split-tag failure, shared by everything that looks a
+// release up: the symptom surfaces late (a checksum read from the wrong half of
+// a split tag), so the message has to name the actual cause.
+export function duplicateReleasesMessage(tag: string, releases: Array<{ id: number; draft: boolean }>) {
+  const detail = releases.map((release) => `${release.id}${release.draft ? " (draft)" : ""}`).join(", ")
+  return `duplicate drafts for tag ${tag}: ${releases.length} releases carry it (ids ${detail}). Assets are split across them; delete all but one before building.`
 }
 
 function githubHeaders() {

--- a/packages/desktop-electron/scripts/verify-release.ts
+++ b/packages/desktop-electron/scripts/verify-release.ts
@@ -170,7 +170,7 @@ export async function fetchReleasesByTag<T extends GithubRelease>(repo: string, 
 // a split tag), so the message has to name the actual cause.
 export function duplicateReleasesMessage(tag: string, releases: Array<{ id: number; draft: boolean }>) {
   const detail = releases.map((release) => `${release.id}${release.draft ? " (draft)" : ""}`).join(", ")
-  return `duplicate drafts for tag ${tag}: ${releases.length} releases carry it (ids ${detail}). Assets are split across them; delete all but one before building.`
+  return `duplicate drafts for tag ${tag}: ${releases.length} releases carry it (ids ${detail}). Assets are split across them; keep the one holding the assets (or the published one), delete the rest, and re-run the build.`
 }
 
 function githubHeaders() {


### PR DESCRIPTION
Closes #1623

## Problem

`electron-builder` creates the release when the tag has none, and it uploads a target's assets concurrently. When a release phase is the first to publish assets for a tag, two of those uploads each created their own draft — twice during 2026.9.1, both times one second apart — and the assets were split between them. The visible failure came much later and pointed at the wrong thing:

```
publish-when-complete failed: could not read sha512 for pawwork-win-x64-2026.9.1.exe
from latest-v2.yml after 4 attempts
```

## What this does

- **Claims the draft before any upload.** A new `Ensure a single release draft` step runs before the publishing `electron-builder` invocations (macOS `Package notarized artifacts`, Windows `Package app`) on every prod finalize/full target. It reuses the tag's release when one exists, creates an empty draft (`--draft --target <build sha>`) when none does, and is idempotent, so every phase can run it.
- **Fails fast on a split.** If the tag already resolves to more than one release, the step exits non-zero with `duplicate drafts for tag v<ver>: N releases carry it (ids ...)`, naming which one to keep. The publisher's own release lookup now raises the same message rather than silently picking one half of a split tag.
- **Closes the create race rather than narrowing it.** Two phases can reach the create together, and the list endpoint lags a create — an immediate re-read can show only the caller's own release and let both conclude they are alone. So: jitter 0–3s before creating (phases dispatched together usually stop colliding at all), then let the list settle for the same window `publish-when-complete` uses before its final re-read, then judge. Whether the create won or lost, one release is fine and two is the split, reported.
- **Requires `GH_TOKEN`.** An anonymous list request cannot see drafts at all, so a missing token would silently turn every run into "this tag has no release" and create another one.
- **Reuses the lookup instead of copying it.** Drafts are not reachable via `GET /releases/tags/{tag}`, so both scripts go through the list endpoint; that lookup (`fetchReleasesByTag`) and the shared duplicate-tag message now live in `verify-release.ts`, and `publish-when-complete.ts` calls them.

Release notes are still written by pre-creating the draft with `--notes-file` before dispatching; the CI-created draft is only the empty fallback.

## Verification

- `actionlint .github/workflows/build.yml` — the 5 shellcheck findings it reports are pre-existing on `main` (unrelated Apple-keychain steps); no new ones.
- `vitest run` in `packages/desktop-electron` — 516 tests pass, including a new `ensure-release-draft.test.ts` that drives the decision on mock `/releases` payloads (none / one draft / one published / the two real 2026.9.1 draft ids) and a workflow-contract test asserting the step exists, precedes every publishing packaging step, and runs under exactly the `if:` condition the metadata finalizer does — checked by mutation: dropping the Windows arm of the gate fails that test.
- Ran the guard outside vitest against a mock releases JSON file via `tsx`, confirming the three outcomes and the exact failure wording.
- `tsgo -b` and `eslint` clean on the changed files.

## Not verified

No release workflow was dispatched, so nothing here ran against the real GitHub API: `gh release create --draft` behaviour, the `GITHUB_TOKEN` permissions for it (the job already has `contents: write` and the same token already creates assets and publishes), and the actual read-after-write lag on the list endpoint. The settle window is taken from `publish-when-complete`'s `SEAL_SETTLE_MS`, which was tuned against that lag, not measured again here; the concurrent-create path is covered only by the unit-level policy tests. The first real prod release exercises them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent desktop release builds from creating duplicate release drafts.
  * Release publishing now detects split release tags and stops with a clear error instead of uploading to an ambiguous release.
  * Existing draft or published releases are reused, while missing releases are created automatically.
  * Improved release consistency by allowing time for newly created releases to become visible before validation.
* **Tests**
  * Added coverage for release creation, reuse, duplicate detection, and workflow ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
