### PR TITLE
fix(desktop): restore minimal-preset bash in packaged macOS builds

### DIFF
--- a/packages/desktop-electron/electron-builder-app-update.test.ts
+++ b/packages/desktop-electron/electron-builder-app-update.test.ts
@@ -42,6 +42,7 @@ afterEach(() => {
 describe("electron builder app-update config", () => {
   test("packages only the DSH production entry", () => {
     const config = createConfig("prod")
+    expect(config.asar).toBe(false)
     const extraResources = config.extraResources
     if (!Array.isArray(extraResources)) throw new Error("extraResources must be a list")
     const dshResources = extraResources.find((resource) => typeof resource === "object" && resource.to === "dsh/")

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -33,10 +33,9 @@ const repositoryUrl = (channel: PawWorkChannel) => `https://github.com/Astro-Han
 
 const getBase = (channel: PawWorkChannel): Configuration => ({
   artifactName: "pawwork-${os}-${arch}-${version}.${ext}",
-  // DSH maintains real symlinks from its user profile to the installed
-  // dependency closure. Keep dependencies outside the virtual ASAR filesystem
-  // so those links remain traversable in packaged builds.
-  asarUnpack: ["node_modules/**/*"],
+  // The plain-Node sidecar needs real dependency paths. An app.asar.unpacked
+  // directory also triggers node-pty's ASAR rewrite a second time.
+  asar: false,
   directories: {
     output: "dist",
     buildResources: "resources",

--- a/packages/desktop-electron/src/main/dsh-product-home.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.test.ts
@@ -71,7 +71,7 @@ describe("DSH product home", () => {
   test("uses external packaged resources and source resources in development", () => {
     expect(
       resolveProductResources({
-        appPath: "/Applications/PawWork.app/Contents/Resources/app.asar",
+        appPath: "/Applications/PawWork.app/Contents/Resources/app",
         isPackaged: true,
         resourcesPath: "/Applications/PawWork.app/Contents/Resources",
       }),
@@ -101,7 +101,7 @@ describe("DSH product home", () => {
     ).toBe(
       join(
         "/Applications/PawWork.app/Contents/Resources",
-        "app.asar.unpacked",
+        "app",
         "node_modules",
         "@deepseek-ai",
         "dsh",
@@ -127,7 +127,7 @@ describe("DSH product home", () => {
       }),
     ).toBe(join(
       "/Applications/PawWork.app/Contents/Resources",
-      "app.asar.unpacked",
+      "app",
       "node_modules",
       "pnpm",
       "package.json",
@@ -180,7 +180,7 @@ describe("DSH product home", () => {
       "/repo/app/node_modules",
     )
     expect(resolveHostModules({ appPath: "/ignored", isPackaged: true, resourcesPath: "/r" })).toBe(
-      "/r/app.asar.unpacked/node_modules",
+      "/r/app/node_modules",
     )
   })
 

--- a/packages/desktop-electron/src/main/dsh-product-home.ts
+++ b/packages/desktop-electron/src/main/dsh-product-home.ts
@@ -49,7 +49,7 @@ export function resolveDshPackagePath(options: ResolveDshPackagePathOptions) {
   if (!options.isPackaged) return options.resolveDevelopmentPackage()
   return join(
     options.resourcesPath,
-    "app.asar.unpacked",
+    "app",
     "node_modules",
     "@deepseek-ai",
     "dsh",
@@ -59,7 +59,7 @@ export function resolveDshPackagePath(options: ResolveDshPackagePathOptions) {
 
 export function resolvePnpmPackagePath(options: ResolvePnpmPackagePathOptions) {
   if (!options.isPackaged) return options.resolveDevelopmentPackage()
-  return join(options.resourcesPath, "app.asar.unpacked", "node_modules", "pnpm", "package.json")
+  return join(options.resourcesPath, "app", "node_modules", "pnpm", "package.json")
 }
 
 // The app's own module tree, not the tree the installed `dsh` package sits in:
@@ -68,7 +68,7 @@ export function resolvePnpmPackagePath(options: ResolvePnpmPackagePathOptions) {
 // needs to reach is what *this* package declared.
 export function resolveHostModules(options: ResolveProductResourcesOptions) {
   return options.isPackaged
-    ? join(options.resourcesPath, "app.asar.unpacked", "node_modules")
+    ? join(options.resourcesPath, "app", "node_modules")
     : join(options.appPath, "node_modules")
 }
 


### PR DESCRIPTION
The minimal preset cannot run any bash command in the macOS packaged app: node-pty rewrites its already-real `app.asar.unpacked` path to `app.asar.unpacked.unpacked`, then fails to spawn its helper. Fixes #1648.

Disable ASAR and keep one real application tree under `Resources/app`. DSH, bundled pnpm and the host dependency scope now resolve from `app/node_modules`; existing profile links are rebuilt by the current startup logic. Dependencies were already fully unpacked, so this removes the archive boundary without patching node-pty or adding a migration path.

Validation:
- Reproduced the installed 2026.9.4 minimal-preset bash failure through CDP. The same node-pty bytes execute successfully when copied outside the ASAR-named directory.
- Built the macOS arm64 app locally without signing/notarization. In that packaged app, the minimal preset ran `echo PAWWORK_PTY_OK` through the real bash tool and the turn completed successfully.
- Seeded a profile with its host scope link pointing to the old installed `app.asar.unpacked` tree; startup repointed it to the new `app/node_modules` tree.
- Packaged CDP smoke passed, including the free-model turn, session persistence after restart, and V1 session/Automation migration.
- Updated existing packaging/path assertions: four fail on the original implementation and pass with the fix. No behavioral tests removed. All 531 Vitest, 157 product Node and 10 label-policy tests pass; typecheck and lint pass.
- Windows packaging validation will run in CI; no local Windows build or signed release acceptance is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaged desktop app resource resolution by using the unpacked application directory.
  * Ensured package discovery and host module loading work correctly in production builds.

* **Refactor**
  * Updated desktop application packaging to disable ASAR archives, providing direct access to packaged resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->