### PR TITLE
test(ci): send a real free-model turn in the desktop smoke

### DIFF
--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -549,24 +549,36 @@ describe("free-model turn", () => {
   const answered: CiSmokeFreeModelTurn = {
     provider: "opencode",
     model: "big-pickle",
-    requested: true,
+    prepared: true,
     answered: true,
+    completed: true,
     code: null,
-    events: ["agent/request", "turn/end"],
+    events: ["request/header", "assistant/message", "turn/end"],
   }
 
   test("accepts a turn the shipped default answered", () => {
     expect(() => assertCiSmokeFreeModelTurn(answered)).not.toThrow()
   })
 
-  test("rejects a default model that is not an OpenCode Free route", () => {
-    expect(() => assertCiSmokeFreeModelTurn({ ...answered, provider: "deepseek", model: "deepseek-chat" }))
-      .toThrow(/not an OpenCode Free route/)
+  test("accepts the second Free route, which serves the other wire protocol", () => {
+    expect(() => assertCiSmokeFreeModelTurn({ ...answered, provider: "opencode-responses" })).not.toThrow()
   })
 
-  test("rejects a turn that never reached the gateway", () => {
-    expect(() => assertCiSmokeFreeModelTurn({ ...answered, requested: false, answered: false, events: [] }))
-      .toThrow(/never reached the gateway/)
+  test("rejects a default model that is not an OpenCode Free route", () => {
+    for (const provider of ["deepseek", "opencode-paid"]) {
+      expect(() => assertCiSmokeFreeModelTurn({ ...answered, provider }))
+        .toThrow(/not an OpenCode Free route/)
+    }
+  })
+
+  test("rejects a turn that never reached the model layer", () => {
+    expect(() => assertCiSmokeFreeModelTurn({ ...answered, prepared: false, answered: false, events: [] }))
+      .toThrow(/never reached the model layer/)
+  })
+
+  test("rejects a turn that never finished, rather than reading no verdict as a pass", () => {
+    expect(() => assertCiSmokeFreeModelTurn({ ...answered, answered: false, completed: false }))
+      .toThrow(/never put to the test/)
   })
 
   test("rejects the credential the gateway refuses", () => {

--- a/packages/desktop-electron/scripts/ci-smoke.test.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.test.ts
@@ -10,6 +10,7 @@ import {
   appIdForSmoke,
   dshHomeForSmoke,
   assertCiSmokeProduct,
+  assertCiSmokeFreeModelTurn,
   buildSmokeEnv,
   captureWindowsAppScreenshot,
   isCiSmokeDshTarget,
@@ -21,7 +22,7 @@ import {
   resolveLaunchCommand,
   resolveMainEntry,
 } from "./ci-smoke"
-import type { CiSmokeProductSnapshot } from "./ci-smoke"
+import type { CiSmokeFreeModelTurn, CiSmokeProductSnapshot } from "./ci-smoke"
 import { packagedAppEnv } from "./packaged-app-env.ts"
 import type { PawWorkChannel } from "../src/main/app-identity.ts"
 
@@ -542,4 +543,42 @@ describe("ci smoke helpers", () => {
       }
     },
   )
+})
+
+describe("free-model turn", () => {
+  const answered: CiSmokeFreeModelTurn = {
+    provider: "opencode",
+    model: "big-pickle",
+    requested: true,
+    answered: true,
+    code: null,
+    events: ["agent/request", "turn/end"],
+  }
+
+  test("accepts a turn the shipped default answered", () => {
+    expect(() => assertCiSmokeFreeModelTurn(answered)).not.toThrow()
+  })
+
+  test("rejects a default model that is not an OpenCode Free route", () => {
+    expect(() => assertCiSmokeFreeModelTurn({ ...answered, provider: "deepseek", model: "deepseek-chat" }))
+      .toThrow(/not an OpenCode Free route/)
+  })
+
+  test("rejects a turn that never reached the gateway", () => {
+    expect(() => assertCiSmokeFreeModelTurn({ ...answered, requested: false, answered: false, events: [] }))
+      .toThrow(/never reached the gateway/)
+  })
+
+  test("rejects the credential the gateway refuses", () => {
+    expect(() => assertCiSmokeFreeModelTurn({ ...answered, answered: false, code: "AUTH" }))
+      .toThrow(/rejected as unauthenticated/)
+  })
+
+  test("accepts a turn the gateway failed for a reason other than the credential", () => {
+    // A smoke that went red on upstream instability would be switched off within a week,
+    // and the seeded key is the only part of this the build actually controls.
+    for (const code of ["RATE_LIMIT", "QUOTA_EXCEEDED", "UNKNOWN"]) {
+      expect(() => assertCiSmokeFreeModelTurn({ ...answered, answered: false, code })).not.toThrow()
+    }
+  })
 })

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -105,8 +105,9 @@ export type CiSmokeProductSnapshot = {
 export type CiSmokeFreeModelTurn = {
   provider: string
   model: string
-  requested: boolean
+  prepared: boolean
   answered: boolean
+  completed: boolean
   code: string | null
   events: string[]
 }
@@ -978,7 +979,7 @@ export async function inspectCiSmokeFreeModelTurn(target: CdpTarget, sessionId: 
         content: [{ type: "text", text: "Reply with the single word: pong" }],
       },
     })
-    const deadline = Date.now() + 90000
+    const deadline = Date.now() + 120000
     let records = []
     for (;;) {
       await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -997,22 +998,40 @@ export async function inspectCiSmokeFreeModelTurn(target: CdpTarget, sessionId: 
       if (Date.now() > deadline) break
     }
     const events = records.map((record) => record.event?.type).filter((type) => type !== undefined)
-    const page = JSON.stringify(records)
+    const reason = records.find((record) => record.event?.type === "turn/end")?.event?.data?.reason
     return JSON.stringify({
       provider: selection.provider,
       model: selection.model,
-      // \`request/header\` is written when the call leaves for the gateway, and
-      // \`assistant/message\` only when one came back whole.
-      requested: events.includes("request/header"),
+      // Appended once the adapter has a call assembled — before it is dispatched, and even
+      // when no adapter resolved at all. It proves the loop reached the model layer, which
+      // is weaker than proving anything left the machine.
+      prepared: events.includes("request/header"),
       answered: events.includes("assistant/message"),
-      code: (/"code":"([A-Z_]+)"/.exec(page) ?? [null, null])[1],
+      completed: reason !== undefined,
+      // Off the terminal record, never a scan of the page: \`llm/retry\` logs the failure it
+      // is retrying, code and all, at a lower seq, so a scan reports whichever transient
+      // blip came first and hides the verdict that actually ended the turn.
+      code: reason?.kind === "error" ? reason.error?.code ?? null : null,
       // Event types only: the log also carries the workspace path and whatever the model
       // said, and a public CI log is not the place for either.
       events: Array.from(new Set(events)),
     })
   })()`
 
-  return await evaluateCiSmokeJson(target, expression, 150_000) as CiSmokeFreeModelTurn
+  return await evaluateCiSmokeJson(target, expression, 180_000) as CiSmokeFreeModelTurn
+}
+
+/**
+ * The routes PawWork serves OpenCode Free on, read from the module that defines them
+ * rather than restated here: the product ships two, one per wire protocol, and a list
+ * copied into the smoke would keep passing a default that moved to a route the product
+ * no longer serves — or start failing one it added.
+ */
+function openCodeFreeRoutes() {
+  const { OPENCODE_ROUTES } = require("../resources/dsh/product/lib/opencode-free.cjs") as {
+    OPENCODE_ROUTES: { route: string }[]
+  }
+  return OPENCODE_ROUTES.map((entry) => entry.route)
 }
 
 /**
@@ -1023,12 +1042,18 @@ export async function inspectCiSmokeFreeModelTurn(target: CdpTarget, sessionId: 
  */
 export function assertCiSmokeFreeModelTurn(turn: CiSmokeFreeModelTurn) {
   const failures = [
-    turn.provider.startsWith("opencode")
+    openCodeFreeRoutes().includes(turn.provider)
       ? null
       : `the shipped default model is ${turn.provider}/${turn.model}, not an OpenCode Free route`,
-    turn.requested
+    turn.prepared
       ? null
-      : `${turn.model} never reached the gateway: ${turn.events.join(", ") || "no events"}`,
+      : `${turn.model} never reached the model layer: ${turn.events.join(", ") || "no events"}`,
+    // Without a terminal record there is no verdict to read, so a silent pass here would
+    // be the check quietly switching itself off. A one-word prompt that cannot finish
+    // inside the budget is its own signal.
+    turn.completed
+      ? null
+      : `${turn.model} did not finish a one-word turn in time, so the credential was never put to the test`,
     turn.code === "AUTH"
       ? `${turn.model} was rejected as unauthenticated on the seeded free-tier credential`
       : null,

--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -102,6 +102,15 @@ export type CiSmokeProductSnapshot = {
   sessionIdsBeforeRestart: string[]
 }
 
+export type CiSmokeFreeModelTurn = {
+  provider: string
+  model: string
+  requested: boolean
+  answered: boolean
+  code: string | null
+  events: string[]
+}
+
 type ProbeOptions = {
   attempts?: number
   delayMs?: number
@@ -929,6 +938,105 @@ export async function inspectCiSmokeProduct(target: CdpTarget, workspacePath: st
   return await evaluateCiSmokeJson(target, expression, 180_000) as CiSmokeProductSnapshot
 }
 
+/**
+ * Send one real turn on the model a fresh install starts with, and report what came back.
+ *
+ * A registered provider is not a usable one: the free routes authenticate with the
+ * credential the product seeds, and a key the gateway rejects answers 401 — which nothing
+ * in the product snapshot can see, because until this runs no request has left the app.
+ *
+ * Its own CDP evaluation rather than another probe folded into that snapshot: this one
+ * waits on a live model, and sharing a budget with the UI probes would report every
+ * unrelated UI failure as a timeout with nothing to read.
+ */
+export async function inspectCiSmokeFreeModelTurn(target: CdpTarget, sessionId: string) {
+  const productSessionId = JSON.stringify(sessionId)
+  const expression = `(async () => {
+    const call = async (method, args) => {
+      const request = { type: "client-request", rpcId: crypto.randomUUID(), method, payload: { args } }
+      const response = await fetch("/api/" + method, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(request),
+      })
+      if (!response.ok) throw new Error(method + ": HTTP " + response.status)
+      const envelope = await response.json()
+      if (!envelope?.result?.ok) throw new Error(method + ": " + (envelope?.result?.error?.message || "unknown failure"))
+      return envelope.result.value
+    }
+    const selection = (await call("session/modelCatalog", {})).default
+    // The workspace the product probe already adopted, which is the only one this run is
+    // known to hold: on Windows it comes from the native picker, not from the harness.
+    const cwd = (await call("session/list", { _request: {} })).items
+      .find((item) => item.sessionId === ${productSessionId})?.cwd
+    const turn = await call("session/create", { request: cwd === undefined ? {} : { cwd } })
+    await call("session/prompt", {
+      request: {
+        requestId: crypto.randomUUID(),
+        sessionId: turn.sessionId,
+        mode: "queue",
+        content: [{ type: "text", text: "Reply with the single word: pong" }],
+      },
+    })
+    const deadline = Date.now() + 90000
+    let records = []
+    for (;;) {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      const item = (await call("session/list", { _request: {} })).items
+        .find((entry) => entry.sessionId === turn.sessionId)
+      // A page is read up to a cursor the caller already holds, and the only one on offer
+      // here is the projection's. \`-1\` is a legal cursor meaning "through nothing", so
+      // passing it reads an empty page forever instead of failing.
+      const throughSeq = item?.projections?.asOfSeq
+      if (throughSeq !== undefined && throughSeq >= 0) {
+        records = (await call("session/page", {
+          request: { address: { kind: "session", sessionId: turn.sessionId }, throughSeq, maxMessages: 200 },
+        })).records
+        if (item.running === false && records.some((record) => record.event?.type === "turn/end")) break
+      }
+      if (Date.now() > deadline) break
+    }
+    const events = records.map((record) => record.event?.type).filter((type) => type !== undefined)
+    const page = JSON.stringify(records)
+    return JSON.stringify({
+      provider: selection.provider,
+      model: selection.model,
+      // \`request/header\` is written when the call leaves for the gateway, and
+      // \`assistant/message\` only when one came back whole.
+      requested: events.includes("request/header"),
+      answered: events.includes("assistant/message"),
+      code: (/"code":"([A-Z_]+)"/.exec(page) ?? [null, null])[1],
+      // Event types only: the log also carries the workspace path and whatever the model
+      // said, and a public CI log is not the place for either.
+      events: Array.from(new Set(events)),
+    })
+  })()`
+
+  return await evaluateCiSmokeJson(target, expression, 150_000) as CiSmokeFreeModelTurn
+}
+
+/**
+ * Hold the build to shipping a credential its own free routes accept — and to nothing
+ * else. A gateway that answers 400, rate-limits, or drops the stream is the model being
+ * unstable, which no smoke can hold a build to; a 401 is the product shipping a key that
+ * cannot buy the models it ships as the default.
+ */
+export function assertCiSmokeFreeModelTurn(turn: CiSmokeFreeModelTurn) {
+  const failures = [
+    turn.provider.startsWith("opencode")
+      ? null
+      : `the shipped default model is ${turn.provider}/${turn.model}, not an OpenCode Free route`,
+    turn.requested
+      ? null
+      : `${turn.model} never reached the gateway: ${turn.events.join(", ") || "no events"}`,
+    turn.code === "AUTH"
+      ? `${turn.model} was rejected as unauthenticated on the seeded free-tier credential`
+      : null,
+  ].filter((failure): failure is string => failure !== null)
+
+  if (failures.length) throw new Error(`DSH free-model turn failed:\n- ${failures.join("\n- ")}`)
+}
+
 async function evaluateCiSmokeJson(target: CdpTarget, expression: string, timeoutMs = 20_000) {
   if (typeof target.webSocketDebuggerUrl !== "string") {
     throw new Error("DSH CDP target does not expose a WebSocket debugger URL")
@@ -1350,7 +1458,12 @@ async function main() {
         captureWindowsAppScreenshot(process.platform, child.pid, process.env.PAWWORK_CI_SCREENSHOT_PATH)
       }
       assertCiSmokeProduct(product)
-      console.log("CI smoke verified DSH product UI, free model, and bundled skills")
+      console.log("CI smoke verified DSH product UI, free-model routing, and bundled skills")
+      const turn = await inspectCiSmokeFreeModelTurn(cdpTarget, product.sessionId)
+      assertCiSmokeFreeModelTurn(turn)
+      console.log(`CI smoke free-model turn on ${turn.provider}/${turn.model}: ${
+        turn.answered ? "answered" : `no answer (${turn.code ?? "no failure code"}) — the model, not the credential`
+      }`)
       await waitForSessionOnDisk(dshHome, product.sessionId)
       console.log(`CI smoke sessions before shutdown: ${product.sessionIdsBeforeRestart.join(", ") || "(none)"}`)
       console.log(`CI smoke session files before shutdown:\n${describeDirectory(join(dshHome, "sessions"))}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@xmldom/xmldom': 0.8.13
   brace-expansion: 5.0.9
   esbuild: 0.28.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   form-data: 4.0.6
   ip-address: 10.3.1
   js-yaml: 4.3.1
@@ -4571,8 +4571,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -10883,7 +10883,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11819,7 +11819,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ overrides:
   '@xmldom/xmldom': 0.8.13
   brace-expansion: 5.0.9
   esbuild: 0.28.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   form-data: 4.0.6
   ip-address: 10.3.1
   js-yaml: 4.3.1


### PR DESCRIPTION
## Problem

The packaged smoke asserted that the OpenCode Free provider had registered, and nothing more. That check reads settings; it passes identically on a build whose seeded credential the gateway rejects, because until a turn runs no request has left the app.

A Windows user hit that on 2026.9.3: every free model answered `Invalid API key` / `AUTH`, on a platform none of us had run natively. CI was green throughout.

## Change

Send one turn on the model a fresh install starts with, then read the session log back.

- `inspectCiSmokeFreeModelTurn` creates a session in the workspace the product probe already adopted (on Windows that comes from the native picker, not from the harness), prompts it, and polls `session/page` until the turn ends or 120s pass.
- `assertCiSmokeFreeModelTurn` fails on four things: a default model that is not an OpenCode Free route, a turn that never reached the model layer, a turn with no terminal record, and `code: "AUTH"` on that record.

Everything else passes. A 400, a rate limit, or a dropped stream is the model being unstable — `STATUS.md` records `Nemotron 3.5 Lightning Free` succeeding once in three on the shipped build — and a smoke that went red on that would be switched off within a week. A 401 is the one part of this the build actually controls.

It gets its own CDP evaluation rather than another probe folded into the product snapshot: a minute spent waiting on a live model would otherwise report every unrelated UI failure as a timeout with nothing to read. That is not hypothetical — the first draft did exactly that.

## What this does not cover

The smoke builds a fresh `mkdtemp` home every run, so `prepareDshProductHome` always takes its seeding branch and the credential is always `public`. **The upgrade path is out of scope** — an install that already has a `.credentials.yaml` keeps it verbatim, deliberately, and `dsh-product-home.test.ts` pins that. This test would have been green for the reporting user too.

So the honest scope is narrower than "catches the reported bug": it catches a build that ships a broken seeded credential, it catches the gateway ceasing to honour the literal string `public`, and it is the first end-to-end check that a fresh install can actually get an answer on Windows. The user-reachable defect behind the report is filed separately as #1638.

## No workflow change

All three `package_smoke` targets already run `ci-smoke.ts packaged dev` with `PAWWORK_CI_SMOKE_CDP=true`, Windows included, so the new assertion runs on the packaged app on every platform without touching `ci.yml`. Measured cost on the previous head: 2.5s on macOS arm64, 3.2s on x64, 6.0s on Windows.

## Review fixes in 1da811c

An adversarial review found the check could defeat itself. Three fixes:

- **The verdict was read from the wrong place.** Scanning the serialized page for the first `"code"` reported whichever failure came first. `llm/retry` appends the failure it is retrying, code and all, at a lower seq — so one rate limit or transport blip ahead of a rejected credential made the smoke log "the model, not the credential" and pass. On shared runners that is ordinary. Now read off the `turn/end` record.
- **`requested` overstated itself.** `request/header` is appended once the adapter has a call assembled, before dispatch and even when no adapter resolved. Renamed `prepared`, with the message corrected. With the meaning fixed, a turn that never finished had no verdict to read and still passed, so a terminal record is now required.
- **The provider prefix was loose.** `startsWith("opencode")` accepted `opencode-paid`; exact `"opencode"` would have wrongly failed `opencode-responses`, the second Free route. Route ids now come from `OPENCODE_ROUTES`.

## Verification

Against the real app on macOS, driven over CDP:

- `pnpm run smoke:ci`: `CI smoke free-model turn on opencode/big-pickle: answered`, exit 0 — on both heads.
- Replacing `OPENCODE_API_KEY: "public"` in `<DSH_HOME>/.credentials.yaml` with any other value reproduces the reported failure verbatim: `turn/end` carrying `{"message":"401: {\"type\":\"AuthError\",\"message\":\"Invalid API key.\"}","code":"AUTH"}`, hot-reloaded without a restart. Restoring `public` answers again.
- CI on `b3b93ea` logged `answered` on all three packaged targets, Windows included.
- `tsgo -b` clean; `vitest run scripts/ci-smoke.test.ts` 94 passed, covering each assertion branch, both Free routes, and the deliberate pass on non-credential failures.

The failing `ci` job is `Audit dependency graph` on freshly published `fast-uri` advisories reached only through `@modelcontextprotocol/sdk>ajv>fast-uri`. This branch does not touch the lockfile and needs its own fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI smoke coverage now includes the OpenCode Responses route.
  * Smoke checks distinguish requests that reach the model from turns that complete successfully.

* **Bug Fixes**
  * Free-model validation now accepts only supported OpenCode Free routes and rejects paid providers.
  * Credential checks require a completed turn, improving detection of incomplete requests and timeout failures.
  * Failure reporting now uses terminal error details for more accurate diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->