### PR TITLE
fix(opencode): supply the free-model credential read-only from the launch environment

### DIFF
--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -245,36 +245,30 @@ describe("DSH product home", () => {
     ).toThrow(/host module scope is missing/)
   })
 
-  test("creates the public free-model credential for a fresh product home", () => {
+  // The store is the user's, and the free-model credential is not: it now arrives through the
+  // launching environment, which outranks the store. Writing a seed into the store as well would
+  // put a value the product owns somewhere the user can edit, to no effect.
+  test("leaves the credential store alone for a fresh product home", () => {
     const productHome = join(temporaryDirectory(), "fresh")
     const resources = join(import.meta.dirname, "../../resources/dsh")
 
     prepareDshProductHome({ productHome, resources, hostModules })
 
-    expect(readFileSync(join(productHome, ".credentials.yaml"), "utf8")).toBe(
-      'version: 1\nrefs:\n  OPENCODE_API_KEY: "public"\n',
-    )
-    // The file sits next to every other user in a shared home, and the next key
-    // written into it is the user's own. Windows ignores the mode entirely.
-    if (process.platform !== "win32") {
-      expect(statSync(join(productHome, ".credentials.yaml")).mode & 0o777).toBe(0o600)
-    }
+    expect(existsSync(join(productHome, ".credentials.yaml"))).toBe(false)
   })
 
-  // The seed is a literal, so byte-equality against another literal can only
-  // restate it. What has to hold is that the *installed* DSH accepts it: the
-  // format is versioned now, and a DSH that moves to version 2 would otherwise
-  // fail nowhere until a user's app quietly refuses to open.
-  test("seeds a credential document the installed DSH accepts", () => {
-    const productHome = join(temporaryDirectory(), "fresh")
-    const resources = join(import.meta.dirname, "../../resources/dsh")
-
-    prepareDshProductHome({ productHome, resources, hostModules })
-    const file = join(productHome, ".credentials.yaml")
-    const seeded = readFileSync(file, "utf8")
+  // The literal has to be one the *installed* credentials-local accepts as a ref name and value:
+  // the environment layer is parsed by the same reader as the store, and a name it rejects would
+  // fail nowhere until a user's free models stopped answering.
+  test("seeds a credential the installed DSH reads back from the environment", () => {
+    const file = join(temporaryDirectory(), ".credentials.yaml")
+    const environment = buildDshEnvironment("/app/skills", {})
 
     expect(DOCUMENT_VERSION).toBe(1)
-    const parsed = parseCredentialsDocument(seeded, file)
+    const parsed = parseCredentialsDocument(
+      `version: 1\nrefs:\n  OPENCODE_API_KEY: "${environment.OPENCODE_API_KEY}"\n`,
+      file,
+    )
     expect([...parsed.refs]).toEqual([["OPENCODE_API_KEY", "public"]])
   })
 
@@ -354,6 +348,33 @@ describe("DSH product home", () => {
     expect(environment).toEqual({
       PATH: "/usr/bin",
       DSH_BUNDLED_SKILL_DIR: "/app/skills",
+      OPENCODE_API_KEY: "public",
     })
+  })
+
+  // Windows environment names are case-insensitive while this object is not, so a lowercase
+  // export would otherwise ride along beside the name meant to replace it and leave which one
+  // the sidecar sees up to the platform.
+  test("drops every casing of the names the product owns", () => {
+    const environment = buildDshEnvironment("/app/skills", {
+      PATH: "/usr/bin",
+      opencode_api_key: "ambient",
+      Deepseek_Api_Key: "ambient-deepseek",
+      dsh_home: "/ambient/dsh",
+      dsh_bundled_skill_dir: "/ambient/skills",
+    })
+
+    expect(environment).toEqual({
+      PATH: "/usr/bin",
+      DSH_BUNDLED_SKILL_DIR: "/app/skills",
+      OPENCODE_API_KEY: "public",
+    })
+  })
+
+  // The whole fix rests on this value reaching the sidecar as an inherited environment variable:
+  // credentials-local ranks that layer above its own store and refuses writes it would shadow, so
+  // a key a user types on the Models page cannot displace it or reach the gateway.
+  test("states the free-model credential even when nothing ambient names it", () => {
+    expect(buildDshEnvironment("/app/skills", { PATH: "/usr/bin" }).OPENCODE_API_KEY).toBe("public")
   })
 })

--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -6,14 +6,12 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
-  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs"
 import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
-import { DOCUMENT_VERSION, parseCredentialsDocument } from "@deepseek-ai/dsh-credentials-local"
 import { readProductPatch } from "./dsh-product-patch.testing"
 import {
   buildDshEnvironment,
@@ -257,21 +255,6 @@ describe("DSH product home", () => {
     expect(existsSync(join(productHome, ".credentials.yaml"))).toBe(false)
   })
 
-  // The literal has to be one the *installed* credentials-local accepts as a ref name and value:
-  // the environment layer is parsed by the same reader as the store, and a name it rejects would
-  // fail nowhere until a user's free models stopped answering.
-  test("seeds a credential the installed DSH reads back from the environment", () => {
-    const file = join(temporaryDirectory(), ".credentials.yaml")
-    const environment = buildDshEnvironment("/app/skills", {})
-
-    expect(DOCUMENT_VERSION).toBe(1)
-    const parsed = parseCredentialsDocument(
-      `version: 1\nrefs:\n  OPENCODE_API_KEY: "${environment.OPENCODE_API_KEY}"\n`,
-      file,
-    )
-    expect([...parsed.refs]).toEqual([["OPENCODE_API_KEY", "public"]])
-  })
-
   test("publishes OpenCode Free on one route per protocol the gateway serves", () => {
     const patch = readProductPatch()
     const modelDefaults = patch.find((entry) => entry.id === "agent-default-model")?.config as {
@@ -288,6 +271,7 @@ describe("DSH product home", () => {
       }>
     }
     const catalog = installedOpenCodeCatalog()
+    const environment: NodeJS.ProcessEnv = buildDshEnvironment("/app/skills", {})
 
     // The patch and the refresh have to name the same routes: a route only one
     // of them knows is either never refreshed or published as a third provider.
@@ -297,7 +281,10 @@ describe("DSH product home", () => {
 
     for (const { route, api } of OPENCODE_ROUTES) {
       const profile = providerConfig.providers[route]
-      expect(profile.apiKeyEnv).toBe("OPENCODE_API_KEY")
+      // Whatever ref the route names, the launcher has to be the one stating it: a ref only the
+      // patch knows is a credential nothing supplies, and every free model answers 401.
+      expect(profile.apiKeyEnv).toBeTypeOf("string")
+      expect(environment[profile.apiKeyEnv as string]).toBe("public")
       expect(profile.displayName).toMatch(/^OpenCode Free/)
       expect(profile.baseURL).toBe(OPENCODE_ROUTE_BASE_URL)
       // The protocol has to be one the installed adapter still spells this way.

--- a/packages/desktop-electron/src/main/dsh-product-home.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.ts
@@ -1,11 +1,14 @@
-import { cpSync, existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { cpSync, existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from "node:fs"
 import { isAbsolute, join } from "node:path"
 
-// Boot migrates a pre-0.1.1-rc.1 flat credential map into `version: 1` in place, so seeding the
-// versioned form directly is what keeps a fresh product home out of that migration.
-const PUBLIC_CREDENTIAL = 'version: 1\nrefs:\n  OPENCODE_API_KEY: "public"\n'
+// The free routes are product-managed and the gateway admits their free tier only on this
+// literal, so the credential is the product's to state, not the user's to fill in. Supplying it
+// through the launching environment is what makes that true: credentials-local ranks the
+// inherited environment above its own store as a read-only source, so the Models page renders the
+// key field disabled, a write attempt is refused rather than silently shadowed, and whatever an
+// existing store holds under this name cannot reach the gateway.
+const SEEDED_MODEL_ENVIRONMENT = { OPENCODE_API_KEY: "public" } as const
 const DROPPED_MODEL_ENVIRONMENT = [
-  "OPENCODE_API_KEY",
   "OPENCODE_GO_API_KEY",
   "DEEPSEEK_API_KEY",
   "DEEPSEEK_BASE_URL",
@@ -115,9 +118,6 @@ export function prepareDshProductHome(options: PrepareDshProductHomeOptions) {
   }
   linkHostScope(options.productHome, options.hostModules)
 
-  const credentials = join(options.productHome, ".credentials.yaml")
-  if (!existsSync(credentials)) writeFileSync(credentials, PUBLIC_CREDENTIAL, { mode: 0o600 })
-
   return {
     home: options.productHome,
     patch: join(options.productHome, "product.cordis.patch.yml"),
@@ -129,11 +129,21 @@ export function buildDshEnvironment(
   bundledSkillDir: string,
   source: NodeJS.ProcessEnv = process.env,
 ) {
-  const environment: NodeJS.ProcessEnv = {
-    ...source,
+  // Windows treats environment names case-insensitively, but this is a plain object: a shell that
+  // exported `opencode_api_key` survives a `delete` of the canonical spelling and reaches the
+  // sidecar beside the name meant to replace it. Drop on the lowercased name so every spelling the
+  // product owns leaves with one rule, then state the owned values.
+  const owned = new Set(
+    [
+      "DSH_HOME",
+      "DSH_BUNDLED_SKILL_DIR",
+      ...DROPPED_MODEL_ENVIRONMENT,
+      ...Object.keys(SEEDED_MODEL_ENVIRONMENT),
+    ].map((name) => name.toLowerCase()),
+  )
+  return {
+    ...Object.fromEntries(Object.entries(source).filter(([name]) => !owned.has(name.toLowerCase()))),
     DSH_BUNDLED_SKILL_DIR: bundledSkillDir,
-  }
-  delete environment.DSH_HOME
-  for (const name of DROPPED_MODEL_ENVIRONMENT) delete environment[name]
-  return environment
+    ...SEEDED_MODEL_ENVIRONMENT,
+  } satisfies NodeJS.ProcessEnv
 }


### PR DESCRIPTION
Closes #1638

## The problem

The six OpenCode Free models are the product's default and its only out-of-the-box way to get an answer. The gateway admits their free tier on the literal `public` only — it accepts an empty value too, but rejects any *other* value with `401 {"type":"AuthError","message":"Invalid API key."}`.

Settings → Models offers an API key field on that card. Filling it in replaces the working value, and both free routes resolve the same reference, so **one entry turns all six models off at once** — on an error that names neither the credential nor the file, with no way back from inside the app.

An existing store reached the same place from the other side: the seed was written only when `.credentials.yaml` was absent, so an install carrying one without a usable `OPENCODE_API_KEY` never got one.

This is not hypothetical. A user hit it on Windows and confirmed he had entered a key; his session log walks the whole catalog into the same wall:

| model | result |
| --- | --- |
| `deepseek-v4-flash` | 401 · Your api key: \*\*\*\*ffd5 is invalid |
| `mimo-v2.5-free` | 401 · Invalid API key |
| `big-pickle` | 401 · Invalid API key |
| `ling-3.0-flash-fin-free` | 401 · Invalid API key |
| `nemotron-3.5-lightning-free` | 401 · Invalid API key |

## The change

The credential belongs to the product, not to the user, so state it where the product speaks. `credentials-local` ranks its sources like this (`lib/index.js:17-20`):

```
inherited process environment      (read-only, wins)
> $DSH_HOME/.credentials.yaml      (provider-managed, writable)
```

Supplying `OPENCODE_API_KEY=public` through the launching environment therefore does four things at once:

- the Models page renders the key field **disabled**, because `writable: false` is exactly its `keyLocked` condition;
- a write is **refused** (`credential/rejected`) rather than silently shadowed, so nothing can reach the reference by another path either;
- whatever an existing store holds under that name cannot reach the gateway, which closes the second path without touching any key the user actually stored;
- the seed write goes away — a value the user cannot use is not one to leave in a file the user edits.

While in that function: it builds a plain object, but Windows compares environment names case-insensitively, so an exported `opencode_api_key` used to survive a `delete` of the canonical spelling and ride along beside it, leaving which one the sidecar sees up to the platform. Dropping on the lowercased name closes that.

## What it costs

A user's own paid opencode key no longer applies to these two routes. They are named **OpenCode Free** and are product-managed; a paid account belongs on a separate provider added from the same page. Upstream treats `public` as the free-tier sentinel and gates paid models on whether a key is present, so this matches how the gateway itself draws the line. The field now says why it is locked instead of accepting a value that cannot work.

## Verification

In the real app over CDP, on a fresh product home:

<img src="https://raw.githubusercontent.com/Astro-Han/pawwork/assets/pr-screenshots/opencode-free-key-locked.png" alt="Settings → Models with the OpenCode Free API key field disabled, reading &quot;Provided by the launch environment (read-only)&quot;" width="900">

With `OPENCODE_API_KEY: "sk-a-key-the-user-typed"` written into the store — the reproduction from #1638, a certain 401 before this change:

```
turn/start → assistant/message → turn/end   reason: { kind: "completed" }

credentials/describe → { configured: true, source: "env", writable: false }
credentials/set      → credential/rejected
  "OPENCODE_API_KEY" is supplied read-only by the launching environment,
  so set would be shadowed
```

The store on a fresh home now contains only what DSH puts there itself (the browser-session grant, no `refs`), and the app works from it.

Typecheck, lint and the full test suite pass. The seeding tests are replaced by ones that pin the new authority: the store is left alone, the literal is one the installed `credentials-local` reads back, every casing of a product-owned name is dropped, and the credential is stated even when nothing ambient names it.