### PR TITLE
fix(dsh): send the session id the OpenCode Zen gateway requires

### DIFF
--- a/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
+++ b/packages/desktop-electron/resources/dsh/home/product.cordis.patch.yml
@@ -11,6 +11,10 @@
 # `ling-3.0-flash-fin-free`, and only the paid `muse-spark-1.2`), so a route
 # without them cannot serve those models before the first refresh lands.
 # resources/dsh/product/lib/opencode-free.cjs keeps both lists current.
+#
+# The gateway requires a per-conversation id on every request, and only the
+# Completions protocol gates that behind `sendSessionAffinityHeaders`. The switch
+# is route-level because a catalog refresh rewrites `models` and would drop it.
 - id: llm-pi-ai
   config:
     providers:
@@ -19,6 +23,8 @@
         displayName: OpenCode Free
         api: openai-completions
         baseURL: https://opencode.ai/zen/v1
+        compat:
+          sendSessionAffinityHeaders: true
         models:
           - id: big-pickle
           - id: ling-3.0-flash-fin-free

--- a/packages/desktop-electron/resources/dsh/zen-identity.mjs
+++ b/packages/desktop-electron/resources/dsh/zen-identity.mjs
@@ -12,6 +12,14 @@ export const OPENCODE_ZEN_HEADERS = Object.freeze({
   'x-opencode-client': 'desktop',
 });
 
+// The gateway groups a conversation's requests by `x-opencode-session` and
+// rejects inference requests that omit it. pi-ai already writes the harness
+// session id, stable for the life of a conversation, as `x-client-request-id`,
+// so it is restated under the name the gateway reads rather than minted here. A
+// request carrying no session — the model list — sends none.
+export const OPENCODE_ZEN_SESSION_SOURCE_HEADER = 'x-client-request-id';
+export const OPENCODE_ZEN_SESSION_HEADER = 'x-opencode-session';
+
 export function requestUrl(input) {
   if (typeof input === 'string') return input;
   if (input instanceof URL) return input.href;
@@ -32,6 +40,8 @@ export function applyOpenCodeZenHeaders(input, init) {
   const headers = new Headers(init?.headers ?? (input && typeof input === 'object' ? input.headers : undefined));
   headers.set('user-agent', OPENCODE_ZEN_HEADERS['user-agent']);
   headers.set('x-opencode-client', OPENCODE_ZEN_HEADERS['x-opencode-client']);
+  const session = headers.get(OPENCODE_ZEN_SESSION_SOURCE_HEADER);
+  if (session) headers.set(OPENCODE_ZEN_SESSION_HEADER, session);
   return { ...(init || {}), headers };
 }
 

--- a/packages/desktop-electron/resources/dsh/zen-identity.test.cjs
+++ b/packages/desktop-electron/resources/dsh/zen-identity.test.cjs
@@ -54,6 +54,30 @@ test('replaces User-Agent and keeps the original request headers', async () => {
   });
 });
 
