### PR TITLE
fix(opencode): address the zen gateway as the opencode desktop client

### DIFF
--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -16,6 +16,9 @@
     providers:
       opencode:
         apiKeyEnv: OPENCODE_API_KEY
+        headers:
+          user-agent: opencode/latest/1.18.15/desktop
+          x-opencode-client: desktop
         displayName: OpenCode Free
         api: openai-completions
         baseURL: https://opencode.ai/zen/v1
@@ -27,6 +30,9 @@
           - id: nemotron-3.5-lightning-free
       opencode-responses:
         apiKeyEnv: OPENCODE_API_KEY
+        headers:
+          user-agent: opencode/latest/1.18.15/desktop
+          x-opencode-client: desktop
         displayName: OpenCode Free (Responses)
         api: openai-responses
         baseURL: https://opencode.ai/zen/v1

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.cjs
@@ -15,6 +15,33 @@ const OPENCODE_MODELS_URL = 'https://models.dev/api.json';
 const LLM_PI_AI_NAMESPACE = 'llm-pi-ai';
 const OPENCODE_ROUTE_BASE_URL = 'https://opencode.ai/zen/v1';
 /**
+ * How PawWork addresses the zen gateway.
+ *
+ * The gateway meters free-tier traffic per client identity, and an unrecognized
+ * `user-agent` lands in a pool that answers `FreeUsageLimitError` (HTTP 429)
+ * long before the desktop-client pool does. Both routes send the desktop client
+ * identity so a PawWork user gets the free access the models are published
+ * under. `user-agent` is lowercase because the adapter compares header names
+ * case-insensitively and prefers the spelling a route declares.
+ *
+ * The shape is the opencode desktop client's own: its embedded server builds
+ * `opencode/<channel>/<version>/<client>`, a release build's channel is
+ * `latest`, and the desktop sets the client to `desktop`. Bump the version to
+ * the current `@opencode-ai/desktop` release, not on PawWork's own cadence.
+ *
+ * The four per-session headers that client also sends (`x-session-affinity`,
+ * `X-Session-Id`, `x-opencode-project`, `x-opencode-session`) are deliberately
+ * absent: they carry one session's identity, and a route profile can only
+ * declare constants, which would report every user's every turn as the same
+ * session.
+ */
+const OPENCODE_CLIENT = 'desktop';
+const OPENCODE_CLIENT_VERSION = '1.18.15';
+const OPENCODE_CLIENT_HEADERS = {
+	'user-agent': `opencode/latest/${OPENCODE_CLIENT_VERSION}/${OPENCODE_CLIENT}`,
+	'x-opencode-client': OPENCODE_CLIENT,
+};
+/**
  * The zen gateway serves one wire protocol per model, not one per gateway: a
  * model reached on the wrong endpoint answers 500 on every attempt. A pi-ai
  * route carries a single protocol (`PiAiModelProfile` has no per-model `api`),
@@ -256,11 +283,13 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 		const unchanged = Array.isArray(currentProvider?.models)
 			&& currentProvider?.api === api
 			&& currentProvider?.baseURL === OPENCODE_ROUTE_BASE_URL
+			&& isDeepStrictEqual(currentProvider.headers, OPENCODE_CLIENT_HEADERS)
 			&& isDeepStrictEqual(currentProvider.models, merged[route]);
 		if (unchanged) continue;
 		ops.push(
 			{ op: 'set', path: ['providers', route, 'api'], value: api },
 			{ op: 'set', path: ['providers', route, 'baseURL'], value: OPENCODE_ROUTE_BASE_URL },
+			{ op: 'set', path: ['providers', route, 'headers'], value: OPENCODE_CLIENT_HEADERS },
 			{ op: 'set', path: ['providers', route, 'models'], value: merged[route] },
 		);
 	}
@@ -278,6 +307,7 @@ async function refreshOpenCodeFreeModels({ settings, defaultModel, logger, fetch
 }
 
 module.exports = {
+	OPENCODE_CLIENT_HEADERS,
 	OPENCODE_ROUTES,
 	OPENCODE_ROUTE_BASE_URL,
 	isZeroCost,

--- a/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
+++ b/packages/desktop-electron/resources/dsh/product/lib/opencode-free.test.cjs
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const {
+	OPENCODE_CLIENT_HEADERS,
 	isZeroCost,
 	selectFreeAndServed,
 	waitForNamespace,
@@ -158,6 +159,7 @@ test('refresh writes free non-deprecated models with serviceable route wiring', 
 	assert.deepEqual(writes[0].ops, [
 		{ op: 'set', path: ['providers', 'opencode', 'api'], value: 'openai-completions' },
 		{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: 'https://opencode.ai/zen/v1' },
+		{ op: 'set', path: ['providers', 'opencode', 'headers'], value: OPENCODE_CLIENT_HEADERS },
 		{ op: 'set', path: ['providers', 'opencode', 'models'], value: [{ id: 'hy3-free' }] },
 	]);
 });
@@ -176,9 +178,11 @@ test('refresh wires each protocol to its own route in one write', async () => {
 	assert.deepEqual(writes[0].ops, [
 		{ op: 'set', path: ['providers', 'opencode', 'api'], value: 'openai-completions' },
 		{ op: 'set', path: ['providers', 'opencode', 'baseURL'], value: 'https://opencode.ai/zen/v1' },
+		{ op: 'set', path: ['providers', 'opencode', 'headers'], value: OPENCODE_CLIENT_HEADERS },
 		{ op: 'set', path: ['providers', 'opencode', 'models'], value: [{ id: 'plain-free' }] },
 		{ op: 'set', path: ['providers', 'opencode-responses', 'api'], value: 'openai-responses' },
 		{ op: 'set', path: ['providers', 'opencode-responses', 'baseURL'], value: 'https://opencode.ai/zen/v1' },
+		{ op: 'set', path: ['providers', 'opencode-responses', 'headers'], value: OPENCODE_CLIENT_HEADERS },
 		{ op: 'set', path: ['providers', 'opencode-responses', 'models'], value: [{ id: 'responses-free' }] },
 	]);
 });
@@ -204,7 +208,7 @@ test('refresh keeps configured metadata within its own route', async () => {
 test('refresh leaves a route the live catalog has nothing for untouched', async () => {
 	const { settings, writes } = settingsHarness({
 		providers: {
-			opencode: { api: 'openai-completions', baseURL: 'https://opencode.ai/zen/v1', models: [{ id: 'plain-free' }] },
+			opencode: { api: 'openai-completions', baseURL: 'https://opencode.ai/zen/v1', headers: OPENCODE_CLIENT_HEADERS, models: [{ id: 'plain-free' }] },
 			'opencode-responses': { models: [{ id: 'packaged-resp' }] },
 		},
 	});
@@ -314,6 +318,7 @@ test('refresh skips the write when live profiles and routing already match', asy
 		providers: { opencode: {
 			api: 'openai-completions',
 			baseURL: 'https://opencode.ai/zen/v1',
+			headers: OPENCODE_CLIENT_HEADERS,
 			models: [{ id: 'hy3-free' }],
 		} },
 	});
@@ -531,4 +536,16 @@ test('product lifecycle retries a failed startup refresh after one and five minu
 			else process.env[name] = value;
 		}
 	}
+});
+
+// The gateway admits the free tier by the client identity it is addressed with:
+// an unrecognized user-agent is metered in a pool that answers 429 long before
+// the desktop-client pool does. A rewrite that drops the shape silently costs
+// every user their free access, so pin it.
+test('the client identity addresses the gateway as the opencode desktop app', () => {
+	assert.match(OPENCODE_CLIENT_HEADERS['user-agent'], /^opencode\/latest\/\d+\.\d+\.\d+\/desktop$/);
+	assert.equal(OPENCODE_CLIENT_HEADERS['x-opencode-client'], 'desktop');
+	// The adapter drops an attribution default only for a name a route declares,
+	// and it compares case-insensitively against its own lowercase spelling.
+	assert.deepEqual(Object.keys(OPENCODE_CLIENT_HEADERS), Object.keys(OPENCODE_CLIENT_HEADERS).map((name) => name.toLowerCase()));
 });

--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -26,9 +26,13 @@ import {
 
 // The product plugin the packaged patch has to stay in step with. It ships as
 // CommonJS into the DSH home, so it is required rather than imported.
-const { OPENCODE_ROUTES, OPENCODE_ROUTE_BASE_URL } = createRequire(import.meta.url)(
+const { OPENCODE_CLIENT_HEADERS, OPENCODE_ROUTES, OPENCODE_ROUTE_BASE_URL } = createRequire(import.meta.url)(
   "../../resources/dsh/product/lib/opencode-free.cjs",
-) as { OPENCODE_ROUTES: Array<{ route: string; api: string }>; OPENCODE_ROUTE_BASE_URL: string }
+) as {
+  OPENCODE_CLIENT_HEADERS: Record<string, string>
+  OPENCODE_ROUTES: Array<{ route: string; api: string }>
+  OPENCODE_ROUTE_BASE_URL: string
+}
 
 const appPath = join(import.meta.dirname, "../..")
 const hostModules = resolveHostModules({ appPath, isPackaged: false, resourcesPath: "/unused" })
@@ -290,6 +294,7 @@ describe("DSH product home", () => {
         displayName?: string
         api?: string
         baseURL?: string
+        headers?: Record<string, string>
         models?: Array<{ id: string }>
       }>
     }
@@ -306,6 +311,9 @@ describe("DSH product home", () => {
       expect(profile.apiKeyEnv).toBe("OPENCODE_API_KEY")
       expect(profile.displayName).toMatch(/^OpenCode Free/)
       expect(profile.baseURL).toBe(OPENCODE_ROUTE_BASE_URL)
+      // The gateway meters the free tier per client identity, so the packaged
+      // patch has to address it as the same client the refresh writes back.
+      expect(profile.headers).toEqual(OPENCODE_CLIENT_HEADERS)
       // The protocol has to be one the installed adapter still spells this way.
       expect([...catalog.keys()]).toContain(api)
       expect(profile.api).toBe(api)

--- a/patches/@deepseek-ai__dsh-llm-pi-ai@0.1.2-alpha.5.patch
+++ b/patches/@deepseek-ai__dsh-llm-pi-ai@0.1.2-alpha.5.patch
@@ -1,8 +1,44 @@
 diff --git a/lib/index.js b/lib/index.js
-index 906afd7..3c42cda 100644
+index c25e5c7afcd9381dec2490fbff24910f173281d0..7dff1ac276c58abf5a35188d33f7addbd0ee0c4b 100644
 --- a/lib/index.js
 +++ b/lib/index.js
-@@ -2439,7 +2439,16 @@ function directoryEntries(profiles) {
+@@ -1643,13 +1643,17 @@ function reasoningInfo(model, defaultLevel) {
+ 		...defaultLevel === void 0 ? {} : { defaultEffort: ReasoningEffortId(defaultLevel) }
+ 	} };
+ }
+-/** Merge deployment headers while removing case-insensitive attribution collisions. */
++/* PawWork patch: a route profile's own header wins over the harness attribution
++header of the same name (case-insensitively), instead of being dropped. A gateway
++may meter or admit traffic by the client identity it is addressed with, so a route
++declared for such a gateway has to be able to state that identity. Routes that
++declare nothing still send attribution unchanged. */
++/** Merge deployment headers, letting a declared name displace the attribution default. */
+ function requestHeaders(headers) {
+-	const attribution = attributionHeaders();
+-	const reserved = new Set(Object.keys(attribution).map((name) => name.toLowerCase()));
++	const declared = new Set(Object.keys(headers ?? {}).map((name) => name.toLowerCase()));
+ 	return {
+-		...Object.fromEntries(Object.entries(headers ?? {}).filter(([name]) => !reserved.has(name.toLowerCase()))),
+-		...attribution
++		...Object.fromEntries(Object.entries(attributionHeaders()).filter(([name]) => !declared.has(name.toLowerCase()))),
++		...headers
+ 	};
+ }
+ /**
+@@ -2178,7 +2182,11 @@ async function discoverModels(request, storedProfile) {
+ 		const headers = new Headers(stored?.headers === void 0 ? void 0 : Object.entries(stored.headers));
+ 		headers.set("accept", "application/json");
+ 		if (apiKey !== void 0) headers.set("authorization", `Bearer ${apiKey}`);
+-		for (const [name, value] of Object.entries(attributionHeaders())) headers.set(name, value);
++		/* PawWork patch: same precedence as requestHeaders — discovery must address the
++		gateway as the same client the completion requests do, or a route admitted for
++		one identity is listed under another. */
++		const declared = new Set(Object.keys(stored?.headers ?? {}).map((name) => name.toLowerCase()));
++		for (const [name, value] of Object.entries(attributionHeaders())) if (!declared.has(name.toLowerCase())) headers.set(name, value);
+ 		response = await fetch(url, {
+ 			method: "GET",
+ 			headers,
+@@ -2447,7 +2455,16 @@ function directoryEntries(profiles) {
  			declared: !catalog.has(provider)
  		});
  	};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ overrides:
   ws: 8.21.0
 
 patchedDependencies:
