### PR TITLE
chore(release): prepare 2026.9.3

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
Bumps the desktop version to 2026.9.3 so the release tag has a version to build.

## What ships in 2026.9.3

- **User-installed CLIs are reachable from agent shells again** (#1632) — a GUI launch inherits launchd's minimal PATH, so `gh`, `python`, `ffmpeg` and everything else installed by Homebrew were missing from every agent tool shell. The login shell's PATH is now resolved at startup and merged before the first child spawn. Fixes #1631.
- **Upgrading from PawWork v1 is visible instead of silent** (#1633) — a second launch while v1 is still running now says so instead of vanishing, an import blocked by v1's open database shows a standing notice and resumes on its own once v1 quits, and a finished import reports its result once.
- **DSH upgraded to 0.1.2-alpha.5** (#1634) — carries the upstream fix for upgrades from `0.1.2-alpha.3` that could stop the app from starting or drop session titles from the session list. That is the hop this product ships, which is why both upstream releases are taken together.

Internal: #1635 makes CI claim a single release draft before any asset upload, so a first upload for a tag can no longer scatter assets across several drafts.

## Verification

CI on this branch, plus the pre-publish CDP pass over every OpenCode Free model listed in the app on the signed, notarized packaged build (not a dev build), per the release checklist. Results are reported on the release before it leaves draft.