+// The id is restated, never minted: the gateway groups a conversation by this
+// value, so a fresh one per request would be worse than sending nothing.
+test('restates the session id the gateway reads, and invents none', async () => {
+  const {
+    applyOpenCodeZenHeaders,
+    OPENCODE_ZEN_SESSION_HEADER,
+    OPENCODE_ZEN_SESSION_SOURCE_HEADER,
+  } = await loadIdentity();
+  // Spelled out, not compared against the same import: the names are the contract
+  // with the gateway, so a rename on both sides has to fail here.
+  assert.equal(OPENCODE_ZEN_SESSION_SOURCE_HEADER, 'x-client-request-id');
+  assert.equal(OPENCODE_ZEN_SESSION_HEADER, 'x-opencode-session');
+  const sessionId = 'session-01513391-0758-4654-9a04-da77af86c553';
+
+  const inference = applyOpenCodeZenHeaders('https://opencode.ai/zen/v1/chat/completions', {
+    headers: { [OPENCODE_ZEN_SESSION_SOURCE_HEADER]: sessionId },
+  });
+  assert.equal(headerRecord(inference)[OPENCODE_ZEN_SESSION_HEADER], sessionId);
+
+  // The settings card's "fetch models" button is the request with no session.
+  const models = applyOpenCodeZenHeaders('https://opencode.ai/zen/v1/models', { headers: {} });
+  assert.equal(headerRecord(models)[OPENCODE_ZEN_SESSION_HEADER], undefined);
+});
+
 test('wraps fetch so only Zen requests carry the official OpenCode identity', async () => {
   const { wrapFetchForOpenCodeZen, OPENCODE_ZEN_HEADERS, OPENCODE_ZEN_HOST } = await loadIdentity();
   const seen = [];

--- a/packages/desktop-electron/scripts/zen-wire-capture.ts
+++ b/packages/desktop-electron/scripts/zen-wire-capture.ts
@@ -1,0 +1,246 @@
+/**
+ * Record what PawWork actually puts on the wire to the OpenCode Zen gateway.
+ *
+ * The identity and session headers this product sends are assembled across
+ * three layers it does not own end to end — the pi-ai adapter patch, the
+ * product patch, and the fetch preload — and each layer can be read correctly
+ * while the bytes leaving the process are still wrong. Reading the sources, or
+ * instrumenting the preload, only proves what we intended to send.
+ *
+ * So this terminates TLS for `opencode.ai` with a throwaway CA and reports the
+ * request head verbatim. The app keeps fetching `https://opencode.ai/...`:
+ * pointing it at a local recorder instead would make `isOpenCodeZenUrl` answer
+ * false, skip the preload, and measure traffic no user ever sends.
+ *
+ * Every other host is tunnelled untouched, and the CA lives in a temporary
+ * directory that goes away with the process.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/zen-wire-capture.ts
+ * then start the app with the environment it prints, exercise the models, and
+ * stop the recorder with Ctrl-C for the summary.
+ */
+import { execFileSync } from "node:child_process"
+import { appendFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { createServer } from "node:http"
+import { connect as netConnect, type Socket } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createServer as createTlsServer, connect as tlsConnect } from "node:tls"
+
+const TARGET = "opencode.ai"
+const PORT = Number(process.env.ZEN_WIRE_PORT ?? 49780)
+
+// RFC 9110 field-name token and field-value: a header the gateway would reject
+// as malformed is a defect this tool has to name, not quietly print.
+const FIELD_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
+const FIELD_VALUE = /^[\x21-\x7E]([\x20\x09\x21-\x7E]*[\x21-\x7E])?$/
+
+type Capture = {
+  readonly at: string
+  readonly requestLine: string
+  readonly headers: ReadonlyArray<readonly [string, string]>
+  readonly model?: string
+}
+
+/**
+ * The model the gateway was actually asked for, read off the body rather than
+ * off whatever the caller believed it requested. A verification run that only
+ * checks its own intent cannot tell a per-model sweep apart from the same model
+ * answering every time.
+ */
+const MODEL_FIELD = /"model"\s*:\s*"([^"]+)"/
+const MODEL_SCAN_BYTES = 4096
+
+const captures: Capture[] = []
+const workDir = mkdtempSync(join(tmpdir(), "pawwork-zen-wire-"))
+const capturePath = join(workDir, "capture.jsonl")
+
+function issueCertificate() {
+  const ca = join(workDir, "ca-cert.pem")
+  const caKey = join(workDir, "ca-key.pem")
+  const leaf = join(workDir, "leaf-cert.pem")
+  const leafKey = join(workDir, "leaf-key.pem")
+  const csr = join(workDir, "leaf.csr")
+  const ext = join(workDir, "ext.cnf")
+  writeFileSync(ext, `subjectAltName=DNS:${TARGET}\n`)
+
+  const openssl = (args: string[]) => {
+    try {
+      execFileSync("openssl", args, { stdio: "pipe" })
+    } catch (error) {
+      throw new Error(
+        `openssl is required to mint the throwaway CA: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+  openssl(["req", "-x509", "-newkey", "rsa:2048", "-keyout", caKey, "-out", ca, "-days", "1", "-nodes", "-subj", "/CN=PawWork Zen Wire Capture"])
+  openssl(["req", "-newkey", "rsa:2048", "-keyout", leafKey, "-out", csr, "-nodes", "-subj", `/CN=${TARGET}`])
+  openssl(["x509", "-req", "-in", csr, "-CA", ca, "-CAkey", caKey, "-CAcreateserial", "-out", leaf, "-days", "1", "-extfile", ext])
+
+  return { ca, cert: readFileSync(leaf), key: readFileSync(leafKey) }
+}
+
+const { ca, cert, key } = issueCertificate()
+
+function record(head: string, model: string | undefined) {
+  const [requestLine, ...fields] = head.split("\r\n").filter((line) => line.length > 0)
+  const headers = fields.map((line) => {
+    const colon = line.indexOf(":")
+    return [line.slice(0, colon), line.slice(colon + 1).trim()] as const
+  })
+  const capture: Capture = {
+    at: new Date().toISOString(),
+    requestLine: requestLine ?? "",
+    headers,
+    ...(model === undefined ? {} : { model }),
+  }
+  captures.push(capture)
+  appendFileSync(capturePath, `${JSON.stringify(capture)}\n`)
+}
+
+const tlsServer = createTlsServer({ cert, key }, (client) => {
+  let head = Buffer.alloc(0)
+  let forwarded = false
+  let upstream: ReturnType<typeof tlsConnect> | undefined
+
+  client.on("data", (chunk: Buffer) => {
+    if (forwarded) return
+    head = Buffer.concat([head, chunk])
+    const end = head.indexOf("\r\n\r\n")
+    if (end === -1) return
+
+    const requestHead = head.subarray(0, end + 4).toString("latin1")
+    const body = head.subarray(end + 4)
+    forwarded = true
+
+    // The head and the start of the body do not have to share a TCP segment, so
+    // hold the record open until the model is in hand or the scan budget is
+    // spent. Forwarding never waits for it.
+    let scan = body
+    let recorded = false
+    const tryRecord = (force: boolean) => {
+      if (recorded) return
+      const model = MODEL_FIELD.exec(scan.subarray(0, MODEL_SCAN_BYTES).toString("utf8"))?.[1]
+      if (!force && model === undefined && scan.length < MODEL_SCAN_BYTES) return
+      recorded = true
+      record(requestHead, model)
+    }
+    tryRecord(!requestHead.startsWith("POST"))
+    client.on("end", () => tryRecord(true))
+
+    // A write on a still-connecting socket is queued, so forwarding later chunks
+    // directly would put body bytes ahead of the head and the origin answers 400.
+    let connected = false
+    const pending: Buffer[] = [head.subarray(0, end + 4), body]
+    upstream = tlsConnect({ host: TARGET, port: 443, servername: TARGET }, () => {
+      connected = true
+      for (const queued of pending.splice(0)) if (queued.length > 0) upstream?.write(queued)
+    })
+    client.on("data", (later: Buffer) => {
+      if (!recorded && scan.length < MODEL_SCAN_BYTES) {
+        scan = Buffer.concat([scan, later])
+        tryRecord(false)
+      }
+      if (connected) upstream?.write(later)
+      else pending.push(later)
+    })
+    upstream.on("error", () => client.destroy())
+    upstream.pipe(client)
+  })
+  client.on("error", () => upstream?.destroy())
+})
+
+const proxy = createServer((_request, response) => {
+  response.writeHead(405).end("CONNECT only")
+})
+
+proxy.on("connect", (request, socket: Socket, head: Buffer) => {
+  const [host, port = "443"] = (request.url ?? "").split(":")
+  socket.write("HTTP/1.1 200 Connection Established\r\n\r\n")
+
+  if (host !== TARGET) {
+    const passthrough = netConnect(Number(port), host, () => {
+      if (head.length > 0) passthrough.write(head)
+      socket.pipe(passthrough).pipe(socket)
+    })
+    passthrough.on("error", () => socket.destroy())
+    socket.on("error", () => passthrough.destroy())
+    return
+  }
+
+  tlsServer.emit("connection", socket)
+  if (head.length > 0) socket.unshift(head)
+})
+
+/** Report each intercepted path, and every way its head could be wrong. */
+function summarize() {
+  if (captures.length === 0) {
+    process.stdout.write("\nNo Zen requests were intercepted.\n")
+    return
+  }
+  process.stdout.write(`\n${captures.length} Zen requests, recorded in ${capturePath}\n`)
+
+  const paths = new Map<string, Capture[]>()
+  for (const capture of captures) {
+    const path = capture.requestLine.split(" ")[1] ?? capture.requestLine
+    paths.set(path, [...(paths.get(path) ?? []), capture])
+  }
+
+  let failed = false
+  for (const [path, group] of paths) {
+    const problems: string[] = []
+    const sessions = new Set<string>()
+    const models = new Set<string>()
+    for (const capture of group) {
+      if (capture.model !== undefined) models.add(capture.model)
+      const fields = new Map(capture.headers.map(([name, value]) => [name.toLowerCase(), value]))
+      const session = fields.get("x-opencode-session")
+      // The model list carries no conversation, so it is the one path allowed to omit it.
+      if (session === undefined) {
+        if (!path.endsWith("/models")) problems.push("no x-opencode-session")
+      } else {
+        sessions.add(session)
+        if (session !== fields.get("x-client-request-id")) problems.push("session id does not match x-client-request-id")
+      }
+      const names = capture.headers.map(([name]) => name.toLowerCase())
+      const duplicate = names.find((name, index) => names.indexOf(name) !== index)
+      if (duplicate !== undefined) problems.push(`duplicate field ${duplicate}`)
+      for (const [name, value] of capture.headers) {
+        if (!FIELD_NAME.test(name)) problems.push(`malformed field name ${JSON.stringify(name)}`)
+        if (!FIELD_VALUE.test(value)) problems.push(`malformed value for ${name}`)
+      }
+    }
+    const unique = [...new Set(problems)]
+    failed ||= unique.length > 0
+    process.stdout.write(
+      `  ${path}: ${group.length} requests, ${sessions.size} session id(s)` +
+        `${unique.length === 0 ? ", head OK" : `, PROBLEMS: ${unique.join("; ")}`}\n` +
+        (models.size === 0 ? "" : `    models served: ${[...models].sort().join(", ")}\n`),
+    )
+  }
+  if (failed) process.exitCode = 1
+}
+
+function shutdown() {
+  summarize()
+  // The capture is the point of running this, so it outlives the process; the
+  // key material does not.
+  for (const secret of ["ca-key.pem", "leaf-key.pem", "leaf.csr"]) {
+    rmSync(join(workDir, secret), { force: true })
+  }
+  process.exit(process.exitCode ?? 0)
+}
+process.on("SIGINT", shutdown)
+process.on("SIGTERM", shutdown)
+
+proxy.listen(PORT, "127.0.0.1", () => {
+  process.stdout.write(
+    `Recording ${TARGET} on 127.0.0.1:${PORT}. Start the app with:\n\n` +
+      `  NODE_OPTIONS=--use-env-proxy \\\n` +
+      `  HTTPS_PROXY=http://127.0.0.1:${PORT} \\\n` +
+      `  NODE_EXTRA_CA_CERTS=${ca}\n\n` +
+      `--use-env-proxy is what makes the sidecar's fetch honour the proxy; it needs Node 24+,\n` +
+      `which Electron 41 provides. Ctrl-C for the summary.\n`,
+  )
+})

--- a/packages/desktop-electron/scripts/zen-wire-capture.ts
+++ b/packages/desktop-electron/scripts/zen-wire-capture.ts
@@ -53,6 +53,8 @@ const MODEL_FIELD = /"model"\s*:\s*"([^"]+)"/
 const MODEL_SCAN_BYTES = 4096
 
 const captures: Capture[] = []
