### PR TITLE
fix(desktop): paint every window surface in the app's own scheme

### DIFF
--- a/packages/desktop-electron/scripts/ci-smoke.ts
+++ b/packages/desktop-electron/scripts/ci-smoke.ts
@@ -1192,7 +1192,7 @@ export function assertCiSmokeProduct(snapshot: CiSmokeProductSnapshot, platform:
   // Assert relationships, never a height: that number is owned by Chromium on Windows and by the
   // main process on macOS. frameless is read from window-options, a different source than the
   // rendered drag strip, so the two diverging goes red.
-  const frameless = "titleBarStyle" in dshTitleBarOptions(platform)
+  const frameless = "titleBarStyle" in dshTitleBarOptions(platform, "light")
   const titlebarInsetsMatchPlatform = platform === "darwin"
     ? snapshot.titlebarInsetLeft > 0 && snapshot.titlebarInsetRight === 0
     : platform === "win32"

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module"
 import { loadDshClientModule } from "./dsh-client-module.testing"
 import { resolve } from "node:path"
 import { describe, expect, vi, test } from "vitest"
+import { windowSurfaceColor } from "./window-options"
 
 const repositoryRoot = resolve(import.meta.dirname, "../../../..")
 const productRoot = resolve(repositoryRoot, "packages/desktop-electron/resources/dsh/product")
@@ -217,6 +218,26 @@ describe("PawWork DSH client product layer", () => {
     expect(collapsedWidth).toBeDefined()
     expect(css).toContain(`--pawwork-dsh-collapsed-sidebar-width: ${collapsedWidth}px;`)
     expect(css).toMatch(/calc\(var\(--pawwork-titlebar-inset-left\) \+ 44px - var\(--pawwork-dsh-collapsed-sidebar-width\)\)/)
+  })
+
+  // The main process paints the native surfaces from its own copy of these two
+  // colours, because they have to be on screen before the web app's stylesheet
+  // exists. That copy is only correct while DSH still resolves bg-base to them,
+  // and the preload only learns the theme because the boot script writes it to
+  // documentElement.style. Both are DSH's to change, so an upgrade that moves
+  // either one fails here instead of shipping a white edge to Windows users.
+  test("pins the DSH theme contracts the native window surfaces mirror", () => {
+    const requireFromTest = createRequire(import.meta.url)
+    const requireFromDsh = createRequire(requireFromTest.resolve("@deepseek-ai/dsh/package.json"))
+    const themeRoot = resolve(requireFromDsh.resolve("@deepseek-ai/dsh-client-ui-theme/package.json"), "..")
+    const client = readFileSync(resolve(themeRoot, "lib/client.js"), "utf8")
+    const boot = readFileSync(resolve(themeRoot, "lib/index.js"), "utf8")
+
+    expect(client).toContain("--dsw-alias-bg-base:var(--dsw-static-neutral-bluish-00)")
+    expect(client).toContain(`--dsw-static-neutral-bluish-00:${windowSurfaceColor("light")}`)
+    expect(client).toContain("--dsw-alias-bg-base:var(--dsw-static-neutral-bluish-950)")
+    expect(client).toContain(`--dsw-static-neutral-bluish-950:${windowSurfaceColor("dark")}`)
+    expect(boot).toContain("document.documentElement.style.colorScheme = dark ? 'dark' : 'light'")
   })
 
   test("owns the public brand slots and replaces the DSH welcome notice", () => {

--- a/packages/desktop-electron/src/main/dsh-product-client.test.ts
+++ b/packages/desktop-electron/src/main/dsh-product-client.test.ts
@@ -3,7 +3,7 @@ import { createRequire } from "node:module"
 import { loadDshClientModule } from "./dsh-client-module.testing"
 import { resolve } from "node:path"
 import { describe, expect, vi, test } from "vitest"
-import { windowSurfaceColor } from "./window-options"
+import { SURFACE_COLOR } from "./window-options"
 
 const repositoryRoot = resolve(import.meta.dirname, "../../../..")
 const productRoot = resolve(repositoryRoot, "packages/desktop-electron/resources/dsh/product")
@@ -220,24 +220,32 @@ describe("PawWork DSH client product layer", () => {
     expect(css).toMatch(/calc\(var\(--pawwork-titlebar-inset-left\) \+ 44px - var\(--pawwork-dsh-collapsed-sidebar-width\)\)/)
   })
 
-  // The main process paints the native surfaces from its own copy of these two
-  // colours, because they have to be on screen before the web app's stylesheet
-  // exists. That copy is only correct while DSH still resolves bg-base to them,
-  // and the preload only learns the theme because the boot script writes it to
-  // documentElement.style. Both are DSH's to change, so an upgrade that moves
-  // either one fails here instead of shipping a white edge to Windows users.
+  // The main process paints the native window surfaces from its own copy of
+  // these two colours, because they have to be on screen before the web app's
+  // stylesheet exists, and it repaints them from what the preload reads out of
+  // documentElement.style. Both halves are DSH's to change, so an upgrade that
+  // moves either fails here instead of shipping a white edge to Windows users.
+  // Each colour is matched through the selector that resolves bg-base to it and
+  // up to its terminator, so a re-mapped or merely nearby value cannot pass.
   test("pins the DSH theme contracts the native window surfaces mirror", () => {
     const requireFromTest = createRequire(import.meta.url)
     const requireFromDsh = createRequire(requireFromTest.resolve("@deepseek-ai/dsh/package.json"))
     const themeRoot = resolve(requireFromDsh.resolve("@deepseek-ai/dsh-client-ui-theme/package.json"), "..")
+    const layoutRoot = resolve(requireFromDsh.resolve("@deepseek-ai/dsh-client-ui-layout/package.json"), "..")
     const client = readFileSync(resolve(themeRoot, "lib/client.js"), "utf8")
     const boot = readFileSync(resolve(themeRoot, "lib/index.js"), "utf8")
+    const layout = readFileSync(resolve(layoutRoot, "lib/client.js"), "utf8")
 
-    expect(client).toContain("--dsw-alias-bg-base:var(--dsw-static-neutral-bluish-00)")
-    expect(client).toContain(`--dsw-static-neutral-bluish-00:${windowSurfaceColor("light")}`)
-    expect(client).toContain("--dsw-alias-bg-base:var(--dsw-static-neutral-bluish-950)")
-    expect(client).toContain(`--dsw-static-neutral-bluish-950:${windowSurfaceColor("dark")}`)
+    expect(client).toContain("body{--dsw-alias-bg-base:var(--dsw-static-neutral-bluish-00)")
+    expect(client).toContain(`--dsw-static-neutral-bluish-00:${SURFACE_COLOR.light};`)
+    expect(client).toContain("body[data-ds-dark-theme]{--dsw-alias-bg-base:var(--dsw-static-neutral-bluish-950)")
+    expect(client).toContain(`--dsw-static-neutral-bluish-950:${SURFACE_COLOR.dark};`)
+    // A third rule would decide the colour for some state the window cannot see.
+    expect(client.match(/--dsw-alias-bg-base:/g)).toHaveLength(2)
+    // The boot script covers the first frame only; every later change is the
+    // layout plugin's presenter, and that is the write the preload observes.
     expect(boot).toContain("document.documentElement.style.colorScheme = dark ? 'dark' : 'light'")
+    expect(layout).toContain("document.documentElement.style.colorScheme = scheme")
   })
 
   test("owns the public brand slots and replaces the DSH welcome notice", () => {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -6,7 +6,7 @@ import { createRequire } from "node:module"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
-import { app, BrowserWindow, dialog, ipcMain, shell, type Event } from "electron"
+import { app, BrowserWindow, dialog, ipcMain, nativeTheme, shell, type Event } from "electron"
 import contextMenu from "electron-context-menu"
 import pkg from "electron-updater"
 import { PAWWORK_APP } from "./app-identity"
@@ -45,14 +45,8 @@ import { createUpdaterController } from "./updater"
 import { createUpdateScheduler } from "./updater-scheduler"
 import { pendingUpdateCacheDir } from "./updater-cache"
 import { readStartupColorScheme, writeStartupColorScheme } from "./startup-theme"
-import {
-  createMainWindow,
-  navigateWindow,
-  setDockIcon,
-  setTitlebarColorScheme,
-  startupUrl,
-  type StartupColorScheme,
-} from "./windows"
+import type { WindowColorScheme } from "./window-options"
+import { applyWindowColorScheme, createMainWindow, navigateWindow, setDockIcon, startupUrl } from "./windows"
 
 contextMenu({ showSaveImageAs: true, showLookUpSelection: false, showSearchWithGoogle: false })
 
@@ -142,7 +136,14 @@ let dshOutputTail = ""
 // Set by launchDsh: the recovery path needs the profile directory, and the home
 // is only settled once the migration inside launchDsh has run.
 let dshHome: string | undefined
-let startupColorScheme: StartupColorScheme | undefined = readStartupColorScheme(STARTUP_THEME_FILE)
+// DSH owns the appearance but only says so once its page is up, so what it
+// published last time stands in until then, and the system appearance until
+// there is one. Asked per use, never resolved once: `nativeTheme` means nothing
+// before the app is ready and follows the OS while we run.
+let publishedColorScheme: WindowColorScheme | undefined = readStartupColorScheme(STARTUP_THEME_FILE)
+function windowColorScheme(): WindowColorScheme {
+  return publishedColorScheme ?? (nativeTheme.shouldUseDarkColors ? "dark" : "light")
+}
 let currentProgress: number | null = null
 const dshHostToken = randomUUID()
 
@@ -284,11 +285,12 @@ function setupApp() {
   })
   ipcMain.on("pawwork:titlebar-color-scheme", (event, colorScheme) => {
     if (event.senderFrame !== event.sender.mainFrame) return
-    const owner = BrowserWindow.fromWebContents(event.sender)
-    if (owner) setTitlebarColorScheme(owner, process.platform, colorScheme)
     if (colorScheme !== "dark" && colorScheme !== "light") return
-    if (colorScheme === startupColorScheme) return
-    startupColorScheme = colorScheme
+    // The theme is one user setting, so every window follows the one that
+    // reported it, including any still sitting on the startup page.
+    for (const win of liveWindows()) applyWindowColorScheme(win, process.platform, colorScheme)
+    if (colorScheme === publishedColorScheme) return
+    publishedColorScheme = colorScheme
     writeStartupColorScheme(STARTUP_THEME_FILE, colorScheme)
   })
 
@@ -429,7 +431,7 @@ function dshUrl() {
 }
 
 function showStartupPage(notice?: string) {
-  for (const win of liveWindows()) navigateWindow(win, startupUrl(startupColorScheme, notice))
+  for (const win of liveWindows()) navigateWindow(win, startupUrl(windowColorScheme(), notice))
 }
 
 async function showDshFailure(state: Extract<DshLifecycleState, { phase: "failed" }>) {
@@ -650,7 +652,7 @@ function openMainWindow() {
   const win = createMainWindow({
     preload: productPreload,
     dshUrl,
-    startupColorScheme,
+    colorScheme: windowColorScheme(),
   })
   if (currentProgress !== null) win.setProgressBar(currentProgress)
   return win

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -136,10 +136,8 @@ let dshOutputTail = ""
 // Set by launchDsh: the recovery path needs the profile directory, and the home
 // is only settled once the migration inside launchDsh has run.
 let dshHome: string | undefined
-// DSH owns the appearance but only says so once its page is up, so what it
-// published last time stands in until then, and the system appearance until
-// there is one. Asked per use, never resolved once: `nativeTheme` means nothing
-// before the app is ready and follows the OS while we run.
+// Asked per use, never resolved once: `nativeTheme` means nothing before the
+// app is ready.
 let publishedColorScheme: WindowColorScheme | undefined = readStartupColorScheme(STARTUP_THEME_FILE)
 function windowColorScheme(): WindowColorScheme {
   return publishedColorScheme ?? (nativeTheme.shouldUseDarkColors ? "dark" : "light")
@@ -286,8 +284,8 @@ function setupApp() {
   ipcMain.on("pawwork:titlebar-color-scheme", (event, colorScheme) => {
     if (event.senderFrame !== event.sender.mainFrame) return
     if (colorScheme !== "dark" && colorScheme !== "light") return
-    // The theme is one user setting, so every window follows the one that
-    // reported it, including any still sitting on the startup page.
+    // One user setting, so every window's native surfaces follow the window
+    // that reported it, not just that window's own.
     for (const win of liveWindows()) applyWindowColorScheme(win, process.platform, colorScheme)
     if (colorScheme === publishedColorScheme) return
     publishedColorScheme = colorScheme

--- a/packages/desktop-electron/src/main/startup-theme.ts
+++ b/packages/desktop-electron/src/main/startup-theme.ts
@@ -1,11 +1,11 @@
 import { readFileSync, writeFileSync } from "node:fs"
-import type { StartupColorScheme } from "./windows"
+import type { WindowColorScheme } from "./window-options"
 
-// The appearance the product last published, kept across runs so the startup
-// page can match the app someone is about to see rather than their OS. It is a
-// cache, not settings: DSH owns the real preference, and a missing or damaged
-// file only costs one launch of the system default.
-export function readStartupColorScheme(path: string): StartupColorScheme | undefined {
+// The appearance the product last published, kept across runs so a window can
+// be painted to match the app someone is about to see rather than their OS. It
+// is a cache, not settings: DSH owns the real preference, and a missing or
+// damaged file only costs one launch of the system appearance.
+export function readStartupColorScheme(path: string): WindowColorScheme | undefined {
   try {
     const scheme = (JSON.parse(readFileSync(path, "utf8")) as { colorScheme?: unknown }).colorScheme
     return scheme === "dark" || scheme === "light" ? scheme : undefined
@@ -14,7 +14,7 @@ export function readStartupColorScheme(path: string): StartupColorScheme | undef
   }
 }
 
-export function writeStartupColorScheme(path: string, scheme: StartupColorScheme) {
+export function writeStartupColorScheme(path: string, scheme: WindowColorScheme) {
   try {
     writeFileSync(path, `${JSON.stringify({ colorScheme: scheme })}\n`, "utf8")
   } catch {

--- a/packages/desktop-electron/src/main/window-options.ts
+++ b/packages/desktop-electron/src/main/window-options.ts
@@ -1,10 +1,22 @@
 import { TITLEBAR_HEIGHT } from "./window-chrome.ts"
 
-export type TitlebarColorScheme = "light" | "dark"
+export type WindowColorScheme = "light" | "dark"
 
-export function titleBarOverlayStyle(colorScheme: TitlebarColorScheme) {
+// Every surface the window shows before the web app's own stylesheet applies —
+// the native window background, the Windows caption overlay, the startup page —
+// has to be the colour the web app is about to paint, or the difference shows as
+// a flash or a permanent white strip. These are DSH's `--dsw-alias-bg-base`; a
+// test in dsh-product-client.test.ts fails if the installed theme moves.
+const SURFACE_COLOR: Record<WindowColorScheme, string> = { light: "#fff", dark: "#151517" }
+
+export function windowSurfaceColor(colorScheme: WindowColorScheme) {
+  return SURFACE_COLOR[colorScheme]
+}
+
+export function titleBarOverlayStyle(colorScheme: WindowColorScheme) {
   return {
     height: TITLEBAR_HEIGHT,
+    color: SURFACE_COLOR[colorScheme],
     symbolColor: colorScheme === "dark" ? "#f0f0f0" : "#1f2328",
   }
 }
@@ -18,9 +30,9 @@ export function dshWebPreferences(preload: string) {
   }
 }
 
-export function dshTitleBarOptions(platform: NodeJS.Platform) {
+export function dshTitleBarOptions(platform: NodeJS.Platform, colorScheme: WindowColorScheme) {
   if (platform === "win32") {
-    return { titleBarOverlay: { height: TITLEBAR_HEIGHT }, titleBarStyle: "hidden" as const }
+    return { titleBarOverlay: titleBarOverlayStyle(colorScheme), titleBarStyle: "hidden" as const }
   }
   if (platform === "darwin") return { titleBarStyle: "hidden" as const }
   return {}

--- a/packages/desktop-electron/src/main/window-options.ts
+++ b/packages/desktop-electron/src/main/window-options.ts
@@ -4,14 +4,9 @@ export type WindowColorScheme = "light" | "dark"
 
 // Every surface the window shows before the web app's own stylesheet applies —
 // the native window background, the Windows caption overlay, the startup page —
-// has to be the colour the web app is about to paint, or the difference shows as
-// a flash or a permanent white strip. These are DSH's `--dsw-alias-bg-base`; a
-// test in dsh-product-client.test.ts fails if the installed theme moves.
-const SURFACE_COLOR: Record<WindowColorScheme, string> = { light: "#fff", dark: "#151517" }
-
-export function windowSurfaceColor(colorScheme: WindowColorScheme) {
-  return SURFACE_COLOR[colorScheme]
-}
+// is painted from here, and all of them have to agree. New values come from
+// DSH's `--dsw-alias-bg-base`, in both of its themes.
+export const SURFACE_COLOR = { light: "#fff", dark: "#151517" } as const satisfies Record<WindowColorScheme, string>
 
 export function titleBarOverlayStyle(colorScheme: WindowColorScheme) {
   return {

--- a/packages/desktop-electron/src/main/windows-security.test.ts
+++ b/packages/desktop-electron/src/main/windows-security.test.ts
@@ -18,6 +18,11 @@ describe("desktop windows security", () => {
       titleBarOverlay: { height: 32, color: "#151517", symbolColor: "#f0f0f0" },
       titleBarStyle: "hidden",
     })
+    // Both schemes, or a caption strip hard-coded to one of them still passes.
+    expect(dshTitleBarOptions("win32", "light")).toEqual({
+      titleBarOverlay: { height: 32, color: "#fff", symbolColor: "#1f2328" },
+      titleBarStyle: "hidden",
+    })
     expect(dshTitleBarOptions("darwin", "dark")).toEqual({ titleBarStyle: "hidden" })
   })
 })

--- a/packages/desktop-electron/src/main/windows-security.test.ts
+++ b/packages/desktop-electron/src/main/windows-security.test.ts
@@ -14,10 +14,10 @@ describe("desktop windows security", () => {
   })
 
   test("Windows uses system caption buttons over the frameless DSH shell", () => {
-    expect(dshTitleBarOptions("win32")).toEqual({
-      titleBarOverlay: { height: 32 },
+    expect(dshTitleBarOptions("win32", "dark")).toEqual({
+      titleBarOverlay: { height: 32, color: "#151517", symbolColor: "#f0f0f0" },
       titleBarStyle: "hidden",
     })
-    expect(dshTitleBarOptions("darwin")).toEqual({ titleBarStyle: "hidden" })
+    expect(dshTitleBarOptions("darwin", "dark")).toEqual({ titleBarStyle: "hidden" })
   })
 })

--- a/packages/desktop-electron/src/main/windows.test.ts
+++ b/packages/desktop-electron/src/main/windows.test.ts
@@ -53,7 +53,9 @@ const win = vi.hoisted(() => ({
   isFullScreen: () => win.fullscreen,
   setTitle: () => {},
   setTitleBarOverlay: vi.fn(() => {}),
+  setBackgroundColor: vi.fn(() => {}),
   show: () => {},
+  created: [] as Record<string, unknown>[],
   loaded: [] as string[],
   async loadURL(url: string) {
     win.loaded.push(url)
@@ -65,12 +67,16 @@ const openExternal = vi.hoisted(() => vi.fn(async () => {}))
 vi.mock("electron", () => ({
   app: { isPackaged: false, dock: undefined },
   BrowserWindow: class {
+    constructor(options: Record<string, unknown>) {
+      win.created.push(options)
+    }
     webContents = webContents
     on = win.on
     once = win.once
     isFullScreen = win.isFullScreen
     setTitle = win.setTitle
     setTitleBarOverlay = win.setTitleBarOverlay
+    setBackgroundColor = win.setBackgroundColor
     show = win.show
     loadURL = win.loadURL
   },
@@ -83,14 +89,15 @@ vi.mock("electron-window-state", () => ({
   default: () => ({ x: 0, y: 0, width: 1280, height: 800, manage: () => {} }),
 }))
 
-const { createMainWindow, setTitlebarColorScheme, startupUrl } = await import("./windows")
+const { applyWindowColorScheme, createMainWindow, startupUrl } = await import("./windows")
 
 const DSH = "http://127.0.0.1:4321/"
 
-function openWindow(dshUrl?: string) {
-  webContents.url = dshUrl ?? startupUrl()
+function openWindow(dshUrl?: string, colorScheme: "light" | "dark" = "light") {
+  webContents.url = dshUrl ?? startupUrl(colorScheme)
   return createMainWindow({
     preload: "/preload.cjs",
+    colorScheme,
     dshUrl: () => dshUrl,
   })
 }
@@ -104,7 +111,9 @@ beforeEach(() => {
   win.fullscreen = false
   webContents.url = ""
   win.loaded.length = 0
+  win.created.length = 0
   win.setTitleBarOverlay.mockClear()
+  win.setBackgroundColor.mockClear()
   openExternal.mockClear()
 })
 
@@ -115,16 +124,37 @@ function navigate(url: string, isMainFrame: boolean) {
 }
 
 describe("main window wiring", () => {
-  test("updates Windows caption symbols from the web app theme", () => {
-    setTitlebarColorScheme(win, "win32", "dark")
+  // Whatever has not been painted by the web app yet is one of these surfaces,
+  // so a scheme that reaches only some of them is the white edge users report.
+  test("repaints the window background and the Windows caption overlay together", () => {
+    applyWindowColorScheme(win, "win32", "dark")
 
+    expect(win.setBackgroundColor).toHaveBeenCalledWith("#151517")
     expect(win.setTitleBarOverlay).toHaveBeenCalledWith({
       height: 32,
+      color: "#151517",
       symbolColor: "#f0f0f0",
     })
-    setTitlebarColorScheme(win, "darwin", "light")
-    setTitlebarColorScheme(win, "win32", "sepia")
+    // The overlay is a Windows control; elsewhere only the background exists.
+    applyWindowColorScheme(win, "darwin", "light")
+    expect(win.setBackgroundColor).toHaveBeenLastCalledWith("#fff")
     expect(win.setTitleBarOverlay).toHaveBeenCalledTimes(1)
+  })
+
+  // The window is restored at the size of the last run, so its first frame is a
+  // full window of whatever this colour is.
+  test("creates the window on the scheme it will be shown in", () => {
+    openWindow(undefined, "dark")
+
+    expect(win.created[0]).toMatchObject({ backgroundColor: "#151517", show: false })
+    expect(decodeURIComponent(win.loaded[0]!)).toContain("color-scheme:dark")
+  })
+
+  // Chromium paints its own canvas white until a declared scheme says otherwise,
+  // and the page's dark background has to be the one DSH is about to paint.
+  test("declares the startup page's scheme and matches the web app's surface", () => {
+    expect(decodeURIComponent(startupUrl("dark"))).toContain(":root{color-scheme:dark;--bg:#151517;")
+    expect(decodeURIComponent(startupUrl("light"))).toContain(":root{color-scheme:light;--bg:#fff;")
   })
 
   test("holds a subframe to the DSH origin", () => {
@@ -160,7 +190,7 @@ describe("main window wiring", () => {
   // the meantime; loading nothing is what the 30-second blank start used to be.
   test("opens on the local startup page until DSH has a URL", () => {
     openWindow()
-    expect(win.loaded).toEqual([startupUrl()])
+    expect(win.loaded).toEqual([startupUrl("light")])
 
     win.loaded.length = 0
     openWindow(DSH)
@@ -190,7 +220,7 @@ describe("main window wiring", () => {
   // was showing a moment before it died.
   test("denies every DSH-origin navigation once the runtime is gone", () => {
     openWindow()
-    webContents.url = startupUrl()
+    webContents.url = startupUrl("light")
 
     expect(navigate("http://127.0.0.1:4321/settings", true).preventDefault).toHaveBeenCalled()
     expect(navigate("http://127.0.0.1:4321/settings", false).preventDefault).toHaveBeenCalled()

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -8,9 +8,9 @@ import { decideDshNavigation, guardDshNavigation, handleDshWindowOpen } from "./
 import {
   dshTitleBarOptions,
   dshWebPreferences,
+  SURFACE_COLOR,
   titleBarOverlayStyle,
   type WindowColorScheme,
-  windowSurfaceColor,
 } from "./window-options"
 
 const root = dirname(fileURLToPath(import.meta.url))
@@ -27,14 +27,14 @@ const HTML_ESCAPES: Record<string, string> = {
 const escapeHtml = (text: string) => text.replace(/[&<>"']/g, (character) => HTML_ESCAPES[character] ?? character)
 
 // The spinner track and the notice text, which have no equivalent in the web
-// app to borrow. The background does, so it comes from the shared surface.
+// app to borrow.
 const STARTUP_PALETTE: Record<WindowColorScheme, { line: string; muted: string }> = {
   light: { line: "#e3e3e7", muted: "#6b6b70" },
   dark: { line: "#2d2d31", muted: "#a1a1a6" },
 }
 
 const startupHtml = (scheme: WindowColorScheme, notice?: string) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
-:root{color-scheme:${scheme};--bg:${windowSurfaceColor(scheme)};--line:${
+:root{color-scheme:${scheme};--bg:${SURFACE_COLOR[scheme]};--line:${
   STARTUP_PALETTE[scheme].line
 };--accent:#fc5c14;--muted:${STARTUP_PALETTE[scheme].muted}}
 html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);display:flex;flex-direction:column;gap:16px;justify-content:center}
@@ -81,17 +81,13 @@ type MainWindowOptions = {
   dshUrl: () => string | undefined
 }
 
-/**
- * Repaints an open window's native surfaces. They move together: one left on
- * the previous scheme is an edge the user sees. The caption overlay is a
- * Windows control; elsewhere only the background exists.
- */
+// The overlay is a Windows control; elsewhere only the background exists.
 export function applyWindowColorScheme(
   win: Pick<BrowserWindow, "setBackgroundColor" | "setTitleBarOverlay">,
   platform: NodeJS.Platform,
   colorScheme: WindowColorScheme,
 ) {
-  win.setBackgroundColor(windowSurfaceColor(colorScheme))
+  win.setBackgroundColor(SURFACE_COLOR[colorScheme])
   if (platform === "win32") win.setTitleBarOverlay(titleBarOverlayStyle(colorScheme))
 }
 
@@ -115,7 +111,7 @@ export function createMainWindow(options: MainWindowOptions) {
     show: false,
     title: "PawWork",
     icon: iconPath(),
-    backgroundColor: windowSurfaceColor(options.colorScheme),
+    backgroundColor: SURFACE_COLOR[options.colorScheme],
     ...dshTitleBarOptions(process.platform, options.colorScheme),
     ...(process.platform === "darwin" ? { trafficLightPosition: macTrafficLightPosition() } : {}),
     webPreferences: dshWebPreferences(options.preload),

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -5,14 +5,15 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { macTrafficLightPosition, pawworkWindowTitle, titlebarInsetCss } from "./window-chrome"
 import { decideDshNavigation, guardDshNavigation, handleDshWindowOpen } from "./window-navigation"
-import { dshTitleBarOptions, dshWebPreferences, titleBarOverlayStyle } from "./window-options"
+import {
+  dshTitleBarOptions,
+  dshWebPreferences,
+  titleBarOverlayStyle,
+  type WindowColorScheme,
+  windowSurfaceColor,
+} from "./window-options"
 
 const root = dirname(fileURLToPath(import.meta.url))
-// The startup page is shown before DSH can say which appearance the user chose,
-// so a system-only default flashes the wrong one at anybody whose app setting
-// disagrees with their OS. `scheme` is the last appearance the product
-// published; the media query stays as the answer for the very first launch,
-// when there is nothing remembered yet.
 // Covers the quote characters too: the result is interpolated into an attribute
 // value as well as into text.
 const HTML_ESCAPES: Record<string, string> = {
@@ -25,10 +26,17 @@ const HTML_ESCAPES: Record<string, string> = {
 
 const escapeHtml = (text: string) => text.replace(/[&<>"']/g, (character) => HTML_ESCAPES[character] ?? character)
 
-const startupHtml = (scheme?: StartupColorScheme, notice?: string) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
-:root{--bg:#fff;--line:#e3e3e7;--accent:#fc5c14;--muted:#6b6b70}${scheme === undefined
-  ? "@media(prefers-color-scheme:dark){:root{--bg:#191919;--line:#2d2d31;--muted:#a1a1a6}}"
-  : scheme === "dark" ? ":root{--bg:#191919;--line:#2d2d31;--muted:#a1a1a6}" : ""}
+// The spinner track and the notice text, which have no equivalent in the web
+// app to borrow. The background does, so it comes from the shared surface.
+const STARTUP_PALETTE: Record<WindowColorScheme, { line: string; muted: string }> = {
+  light: { line: "#e3e3e7", muted: "#6b6b70" },
+  dark: { line: "#2d2d31", muted: "#a1a1a6" },
+}
+
+const startupHtml = (scheme: WindowColorScheme, notice?: string) => `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'"><title>PawWork</title><style>
+:root{color-scheme:${scheme};--bg:${windowSurfaceColor(scheme)};--line:${
+  STARTUP_PALETTE[scheme].line
+};--accent:#fc5c14;--muted:${STARTUP_PALETTE[scheme].muted}}
 html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);display:flex;flex-direction:column;gap:16px;justify-content:center}
 .titlebar{-webkit-app-region:drag;height:var(--pawwork-titlebar-host-height,env(titlebar-area-height,0px));left:0;position:fixed;right:0;top:0}
 .spinner{animation:spin .8s linear infinite;border:2px solid var(--line);border-radius:50%;box-sizing:border-box;height:20px;position:relative;width:20px}
@@ -41,14 +49,12 @@ html,body{height:100%;margin:0}body{align-items:center;background:var(--bg);disp
   notice === undefined ? "" : `<p class="notice">${escapeHtml(notice)}</p>`
 }</body></html>`
 
-export type StartupColorScheme = "dark" | "light"
-
 /**
  * The page every window sits on while DSH is not serving one. `notice` names
  * the step being waited on; without it a wait in front of DSH, which prints
  * nothing until it is ready, is indistinguishable from a hang.
  */
-export function startupUrl(scheme?: StartupColorScheme, notice?: string) {
+export function startupUrl(scheme: WindowColorScheme, notice?: string) {
   return `data:text/html;charset=utf-8,${encodeURIComponent(startupHtml(scheme, notice))}`
 }
 
@@ -69,19 +75,24 @@ export function setDockIcon() {
 
 type MainWindowOptions = {
   preload: string
-  startupColorScheme?: StartupColorScheme
+  colorScheme: WindowColorScheme
   // Read on every navigation rather than captured: the window is created before
   // DSH has an origin, and outlives the one it eventually gets.
   dshUrl: () => string | undefined
 }
 
-export function setTitlebarColorScheme(
-  win: Pick<BrowserWindow, "setTitleBarOverlay">,
+/**
+ * Repaints an open window's native surfaces. They move together: one left on
+ * the previous scheme is an edge the user sees. The caption overlay is a
+ * Windows control; elsewhere only the background exists.
+ */
+export function applyWindowColorScheme(
+  win: Pick<BrowserWindow, "setBackgroundColor" | "setTitleBarOverlay">,
   platform: NodeJS.Platform,
-  colorScheme: unknown,
+  colorScheme: WindowColorScheme,
 ) {
-  if (platform !== "win32" || (colorScheme !== "light" && colorScheme !== "dark")) return
-  win.setTitleBarOverlay(titleBarOverlayStyle(colorScheme))
+  win.setBackgroundColor(windowSurfaceColor(colorScheme))
+  if (platform === "win32") win.setTitleBarOverlay(titleBarOverlayStyle(colorScheme))
 }
 
 // A load that is superseded rejects with ERR_ABORTED, and an unhandled rejection
@@ -104,7 +115,8 @@ export function createMainWindow(options: MainWindowOptions) {
     show: false,
     title: "PawWork",
     icon: iconPath(),
-    ...dshTitleBarOptions(process.platform),
+    backgroundColor: windowSurfaceColor(options.colorScheme),
+    ...dshTitleBarOptions(process.platform, options.colorScheme),
     ...(process.platform === "darwin" ? { trafficLightPosition: macTrafficLightPosition() } : {}),
     webPreferences: dshWebPreferences(options.preload),
   })
@@ -152,7 +164,7 @@ export function createMainWindow(options: MainWindowOptions) {
     event.preventDefault()
     win.setTitle(pawworkWindowTitle(title))
   })
-  navigateWindow(win, options.dshUrl() ?? startupUrl(options.startupColorScheme))
+  navigateWindow(win, options.dshUrl() ?? startupUrl(options.colorScheme))
   win.once("ready-to-show", () => win.show())
 
   return win


### PR DESCRIPTION
Closes #1652.

## What was wrong

Four surfaces can be on screen before the web app's own stylesheet applies, and none of them had an owner:

| Surface | Before |
| --- | --- |
| `BrowserWindow` background | never set, so Electron's default white |
| Windows caption overlay | created with a height and no `color`; only `symbolColor` was ever updated, and only after the product reported ready |
| Startup page canvas | no `color-scheme`, so Chromium paints it light whatever `--bg` says |
| Startup page background | `#191919`, a different dark from the app it is waiting for |

On Windows dark mode that reads as a permanent white caption strip and a white flash on every startup and DSH restart. The main process never owned "which appearance is this window"; it only proxied one field of it, late.

## What changed

The main process holds the appearance itself: the scheme DSH published on the last run, falling back to `nativeTheme`, resolved before the window is created and never absent. Every surface derives from that single value, and a theme change repaints all of them in one call instead of leaving some behind.

- `windowSurfaceColor` is the one table: light `#fff`, dark `#151517`.
- `createMainWindow` takes the scheme and sets `backgroundColor` plus a fully coloured `titleBarOverlay` at construction.
- `setTitlebarColorScheme` becomes `applyWindowColorScheme`, which sets the background as well as the overlay, and now runs for every open window rather than only the sender's.
- The startup page declares `color-scheme` and drops the media-query branch, so `startupUrl` no longer has an "appearance unknown" case.

The two colours are DSH's `--dsw-alias-bg-base`. They are copied rather than read at runtime because they have to exist before any DSH asset loads, so `dsh-product-client.test.ts` reads the installed theme package and fails if either the values or the boot script's `documentElement.style.colorScheme` write moves. That write is also what the product preload reads to report the theme, so the sentinel covers both halves of the contract.

## Verification

- macOS, real window, main-process inspector: with no remembered scheme the window follows the system; with `dark` remembered it comes up `#151517`; with `light`, `#FFFFFF`. The startup page's computed `color-scheme` and canvas match in each case.
- tsgo, eslint, vitest 542/542, `node --test` 165/165, raw CI smoke with CDP.
- The Windows overlay has no read-back API, so its options are pinned in unit tests; the visual result on Windows needs the reporter to confirm on the next build.

## Known trade-offs

- **A `system` preference resolved across restarts.** The cache stores the scheme DSH resolved, not the preference behind it, and DSH defaults to `system`. Change the OS appearance while the app is closed and the first frames use the previous run's answer until the product publishes the new one, measured at ~200ms warm and longer on a cold start. Storing the system appearance alongside and discarding the cache when it moves was rejected: it would throw away a correct answer whenever the preference is an explicit light or dark. Reading `ui-theme.preference` out of the DSH settings file would fix it properly, at the price of binding the main process to an on-disk format that is not part of the typed contract. Before this change the same start painted a white window in dark mode every time, so it is strictly better as it stands.
- **A window stranded on the startup page does not repaint.** The startup page's scheme is baked into its `data:` URL. A window that never reached DSH — a `loadURL` refused during a sidecar restart — keeps its page while its native surfaces follow the window that published. Re-navigating it would drop whatever notice it was showing, so the comment says what the code does instead.
- **The Windows result is unverified locally.** `setTitleBarOverlay` does not exist on macOS, so the caption overlay path is covered by unit tests and the Windows packaging smoke only. The overlay sits over the layout plugin's root container, whose background is `--dsw-alias-bg-base`, which is why that is the colour it is given.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved light and dark theme consistency across the startup screen and application windows.
  - Window backgrounds and title-bar overlays now update together when the color scheme changes.
  - The app now correctly applies the active color scheme when creating windows and starting up.
  - When no preference is saved, the app falls back to the system’s light or dark mode.
- **Tests**
  - Expanded coverage for theme rendering, window creation, and color updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->