### PR TITLE
fix(desktop): raise the verified community market floor to 1.44.0

### DIFF
--- a/packages/desktop-electron/src/main/dsh-market-guard.test.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.test.ts
@@ -63,7 +63,7 @@ function guard(
     messages,
     kills,
     notices: () => notices,
-    run: (verifiedVersion = "1.39.0") => ensureVerifiedCommunityMarket({
+    run: (verifiedVersion = VERIFIED_COMMUNITY_MARKET.market) => ensureVerifiedCommunityMarket({
       dshBin: "/app/dsh/bin.js",
       env: { DSH_HOME: "/home/u/.pawwork/dsh" },
       executable: "/app/PawWork",
@@ -137,7 +137,7 @@ describe("ensureVerifiedCommunityMarket", () => {
 
     expect(harness.spawns).toEqual([{
       executable: "/app/PawWork",
-      args: ["/app/dsh/bin.js", "plugin", "--profile", "web", "add", "dshmarket@1.39.0"],
+      args: ["/app/dsh/bin.js", "plugin", "--profile", "web", "add", `dshmarket@${VERIFIED_COMMUNITY_MARKET.market}`],
       options: {
         cwd: expect.stringContaining("pawwork-market-guard-") as unknown,
         detached: true,
@@ -153,7 +153,10 @@ describe("ensureVerifiedCommunityMarket", () => {
   })
 
   test("does nothing, and says nothing, on a normal start", async () => {
-    const harness = guard(profileWith({ declared: "1.39.0", installed: "1.39.0" }))
+    const harness = guard(profileWith({
+      declared: VERIFIED_COMMUNITY_MARKET.market,
+      installed: VERIFIED_COMMUNITY_MARKET.market,
+    }))
 
     await harness.run()
 

--- a/packages/desktop-electron/src/main/dsh-market-guard.ts
+++ b/packages/desktop-electron/src/main/dsh-market-guard.ts
@@ -15,7 +15,7 @@ const MARKET_NAME = "dshmarket"
  */
 export const VERIFIED_COMMUNITY_MARKET = {
   dsh: "0.1.2-rc.1",
-  market: "1.39.0",
+  market: "1.44.0",
 } as const
 
 // Bounds the wait on the startup page. Overrunning it is not fatal.


### PR DESCRIPTION
## Summary
- Raise `VERIFIED_COMMUNITY_MARKET` from dshmarket 1.39.0 to 1.44.0 so the next launch upgrades with `dsh plugin add dshmarket@1.44.0`.
- The in-app Update button still sends `@latest`; on 1.39 that hits pnpm `minimumReleaseAge`, lands on N−1, and `RESOLVED_VERSION_MISMATCH` rolls back to 1.39 (dsh-market/dsh-market#531, related #496). Exact add at boot skips that path.
- Guard tests now read the pin instead of a hardcoded 1.39.0.

## Test plan
- [x] `vitest run src/main/dsh-market-guard.test.ts` (14 passed)
- [x] Local `dsh plugin --profile web add dshmarket@1.44.0` installed 1.44.0
- [ ] Cold-start PawWork with a 1.39.0 market still in the profile; confirm the startup upgrade lands on 1.44.0
- [ ] Open Settings → 插件市场 and confirm the header shows v1.44.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the verified Community Market release to version 1.44.0.
  * Desktop installations below this version will now be directed to the newer verified market release when required.
  * Updated related validation checks to use the current verified market version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->