+/** Connections whose framing this parser cannot follow, so their later requests went unchecked. */
+let unframed = 0
 const workDir = mkdtempSync(join(tmpdir(), "pawwork-zen-wire-"))
 const capturePath = join(workDir, "capture.jsonl")
 
@@ -100,55 +102,72 @@ function record(head: string, model: string | undefined) {
 }
 
 const tlsServer = createTlsServer({ cert, key }, (client) => {
-  let head = Buffer.alloc(0)
-  let forwarded = false
-  let upstream: ReturnType<typeof tlsConnect> | undefined
+  // A write on a still-connecting socket is queued, so writing chunks straight
+  // through would put body bytes ahead of the head and the origin answers 400.
+  let connected = false
+  const pending: Buffer[] = []
+  const upstream = tlsConnect({ host: TARGET, port: 443, servername: TARGET }, () => {
+    connected = true
+    for (const queued of pending.splice(0)) if (queued.length > 0) upstream.write(queued)
+  })
+  upstream.on("error", () => client.destroy())
+  upstream.pipe(client)
+
+  // One tunnel carries many requests, so the stream is parsed continuously
+  // rather than only as far as the first blank line. Bodies are stepped over by
+  // Content-Length, because a body containing a blank line would otherwise be
+  // read as the next request head.
+  let buffer = Buffer.alloc(0)
+  let head: string | undefined
+  let bodyRemaining = 0
+  let scan = Buffer.alloc(0)
+  let framed = true
+
+  const flush = () => {
+    if (head === undefined) return
+    record(head, MODEL_FIELD.exec(scan.toString("utf8"))?.[1])
+    head = undefined
+    scan = Buffer.alloc(0)
+  }
 
   client.on("data", (chunk: Buffer) => {
-    if (forwarded) return
-    head = Buffer.concat([head, chunk])
-    const end = head.indexOf("\r\n\r\n")
-    if (end === -1) return
+    if (connected) upstream.write(chunk)
+    else pending.push(chunk)
+    if (!framed) return
 
-    const requestHead = head.subarray(0, end + 4).toString("latin1")
-    const body = head.subarray(end + 4)
-    forwarded = true
-
-    // The head and the start of the body do not have to share a TCP segment, so
-    // hold the record open until the model is in hand or the scan budget is
-    // spent. Forwarding never waits for it.
-    let scan = body
-    let recorded = false
-    const tryRecord = (force: boolean) => {
-      if (recorded) return
-      const model = MODEL_FIELD.exec(scan.subarray(0, MODEL_SCAN_BYTES).toString("utf8"))?.[1]
-      if (!force && model === undefined && scan.length < MODEL_SCAN_BYTES) return
-      recorded = true
-      record(requestHead, model)
-    }
-    tryRecord(!requestHead.startsWith("POST"))
-    client.on("end", () => tryRecord(true))
-
-    // A write on a still-connecting socket is queued, so forwarding later chunks
-    // directly would put body bytes ahead of the head and the origin answers 400.
-    let connected = false
-    const pending: Buffer[] = [head.subarray(0, end + 4), body]
-    upstream = tlsConnect({ host: TARGET, port: 443, servername: TARGET }, () => {
-      connected = true
-      for (const queued of pending.splice(0)) if (queued.length > 0) upstream?.write(queued)
-    })
-    client.on("data", (later: Buffer) => {
-      if (!recorded && scan.length < MODEL_SCAN_BYTES) {
-        scan = Buffer.concat([scan, later])
-        tryRecord(false)
+    buffer = Buffer.concat([buffer, chunk])
+    for (;;) {
+      if (bodyRemaining > 0) {
+        const take = Math.min(bodyRemaining, buffer.length)
+        if (scan.length < MODEL_SCAN_BYTES) {
+          scan = Buffer.concat([scan, buffer.subarray(0, Math.min(take, MODEL_SCAN_BYTES - scan.length))])
+        }
+        buffer = buffer.subarray(take)
+        bodyRemaining -= take
+        if (bodyRemaining > 0) return
+        flush()
+        continue
       }
-      if (connected) upstream?.write(later)
-      else pending.push(later)
-    })
-    upstream.on("error", () => client.destroy())
-    upstream.pipe(client)
+      const end = buffer.indexOf("\r\n\r\n")
+      if (end === -1) return
+      head = buffer.subarray(0, end + 4).toString("latin1")
+      buffer = buffer.subarray(end + 4)
+      // Only Content-Length framing can be stepped over exactly. Anything else
+      // desynchronises the parser, so recording stops and the summary says so
+      // rather than reporting heads it may have invented.
+      if (/^transfer-encoding:/im.test(head)) {
+        flush()
+        framed = false
+        unframed += 1
+        return
+      }
+      bodyRemaining = Number(/^content-length:[ \t]*(\d+)/im.exec(head)?.[1] ?? 0)
+      if (bodyRemaining === 0) flush()
+    }
   })
-  client.on("error", () => upstream?.destroy())
+  // A request cut off mid-body still had a head worth checking.
+  client.on("end", flush)
+  client.on("error", () => upstream.destroy())
 })
 
 const proxy = createServer((_request, response) => {
@@ -218,6 +237,12 @@ function summarize() {
         `${unique.length === 0 ? ", head OK" : `, PROBLEMS: ${unique.join("; ")}`}\n` +
         (models.size === 0 ? "" : `    models served: ${[...models].sort().join(", ")}\n`),
     )
+  }
+  // The point of the tool is completeness, so an incomplete run fails rather
+  // than reporting OK over the requests it could not read.
+  if (unframed > 0) {
+    process.stdout.write(`  PROBLEMS: ${unframed} connection(s) used framing this parser cannot follow\n`)
+    failed = true
   }
   if (failed) process.exitCode = 1
 }

--- a/packages/desktop-electron/scripts/zen-wire-capture.ts
+++ b/packages/desktop-electron/scripts/zen-wire-capture.ts
@@ -105,10 +105,12 @@ const tlsServer = createTlsServer({ cert, key }, (client) => {
   // A write on a still-connecting socket is queued, so writing chunks straight
   // through would put body bytes ahead of the head and the origin answers 400.
   let connected = false
+  let clientEnded = false
   const pending: Buffer[] = []
   const upstream = tlsConnect({ host: TARGET, port: 443, servername: TARGET }, () => {
     connected = true
     for (const queued of pending.splice(0)) if (queued.length > 0) upstream.write(queued)
+    if (clientEnded) upstream.end()
   })
   upstream.on("error", () => client.destroy())
   upstream.pipe(client)
@@ -165,8 +167,15 @@ const tlsServer = createTlsServer({ cert, key }, (client) => {
       if (bodyRemaining === 0) flush()
     }
   })
-  // A request cut off mid-body still had a head worth checking.
-  client.on("end", flush)
+  // A request cut off mid-body still had a head worth checking, and the tunnel's
+  // own EOF has to reach the gateway or that upstream socket lingers until the
+  // gateway times it out. Ending waits for `pending`, so a client that closes
+  // before the upstream handshake finishes cannot truncate its own body.
+  client.on("end", () => {
+    flush()
+    clientEnded = true
+    if (connected) upstream.end()
+  })
   client.on("error", () => upstream.destroy())
 })
 