-  '@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.5': 56f38d6743e843dee8ae545b573be99d831ace3758a4a5dd012e31a0137eb94f
+  '@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.5': b3027ef3a71de9100063ea5a5732414dbfdf6c2606f8f355565c360cc1ea0e29
   brace-expansion@5.0.9: ef72a243d0bee0990f9a97f527cdcbbb43bc8677f6337ac800e6d1df6ecb5a8b
 
 importers:
@@ -7479,7 +7479,7 @@ snapshots:
       '@deepseek-ai/dsh-jobs-local': 0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-alpha.5(fa501c54d1bae9af3acbbd6956a25b22))(@deepseek-ai/dsh-jobs@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-alpha.5(fa501c54d1bae9af3acbbd6956a25b22))(@deepseek-ai/dsh-brand@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)))))(@deepseek-ai/dsh-scope@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-timeout@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-llm': 0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-llm-deepseek': 0.1.2-alpha.5(682374706cf0a3cc3f3794be986a7602)
-      '@deepseek-ai/dsh-llm-pi-ai': 0.1.2-alpha.5(patch_hash=56f38d6743e843dee8ae545b573be99d831ace3758a4a5dd012e31a0137eb94f)(57c1f6dc33e7be5eaa12899f7c7deeac)
+      '@deepseek-ai/dsh-llm-pi-ai': 0.1.2-alpha.5(patch_hash=b3027ef3a71de9100063ea5a5732414dbfdf6c2606f8f355565c360cc1ea0e29)(57c1f6dc33e7be5eaa12899f7c7deeac)
       '@deepseek-ai/dsh-llm-retry': 0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-alpha.5(fa501c54d1bae9af3acbbd6956a25b22))(@deepseek-ai/dsh-brand@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session-projection@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-session@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)))))(@deepseek-ai/dsh-session@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))))(@deepseek-ai/dsh-timeout@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-permission-presets': 0.1.2-alpha.5(6c66180bcc4683d1c5d422ae1b8bdb8a)
       '@deepseek-ai/dsh-plan-mode': 0.1.2-alpha.5(ed5a0bea44fe24b8ce8b3aa4d17ea17a)
@@ -8150,7 +8150,7 @@ snapshots:
       '@deepseek-ai/schemastery': 3.18.2
       eventsource-parser: 3.1.1
 
-  '@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.5(patch_hash=56f38d6743e843dee8ae545b573be99d831ace3758a4a5dd012e31a0137eb94f)(57c1f6dc33e7be5eaa12899f7c7deeac)':
+  '@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.5(patch_hash=b3027ef3a71de9100063ea5a5732414dbfdf6c2606f8f355565c360cc1ea0e29)(57c1f6dc33e7be5eaa12899f7c7deeac)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2(@deepseek-ai/cordis-plugin-include@1.0.7)(@deepseek-ai/cordis-plugin-loader@1.0.3)
       '@deepseek-ai/dsh-attachment': 0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-brand@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))


