### PR TITLE
fix(automations): treat a definition with no usable timestamp as unscheduled

### DIFF
--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.cjs
@@ -50,6 +50,15 @@ function recurringNext(createdAt, everyMs, after) {
   return createdAt + (Math.floor(elapsed / everyMs) + 1) * everyMs;
 }
 
+// The store persists whatever the document on disk holds, so a definition can
+// reach the scheduler without a usable timestamp. Only a real one counts as
+// scheduled: as a delay it arms a timer every millisecond for the life of the
+// process, and as a claim target it fails the run record's own validation and
+// leaves the scheduler unstarted.
+function scheduledAt(definition) {
+  return Number.isFinite(definition.nextFireAt) ? definition.nextFireAt : null;
+}
+
 function definitionNext(definition, after, completedRunCount = 0) {
   if (definition.paused) return null;
   if (definition.stop?.kind === 'count' && completedRunCount >= definition.stop.count) return null;
@@ -540,7 +549,7 @@ class AutomationScheduler {
     const now = this.clock.now();
     this.store.interruptActiveRuns(now);
     for (const definition of this.store.listDefinitions()) {
-      const target = definition.nextFireAt;
+      const target = scheduledAt(definition);
       if (target === null || target > now || definition.paused) continue;
       this.store.claimDue(definition.id, target, now, {
         state: 'stopped',
@@ -560,7 +569,7 @@ class AutomationScheduler {
     this.timer = null;
     if (this.stopping) return;
     const targets = this.store.listDefinitions()
-      .map((definition) => definition.nextFireAt)
+      .map(scheduledAt)
       .filter((value) => value !== null);
     if (targets.length === 0) return;
     this.armIn(Math.max(0, Math.min(Math.min(...targets) - this.clock.now(), MAX_TIMER_DELAY_MS)));

--- a/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
+++ b/packages/desktop-electron/resources/dsh/automations/lib/automations.test.cjs
@@ -197,6 +197,31 @@ test('startup interrupts unfinished runs, does not replay misses, and arms only 
   await scheduler.stop();
 });
 
+// The scheduler reads timestamps straight out of the stored document, and only
+// `null` used to mean "not scheduled". A definition carrying anything else armed
+// a timer on NaN — one per millisecond, forever — or, unpaused, threw out of
+// start() into a warning nothing exports, leaving every automation dead.
+test('treats a definition with no usable timestamp as unscheduled', async () => {
+  const { file, cwd } = fixture();
+  const stranded = oneShot(new AutomationStore(file), cwd, 2_000);
+  const document = JSON.parse(fs.readFileSync(file, 'utf8'));
+  delete document.definitions[0].nextFireAt;
+  fs.writeFileSync(file, JSON.stringify(document));
+  const store = new AutomationStore(file);
+  const clock = fakeClock(9_000);
+  const scheduler = new AutomationScheduler({
+    store,
+    execute: async () => assert.fail('an unscheduled definition must not run'),
+    clock,
+  });
+
+  await scheduler.start();
+
+  assert.equal(clock.armed(), undefined);
+  assert.equal(store.listRuns(stranded.id).length, 0);
+  await scheduler.stop();
+});
+
 // An automation turn still in flight when the sidecar quits is the case the
 // abort loop exists for: without it stop() waits on a promise nothing will ever
 // settle. This test is the only one that reaches that deadlock — the others


### PR DESCRIPTION
The automation scheduler read `nextFireAt` straight out of the stored document, and only `null` counted as "not scheduled". A definition carrying anything else broke both of its consumers.

| Consumer | With a non-timestamp `nextFireAt` |
| --- | --- |
| `arm()` | `Math.min` over the targets yields `NaN`, so the timer is armed on `NaN` and re-arms about once a millisecond for the life of the sidecar |
| `start()` | an unpaused definition is passed to `claimDue`, whose run record rejects a non-integer timestamp, so `start()` throws |

Measured on `origin/main` with a definition whose record has no `nextFireAt`:

```
TimeoutNaNWarning: NaN is not a number. Timeout duration was set to 1.
timer arms in 300ms: 260
```

```
Error: triggeredAt must be a non-negative integer
    at AutomationStore.createRunRecord
    at AutomationStore.claimDue
    at AutomationScheduler.start
```

The `start()` rejection is caught and logged through `ctx.logger.warn`, and the sidecar has no console exporter for the cordis logger, so that path ends with every automation dead and nothing in `main.log`.

`Number.isFinite` is now asked once, in a predicate both consumers share, instead of each of them restating what counts as scheduled.

## Scope

Every supported writer stores a real timestamp or `null`: `createDefinition` computes one, `importDefinition` normalizes the rhythm before it does, and `NaN` does not survive `JSON.stringify`. So this guards a state that reaches the scheduler only from a document written by something else. The `TimeoutNaNWarning` this started from does not reproduce — zero occurrences in `main.log` on this machine or in a fresh raw smoke run, and both real stores hold a valid `null`. It is hardening, not a live-bug fix.

## Verification

`node --test` 165/165 with one new regression test, vitest 542/542, tsgo and eslint clean. Removing the guard fails the new test; the test drives the state through the store file, the way it would actually arrive.