--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -49,14 +49,20 @@ type InstalledOpenCodeModel = { id: string; cost?: { input?: number } }
 // files each model under. This is the upgrade tripwire behind the route split:
 // PawWork names a protocol per route, so a pi-ai release that respells one, or
 // moves a model between them, has to fail here rather than at the gateway.
-function installedOpenCodeCatalog() {
+function installedPiAi() {
   const require = createRequire(import.meta.url)
   const dshPackage = require.resolve("@deepseek-ai/dsh/package.json")
   const webAppPackage = createRequire(dshPackage).resolve("@deepseek-ai/dsh-web-app/package.json")
   const adapterPackage = createRequire(webAppPackage).resolve("@deepseek-ai/dsh-llm-pi-ai/package.json")
-  const piAiRoot = join(dirname(adapterPackage), "..", "..", "@earendil-works", "pi-ai")
-  const catalog = JSON.parse(readFileSync(join(piAiRoot, "dist/providers/data/opencode.json"), "utf8")) as
-    Record<string, Record<string, InstalledOpenCodeModel>>
+  const adapterRoot = dirname(adapterPackage)
+
+  return { adapterRoot, piAiRoot: join(adapterRoot, "..", "..", "@earendil-works", "pi-ai") }
+}
+
+function installedOpenCodeCatalog() {
+  const catalog = JSON.parse(
+    readFileSync(join(installedPiAi().piAiRoot, "dist/providers/data/opencode.json"), "utf8"),
+  ) as Record<string, Record<string, InstalledOpenCodeModel>>
 
   return new Map(Object.entries(catalog).map(([api, models]) => [api, new Map(Object.entries(models))]))
 }
@@ -305,6 +311,43 @@ describe("DSH product home", () => {
 
     expect(modelDefaults.provider).toBe("opencode")
     expect(providerConfig.providers.opencode.models?.map((model) => model.id)).toContain(modelDefaults.model)
+  })
+
+  // The gateway rejects an inference request with no per-conversation id, and three
+  // packages have to agree for one to go out: the patched adapter has to let a route
+  // ask for it, the packaged patch has to ask, and the header the preload restates
+  // has to be the one pi-ai still writes. Each half is silent on its own.
+  test("carries a per-conversation id to the gateway on both routes", async () => {
+    const { adapterRoot, piAiRoot } = installedPiAi()
+    const adapter = readFileSync(join(adapterRoot, "lib/index.js"), "utf8")
+    const { OPENCODE_ZEN_SESSION_SOURCE_HEADER } = (await import(
+      "../../resources/dsh/zen-identity.mjs"
+    )) as { OPENCODE_ZEN_SESSION_SOURCE_HEADER: string }
+    const providerConfig = readProductPatch().find((entry) => entry.id === "llm-pi-ai")?.config as {
+      providers: Record<string, { compat?: { sendSessionAffinityHeaders?: boolean } }>
+    }
+
+    // Scoped to the Completions gate, because the adapter drops a route-level
+    // switch its gate does not offer with a bare `continue`, and asks whether ANY
+    // protocol offers the field before it complains — a question
+    // `anthropic-messages` already answers for this one. So a whole-file match
+    // would go green off another protocol's gate while the route silently sends
+    // nothing.
+    const completionsGate = adapter.indexOf("const COMPLETIONS_COMPAT_GATE = {")
+    expect(completionsGate).toBeGreaterThan(-1)
+    // Upstream withholds this switch; the packaged patch is what reopens it.
+    expect(adapter.slice(completionsGate, adapter.indexOf("\n};", completionsGate))).toContain(
+      'sendSessionAffinityHeaders: "offer"',
+    )
+    // Completions gates the id behind the switch and defaults it off. Responses
+    // sends it unconditionally, which is why only one route names it.
+    expect(providerConfig.providers.opencode.compat?.sendSessionAffinityHeaders).toBe(true)
+    expect(providerConfig.providers["opencode-responses"].compat?.sendSessionAffinityHeaders).toBeUndefined()
+
+    for (const api of ["openai-completions", "openai-responses"]) {
+      const source = readFileSync(join(piAiRoot, `dist/api/${api}.js`), "utf8")
+      expect(source).toContain(`"${OPENCODE_ZEN_SESSION_SOURCE_HEADER}"`)
+    }
   })
 
   test("does not publish the bundled paid DeepSeek route", () => {

--- a/patches/@deepseek-ai__dsh-llm-pi-ai@0.1.2-alpha.5.patch
+++ b/patches/@deepseek-ai__dsh-llm-pi-ai@0.1.2-alpha.5.patch
@@ -1,8 +1,22 @@
 diff --git a/lib/index.js b/lib/index.js
-index 906afd7..3c42cda 100644
+index c25e5c7afcd9381dec2490fbff24910f173281d0..139d623cb1e08c8e5094779d0e5bb2bf17e9056c 100644
 --- a/lib/index.js
 +++ b/lib/index.js
-@@ -2439,7 +2439,16 @@ function directoryEntries(profiles) {
+@@ -386,7 +386,12 @@ const COMPLETIONS_COMPAT_GATE = {
+ 	vercelGatewayRouting: "withhold",
+ 	zaiToolStream: "withhold",
+ 	supportsOpenAIGrammarTools: "withhold",
+-	sendSessionAffinityHeaders: "withhold",
++	/* PawWork patch: let a route ask for the session-affinity headers, which
++	Completions gates off and Responses sends unconditionally. The decision stays
++	in the product patch. The switch also writes `session_id` and
++	`x-session-affinity`; narrowing it to one header would mean opening
++	`sessionAffinityFormat` too. Drop this once upstream offers the field. */
++	sendSessionAffinityHeaders: "offer",
+ 	deferredToolsMode: "withhold",
+ 	sessionAffinityFormat: "withhold"
+ };
+@@ -2447,7 +2464,16 @@ function directoryEntries(profiles) {
  			declared: !catalog.has(provider)
  		});
  	};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ overrides:
   ws: 8.21.0
 
 patchedDependencies:
-  '@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.5': 56f38d6743e843dee8ae545b573be99d831ace3758a4a5dd012e31a0137eb94f
+  '@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.5': 0ade87e255ff73099e5d05206e96ea075460db43a0feb63958ede4b4868d48fb
   brace-expansion@5.0.9: ef72a243d0bee0990f9a97f527cdcbbb43bc8677f6337ac800e6d1df6ecb5a8b
 
 importers:
@@ -7479,7 +7479,7 @@ snapshots:
       '@deepseek-ai/dsh-jobs-local': 0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-alpha.5(fa501c54d1bae9af3acbbd6956a25b22))(@deepseek-ai/dsh-jobs@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-alpha.5(fa501c54d1bae9af3acbbd6956a25b22))(@deepseek-ai/dsh-brand@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)))))(@deepseek-ai/dsh-scope@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-timeout@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-llm': 0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-llm-deepseek': 0.1.2-alpha.5(682374706cf0a3cc3f3794be986a7602)
-      '@deepseek-ai/dsh-llm-pi-ai': 0.1.2-alpha.5(patch_hash=56f38d6743e843dee8ae545b573be99d831ace3758a4a5dd012e31a0137eb94f)(57c1f6dc33e7be5eaa12899f7c7deeac)
+      '@deepseek-ai/dsh-llm-pi-ai': 0.1.2-alpha.5(patch_hash=0ade87e255ff73099e5d05206e96ea075460db43a0feb63958ede4b4868d48fb)(57c1f6dc33e7be5eaa12899f7c7deeac)
       '@deepseek-ai/dsh-llm-retry': 0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-alpha.5(fa501c54d1bae9af3acbbd6956a25b22))(@deepseek-ai/dsh-brand@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session-projection@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-session@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)))))(@deepseek-ai/dsh-session@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-scope@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))))(@deepseek-ai/dsh-timeout@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-permission-presets': 0.1.2-alpha.5(6c66180bcc4683d1c5d422ae1b8bdb8a)
       '@deepseek-ai/dsh-plan-mode': 0.1.2-alpha.5(ed5a0bea44fe24b8ce8b3aa4d17ea17a)
@@ -8150,7 +8150,7 @@ snapshots:
       '@deepseek-ai/schemastery': 3.18.2
       eventsource-parser: 3.1.1
 
-  '@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.5(patch_hash=56f38d6743e843dee8ae545b573be99d831ace3758a4a5dd012e31a0137eb94f)(57c1f6dc33e7be5eaa12899f7c7deeac)':
+  '@deepseek-ai/dsh-llm-pi-ai@0.1.2-alpha.5(patch_hash=0ade87e255ff73099e5d05206e96ea075460db43a0feb63958ede4b4868d48fb)(57c1f6dc33e7be5eaa12899f7c7deeac)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2(@deepseek-ai/cordis-plugin-include@1.0.7)(@deepseek-ai/cordis-plugin-loader@1.0.3)
       '@deepseek-ai/dsh-attachment': 0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-brand@0.1.2-alpha.5(@deepseek-ai/cordis@4.0.2))