### PR DESCRIPTION
## The problem

The six OpenCode Free models are the product's default and its only out-of-the-box way to get an answer. The zen gateway meters that free tier per client identity, and it reads the identity off `user-agent`.

From one IP within one second:

| `user-agent` | `POST https://opencode.ai/zen/v1/chat/completions` |
| --- | --- |
| `opencode/stable/1.0.0/opencode` | 200 |
| `opencode/x/y/z` | 200 |
| `deepseek-harness/0.1.2-alpha.5 (+https://github.com/deepseek-ai/deepseek-harness)` — what PawWork sends today | 429 |
| curl default / `PawWork/2026.9.3 Electron/41` / `node` / empty | 429 |

The 429 body is `{"type":"error","error":{"type":"FreeUsageLimitError","message":"Rate limit exceeded. Please try again later."}}`. So PawWork's free traffic is metered in a pool shared with every unrecognized client, not the one these models are published under. Nothing else in the request distinguishes them — `authorization: Bearer public` is identical, and `public` is still the current sentinel upstream (`packages/core/src/plugin/provider/opencode.ts`, opencode main `8d4ef01621`); it is not a token and has not expired.

## Why it regressed

v1 already sent this identity. #940 added `httpIdentity()` — `User-Agent: opencode/latest/<version>/desktop` plus `x-opencode-client` — for every outbound request to an OpenCode backend, down to rewriting Electron's `userAgentFallback`. #1573 moved the LLM path onto DSH, where `dsh-llm`'s `attributionHeaders()` hardcodes its own user-agent, and the identity went with it.

