### PR TITLE
chore(release): prepare 2026.9.4

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.9.3",
+  "version": "2026.9.4",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
Bumps the desktop version so the release tag has a version to build.

Ships the OpenCode Free credential fix (#1641): an existing install whose `.credentials.yaml` holds a user-typed `OPENCODE_API_KEY` starts answering again on upgrade, with no action from the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application version to 2026.9.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->