### PR DESCRIPTION
## Problem

OpenCode notified this account that requests to its gateway are missing an `x-opencode-session` header, and that from **09/06** requests without it may error. The reported user agent is "JavaScript OpenAI client".

That is us. `pi-ai` reaches the gateway through `openai@6.40.0`, which always sends `X-Stainless-Lang: js` alongside whatever `User-Agent` we set. Confirmed on decrypted traffic — `user-agent: opencode/latest/1.18.15/desktop` and `X-Stainless-Lang: js` are both on the wire, so the preload's identity override is intact and the classification comes from the Stainless headers. Both OpenCode Free routes were sending no session header at all.

## Why three files

The id already exists and already reaches the wire layer. The harness session id travels as `GenerateOptions.sessionId` into `pi-ai`, which writes it onto the request as `x-client-request-id`. From there the two protocols diverge:

| route | protocol | source header before this PR |
| --- | --- | --- |
| `opencode` (big-pickle + 4) | `openai-completions` | none — gated behind `sendSessionAffinityHeaders`, default `false` |
| `opencode-responses` (muse spark) | `openai-responses` | sent unconditionally |

and the DSH adapter marks that switch `"withhold"`, so configuration cannot reach it. One layer each:

1. **`patches/@deepseek-ai__dsh-llm-pi-ai@0.1.2-alpha.5.patch`** — reopen the switch. Widening the gate only restores configurability; no behaviour is decided here. Extends the patch this package already carries, so no new package joins `patchedDependencies`. Drop it once upstream offers the field.
2. **`product.cordis.patch.yml`** — turn it on for the Completions route. Route-level, not per model: the catalog refresh rewrites `models`, so a per-model switch would be dropped and new models would not inherit it. The Responses route names nothing, because it needs nothing.
3. **`zen-identity.mjs`** — restate the id under the name the gateway reads.

