### PR TITLE
chore(opencode): refresh the zen client identity to the current desktop release

### DIFF
--- a/packages/desktop-electron/resources/dsh/zen-identity.mjs
+++ b/packages/desktop-electron/resources/dsh/zen-identity.mjs
@@ -1,11 +1,15 @@
-// Process preload: wrap global fetch so OpenCode Zen requests look like the official CLI.
+// Process preload: wrap global fetch so OpenCode Zen requests look like the official client.
 // DSH's llm-pi-ai overwrites User-Agent with deepseek-harness attribution, and
 // llm/stream cannot change outbound headers. Loaded with Node --import before dsh.
 
+// The identity the official client sends: its server builds
+// `opencode/<channel>/<version>/<client>`, a release build's channel is `latest`,
+// and PawWork is a desktop app, which is the client the opencode desktop sets too.
+// Track the version against the current @opencode-ai/desktop release.
 export const OPENCODE_ZEN_HOST = 'opencode.ai';
 export const OPENCODE_ZEN_HEADERS = Object.freeze({
-  'user-agent': 'opencode/latest/1.16.2/cli',
-  'x-opencode-client': 'cli',
+  'user-agent': 'opencode/latest/1.18.15/desktop',
+  'x-opencode-client': 'desktop',
 });
 
 export function requestUrl(input) {

--- a/packages/desktop-electron/resources/dsh/zen-identity.test.cjs
+++ b/packages/desktop-electron/resources/dsh/zen-identity.test.cjs
@@ -18,11 +18,11 @@ function loadIdentity() {
 // The module exists to send exactly these two headers: the whole point is the
 // value, and every other test here compares the value against the same import,
 // so any string would have passed them.
-test('sends the official OpenCode CLI identity, not our own', async () => {
+test('sends the official OpenCode desktop identity, not our own', async () => {
   const { OPENCODE_ZEN_HEADERS, OPENCODE_ZEN_HOST } = await loadIdentity();
   assert.deepEqual({ ...OPENCODE_ZEN_HEADERS }, {
-    'user-agent': 'opencode/latest/1.16.2/cli',
-    'x-opencode-client': 'cli',
+    'user-agent': 'opencode/latest/1.18.15/desktop',
+    'x-opencode-client': 'desktop',
   });
   assert.equal(OPENCODE_ZEN_HOST, 'opencode.ai');
 });


### PR DESCRIPTION
The preloaded fetch wrapper (`resources/dsh/zen-identity.mjs`, added in #1573) has claimed `opencode/latest/1.16.2/cli` ever since. Upstream's desktop client is now 1.18.15 and identifies itself as `desktop` rather than `cli` — which is also what PawWork is.

Its server builds `opencode/<channel>/<version>/<client>`, a release build's channel is `latest`, and the desktop sets the client to `desktop` (`packages/desktop/src/main/lifecycle/environment.ts`).

No behavior change. The gateway admits the free tier on the `opencode/` prefix — `opencode/x/y/z` answers 200 where a non-opencode user-agent answers 429 `FreeUsageLimitError` — so both the old and the new value pass. This only keeps the claim true.

Verified that the wrapper is what actually reaches the gateway: with a log point inside it, both outbound `https://opencode.ai/zen/v1/chat/completions` requests of a real turn go through it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Requests from the desktop app now identify themselves as the official OpenCode desktop client.
  * The reported desktop client version is updated to 1.18.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->