### PR TITLE
chore(release): prepare 2026.9.7

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pawwork/desktop",
   "private": true,
-  "version": "2026.9.6",
+  "version": "2026.9.7",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://pawwork.ai",


### PR DESCRIPTION
Version bump for 2026.9.7.

Contents since v2026.9.6:

- #1655 — Windows dark mode: the window background, the caption overlay and the startup page all come up in the app's own appearance.
- #1654 — DSH 0.1.5-rc.1. Sessions written from this version on use format V3, which earlier versions cannot read; existing V2 files are kept, so a rollback loses only sessions created after the upgrade.
- #1653 — automations pick their model from the routable catalog and fall back to the default at run time, recording the fallback in the run record.