The switch also emits `session_id` and `x-session-affinity` beside it. Both were sent to the live gateway and every request completed, so they are carried rather than suppressed; narrowing them would mean opening `sessionAffinityFormat` as well.

## What this deliberately does not do

**No minted ids.** A fresh UUID per request would pass a presence check while destroying the grouping the header exists for. A request with no session — the settings card's model list — sends none.

**No imitation of OpenCode's own `ses_...` scheme.** Their ids are structured, not opaque: `<9 hex, time-ordered><ffe|ffc>` plus 14 base62 chars. Synthesising them means fabricating a timestamp in someone else's id space, with silent collisions as the failure mode — and a synthetic id has to be *stable*, which means persisting a second identity per conversation next to the one already on disk. The notice itself tells other clients to supply their own ids, so nothing requires it.

## Verification

`scripts/zen-wire-capture.ts` terminates TLS for `opencode.ai` with a throwaway CA and reports each request head verbatim, plus the model named in the body. It records rather than redirects: pointing the app at a local recorder would make `isOpenCodeZenUrl` answer false, skip the preload, and measure traffic no user ever sends.

Reading the model off the body is what makes a per-model claim checkable. `SessionPromptRequest` has no `model` field, so a driver that puts one there is ignored without complaint and every turn lands on the session default — that is how the 2026.9.4 note came to report seven verified models on the evidence of one. The model that answered is now read from the wire, not from the driver's own intent.

