### PR TITLE
chore(release): prepare 2026.9.5

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.9.4",
+  "version": "2026.9.5",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
Bump the desktop package version for the OpenCode Free session-header fix, macOS minimal-preset bash fix, and merged DSH/community-market compatibility updates. Signed artifact acceptance runs before the remaining release targets are built and the draft is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application version to 2026.9.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->