## The change

Both Free routes declare the current opencode desktop client identity, taken from the upstream tree rather than from v1: its embedded server builds `opencode/<channel>/<version>/<client>`, a release build's channel is `latest`, and the desktop sets the client to `desktop`.

`dsh-llm-pi-ai` dropped any deployment header colliding with attribution, so a route could not state an identity at all. The patch inverts that precedence — a name a route declares wins, case-insensitively — on the completion path and on model discovery alike, so a route admitted as one client is not listed as another. A route that declares nothing sends attribution unchanged.

The four per-session headers that client also sends (`x-session-affinity`, `X-Session-Id`, `x-opencode-project`, `x-opencode-session`) are deliberately absent: they carry one session's identity, and a route profile can only declare constants, which would report every user's every turn as the same session.

The periodic catalog refresh re-asserts the headers alongside `api` and `baseURL`, so an existing install picks them up without waiting for a fresh home, and the no-churn check accounts for them.

## Verification

Against the real app over CDP, with a recording proxy standing in for the gateway: the turn answered (`assistant/message`, `turn/end`) and both outbound requests carried

```
user-agent: opencode/latest/1.18.15/desktop
x-opencode-client: desktop
authorization: Bearer public
```

with no attribution header. `dsh-product-home.test.ts` pins the packaged patch against `OPENCODE_CLIENT_HEADERS` so the two cannot drift, and a unit test pins the identity's shape. Typecheck, lint and 167 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenCode provider connections now send desktop client identification headers.
  - Provider discovery and completion requests consistently use configured client identity information.

- **Bug Fixes**
  - Custom provider headers now correctly override default attribution headers, regardless of capitalization.
  - Providers that cannot authenticate through supported API keys are no longer shown in the catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->