Real Electron run, real gateway, decrypted, one launch, one tool-calling turn per model:

```
10 Zen requests
  /zen/v1/chat/completions: 8 requests, 5 session id(s), head OK
    models served: big-pickle, ling-3.0-flash-fin-free, mimo-v2.5-free,
                   nemotron-3-ultra-free, nemotron-3.5-lightning-free
  /zen/v1/responses: 2 requests, 2 session id(s), head OK
    models served: muse-spark-1.2-contributor-free, muse-spark-1.3-contributor-free
```

7/7 models completed the turn — write a file, read it back, answer from its contents. "head OK" is the checked claim: every request carried `x-opencode-session` equal to its own `x-client-request-id` (e.g. `session-a1329604-54ba-4ba2-a00b-f96c9e553db8`), one session id per conversation, no duplicate field names, and no malformed field name or value under RFC 9110. The `/models` path is the one path allowed to omit the header, because it carries no conversation.

The value is a short opaque ASCII token either way: `session-<uuid>` for a native session, `pawwork-v1-ses_...` for an imported one.

`pnpm test` (531 vitest + 157 node), `typecheck`, `lint` all pass.

## Sentinel

`dsh-product-home.test.ts` fails if a DSH upgrade drops the patch, if the product patch stops asking, or if `pi-ai` renames the header the preload reads. The gate assertion is scoped to `COMPLETIONS_COMPAT_GATE` on purpose: the runtime failure on this path is silent — `resolveModelCompat` drops a route-level field its gate does not offer with a bare `continue`, and `assertOfferedCompatFields` only asks whether *any* protocol offers the field, which `anthropic-messages` already answers for. A whole-file match would go green off another protocol's gate while the route sent nothing.

## Follow-up

This needs a release before 09/06. Release verification runs the capture against the signed, notarized artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conversation requests now preserve session affinity across catalog refreshes, improving continuity for OpenCode Free completions.
  - OpenCode Zen requests consistently associate responses with the active conversation when session information is available.
  - Provider listings now show providers available through the supported API-key sign-in flow.

- **Bug Fixes**
  - Improved request handling across reused connections and session headers for more reliable model interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
